### PR TITLE
Add YASQE - allows for syntax highlighting and prefix autocompletion.

### DIFF
--- a/webapp/web/css/edit.css
+++ b/webapp/web/css/edit.css
@@ -12,9 +12,11 @@ div.sparqlform label {
 input.block {
     display: block;
 }
-textarea,
-div.sparqlform div {
+textarea {
     margin-bottom: 1.5em;
+}
+div.sparqlform div.options, div.sparqlform input.submit {
+    margin-top: 1.5em;
 }
 form {
     padding-bottom: 20px;

--- a/webapp/web/js/sparql/init-yasqe.js
+++ b/webapp/web/js/sparql/init-yasqe.js
@@ -1,0 +1,2 @@
+YASQE.defaults.createShareLink = false;
+var yasqe = YASQE.fromTextArea(document.getElementById('query-area'));

--- a/webapp/web/templates/freemarker/body/admin/admin-sparqlQueryForm.ftl
+++ b/webapp/web/templates/freemarker/body/admin/admin-sparqlQueryForm.ftl
@@ -6,13 +6,10 @@
     <h2>SPARQL Query</h2>
     <form action='${submitUrl}' method="get">
         <h3>Query:</h3>
-        <div>
-            <textarea name='query' rows ='30' cols='100' class="span-23 maxWidth">
-${sampleQuery}
-            </textarea>
-        </div>
 
-        <div>
+        <textarea name='query' rows='30' cols='100' class="span-23 maxWidth" id="query-area">${sampleQuery}</textarea>
+
+        <div class="options">
         	 <h3>Format for SELECT and ASK query results:</h3>
         	 <label><input type='radio' name='resultFormat' value='text/plain' checked>RS_TEXT</label>
         	 <label><input type='radio' name='resultFormat' value='text/csv'>CSV</label>
@@ -21,7 +18,7 @@ ${sampleQuery}
         	 <label><input type='radio' name='resultFormat' value='application/sparql-results+json'>RS_JSON</label>
         </div>
 
-        <div>
+        <div class="options">
         	 <h3>Format for CONSTRUCT and DESCRIBE query results:</h3>
         	 <label><input type='radio' name='rdfResultFormat' value='text/plain'>N-Triples</label>
         	 <label><input type='radio' name='rdfResultFormat' value='application/rdf+xml' checked>RDF/XML</label>
@@ -33,3 +30,7 @@ ${sampleQuery}
         <input class="submit" type="submit" value="Run Query" />
     </form>
 </div><!-- content -->
+
+${stylesheets.add('<link rel="stylesheet" href="//cdn.jsdelivr.net/yasqe/2.6.1/yasqe.min.css" />')}
+${scripts.add('<script type="text/javascript" src="//cdn.jsdelivr.net/yasqe/2.6.1/yasqe.bundled.min.js"></script>',
+'<script type="text/javascript" src="${urls.base}/js/sparql/init-yasqe.js"></script>')}


### PR DESCRIPTION
This adds the [YASQE](http://yasqe.yasgui.org/) SPARQL query editor to the default site admin SPARQL query tool/form. YASQE has many nice features like syntax highlighting and auto-completion. See image below for example. 

There's more that could be done with YASQE but this adds initial support without changing the functionality of the existing SPARQL admin form.

![image](https://cloud.githubusercontent.com/assets/440128/11128175/241311ba-8946-11e5-9fcb-98bcd9a7944a.png)