### PR TITLE
tweak index page initHeight and don't add (cont'd) text if there aren't any more classes to show

### DIFF
--- a/webapp/web/templates/freemarker/body/classGroups.ftl
+++ b/webapp/web/templates/freemarker/body/classGroups.ftl
@@ -8,12 +8,19 @@
     <section class="siteMap" role="region">
         <div id="isotope-container">
             <#list classGroups as classGroup>
-                <#assign groupSize = classGroup.classes?size >
+                <#assign groupSize = 0 >
                 <#assign classCount = 0 >
                 <#assign splitGroup = false>
                 <#-- Only render classgroups that have at least one populated class -->
-                <#if (classGroup.individualCount > 0)> 
-                	<div class="class-group">             
+                <#if (classGroup.individualCount > 0)>
+
+                    <#list classGroup.classes as class>  
+                        <#if (class.individualCount > 0)>
+                            <#assign groupSize = groupSize + 1 >
+                        </#if>
+                    </#list> 
+ 
+                    <div class="class-group">             
                         <h2>${classGroup.displayName}</h2>
                         <ul role="list">
                             <#list classGroup.classes as class> 
@@ -22,7 +29,7 @@
                                     <li role="listitem"><a href="${class.url}" title="${i18n().class_name}">${class.name}</a> (${class.individualCount})</li>
                                 <#assign classCount = classCount + 1 >
                                 </#if>
-                                <#if (classCount > 34) && !splitGroup >
+                                <#if (classCount > 34) && (classCount < groupSize) && !splitGroup >
                                    <#assign splitGroup = true >
                                    </ul></div>
                                    <div class="class-group">
@@ -40,7 +47,7 @@
     ${headScripts.add('<script type="text/javascript" src="${urls.base}/js/jquery_plugins/isotope/jquery.isotope.min.js"></script>')}
     <script>
         var initHeight = $("#isotope-container").height();
-        initHeight = (initHeight/2.1) ;
+        initHeight = (initHeight/2.05) ;
         $("#isotope-container").css("height",initHeight + "px");
     </script>
     <script>


### PR DESCRIPTION
The index page may roll over into 4 columns with the initHeight set to the container height / 2.1 (see attached). Adjusting to / 2.05 appears to fix the problem.
Additionally, added a fix that accounts for if the number of populated classes in the group was exactly equal to 35. Previously, the class group would be split even if there weren't any more classes to display.

![screen shot 2015-12-01 at 11 09 08 am](https://cloud.githubusercontent.com/assets/10748475/11518645/93aee53a-9850-11e5-8a71-46c7f4acec73.png)
