### PR TITLE
SPARQL query fix in `IndividualSDB` class

### DIFF
--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/dao/jena/IndividualSDB.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/dao/jena/IndividualSDB.java
@@ -508,7 +508,7 @@ public class IndividualSDB extends IndividualImpl implements Individual {
     	dataset.getLock().enterCriticalSection(Lock.READ);
     	try {
     		String valuesOfProperty = 
-    			"SELECT ?object" +
+    			"SELECT ?object " +
     			"WHERE{ <" + this.individualURI + "> <" + 
     			        propertyURI + "> ?object } \n";
     		ResultSet values = QueryExecutionFactory.create(


### PR DESCRIPTION
This fixes an SPARQL query found in the IndividualSDB class, which triggers `NullPointerException`s when trying to use individuals retrieved using the `getRelatedIndividuals()` method. The defect was observed in the Vitro 1.8 release branch.

After fixing this, the `Individual` instances returned by the aforementioned method work correctly.