### PR TITLE
Fix string conversion

### DIFF
--- a/webapp/src/edu/cornell/mannlib/vitro/webapp/controller/individual/IndividualResponseBuilder.java
+++ b/webapp/src/edu/cornell/mannlib/vitro/webapp/controller/individual/IndividualResponseBuilder.java
@@ -290,7 +290,7 @@ class IndividualResponseBuilder {
             ResultSet results = QueryUtils.getLanguageNeutralQueryResults(queryStr, vreq);
             if (results.hasNext()) {
                 QuerySolution soln = results.nextSolution();
-                String countStr = soln.get("labelCount").toString();
+                String countStr = soln.get("labelCount").toString().replaceFirst("\\^.*", "");
                 theCount = Integer.parseInt(countStr);
             }
         } catch (Exception e) {
@@ -309,7 +309,7 @@ class IndividualResponseBuilder {
                ResultSet results = QueryUtils.getLanguageNeutralQueryResults(queryStr, vreq);
                if (results.hasNext()) {
                    QuerySolution soln = results.nextSolution();
-                   String countStr = soln.get("languageCount").toString();
+                   String countStr = soln.get("languageCount").toString().replaceFirst("\\^.*", "");
                    theCount = Integer.parseInt(countStr);
                }
            } catch (Exception e) {


### PR DESCRIPTION
I ran into this problem when running VIVO on MarkLogic, which always returns
type annotations for strings (which is consistent with the SPARQL spec, but
different from the Jena SDB behavior)

Strings of the form, "1^^http://www.w3.org/2001/XMLSchema#string", were
being created and then not correctly parsed into ints. (The
RDFNode.toString() method maintains the type annotation.)

To fix, make sure we remove the type information if it exists before trying to
parseInt.