### PR TITLE
Allow getFormat function to accept qualified date precisions

### DIFF
--- a/webapp/web/templates/freemarker/lib/lib-datetime.ftl
+++ b/webapp/web/templates/freemarker/lib/lib-datetime.ftl
@@ -159,15 +159,15 @@
          and the format type to determine how to display it.  -->    
     <#local format>
         <#if formatType == "long">
-            <#if precision == "yearPrecision">yyyy
-            <#elseif precision == "yearMonthPrecision">MMMM yyyy
-            <#elseif precision == "yearMonthDayPrecision">MMMM d, yyyy
+            <#if precision?ends_with("yearPrecision")>yyyy
+            <#elseif precision?ends_with("yearMonthPrecision")>MMMM yyyy
+            <#elseif precision?ends_with("yearMonthDayPrecision")>MMMM d, yyyy
             <#else>MMMM d, yyyy h:mm a
             </#if>
         <#else> <#-- formatType == "short" -->
-            <#if precision == "yearPrecision">yyyy
-            <#elseif precision == "yearMonthPrecision">M/yyyy
-            <#elseif precision == "yearMonthDayPrecision">M/d/yyyy
+            <#if precision?ends_with("yearPrecision")>yyyy
+            <#elseif precision?ends_with("yearMonthPrecision")>M/yyyy
+            <#elseif precision?ends_with("yearMonthDayPrecision")>M/d/yyyy
             <#else>M/d/yyyy h:mm a
             </#if>
         </#if>


### PR DESCRIPTION
When trying to use some of the helpful date functions in lib-datetime while customizing a page, I ran into this issue where the getFormat function wanted unqualified precisions like "yearPrecision". But I was passing in the precision directly from a listViewConfig statement, which was fully qualified. It seemed to me to make sense to override getFormat to permit both qualified and unqualified precisions. (The alternative would be to strip out the qualification, which would work, but is inconsistent with how I've worked with URIs elsewhere in the freemarker templates.)

This change allows the date precision to be a fully qualified URL, like
"http://vivoweb.org/ontology/core#yearPrecision", while still accepting
"yearPrecision"
