### PR TITLE
Create deferrable task for search tasks, allowing them to be created eve...

### DIFF
--- a/webapp/src/edu/cornell/mannlib/vitro/webapp/modules/searchIndexer/SearchIndexer.java
+++ b/webapp/src/edu/cornell/mannlib/vitro/webapp/modules/searchIndexer/SearchIndexer.java
@@ -40,10 +40,18 @@ public interface SearchIndexer extends Application.Module {
 	 * unpause(). Fires a PAUSED event to listeners.
 	 * 
 	 * This call has no effect if already paused, or if called after shutdown.
-	 */
+     */
 	void pause();
 
-	/**
+    /**
+     * Stop processing new tasks. Requests will be ignored and the index rebuilt when unpaused.
+     * Fires a PAUSED event to listeners.
+     *
+     * This call has no effect if already paused, or if called after shutdown.
+     */
+    void pauseWithoutDeferring();
+
+    /**
 	 * Resume processing new tasks. Any requests that were received since the
 	 * call to pause() will now be scheduled for processing. Fires an UNPAUSED
 	 * event to listeners.

--- a/webapp/src/edu/cornell/mannlib/vitro/webapp/reasoner/ABoxRecomputer.java
+++ b/webapp/src/edu/cornell/mannlib/vitro/webapp/reasoner/ABoxRecomputer.java
@@ -104,7 +104,7 @@ public class ABoxRecomputer {
         }
         try {
             if  (searchIndexer != null) {
-                searchIndexer.pause();
+                searchIndexer.pauseWithoutDeferring();
             }
             recomputeABox();
         } finally {

--- a/webapp/src/edu/cornell/mannlib/vitro/webapp/searchindex/tasks/RebuildIndexTask.java
+++ b/webapp/src/edu/cornell/mannlib/vitro/webapp/searchindex/tasks/RebuildIndexTask.java
@@ -10,6 +10,8 @@ import java.text.SimpleDateFormat;
 import java.util.Collection;
 import java.util.Date;
 
+import edu.cornell.mannlib.vitro.webapp.searchindex.SearchIndexerImpl;
+import edu.cornell.mannlib.vitro.webapp.searchindex.indexing.IndexingUriFinderList;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
@@ -22,6 +24,7 @@ import edu.cornell.mannlib.vitro.webapp.modules.searchIndexer.SearchIndexer.Even
 import edu.cornell.mannlib.vitro.webapp.modules.searchIndexer.SearchIndexerStatus;
 import edu.cornell.mannlib.vitro.webapp.modules.searchIndexer.SearchIndexerStatus.RebuildCounts;
 import edu.cornell.mannlib.vitro.webapp.modules.searchIndexer.SearchIndexerStatus.State;
+import edu.cornell.mannlib.vitro.webapp.searchindex.SearchIndexerImpl.DeferrableTask;
 import edu.cornell.mannlib.vitro.webapp.searchindex.SearchIndexerImpl.ListenerList;
 import edu.cornell.mannlib.vitro.webapp.searchindex.SearchIndexerImpl.Task;
 import edu.cornell.mannlib.vitro.webapp.searchindex.SearchIndexerImpl.WorkerThreadPool;
@@ -49,6 +52,15 @@ public class RebuildIndexTask implements Task {
 	private final int documentsBefore;
 
 	private volatile SearchIndexerStatus status;
+
+    public static class Deferrable implements DeferrableTask {
+        public Deferrable() {}
+
+        @Override
+        public Task makeRunnable(IndexingUriFinderList uriFinders, SearchIndexExcluderList excluders, DocumentModifierList modifiers, IndividualDao indDao, ListenerList listeners, WorkerThreadPool pool) {
+            return new RebuildIndexTask(excluders, modifiers, indDao, listeners, pool);
+        }
+    }
 
 	public RebuildIndexTask(SearchIndexExcluderList excluders,
 			DocumentModifierList modifiers, IndividualDao indDao,

--- a/webapp/src/edu/cornell/mannlib/vitro/webapp/searchindex/tasks/UpdateStatementsTask.java
+++ b/webapp/src/edu/cornell/mannlib/vitro/webapp/searchindex/tasks/UpdateStatementsTask.java
@@ -14,6 +14,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import edu.cornell.mannlib.vitro.webapp.searchindex.SearchIndexerImpl;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
@@ -23,6 +24,7 @@ import edu.cornell.mannlib.vitro.webapp.dao.IndividualDao;
 import edu.cornell.mannlib.vitro.webapp.modules.searchIndexer.SearchIndexer.Event;
 import edu.cornell.mannlib.vitro.webapp.modules.searchIndexer.SearchIndexerStatus;
 import edu.cornell.mannlib.vitro.webapp.modules.searchIndexer.SearchIndexerStatus.StatementCounts;
+import edu.cornell.mannlib.vitro.webapp.searchindex.SearchIndexerImpl.DeferrableTask;
 import edu.cornell.mannlib.vitro.webapp.searchindex.SearchIndexerImpl.ListenerList;
 import edu.cornell.mannlib.vitro.webapp.searchindex.SearchIndexerImpl.Task;
 import edu.cornell.mannlib.vitro.webapp.searchindex.SearchIndexerImpl.WorkerThreadPool;
@@ -63,7 +65,18 @@ public class UpdateStatementsTask implements Task {
 	private final Set<String> uris;
 	private final Status status;
 
-	public UpdateStatementsTask(List<Statement> changes,
+    public static class Deferrable implements DeferrableTask {
+        List<Statement> changes;
+
+        public Deferrable(List<Statement> changes) { this.changes = changes; }
+
+        @Override
+        public Task makeRunnable(IndexingUriFinderList uriFinders, SearchIndexExcluderList excluders, DocumentModifierList modifiers, IndividualDao indDao, ListenerList listeners, WorkerThreadPool pool) {
+            return new UpdateStatementsTask(changes, uriFinders, excluders, modifiers, indDao, listeners, pool);
+        }
+    }
+
+    public UpdateStatementsTask(List<Statement> changes,
 			IndexingUriFinderList uriFinders,
 			SearchIndexExcluderList excluders, DocumentModifierList modifiers,
 			IndividualDao indDao, ListenerList listeners, WorkerThreadPool pool) {

--- a/webapp/src/edu/cornell/mannlib/vitro/webapp/searchindex/tasks/UpdateUrisTask.java
+++ b/webapp/src/edu/cornell/mannlib/vitro/webapp/searchindex/tasks/UpdateUrisTask.java
@@ -13,6 +13,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import edu.cornell.mannlib.vitro.webapp.searchindex.SearchIndexerImpl;
+import edu.cornell.mannlib.vitro.webapp.searchindex.indexing.IndexingUriFinderList;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
@@ -61,7 +63,17 @@ public class UpdateUrisTask implements Task {
 	private final Status status;
 	private final SearchEngine searchEngine;
 
-	public UpdateUrisTask(Collection<String> uris,
+    public static class Deferrable implements SearchIndexerImpl.DeferrableTask {
+        Collection<String> uris;
+        public Deferrable(Collection<String> uris) { this.uris = uris; }
+
+        @Override
+        public Task makeRunnable(IndexingUriFinderList uriFinders, SearchIndexExcluderList excluders, DocumentModifierList modifiers, IndividualDao indDao, ListenerList listeners, WorkerThreadPool pool) {
+            return new UpdateUrisTask(uris, excluders, modifiers, indDao, listeners, pool);
+        }
+    }
+
+    public UpdateUrisTask(Collection<String> uris,
 			SearchIndexExcluderList excluders, DocumentModifierList modifiers,
 			IndividualDao indDao, ListenerList listeners, WorkerThreadPool pool) {
 		this.uris = new HashSet<>(uris);

--- a/webapp/test/stubs/edu/cornell/mannlib/vitro/webapp/modules/searchIndexer/SearchIndexerStub.java
+++ b/webapp/test/stubs/edu/cornell/mannlib/vitro/webapp/modules/searchIndexer/SearchIndexerStub.java
@@ -31,7 +31,12 @@ public class SearchIndexerStub implements SearchIndexer {
 		paused = true;
 	}
 
-	@Override
+    @Override
+    public void pauseWithoutDeferring() {
+        paused = true;
+    }
+
+    @Override
 	public void unpause() {
 		paused = false;
 	}


### PR DESCRIPTION
Thinking about the searchindexer / paused issue a bit more.

1) This patch clears the deferred queue when scheduling tasks after start / unpause. Otherwise, multiple pauses / unpauses would cause the same deferred tasks to be run again and again.

2) Created a DeferrableTask interface, where task parameters that come from an initialized SearchIndexerImpl are passed in when using the factory method to create a Task.

The DeferrableTask can then be created even when the SearchIndexerImpl has not been initialized (e.g. NullPointerException if the ABoxRecomputer is initialized before SearchIndexerImpl), and the dao, lists, etc. are only passed in when it is converted to an executable Task - which only occurs after SearchIndexerImpl is iniitialized and started.