### PR TITLE
bug fix for search help back link [VIVO-1226]

### DIFF
--- a/webapp/src/main/webapp/templates/freemarker/body/search/search-help.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/body/search/search-help.ftl
@@ -15,8 +15,9 @@
     <li>If you are unsure of the correct spelling, put ~ at the end of your search term -- e.g., <i>cabage~</i> finds <i>cabbage</i>, <i>steven~</i> finds <i>Stephen</i> and <i>Stefan</i> (as well as other similar names).</li>
 </ul>
     
-<h4><a id="advTipsLink" href="#">Advanced Tips</a></h4>    
-<ul id="advanced" class="searchTips" style="visibility:hidden">
+<h4><a onclick="document.getElementById('advanced').style.display='';return false;" href="">Advanced Tips</a></h4> 
+<div id="advanced" style="display:none;">   
+<ul class="searchTips">
     <li>When you enter more than one term, search will return results containing all of them unless you add the Boolean "OR" -- e.g., <i>chicken</i> OR <i>egg</i>.</li>
     <li>NOT" can help limit searches -- e.g., <i>climate</i> NOT <i>change</i>.</li>
     <li>Phrase searches may be combined with Boolean operators -- e.g. "<i>climate change</i>" OR "<i>global warming</i>".</li>
@@ -24,19 +25,6 @@
     <li>Use the wildcard * character to match an even wider variation -- e.g., <i>nano*</i> will match both <i>nanotechnology</i> and <i>nanofabrication</i>.</li>
     <li>Search uses shortened versions of words -- e.g., a search for <i>cogniti*</i> finds nothing, while <i>cognit*</i> finds both <i>cognitive</i> and <i>cognition</i>.</li> 
 </ul>
-<a id="closeLink" href="#"  style="visibility:hidden;font-size:.825em;padding-left:8px">Close</a>
+<a onclick="document.getElementById('advanced').style.display='none';return false;" href="">Close</a>
+</div>
 ${stylesheets.add('<link rel="stylesheet" href="${urls.base}/css/search.css" />')}
-<script type="text/javascript">
-    $(document).ready(function(){
-        $('a#advTipsLink').click(function() {
-           $('ul#advanced').css("visibility","visible"); 
-           $('a#closeLink').css("visibility","visible");
-           $('a#closeLink').click(function() {
-              $('ul#advanced').css("visibility","hidden"); 
-              $('a#closeLink').css("visibility","hidden");
-           });
-
-        });
-    });
-    
-</script>


### PR DESCRIPTION
https://jira.duraspace.org/browse/VIVO-1226
Switched the Advanced Tips to be a div to avoid adding the anchor link to the browser history.