### PR TITLE
changed jquery imports to be protocol relative so they don't fail on HTT...

### DIFF
--- a/webapp/web/templates/freemarker/body/search/search-pagedResults.ftl
+++ b/webapp/web/templates/freemarker/body/search/search-pagedResults.ftl
@@ -108,10 +108,10 @@
 
 </div> <!-- end contentsBrowseGroup -->
 
-${stylesheets.add('<link rel="stylesheet" href="http://code.jquery.com/ui/1.10.3/themes/smoothness/jquery-ui.css" />',
+${stylesheets.add('<link rel="stylesheet" href="//code.jquery.com/ui/1.10.3/themes/smoothness/jquery-ui.css" />',
   				  '<link rel="stylesheet" href="${urls.base}/css/search.css" />')}
 
-${headScripts.add('<script src="http://code.jquery.com/ui/1.10.3/jquery-ui.js"></script>',
+${headScripts.add('<script src="//code.jquery.com/ui/1.10.3/jquery-ui.js"></script>',
 				  '<script type="text/javascript" src="${urls.base}/js/jquery_plugins/qtip/jquery.qtip-1.0.0-rc3.min.js"></script>',
                   '<script type="text/javascript" src="${urls.base}/js/tiny_mce/tiny_mce.js"></script>'
                   )}


### PR DESCRIPTION
...PS sites.

JQuery-UI imports cause insecure content warnings and fail to load by default. I changed the imports to be protocol relative so it will pull based on the current page's protocol. No associated issue.