### PR TITLE
Update log4j.properties

### DIFF
--- a/webapp/config/log4j.properties
+++ b/webapp/config/log4j.properties
@@ -45,4 +45,5 @@ log4j.logger.org.springframework=WARN
 log4j.logger.com.hp.hpl.jena.sdb.layout2.LoaderTuplesNodes=FATAL
 log4j.logger.com.hp.hpl.jena.sdb.sql.SDBConnection=ERROR
 log4j.logger.org.openjena.riot=FATAL
+log4j.logger.org.apache.jena.riot=FATAL
 log4j.logger.org.directwebremoting=FATAL


### PR DESCRIPTION
Add org.apache.jena.riot to log4j, as the packages moved in 2.10.x (suppress riot errors in ProcessRDdfForm.parseN3ToRDF which were previously suppressed by log4j.logger.org.openjena.riot=FATAL)