### PR TITLE
FileGraphSetup loads .ttl extension with TURTLE format rather than N3.

### DIFF
--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/servlet/setup/FileGraphSetup.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/servlet/setup/FileGraphSetup.java
@@ -162,8 +162,10 @@ public class FileGraphSetup implements ServletContextListener {
                     String fn = p.getFileName().toString().toLowerCase();
                     if ( fn.endsWith(".nt") ) {
                         model.read( fis, null, "N-TRIPLE" );
-                    } else if ( fn.endsWith(".n3") || fn.endsWith(".ttl") ) {
-                        model.read( fis, null, "N3" );
+                    } else if ( fn.endsWith(".n3") ) {
+                        model.read(fis, null, "N3");
+                    } else if ( fn.endsWith(".ttl") ) {
+                        model.read(fis, null, "TURTLE");
                     } else if ( fn.endsWith(".owl") || fn.endsWith(".rdf") || fn.endsWith(".xml") ) {
                         model.read( fis, null, "RDF/XML" );
                     } else if ( fn.endsWith(".md") ) {


### PR DESCRIPTION
FileGraphSetup fails to load valid turtle files from `vdata/rdf/tbox/filegraph/` because N3 is specified as the Jena format for '.ttl' extensions. This change loads these files explicitly as turtle, which is what the [RDFFilesLoader](https://github.com/vivo-project/Vitro/blob/b513ad10565eb515a7051e1ca70f1cad8f9bc0fd/api/src/main/java/edu/cornell/mannlib/vitro/webapp/servlet/setup/RDFFilesLoader.java#L173) code does. 