### PR TITLE
removed extra } from title attributes in vitro templates

### DIFF
--- a/webapp/web/templates/freemarker/body/accounts/userAccounts-list.ftl
+++ b/webapp/web/templates/freemarker/body/accounts/userAccounts-list.ftl
@@ -25,7 +25,7 @@
     <section class="account-feedback">
         <p>
             ${strings.updated_account_1}
-            <a href="${updatedUserAccount.editUrl}" title="${strings.updated_account_title}}">${updatedUserAccount.firstName} ${updatedUserAccount.lastName}</a>
+            <a href="${updatedUserAccount.editUrl}" title="${strings.updated_account_title}">${updatedUserAccount.firstName} ${updatedUserAccount.lastName}</a>
             ${strings.updated_account_2}
             <#if emailWasSent?? >${strings.updated_account_notification(updatedUserAccount.emailAddress)}</#if>
         </p>

--- a/webapp/web/templates/freemarker/body/partials/shortview/view-browse-default.ftl
+++ b/webapp/web/templates/freemarker/body/partials/shortview/view-browse-default.ftl
@@ -9,11 +9,11 @@
 <#if (individual.thumbUrl)??>
     <img src="${individual.thumbUrl}" width="90" alt="${individual.name}" />
     <h1 class="thumb">
-        <a href="${individual.profileUrl}" title="${i18n().view_profile_page_for} ${individual.name}}">${individual.name}</a>
+        <a href="${individual.profileUrl}" title="${i18n().view_profile_page_for} ${individual.name}">${individual.name}</a>
     </h1>
 <#else>
     <h1>
-        <a href="${individual.profileUrl}" title="${i18n().view_profile_page_for} ${individual.name}}">${individual.name}</a>
+        <a href="${individual.profileUrl}" title="${i18n().view_profile_page_for} ${individual.name}">${individual.name}</a>
     </h1>
 </#if>
 


### PR DESCRIPTION
This is just a minor syntax fix. The hover title was appending an extra } to the end of the phrase "View the profile page for ____" on all group pages. I'm also including a related fix to affected templates in VIVO in a separate pull request.