### PR TITLE
Fix correct version of fluent-hc

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -178,7 +178,7 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>fluent-hc</artifactId>
-            <version>4.5.2</version>
+            <version>4.2.5</version>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>


### PR DESCRIPTION
Version 4.5.2 is not in sync with the other apache http libraries, causing the ORCID integration to fail when confirming IDs.

I believe it's a typo and it should be 4.2.5