### PR TITLE
Adds UTF-8 charset to emails

### DIFF
--- a/webapp/src/edu/cornell/mannlib/vitro/webapp/controller/MailUsersServlet.java
+++ b/webapp/src/edu/cornell/mannlib/vitro/webapp/controller/MailUsersServlet.java
@@ -171,7 +171,7 @@ public class MailUsersServlet extends VitroHttpServlet {
             msg.setSubject( deliveryfrom );
 
             // add the multipart to the message
-            msg.setContent(msgText,"text/html");
+            msg.setContent(msgText,"text/html; charset=UTF-8");
 
             // set the Date: header
             msg.setSentDate( new Date() );

--- a/webapp/src/edu/cornell/mannlib/vitro/webapp/controller/freemarker/ContactMailController.java
+++ b/webapp/src/edu/cornell/mannlib/vitro/webapp/controller/freemarker/ContactMailController.java
@@ -276,7 +276,7 @@ public class ContactMailController extends FreemarkerHttpServlet {
         msg.setSubject( deliveryfrom );
 
         // add the multipart to the message
-        msg.setContent(msgText,"text/html");
+        msg.setContent(msgText,"text/html; charset=UTF-8");
 
         // set the Date: header
         msg.setSentDate( new Date() );

--- a/webapp/src/edu/cornell/mannlib/vitro/webapp/email/FreemarkerEmailMessage.java
+++ b/webapp/src/edu/cornell/mannlib/vitro/webapp/email/FreemarkerEmailMessage.java
@@ -172,15 +172,15 @@ public class FreemarkerEmailMessage {
 				if (htmlContent.isEmpty()) {
 					log.error("Message has neither text body nor HTML body");
 				} else {
-					msg.setContent(htmlContent, "text/html");
+					msg.setContent(htmlContent, "text/html; charset=UTF-8");
 				}
 			} else {
 				if (htmlContent.isEmpty()) {
-					msg.setContent(textContent, "text/plain");
+					msg.setContent(textContent, "text/plain; charset=UTF-8");
 				} else {
 					MimeMultipart content = new MimeMultipart("alternative");
-					addBodyPart(content, textContent, "text/plain");
-					addBodyPart(content, htmlContent, "text/html");
+					addBodyPart(content, textContent, "text/plain; charset=UTF-8");
+					addBodyPart(content, htmlContent, "text/html; charset=UTF-8");
 					msg.setContent(content);
 				}
 			}

--- a/webapp/src/edu/cornell/mannlib/vitro/webapp/utils/MailUtil.java
+++ b/webapp/src/edu/cornell/mannlib/vitro/webapp/utils/MailUtil.java
@@ -56,7 +56,7 @@ public class MailUtil {
 	            msg.setSubject( subject );
 
 	            // add the multipart to the message
-	            msg.setContent(messageText,"text/html");
+	            msg.setContent(messageText,"text/html; charset=UTF-8");
 
 	            // set the Date: header
 	            msg.setSentDate( new Date() );


### PR DESCRIPTION
This is required for emails that contain non-ASCII characters (like Spanish accents).

If *setContent(…)* has a MIME type but no charset, emails are sent with the given MIME type and UTF-8 charset, but the contents will not be encoded using UTF-8.

If an explicit charset is given, the emails are encoded correctly.