### PR TITLE
Unpause indexer before rebuild, change listener startup order

### DIFF
--- a/webapp/src/edu/cornell/mannlib/vitro/webapp/reasoner/ABoxRecomputer.java
+++ b/webapp/src/edu/cornell/mannlib/vitro/webapp/reasoner/ABoxRecomputer.java
@@ -109,8 +109,8 @@ public class ABoxRecomputer {
             recomputeABox();
         } finally {
             if  (searchIndexer != null) {
-                searchIndexer.rebuildIndex();
                 searchIndexer.unpause();
+                searchIndexer.rebuildIndex();
             }
             synchronized (lock1) {
                 recomputing = false;	    		

--- a/webapp/web/WEB-INF/resources/startup_listeners.txt
+++ b/webapp/web/WEB-INF/resources/startup_listeners.txt
@@ -31,9 +31,6 @@ edu.cornell.mannlib.vitro.webapp.servlet.setup.RemoveObsoletePermissions
 
 edu.cornell.mannlib.vitro.webapp.servlet.setup.FileGraphSetup
 
-edu.cornell.mannlib.vitro.webapp.application.ApplicationImpl$ReasonersSetup
-edu.cornell.mannlib.vitro.webapp.servlet.setup.SimpleReasonerSetup
-
 #edu.cornell.mannlib.vitro.webapp.servlet.setup.UpdateKnowledgeBase
 edu.cornell.mannlib.vitro.webapp.migration.Release18Migrator
 
@@ -62,6 +59,10 @@ edu.cornell.mannlib.vitro.webapp.i18n.selection.LocaleSelectionSetup
 # The search indexer uses a "public" permission, so the PropertyRestrictionPolicyHelper 
 #   and the PermissionRegistry must already be set up.
 edu.cornell.mannlib.vitro.webapp.searchindex.SearchIndexerSetup
+
+# Must run after the search indexer setup
+edu.cornell.mannlib.vitro.webapp.application.ApplicationImpl$ReasonersSetup
+edu.cornell.mannlib.vitro.webapp.servlet.setup.SimpleReasonerSetup
 
 edu.cornell.mannlib.vitro.webapp.controller.freemarker.FreemarkerSetup
 edu.cornell.mannlib.vitro.webapp.freemarker.config.FreemarkerConfiguration$Setup


### PR DESCRIPTION
If you start up an empty VIVO (/Vitro) application, then the ABoxRecompute will start, pausing the index, then restarting it after.

However, before the restart, it was attempting to schedule an index rebuild, which threw a NullPointerException, as the SearchIndexer had not started, and a DAO was null.

I've put the unpause before the rebuildIndex, so that any exceptions thrown by the rebuildIndex won't cause the search indexer to be stuck in a paused state.

Also, moved the reasonor listener to after the SearchIndexer, so that the searchindexer is started first, ensuring that it is initialized before the reasoner, so that the rebuildIndex won't throw a NullPointerException.