### PR TITLE
Allow searchindex tasks to be created before startup, simplify indexlistener

### DIFF
--- a/webapp/src/edu/cornell/mannlib/vitro/webapp/modules/searchIndexer/SearchIndexer.java
+++ b/webapp/src/edu/cornell/mannlib/vitro/webapp/modules/searchIndexer/SearchIndexer.java
@@ -40,10 +40,18 @@ public interface SearchIndexer extends Application.Module {
 	 * unpause(). Fires a PAUSED event to listeners.
 	 * 
 	 * This call has no effect if already paused, or if called after shutdown.
-	 */
+     */
 	void pause();
 
-	/**
+    /**
+     * Stop processing new tasks. Requests will be ignored and the index rebuilt when unpaused.
+     * Fires a PAUSED event to listeners.
+     *
+     * This call has no effect if already paused, or if called after shutdown.
+     */
+    void pauseWithoutDeferring();
+
+    /**
 	 * Resume processing new tasks. Any requests that were received since the
 	 * call to pause() will now be scheduled for processing. Fires an UNPAUSED
 	 * event to listeners.

--- a/webapp/src/edu/cornell/mannlib/vitro/webapp/reasoner/ABoxRecomputer.java
+++ b/webapp/src/edu/cornell/mannlib/vitro/webapp/reasoner/ABoxRecomputer.java
@@ -104,7 +104,7 @@ public class ABoxRecomputer {
         }
         try {
             if  (searchIndexer != null) {
-                searchIndexer.pause();
+                searchIndexer.pauseWithoutDeferring();
             }
             recomputeABox();
         } finally {

--- a/webapp/src/edu/cornell/mannlib/vitro/webapp/searchindex/tasks/RebuildIndexTask.java
+++ b/webapp/src/edu/cornell/mannlib/vitro/webapp/searchindex/tasks/RebuildIndexTask.java
@@ -10,6 +10,8 @@ import java.text.SimpleDateFormat;
 import java.util.Collection;
 import java.util.Date;
 
+import edu.cornell.mannlib.vitro.webapp.searchindex.SearchIndexerImpl;
+import edu.cornell.mannlib.vitro.webapp.searchindex.indexing.IndexingUriFinderList;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
@@ -22,6 +24,7 @@ import edu.cornell.mannlib.vitro.webapp.modules.searchIndexer.SearchIndexer.Even
 import edu.cornell.mannlib.vitro.webapp.modules.searchIndexer.SearchIndexerStatus;
 import edu.cornell.mannlib.vitro.webapp.modules.searchIndexer.SearchIndexerStatus.RebuildCounts;
 import edu.cornell.mannlib.vitro.webapp.modules.searchIndexer.SearchIndexerStatus.State;
+import edu.cornell.mannlib.vitro.webapp.searchindex.SearchIndexerImpl.DeferrableTask;
 import edu.cornell.mannlib.vitro.webapp.searchindex.SearchIndexerImpl.ListenerList;
 import edu.cornell.mannlib.vitro.webapp.searchindex.SearchIndexerImpl.Task;
 import edu.cornell.mannlib.vitro.webapp.searchindex.SearchIndexerImpl.WorkerThreadPool;
@@ -49,6 +52,15 @@ public class RebuildIndexTask implements Task {
 	private final int documentsBefore;
 
 	private volatile SearchIndexerStatus status;
+
+    public static class Deferrable implements DeferrableTask {
+        public Deferrable() {}
+
+        @Override
+        public Task makeRunnable(IndexingUriFinderList uriFinders, SearchIndexExcluderList excluders, DocumentModifierList modifiers, IndividualDao indDao, ListenerList listeners, WorkerThreadPool pool) {
+            return new RebuildIndexTask(excluders, modifiers, indDao, listeners, pool);
+        }
+    }
 
 	public RebuildIndexTask(SearchIndexExcluderList excluders,
 			DocumentModifierList modifiers, IndividualDao indDao,

--- a/webapp/src/edu/cornell/mannlib/vitro/webapp/searchindex/tasks/RebuildIndexTask.java
+++ b/webapp/src/edu/cornell/mannlib/vitro/webapp/searchindex/tasks/RebuildIndexTask.java
@@ -10,8 +10,6 @@ import java.text.SimpleDateFormat;
 import java.util.Collection;
 import java.util.Date;
 
-import edu.cornell.mannlib.vitro.webapp.searchindex.SearchIndexerImpl;
-import edu.cornell.mannlib.vitro.webapp.searchindex.indexing.IndexingUriFinderList;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
@@ -24,7 +22,7 @@ import edu.cornell.mannlib.vitro.webapp.modules.searchIndexer.SearchIndexer.Even
 import edu.cornell.mannlib.vitro.webapp.modules.searchIndexer.SearchIndexerStatus;
 import edu.cornell.mannlib.vitro.webapp.modules.searchIndexer.SearchIndexerStatus.RebuildCounts;
 import edu.cornell.mannlib.vitro.webapp.modules.searchIndexer.SearchIndexerStatus.State;
-import edu.cornell.mannlib.vitro.webapp.searchindex.SearchIndexerImpl.DeferrableTask;
+import edu.cornell.mannlib.vitro.webapp.searchindex.SearchIndexerImpl.IndexerConfig;
 import edu.cornell.mannlib.vitro.webapp.searchindex.SearchIndexerImpl.ListenerList;
 import edu.cornell.mannlib.vitro.webapp.searchindex.SearchIndexerImpl.Task;
 import edu.cornell.mannlib.vitro.webapp.searchindex.SearchIndexerImpl.WorkerThreadPool;
@@ -40,126 +38,150 @@ import edu.cornell.mannlib.vitro.webapp.searchindex.exclusions.SearchIndexExclud
  */
 public class RebuildIndexTask implements Task {
 	private static final Log log = LogFactory.getLog(RebuildIndexTask.class);
-
-	private final IndividualDao indDao;
-	private final SearchIndexExcluderList excluders;
-	private final DocumentModifierList modifiers;
-	private final ListenerList listeners;
-	private final WorkerThreadPool pool;
-	private final SearchEngine searchEngine;
-
 	private final Date requestedAt;
-	private final int documentsBefore;
 
-	private volatile SearchIndexerStatus status;
+    private final IndexerConfig config;
+    private RebuildIndexTaskImpl impl;
 
-    public static class Deferrable implements DeferrableTask {
-        public Deferrable() {}
-
-        @Override
-        public Task makeRunnable(IndexingUriFinderList uriFinders, SearchIndexExcluderList excluders, DocumentModifierList modifiers, IndividualDao indDao, ListenerList listeners, WorkerThreadPool pool) {
-            return new RebuildIndexTask(excluders, modifiers, indDao, listeners, pool);
-        }
+    public RebuildIndexTask(IndexerConfig config) {
+        this.config = config;
+        this.requestedAt = new Date();
     }
-
-	public RebuildIndexTask(SearchIndexExcluderList excluders,
-			DocumentModifierList modifiers, IndividualDao indDao,
-			ListenerList listeners, WorkerThreadPool pool) {
-		this.excluders = excluders;
-		this.modifiers = modifiers;
-		this.indDao = indDao;
-		this.listeners = listeners;
-		this.pool = pool;
-
-		this.searchEngine = ApplicationUtils.instance().getSearchEngine();
-
-		this.requestedAt = new Date();
-		this.documentsBefore = getDocumentCount();
-		this.status = buildStatus(REBUILDING, 0);
-	}
 
 	@Override
 	public void run() {
-		listeners.fireEvent(new Event(START_REBUILD, status));
-
-		Collection<String> uris = getAllUrisInTheModel();
-
-		if (!isInterrupted()) {
-			updateTheUris(uris);
-			if (!isInterrupted()) {
-				deleteOutdatedDocuments();
-			}
-		}
-
-		status = buildStatus(REBUILDING, getDocumentCount());
-		listeners.fireEvent(new Event(STOP_REBUILD, status));
-	}
-
-	private boolean isInterrupted() {
-		if (Thread.interrupted()) {
-			Thread.currentThread().interrupt();
-			return true;
-		} else {
-			return false;
-		}
-	}
-
-	private Collection<String> getAllUrisInTheModel() {
-		return indDao.getAllIndividualUris();
-	}
-
-	private void updateTheUris(Collection<String> uris) {
-		new UpdateUrisTask(uris, excluders, modifiers, indDao, listeners, pool)
-				.run();
-	}
-
-	private void deleteOutdatedDocuments() {
-		String query = "indexedTime:[ * TO " + requestedAt.getTime() + " ]";
-		try {
-			searchEngine.deleteByQuery(query);
-			searchEngine.commit();
-		} catch (SearchEngineNotRespondingException e) {
-			log.warn("Failed to delete outdated documents from the search index: "
-					+ "the search engine is not responding.");
-		} catch (SearchEngineException e) {
-			log.warn("Failed to delete outdated documents "
-					+ "from the search index", e);
-		}
-	}
-
-	private int getDocumentCount() {
-		try {
-			return searchEngine.documentCount();
-		} catch (SearchEngineNotRespondingException e) {
-			log.warn("Failed to get document count from the search index: "
-					+ "the search engine is not responding.");
-			return 0;
-		} catch (SearchEngineException e) {
-			log.warn("Failed to get document count from the search index.", e);
-			return 0;
-		}
-	}
-
-	private SearchIndexerStatus buildStatus(State state, int documentsAfter) {
-		return new SearchIndexerStatus(state, new Date(), new RebuildCounts(
-				documentsBefore, documentsAfter));
+        impl = new RebuildIndexTaskImpl(config, requestedAt);
+        impl.run();
 	}
 
 	@Override
 	public SearchIndexerStatus getStatus() {
-		return status;
+        return impl == null ? null : impl.getStatus();
 	}
 
 	@Override
 	public void notifyWorkUnitCompletion(Runnable workUnit) {
-		// We don't submit any work units, so we won't see any calls to this.
-		log.error("Why was this called?");
+        if (impl != null) {
+            impl.notifyWorkUnitCompletion(workUnit);
+        }
 	}
 
 	@Override
 	public String toString() {
-		return "RebuildIndexTask[requestedAt="
-				+ new SimpleDateFormat().format(requestedAt) + "]";
+		return "RebuildIndexTask[requestedAt=" + new SimpleDateFormat().format(requestedAt) + "]";
 	}
 
+    private static class RebuildIndexTaskImpl implements Task {
+        private final IndexerConfig config;
+
+        private final IndividualDao indDao;
+        private final SearchIndexExcluderList excluders;
+        private final DocumentModifierList modifiers;
+        private final ListenerList listeners;
+        private final WorkerThreadPool pool;
+        private final SearchEngine searchEngine;
+
+        private final Date requestedAt;
+        private final int documentsBefore;
+
+        private volatile SearchIndexerStatus status;
+
+        public RebuildIndexTaskImpl(IndexerConfig config, Date requestedAt) {
+            this.config = config;
+            this.excluders = config.excluderList();
+            this.modifiers = config.documentModifierList();
+            this.indDao = config.individualDao();
+            this.listeners = config.listenerList();
+            this.pool = config.workerThreadPool();
+
+            this.searchEngine = ApplicationUtils.instance().getSearchEngine();
+
+            this.requestedAt = requestedAt;
+            this.documentsBefore = getDocumentCount();
+            this.status = buildStatus(REBUILDING, 0);
+        }
+
+        @Override
+        public void run() {
+            listeners.fireEvent(new Event(START_REBUILD, status));
+
+            Collection<String> uris = getAllUrisInTheModel();
+
+            if (!isInterrupted()) {
+                updateTheUris(uris);
+                if (!isInterrupted()) {
+                    deleteOutdatedDocuments();
+                }
+            }
+
+            status = buildStatus(REBUILDING, getDocumentCount());
+            listeners.fireEvent(new Event(STOP_REBUILD, status));
+        }
+
+        private boolean isInterrupted() {
+            if (Thread.interrupted()) {
+                Thread.currentThread().interrupt();
+                return true;
+            } else {
+                return false;
+            }
+        }
+
+        private Collection<String> getAllUrisInTheModel() {
+            return indDao.getAllIndividualUris();
+        }
+
+        private void updateTheUris(Collection<String> uris) {
+            UpdateUrisTask.runNow(uris, excluders, modifiers, indDao, listeners, pool);
+        }
+
+        private void deleteOutdatedDocuments() {
+            String query = "indexedTime:[ * TO " + requestedAt.getTime() + " ]";
+            try {
+                searchEngine.deleteByQuery(query);
+                searchEngine.commit();
+            } catch (SearchEngineNotRespondingException e) {
+                log.warn("Failed to delete outdated documents from the search index: "
+                        + "the search engine is not responding.");
+            } catch (SearchEngineException e) {
+                log.warn("Failed to delete outdated documents "
+                        + "from the search index", e);
+            }
+        }
+
+        private int getDocumentCount() {
+            try {
+                return searchEngine.documentCount();
+            } catch (SearchEngineNotRespondingException e) {
+                log.warn("Failed to get document count from the search index: "
+                        + "the search engine is not responding.");
+                return 0;
+            } catch (SearchEngineException e) {
+                log.warn("Failed to get document count from the search index.", e);
+                return 0;
+            }
+        }
+
+        private SearchIndexerStatus buildStatus(State state, int documentsAfter) {
+            return new SearchIndexerStatus(state, new Date(), new RebuildCounts(
+                    documentsBefore, documentsAfter));
+        }
+
+        @Override
+        public SearchIndexerStatus getStatus() {
+            return status;
+        }
+
+        @Override
+        public void notifyWorkUnitCompletion(Runnable workUnit) {
+            // We don't submit any work units, so we won't see any calls to this.
+            log.error("Why was this called?");
+        }
+
+        @Override
+        public String toString() {
+            return "RebuildIndexTask[requestedAt="
+                    + new SimpleDateFormat().format(requestedAt) + "]";
+        }
+    }
 }

--- a/webapp/src/edu/cornell/mannlib/vitro/webapp/searchindex/tasks/UpdateStatementsTask.java
+++ b/webapp/src/edu/cornell/mannlib/vitro/webapp/searchindex/tasks/UpdateStatementsTask.java
@@ -14,6 +14,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import edu.cornell.mannlib.vitro.webapp.searchindex.SearchIndexerImpl;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
@@ -23,6 +24,7 @@ import edu.cornell.mannlib.vitro.webapp.dao.IndividualDao;
 import edu.cornell.mannlib.vitro.webapp.modules.searchIndexer.SearchIndexer.Event;
 import edu.cornell.mannlib.vitro.webapp.modules.searchIndexer.SearchIndexerStatus;
 import edu.cornell.mannlib.vitro.webapp.modules.searchIndexer.SearchIndexerStatus.StatementCounts;
+import edu.cornell.mannlib.vitro.webapp.searchindex.SearchIndexerImpl.DeferrableTask;
 import edu.cornell.mannlib.vitro.webapp.searchindex.SearchIndexerImpl.ListenerList;
 import edu.cornell.mannlib.vitro.webapp.searchindex.SearchIndexerImpl.Task;
 import edu.cornell.mannlib.vitro.webapp.searchindex.SearchIndexerImpl.WorkerThreadPool;
@@ -63,7 +65,18 @@ public class UpdateStatementsTask implements Task {
 	private final Set<String> uris;
 	private final Status status;
 
-	public UpdateStatementsTask(List<Statement> changes,
+    public static class Deferrable implements DeferrableTask {
+        List<Statement> changes;
+
+        public Deferrable(List<Statement> changes) { this.changes = changes; }
+
+        @Override
+        public Task makeRunnable(IndexingUriFinderList uriFinders, SearchIndexExcluderList excluders, DocumentModifierList modifiers, IndividualDao indDao, ListenerList listeners, WorkerThreadPool pool) {
+            return new UpdateStatementsTask(changes, uriFinders, excluders, modifiers, indDao, listeners, pool);
+        }
+    }
+
+    public UpdateStatementsTask(List<Statement> changes,
 			IndexingUriFinderList uriFinders,
 			SearchIndexExcluderList excluders, DocumentModifierList modifiers,
 			IndividualDao indDao, ListenerList listeners, WorkerThreadPool pool) {

--- a/webapp/src/edu/cornell/mannlib/vitro/webapp/searchindex/tasks/UpdateUrisTask.java
+++ b/webapp/src/edu/cornell/mannlib/vitro/webapp/searchindex/tasks/UpdateUrisTask.java
@@ -13,6 +13,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import edu.cornell.mannlib.vitro.webapp.searchindex.SearchIndexerImpl;
+import edu.cornell.mannlib.vitro.webapp.searchindex.indexing.IndexingUriFinderList;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
@@ -61,7 +63,17 @@ public class UpdateUrisTask implements Task {
 	private final Status status;
 	private final SearchEngine searchEngine;
 
-	public UpdateUrisTask(Collection<String> uris,
+    public static class Deferrable implements SearchIndexerImpl.DeferrableTask {
+        Collection<String> uris;
+        public Deferrable(Collection<String> uris) { this.uris = uris; }
+
+        @Override
+        public Task makeRunnable(IndexingUriFinderList uriFinders, SearchIndexExcluderList excluders, DocumentModifierList modifiers, IndividualDao indDao, ListenerList listeners, WorkerThreadPool pool) {
+            return new UpdateUrisTask(uris, excluders, modifiers, indDao, listeners, pool);
+        }
+    }
+
+    public UpdateUrisTask(Collection<String> uris,
 			SearchIndexExcluderList excluders, DocumentModifierList modifiers,
 			IndividualDao indDao, ListenerList listeners, WorkerThreadPool pool) {
 		this.uris = new HashSet<>(uris);

--- a/webapp/src/edu/cornell/mannlib/vitro/webapp/searchindex/tasks/UpdateUrisTask.java
+++ b/webapp/src/edu/cornell/mannlib/vitro/webapp/searchindex/tasks/UpdateUrisTask.java
@@ -7,14 +7,8 @@ import static edu.cornell.mannlib.vitro.webapp.modules.searchIndexer.SearchIndex
 import static edu.cornell.mannlib.vitro.webapp.modules.searchIndexer.SearchIndexer.Event.Type.STOP_URIS;
 import static edu.cornell.mannlib.vitro.webapp.modules.searchIndexer.SearchIndexerStatus.State.PROCESSING_URIS;
 
-import java.util.Collection;
-import java.util.Date;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 
-import edu.cornell.mannlib.vitro.webapp.searchindex.SearchIndexerImpl;
-import edu.cornell.mannlib.vitro.webapp.searchindex.indexing.IndexingUriFinderList;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
@@ -29,6 +23,7 @@ import edu.cornell.mannlib.vitro.webapp.modules.searchIndexer.SearchIndexer.Even
 import edu.cornell.mannlib.vitro.webapp.modules.searchIndexer.SearchIndexerStatus;
 import edu.cornell.mannlib.vitro.webapp.modules.searchIndexer.SearchIndexerStatus.UriCounts;
 import edu.cornell.mannlib.vitro.webapp.modules.searchIndexer.SearchIndexerUtils;
+import edu.cornell.mannlib.vitro.webapp.searchindex.SearchIndexerImpl.IndexerConfig;
 import edu.cornell.mannlib.vitro.webapp.searchindex.SearchIndexerImpl.ListenerList;
 import edu.cornell.mannlib.vitro.webapp.searchindex.SearchIndexerImpl.Task;
 import edu.cornell.mannlib.vitro.webapp.searchindex.SearchIndexerImpl.WorkerThreadPool;
@@ -51,230 +46,268 @@ import edu.cornell.mannlib.vitro.webapp.searchindex.exclusions.SearchIndexExclud
  * again at the end of the task.
  */
 public class UpdateUrisTask implements Task {
-	private static final Log log = LogFactory.getLog(UpdateUrisTask.class);
+    private static final Log log = LogFactory.getLog(UpdateUrisTask.class);
 
-	private final Set<String> uris;
-	private final IndividualDao indDao;
-	private final SearchIndexExcluderList excluders;
-	private final DocumentModifierList modifiers;
-	private final ListenerList listeners;
-	private final WorkerThreadPool pool;
+    private final IndexerConfig config;
+    private UpdateUrisTaskImpl impl;
 
-	private final Status status;
-	private final SearchEngine searchEngine;
+    private final Collection<String> uris;
+    private Date since = new Date();
 
-    public static class Deferrable implements SearchIndexerImpl.DeferrableTask {
-        Collection<String> uris;
-        public Deferrable(Collection<String> uris) { this.uris = uris; }
+    public UpdateUrisTask(IndexerConfig config, Collection<String> uris) {
+        this.config = config;
+        this.uris = new HashSet<>(uris);
+    }
 
-        @Override
-        public Task makeRunnable(IndexingUriFinderList uriFinders, SearchIndexExcluderList excluders, DocumentModifierList modifiers, IndividualDao indDao, ListenerList listeners, WorkerThreadPool pool) {
-            return new UpdateUrisTask(uris, excluders, modifiers, indDao, listeners, pool);
+    static void runNow(Collection<String> uris, SearchIndexExcluderList excluders, DocumentModifierList modifiers, IndividualDao indDao, ListenerList listeners, WorkerThreadPool pool) {
+        UpdateUrisTaskImpl impl = new UpdateUrisTaskImpl(uris, excluders, modifiers, indDao, listeners, pool);
+        impl.run();
+    }
+
+    @Override
+    public void run() {
+        impl = new UpdateUrisTaskImpl(config, uris);
+        impl.run();
+    }
+
+    @Override
+    public SearchIndexerStatus getStatus() {
+        if (impl != null) {
+            return impl.getStatus();
+        }
+
+        return new SearchIndexerStatus(PROCESSING_URIS, since, new UriCounts(0, 0, 0, uris.size(), uris.size()));
+    }
+
+    @Override
+    public void notifyWorkUnitCompletion(Runnable workUnit) {
+        if (impl != null) {
+            impl.notifyWorkUnitCompletion(workUnit);
         }
     }
 
-    public UpdateUrisTask(Collection<String> uris,
-			SearchIndexExcluderList excluders, DocumentModifierList modifiers,
-			IndividualDao indDao, ListenerList listeners, WorkerThreadPool pool) {
-		this.uris = new HashSet<>(uris);
-		this.excluders = excluders;
-		this.modifiers = modifiers;
-		this.indDao = indDao;
-		this.listeners = listeners;
-		this.pool = pool;
+    private static class UpdateUrisTaskImpl implements Task {
+        private final Collection<String> uris;
+        private final IndividualDao indDao;
+        private final SearchIndexExcluderList excluders;
+        private final DocumentModifierList modifiers;
+        private final ListenerList listeners;
+        private final WorkerThreadPool pool;
 
-		this.status = new Status(this, uris.size(), 500);
+        private final Status status;
+        private final SearchEngine searchEngine;
 
-		this.searchEngine = ApplicationUtils.instance().getSearchEngine();
+        public UpdateUrisTaskImpl(IndexerConfig config, Collection<String> uris) {
+            this.excluders = config.excluderList();
+            this.modifiers = config.documentModifierList();
+            this.indDao = config.individualDao();
+            this.listeners = config.listenerList();
+            this.pool = config.workerThreadPool();
 
-	}
+            this.uris = uris;
+            this.status = new Status(this, uris.size(), 500);
 
-	@Override
-	public void run() {
-		listeners.fireEvent(new Event(START_URIS, status
-				.getSearchIndexerStatus()));
-		excluders.startIndexing();
-		modifiers.startIndexing();
+            this.searchEngine = ApplicationUtils.instance().getSearchEngine();
+        }
 
-		for (String uri : uris) {
-			if (isInterrupted()) {
-				log.info("Interrupted: " + status.getSearchIndexerStatus());
-				break;
-			} else if (uri == null) {
-				// Nothing to do
-			} else {
-				Individual ind = getIndividual(uri);
-				if (ind == null) {
-					deleteDocument(uri);
-				} else if (isExcluded(ind)) {
-					excludeDocument(uri);
-				} else {
-					updateDocument(ind);
-				}
-			}
-		}
-		pool.waitUntilIdle();
+        public UpdateUrisTaskImpl(Collection<String> uris, SearchIndexExcluderList excluders, DocumentModifierList modifiers, IndividualDao indDao, ListenerList listeners, WorkerThreadPool pool) {
+            this.uris = uris;
+            this.excluders = excluders;
+            this.modifiers = modifiers;
+            this.indDao = indDao;
+            this.listeners = listeners;
+            this.pool = pool;
+            this.status = new Status(this, uris.size(), 500);
 
-		commitChanges();
+            this.searchEngine = ApplicationUtils.instance().getSearchEngine();
+        }
 
-		excluders.stopIndexing();
-		modifiers.stopIndexing();
-		listeners.fireEvent(new Event(STOP_URIS, status
-				.getSearchIndexerStatus()));
-	}
+        @Override
+        public void run() {
+            listeners.fireEvent(new Event(START_URIS, status.getSearchIndexerStatus()));
+            excluders.startIndexing();
+            modifiers.startIndexing();
 
-	private boolean isInterrupted() {
-		if (Thread.interrupted()) {
-			Thread.currentThread().interrupt();
-			return true;
-		} else {
-			return false;
-		}
-	}
+            for (String uri : uris) {
+                if (isInterrupted()) {
+                    log.info("Interrupted: " + status.getSearchIndexerStatus());
+                    break;
+                } else if (uri == null) {
+                    // Nothing to do
+                } else {
+                    Individual ind = getIndividual(uri);
+                    if (ind == null) {
+                        deleteDocument(uri);
+                    } else if (isExcluded(ind)) {
+                        excludeDocument(uri);
+                    } else {
+                        updateDocument(ind);
+                    }
+                }
+            }
+            pool.waitUntilIdle();
 
-	private Individual getIndividual(String uri) {
-		Individual ind = indDao.getIndividualByURI(uri);
-		if (ind == null) {
-			log.debug("Found no individual for '" + uri + "'");
-		}
-		return ind;
-	}
+            commitChanges();
 
-	private boolean isExcluded(Individual ind) {
-		return excluders.isExcluded(ind);
-	}
+            excluders.stopIndexing();
+            modifiers.stopIndexing();
+            listeners.fireEvent(new Event(STOP_URIS, status.getSearchIndexerStatus()));
+        }
 
-	/** A delete is fast enough to be done synchronously. */
-	private void deleteDocument(String uri) {
-		try {
-			searchEngine.deleteById(SearchIndexerUtils.getIdForUri(uri));
-			status.incrementDeletes();
-			log.debug("deleted '" + uri + "' from search index.");
-		} catch (SearchEngineNotRespondingException e) {
-			log.warn("Failed to delete '" + uri + "' from search index: "
-					+ "the search engine is not responding.");
-		} catch (Exception e) {
-			log.warn("Failed to delete '" + uri + "' from search index", e);
-		}
-	}
+        private boolean isInterrupted() {
+            if (Thread.interrupted()) {
+                Thread.currentThread().interrupt();
+                return true;
+            } else {
+                return false;
+            }
+        }
 
-	/** An exclusion is just a delete for different reasons. */
-	private void excludeDocument(String uri) {
-		try {
-			searchEngine.deleteById(SearchIndexerUtils.getIdForUri(uri));
-			status.incrementExclusions();
-			log.debug("excluded '" + uri + "' from search index.");
-		} catch (SearchEngineNotRespondingException e) {
-			log.warn("Failed to exclude '" + uri + "' from search index: "
-					+ "the search engine is not responding.", e);
-		} catch (Exception e) {
-			log.warn("Failed to exclude '" + uri + "' from search index", e);
-		}
-	}
+        private Individual getIndividual(String uri) {
+            Individual ind = indDao.getIndividualByURI(uri);
+            if (ind == null) {
+                log.debug("Found no individual for '" + uri + "'");
+            }
+            return ind;
+        }
 
-	private void updateDocument(Individual ind) {
-		Runnable workUnit = new UpdateDocumentWorkUnit(ind, modifiers);
-		pool.submit(workUnit, this);
-		log.debug("scheduled update to " + ind);
-	}
+        private boolean isExcluded(Individual ind) {
+            return excluders.isExcluded(ind);
+        }
 
-	private void fireEvent(Event event) {
-		listeners.fireEvent(event);
-		if (event.getType() == PROGRESS || event.getType() == STOP_URIS) {
-			commitChanges();
-		}
-	}
+        /**
+         * A delete is fast enough to be done synchronously.
+         */
+        private void deleteDocument(String uri) {
+            try {
+                searchEngine.deleteById(SearchIndexerUtils.getIdForUri(uri));
+                status.incrementDeletes();
+                log.debug("deleted '" + uri + "' from search index.");
+            } catch (SearchEngineNotRespondingException e) {
+                log.warn("Failed to delete '" + uri + "' from search index: "
+                        + "the search engine is not responding.");
+            } catch (Exception e) {
+                log.warn("Failed to delete '" + uri + "' from search index", e);
+            }
+        }
 
-	private void commitChanges() {
-		try {
-			searchEngine.commit();
-		} catch (SearchEngineException e) {
-			log.warn("Failed to commit changes.", e);
-		}
-	}
+        /**
+         * An exclusion is just a delete for different reasons.
+         */
+        private void excludeDocument(String uri) {
+            try {
+                searchEngine.deleteById(SearchIndexerUtils.getIdForUri(uri));
+                status.incrementExclusions();
+                log.debug("excluded '" + uri + "' from search index.");
+            } catch (SearchEngineNotRespondingException e) {
+                log.warn("Failed to exclude '" + uri + "' from search index: "
+                        + "the search engine is not responding.", e);
+            } catch (Exception e) {
+                log.warn("Failed to exclude '" + uri + "' from search index", e);
+            }
+        }
 
-	@Override
-	public void notifyWorkUnitCompletion(Runnable workUnit) {
-		log.debug("completed update to "
-				+ ((UpdateDocumentWorkUnit) workUnit).getInd());
-		status.incrementUpdates();
-	}
+        private void updateDocument(Individual ind) {
+            Runnable workUnit = new UpdateDocumentWorkUnit(ind, modifiers);
+            pool.submit(workUnit, this);
+            log.debug("scheduled update to " + ind);
+        }
 
-	@Override
-	public SearchIndexerStatus getStatus() {
-		return status.getSearchIndexerStatus();
-	}
+        private void fireEvent(Event event) {
+            listeners.fireEvent(event);
+            if (event.getType() == PROGRESS || event.getType() == STOP_URIS) {
+                commitChanges();
+            }
+        }
 
-	// ----------------------------------------------------------------------
-	// helper classes
-	// ----------------------------------------------------------------------
+        private void commitChanges() {
+            try {
+                searchEngine.commit();
+            } catch (SearchEngineException e) {
+                log.warn("Failed to commit changes.", e);
+            }
+        }
 
-	/**
-	 * A thread-safe collection of status information. All methods are
-	 * synchronized.
-	 */
-	private static class Status {
-		private final UpdateUrisTask parent;
-		private final int total;
-		private final int progressInterval;
-		private int updated = 0;
-		private int deleted = 0;
-		private int excluded = 0;
-		private Date since = new Date();
+        @Override
+        public void notifyWorkUnitCompletion(Runnable workUnit) {
+            log.debug("completed update to "
+                    + ((UpdateDocumentWorkUnit) workUnit).getInd());
+            status.incrementUpdates();
+        }
 
-		public Status(UpdateUrisTask parent, int total, int progressInterval) {
-			this.parent = parent;
-			this.total = total;
-			this.progressInterval = progressInterval;
-		}
+        @Override
+        public SearchIndexerStatus getStatus() {
+            return status.getSearchIndexerStatus();
+        }
 
-		public synchronized void incrementUpdates() {
-			updated++;
-			since = new Date();
-			maybeFireProgressEvent();
-		}
+        /**
+         * A thread-safe collection of status information. All methods are
+         * synchronized.
+         */
+        private static class Status {
+            private final UpdateUrisTaskImpl parent;
+            private final int total;
+            private final int progressInterval;
+            private int updated = 0;
+            private int deleted = 0;
+            private int excluded = 0;
+            private Date since = new Date();
 
-		public synchronized void incrementDeletes() {
-			deleted++;
-			since = new Date();
-		}
+            public Status(UpdateUrisTaskImpl parent, int total, int progressInterval) {
+                this.parent = parent;
+                this.total = total;
+                this.progressInterval = progressInterval;
+            }
 
-		public synchronized void incrementExclusions() {
-			excluded++;
-			since = new Date();
-		}
+            public synchronized void incrementUpdates() {
+                updated++;
+                since = new Date();
+                maybeFireProgressEvent();
+            }
 
-		private void maybeFireProgressEvent() {
-			if (updated > 0 && updated % progressInterval == 0) {
-				parent.fireEvent(new Event(PROGRESS, getSearchIndexerStatus()));
-			}
-		}
+            public synchronized void incrementDeletes() {
+                deleted++;
+                since = new Date();
+            }
 
-		public synchronized SearchIndexerStatus getSearchIndexerStatus() {
-			int remaining = total - updated - deleted - excluded;
-			return new SearchIndexerStatus(PROCESSING_URIS, since,
-					new UriCounts(excluded, deleted, updated, remaining, total));
-		}
+            public synchronized void incrementExclusions() {
+                excluded++;
+                since = new Date();
+            }
 
-	}
+            private void maybeFireProgressEvent() {
+                if (updated > 0 && updated % progressInterval == 0) {
+                    parent.fireEvent(new Event(PROGRESS, getSearchIndexerStatus()));
+                }
+            }
 
-	/**
-	 * This will be first in the list of SearchIndexExcluders.
-	 */
-	public static class ExcludeIfNoVClasses implements SearchIndexExcluder {
-		@Override
-		public String checkForExclusion(Individual ind) {
-			List<VClass> vclasses = ind.getVClasses(false);
-			if (vclasses == null || vclasses.isEmpty()) {
-				return "Individual " + ind + " has no classes.";
-			}
-			return null;
-		}
+            public synchronized SearchIndexerStatus getSearchIndexerStatus() {
+                int remaining = total - updated - deleted - excluded;
+                return new SearchIndexerStatus(PROCESSING_URIS, since,
+                        new UriCounts(excluded, deleted, updated, remaining, total));
+            }
+        }
+    }
 
-		@Override
-		public String toString() {
-			return "Internal: ExcludeIfNoVClasses";
-		}
+    // ----------------------------------------------------------------------
+    // helper classes
+    // ----------------------------------------------------------------------
+    /**
+     * This will be first in the list of SearchIndexExcluders.
+     */
+    public static class ExcludeIfNoVClasses implements SearchIndexExcluder {
+        @Override
+        public String checkForExclusion(Individual ind) {
+            List<VClass> vclasses = ind.getVClasses(false);
+            if (vclasses == null || vclasses.isEmpty()) {
+                return "Individual " + ind + " has no classes.";
+            }
+            return null;
+        }
 
-	}
+        @Override
+        public String toString() {
+            return "Internal: ExcludeIfNoVClasses";
+        }
+   }
 }

--- a/webapp/test/stubs/edu/cornell/mannlib/vitro/webapp/modules/searchIndexer/SearchIndexerStub.java
+++ b/webapp/test/stubs/edu/cornell/mannlib/vitro/webapp/modules/searchIndexer/SearchIndexerStub.java
@@ -31,7 +31,12 @@ public class SearchIndexerStub implements SearchIndexer {
 		paused = true;
 	}
 
-	@Override
+    @Override
+    public void pauseWithoutDeferring() {
+        paused = true;
+    }
+
+    @Override
 	public void unpause() {
 		paused = false;
 	}


### PR DESCRIPTION
This pull request encompasses a number of related changes:

1) Push implementation of SearchIndex.Tasks into inner classes, and introduce an IndexerConfig adapter that allows accessing of the lists, dao, etc. to be deferred until the Task is about to run.

- this avoids a NullPointerException that can occur when creating a Task before the SearchIndexer has started.

2) Add a method to allow pausing without deferring tasks / scheduling a full rebuild when unpaused. Useful for tasks like ABoxRecomputer which is going to schedule a full rebuild anyway, to prevent accumulations of unnecessary tasks / changes when they are never going to be processed.

(Observed reduction of recompute memory usage by about 0.5GB - 1GB on a large dataset)

3) Simplify IndexChangeListener, avoiding having two places buffering changes when the indexer is paused. (On unpausing, if they survive, a few update tasks with smaller changesets should require less memory to process)

4) Implement RiotReader and Model.asStatement to reduce number of Models created, and remove need to disconnect Statements from the Model they were created as part of.

NB: Not sure why I haven't seen this before, but on develop I've stated getting log messages like:

2015-02-15 15:15:43,748 ERROR [riot] [line: 7, col: 95] Unrecognized: [DOT]
2015-02-15 15:16:10,614 ERROR [riot] [line: 1, col: 113] Triples not terminated by DOT
2015-02-15 15:16:10,615 ERROR [riot] [line: 2, col: 3 ] Unrecognized: SUBMITTED

when adding / editing nodes - particularly where there are empty assertions (e.g. a full name without middle name). This is coming from the parseN3ToRDF() method.

Log4J settings look to suppress these with:

log4j.logger.org.openjena.riot=FATAL

but now it should be:

log4j.logger.org.apache.jena.riot=FATAL

for Jena 2.10.0+
