### PR TITLE
Use posix extensions for maven-assembly-plugin

### DIFF
--- a/home/pom.xml
+++ b/home/pom.xml
@@ -25,6 +25,7 @@
                 <artifactId>maven-assembly-plugin</artifactId>
                 <version>2.5.5</version>
                 <configuration>
+                    <tarLongFileMode>posix</tarLongFileMode>
                     <descriptors>
                         <descriptor>src/main/assembly/home.xml</descriptor>
                     </descriptors>


### PR DESCRIPTION
After encountering the following error when attempting to build the application with maven

  [ERROR] Failed to execute goal org.apache.maven.plugins:maven-assembly-plugin:2.5.5:single (default) on project vitro-home: Execution default of goal org.apache.maven.plugins:maven-assembly-plugin:2.5.5:single failed: group id '1162086330' is too big ( > 2097151 ). Use STAR or POSIX extensions to overcome this limit -> [Help 1]

set the tarLongFileMode option to posix as it says in the error message and in the FAQ

  https://maven.apache.org/plugins/maven-assembly-plugin/faq.html#tarFileModes