### PR TITLE
Preserve original when applying ASCIIFoldingFilter

### DIFF
--- a/solr/homeDirectoryTemplate/conf/schema.xml
+++ b/solr/homeDirectoryTemplate/conf/schema.xml
@@ -523,7 +523,7 @@
     <fieldType name="text" class="solr.TextField" positionIncrementGap="100" autoGeneratePhraseQueries="true">
     <analyzer type="index">
       <tokenizer class="solr.WhitespaceTokenizerFactory"/>      
-      <filter class="solr.ASCIIFoldingFilterFactory"/>
+      <filter class="solr.ASCIIFoldingFilterFactory" preserveOriginal="true"/>
       <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords.txt"/>
       <filter class="solr.WordDelimiterFilterFactory" generateWordParts="1" generateNumberParts="1" 
               catenateWords="1" catenateNumbers="1" catenateAll="0"/>
@@ -533,7 +533,7 @@
     </analyzer>
     <analyzer type="query">
       <tokenizer class="solr.WhitespaceTokenizerFactory"/>
-      <filter class="solr.ASCIIFoldingFilterFactory"/>      
+      <filter class="solr.ASCIIFoldingFilterFactory" preserveOriginal="true"/>      
       <filter class="solr.SynonymFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="true"/>
       <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords.txt"/>
       <filter class="solr.WordDelimiterFilterFactory" generateWordParts="1" generateNumberParts="1" 
@@ -554,7 +554,7 @@
         <filter class="solr.WordDelimiterFilterFactory" 
                 generateWordParts="1"  generateNumberParts="1" catenateWords="0" 
                 catenateNumbers="0" catenateAll="0" splitOnCaseChange="0" />
-        <filter class="solr.ASCIIFoldingFilterFactory"/>
+        <filter class="solr.ASCIIFoldingFilterFactory" preserveOriginal="true"/>
         <filter class="solr.LowerCaseFilterFactory"/> 
       </analyzer>  
     </fieldType>
@@ -570,7 +570,7 @@
         <filter class="solr.WordDelimiterFilterFactory" 
                 generateWordParts="1"  generateNumberParts="1" catenateWords="0" 
                 catenateNumbers="0" catenateAll="0" splitOnCaseChange="1" />
-        <filter class="solr.ASCIIFoldingFilterFactory"/>        
+        <filter class="solr.ASCIIFoldingFilterFactory" preserveOriginal="true"/>        
         <filter class="solr.LowerCaseFilterFactory"/>        
         <filter class="solr.SnowballPorterFilterFactory" language="English" protected="protwords.txt"/>  
       </analyzer>
@@ -583,7 +583,7 @@
         <tokenizer class="solr.WhitespaceTokenizerFactory"/>
         <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords.txt" enablePositionIncrements="true" />
         <filter class="solr.WordDelimiterFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="1" catenateNumbers="1" catenateAll="0" splitOnCaseChange="0"/>
-        <filter class="solr.ASCIIFoldingFilterFactory"/>
+        <filter class="solr.ASCIIFoldingFilterFactory" preserveOriginal="true"/>
         <filter class="solr.LowerCaseFilterFactory"/>
       </analyzer>
       <analyzer type="query">
@@ -591,7 +591,7 @@
         <filter class="solr.SynonymFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="true"/>
         <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords.txt" enablePositionIncrements="true" />
         <filter class="solr.WordDelimiterFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="0" catenateNumbers="0" catenateAll="0" splitOnCaseChange="0"/>
-        <filter class="solr.ASCIIFoldingFilterFactory"/>
+        <filter class="solr.ASCIIFoldingFilterFactory" preserveOriginal="true"/>
         <filter class="solr.LowerCaseFilterFactory"/>
       </analyzer>
     </fieldType>
@@ -826,7 +826,7 @@
       <analyzer>
         <tokenizer class="solr.KeywordTokenizerFactory"/>
         <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords.txt" enablePositionIncrements="true" />
-        <filter class="solr.ASCIIFoldingFilterFactory"/>
+        <filter class="solr.ASCIIFoldingFilterFactory" preserveOriginal="true"/>
         <filter class="solr.LowerCaseFilterFactory" />
       </analyzer>
     </fieldType>


### PR DESCRIPTION
This is a suggestion, but here at Duke, we recently ran into a situation where a faculty member with an umlat (`ö`) in her name could be found only with her name spelled out with `o`. This change allows her name to be searched either way. This seems like the appropriate default behavior.
