### PR TITLE
Problem with paused indexer

### DIFF
--- a/webapp/src/edu/cornell/mannlib/vitro/webapp/search/controller/IndexController.java
+++ b/webapp/src/edu/cornell/mannlib/vitro/webapp/search/controller/IndexController.java
@@ -172,6 +172,7 @@ public class IndexController extends FreemarkerHttpServlet {
 
 	private void requestRebuild() {
 		indexer.rebuildIndex();
+		indexer.unpause();
 	}
 
 	private Map<String, Object> buildStatusMap(SearchIndexerStatus status) {


### PR DESCRIPTION
The SearchIndexer is starting PAUSED. Requesting a reindex just puts it into the deferred queue, but doesn't start the indexer.

This patch will unpause the index when you request a rebuild, avoiding the problem of the index request not being processed.

It would probably be better to ensure that the indexer starts UNPAUSED, and that the reindex screen provides feedback as to when and why the indexer is paused, and when it will be unpaused.