### PR TITLE
Fixes ETag quoting and strips white space from generated Etag.

### DIFF
--- a/webapp/src/edu/cornell/mannlib/vitro/webapp/filters/CachingResponseFilter.java
+++ b/webapp/src/edu/cornell/mannlib/vitro/webapp/filters/CachingResponseFilter.java
@@ -282,13 +282,13 @@ public class CachingResponseFilter implements Filter {
 		@SuppressWarnings("unchecked")
 		List<Locale> locales = EnumerationUtils.toList(req.getLocales());
 
-		StringBuilder buffer = new StringBuilder('"').append(rawEtag);
+		StringBuilder buffer = new StringBuilder("\"").append(rawEtag);
 		for (Locale locale : locales) {
-			buffer.append(locale.toString()).append(" ");
+			buffer.append(locale.toString());
 		}
-		buffer.append('"');
+		buffer.append("\"");
 
-		String etag = buffer.toString();
+		String etag = buffer.toString().replaceAll("\\s", "");
 		log.debug("Language-specific ETAG = " + etag);
 		return etag;
 	}


### PR DESCRIPTION
The Etags being generated aren't quoted.  The initial quote was missing.   

`Language-specific ETAG = 3a6d8837c0078966en_US en "`

This change wraps the ETag in quote as [recommended/specified](http://tools.ietf.org/html/rfc7232#section-2.3).  This also removes trailing white space that was being added when appending the locales to rawEtag.  Although it doesn't seem to be invalid, I'm also striping whitespace from locales for consistency.  
