### PR TITLE
VIVO-1408 ConfigurationBeanLoader: java rdf namespaces

### DIFF
--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/utils/configuration/README.md
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/utils/configuration/README.md
@@ -95,8 +95,36 @@ The principal methods are:
  + Search the graph for all individuals of type `resultClass`. For each such individual, call `loadInstance`. 
    Return a set containing the created instances. If no individuals are found, return an empty `Set`.
    
+### Specifying Java class URIs
+
+Java classes are specified as types in the configurations. The type URIs consist of `java:` and the fully-qualified class path and name. For example,
+
+```
+:application 
+      a   <java:edu.cornell.mannlib.vitro.webapp.application.ApplicationImpl> .
+```
+
+It would be nice to use prefixes to make URIs more readable. This doesn't 
+work with the scheme above, since none of the characters in the URI are valid 
+as delimiters of a prefix.
+
+For this reason, the loader will also recognize a type URI if one of the periods is replaced by a hash (`#`). So, this is equivalent to the previous example (note the `#` after `webapp`):
+
+```
+:application 
+      a   <java:edu.cornell.mannlib.vitro.webapp#application.ApplicationImpl> .
+```
+
+which implies that this is equivalent also:
+
+```
+@prefix javaWebapp: <java:edu.cornell.mannlib.vitro.webapp#>
+:application   a   javaWebapp:application.ApplicationImpl .
+
+```
+
 ### Restrictions on instantiated classes.
-Each class to be instantiated must have a niladic constructor.
+Each class to be instantiated must have a public niladic constructor.
 
 ### Property methods
 When the loader encounters a data property or an object property in a description, 
@@ -116,7 +144,8 @@ For example:
      
 In more detail:
 
-+ A class must contain exactly one method that serves each property URI in the description.
++ Each property URI in the description may be served by only one method in the class.
++ If a property URI in the description is not served by any method in the class, the loader will ignore that property.
 + The description need not include properies for all of the property methods in the class.
 + Each property method must be public, must have exactly one parameter, and must return null.
 + The name of the property method is immaterial, except that there must not be another method
@@ -159,7 +188,7 @@ Again, in detail:
 
 + Each validation method must be public, must accept no parameters, and must return null.
 + The name of the validation method is immaterial, except that there must not be another 
-+ method with the same name in the lass.
++ method with the same name in the class.
 + Validation methods in superclasses will be called, but may not be overridden in a subclass.
 
 ### Life cycle

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/utils/configuration/WrappedInstance.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/utils/configuration/WrappedInstance.java
@@ -70,7 +70,8 @@ public class WrappedInstance<T> {
 	 */
 	public void checkCardinality(Set<PropertyStatement> propertyStatements)
 			throws CardinalityException {
-		Map<String, Integer> statementCounts = countPropertyStatementsByPredicateUri(propertyStatements);
+		Map<String, Integer> statementCounts = countPropertyStatementsByPredicateUri(
+				propertyStatements);
 		for (PropertyMethod pm : propertyMethods.values()) {
 			Integer c = statementCounts.get(pm.getPropertyUri());
 			int count = (c == null) ? 0 : c;
@@ -109,12 +110,11 @@ public class WrappedInstance<T> {
 	 */
 	public void setProperties(ConfigurationBeanLoader loader,
 			Collection<PropertyStatement> propertyStatements)
-			throws PropertyTypeException, NoSuchPropertyMethodException,
-			ConfigurationBeanLoaderException {
+			throws PropertyTypeException, ConfigurationBeanLoaderException {
 		for (PropertyStatement ps : propertyStatements) {
 			PropertyMethod pm = propertyMethods.get(ps.getPredicateUri());
 			if (pm == null) {
-				throw new NoSuchPropertyMethodException(ps);
+				continue; // No method for this property? Ignore it.
 			}
 			pm.confirmCompatible(ps);
 
@@ -141,7 +141,8 @@ public class WrappedInstance<T> {
 			} catch (IllegalAccessException | IllegalArgumentException
 					| InvocationTargetException e) {
 				throw new ValidationFailedException(
-						"Error executing validation method '" + method + "'", e);
+						"Error executing validation method '" + method + "'",
+						e);
 			}
 		}
 	}
@@ -162,12 +163,6 @@ public class WrappedInstance<T> {
 	public static class ValidationFailedException extends Exception {
 		public ValidationFailedException(String message, Throwable cause) {
 			super(message, cause);
-		}
-	}
-
-	public static class NoSuchPropertyMethodException extends Exception {
-		public NoSuchPropertyMethodException(PropertyStatement ps) {
-			super("No property method for '" + ps.getPredicateUri() + "'");
 		}
 	}
 

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/web/templatemodels/Tags.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/web/templatemodels/Tags.java
@@ -17,6 +17,7 @@ import org.apache.commons.logging.LogFactory;
 import edu.cornell.mannlib.vitro.webapp.application.ApplicationUtils;
 import edu.cornell.mannlib.vitro.webapp.controller.freemarker.UrlBuilder;
 import freemarker.ext.beans.BeansWrapper;
+import freemarker.template.Configuration;
 import freemarker.template.TemplateModel;
 import freemarker.template.TemplateModelException;
 
@@ -72,6 +73,8 @@ public class Tags extends BaseTemplateModel {
 	static public class TagsWrapper extends BeansWrapper {
 
 		public TagsWrapper() {
+			super(Configuration.DEFAULT_INCOMPATIBLE_IMPROVEMENTS);
+			
 			// Start by exposing all safe methods.
 			setExposureLevel(EXPOSE_SAFE);
 		}

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/web/templatemodels/Tags.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/web/templatemodels/Tags.java
@@ -2,82 +2,267 @@
 
 package edu.cornell.mannlib.vitro.webapp.web.templatemodels;
 
+import java.io.File;
+import java.lang.reflect.Method;
 import java.util.LinkedHashSet;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
-import freemarker.ext.beans.MethodAppearanceFineTuner;
+import javax.servlet.ServletContext;
+
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
+import edu.cornell.mannlib.vitro.webapp.application.ApplicationUtils;
+import edu.cornell.mannlib.vitro.webapp.controller.freemarker.UrlBuilder;
 import freemarker.ext.beans.BeansWrapper;
 import freemarker.template.TemplateModel;
 import freemarker.template.TemplateModelException;
 
+/**
+ * Provides a mechanism for Freemarker templates (main or included, parent or
+ * child) to add to the lists of scripts and style sheets for the current page.
+ * 
+ * Each page uses 3 instances of Tags, exposed as ${scripts}, ${headScripts} and
+ * ${stylesheets}. A template may add a complete &lt;script/$gt; element (for
+ * scripts or headScripts) or a &lt;link&gt; tag (for stylesheets), and these
+ * elements will appear at the proper location in the rendered HTML for the
+ * page.
+ * 
+ * VIVO-1405: This process is augmented by the TagVersionInfo inner class, which
+ * attempts to add a "version=" query string to the URL in the supplied element.
+ * The version number is derived from the last-modified date of the specified
+ * script or stylesheet on the server. The effect is that a user's browser cache
+ * is effectively invalidated each time a new version of the script or
+ * stylesheet is deployed.
+ */
 public class Tags extends BaseTemplateModel {
-    
-    private static final Log log = LogFactory.getLog(Tags.class);
-    
-    protected final LinkedHashSet<String> tags;
+	private static final Log log = LogFactory.getLog(Tags.class);
 
-    public Tags() {
-        this.tags = new LinkedHashSet<String>();
-    }
-    
-    public Tags(LinkedHashSet<String> tags) {
-        this.tags = tags;
-    }
-    
-    public TemplateModel wrap() {
-        try {
-            return new TagsWrapper().wrap(this);    	
-        } catch (TemplateModelException e) {
-            log.error("Error creating Tags template model");
-            return null;
-        }
-    }
-    
-    /** Script and stylesheet lists are wrapped with a specialized BeansWrapper
-     * that exposes certain write methods, instead of the configuration's object wrapper,
-     * which doesn't. The templates can then add stylesheets and scripts to the lists
-     * by calling their add() methods.
-     */
-    static public class TagsWrapper extends BeansWrapper {
-        
-        public TagsWrapper() {
-            // Start by exposing all safe methods.
-            setExposureLevel(EXPOSE_SAFE);
-            setMethodAppearanceFineTuner(new MethodAppearanceFineTuner() {
-                @Override
-                public void process(MethodAppearanceDecisionInput methodAppearanceDecisionInput, MethodAppearanceDecision methodAppearanceDecision) {
-                    try {
-                        String methodName = methodAppearanceDecisionInput.getMethod().getName();
-                        if ( ! ( methodName.equals("add") || methodName.equals("list")) ) {
-                            methodAppearanceDecision.setExposeMethodAs(null);
-                        }
-                    } catch (Exception e) {
-                        log.error(e, e);
-                    }
-                }
-            });
-        }
-    }
-    
-    
-    /* Template methods */
+	protected final LinkedHashSet<String> tags;
 
-    public void add(String... tags) {
-        for (String tag : tags) {
-            add(tag);
-        }
-    }
-    
-    public void add(String tag) {
-        tags.add(tag);
-    }
- 
-    public String list() {
-        return StringUtils.join(tags, "\n");
-    }
-    
+	public Tags() {
+		this.tags = new LinkedHashSet<String>();
+	}
 
+	public Tags(LinkedHashSet<String> tags) {
+		this.tags = tags;
+	}
+
+	public TemplateModel wrap() {
+		try {
+			return new TagsWrapper().wrap(this);
+		} catch (TemplateModelException e) {
+			log.error("Error creating Tags template model");
+			return null;
+		}
+	}
+
+	/**
+	 * Script and stylesheet lists are wrapped with a specialized BeansWrapper
+	 * that exposes certain write methods, instead of the configuration's object
+	 * wrapper, which doesn't. The templates can then add stylesheets and
+	 * scripts to the lists by calling their add() methods.
+	 * 
+	 * @param Tags
+	 *            tags
+	 * @return TemplateModel
+	 */
+	static public class TagsWrapper extends BeansWrapper {
+
+		public TagsWrapper() {
+			// Start by exposing all safe methods.
+			setExposureLevel(EXPOSE_SAFE);
+		}
+
+		@SuppressWarnings("rawtypes")
+		@Override
+		protected void finetuneMethodAppearance(Class cls, Method method,
+				MethodAppearanceDecision decision) {
+
+			try {
+				String methodName = method.getName();
+				if (!(methodName.equals("add") || methodName.equals("list"))) {
+					decision.setExposeMethodAs(null);
+				}
+			} catch (Exception e) {
+				log.error(e, e);
+			}
+		}
+	}
+
+	/* Template methods */
+
+	@SuppressWarnings("hiding")
+	public void add(String... tags) {
+		for (String tag : tags) {
+			add(tag);
+		}
+	}
+
+	public void add(String tag) {
+		TagVersionInfo info = new TagVersionInfo(tag);
+		if (info.hasVersion()) {
+			tags.add(TagVersionInfo.addVersionNumber(tag, info));
+		} else {
+			tags.add(tag);
+		}
+	}
+
+	public String list() {
+		return StringUtils.join(tags, "\n");
+	}
+
+	/**
+	 * Find the value of "href" or "src".
+	 * 
+	 * If there is such a value, and it doesn't have a query string already, and
+	 * it represents a local URL, and we can locate the file that is served by
+	 * the URL and get the last modified date, then we have found a "version
+	 * number" that we can add to the attribute value.
+	 * 
+	 * Reference for parsing attributes:
+	 * https://www.w3.org/TR/html/syntax.html#elements-attributes
+	 */
+	protected static class TagVersionInfo {
+		private static final Pattern PATTERN_DOUBLE_QUOTES = Pattern
+				.compile("(href|src)\\s*=\\s*\"([^\"]+)\"[\\s|>]");
+		private static final int GROUP_INDEX_DOUBLE_QUOTES = 2;
+
+		private static final Pattern PATTERN_SINGLE_QUOTES = Pattern
+				.compile("(href|src)\\s*=\\s*'([^']+)'[\\s|>]");
+		private static final int GROUP_INDEX_SINGLE_QUOTES = 2;
+
+		private static final Pattern PATTERN_NO_QUOTES = Pattern
+				.compile("(href|src)\\s*=\\s*([^\"'<=>\\s]+)[\\s|>]");
+		private static final int GROUP_INDEX_NO_QUOTES = 2;
+
+		public static String addVersionNumber(String rawTag,
+				TagVersionInfo info) {
+			String versionString = (info.match.style == MatchResult.Style.NO_QUOTES)
+					? "?version&eq;"
+					: "?version=";
+			return rawTag.substring(0, info.match.start) + info.match.group
+					+ versionString + smushTimeStamp(info)
+					+ rawTag.substring(info.match.end);
+		}
+
+		private static String smushTimeStamp(TagVersionInfo info) {
+			int smushed = (((char) (info.timestamp >> 48))
+					^ ((char) (info.timestamp >> 32))
+					^ ((char) (info.timestamp >> 16))
+					^ ((char) info.timestamp));
+			return String.format("%04x", smushed);
+		}
+
+		private MatchResult match;
+		private long timestamp = 0L;
+
+		public TagVersionInfo(String rawTag) {
+			try {
+				match = findUrlValue(rawTag);
+
+				if (match != null && !hasQueryString(match.group)) {
+					String stripped = stripContextPath(match.group);
+
+					if (stripped != null) {
+						String realPath = locateRealPath(stripped);
+
+						if (realPath != null) {
+							timestamp = getLastModified(realPath);
+						}
+					}
+				}
+			} catch (Exception e) {
+				log.debug("Failed to add version info to tag: " + rawTag, e);
+				timestamp = 0L;
+			}
+		}
+
+		public boolean hasVersion() {
+			return timestamp != 0L;
+		}
+
+		private static MatchResult findUrlValue(String rawTag) {
+			Matcher mDouble = PATTERN_DOUBLE_QUOTES.matcher(rawTag);
+			if (mDouble.find()) {
+				return new MatchResult(mDouble, GROUP_INDEX_DOUBLE_QUOTES,
+						MatchResult.Style.DOUBLE_QUOTES);
+			}
+
+			Matcher mSingle = PATTERN_SINGLE_QUOTES.matcher(rawTag);
+			if (mSingle.find()) {
+				return new MatchResult(mSingle, GROUP_INDEX_SINGLE_QUOTES,
+						MatchResult.Style.SINGLE_QUOTES);
+			}
+
+			Matcher mNo = PATTERN_NO_QUOTES.matcher(rawTag);
+			if (mNo.find()) {
+				return new MatchResult(mNo, GROUP_INDEX_NO_QUOTES,
+						MatchResult.Style.NO_QUOTES);
+			}
+
+			log.debug(rawTag + " no match");
+			return null;
+		}
+
+		private static boolean hasQueryString(String group) {
+			if (group.indexOf('?') > -1) {
+				log.debug(group + " has query string already");
+				return true;
+			} else {
+				return false;
+			}
+		}
+
+		private static String stripContextPath(String group) {
+			String contextPath = UrlBuilder.getBaseUrl();
+			if (contextPath.isEmpty() || group.startsWith(contextPath)) {
+				return group.substring(contextPath.length());
+			} else {
+				log.debug(group + " doesn't match context path");
+				return null;
+			}
+		}
+
+		private static String locateRealPath(String stripped) {
+			ServletContext ctx = ApplicationUtils.instance()
+					.getServletContext();
+			String realPath = ctx.getRealPath(stripped);
+			if (realPath == null) {
+				log.debug(stripped + " has no real path");
+			}
+			return realPath;
+		}
+
+		private static long getLastModified(String realPath) {
+			return new File(realPath).lastModified();
+		}
+
+		protected static class MatchResult {
+			public enum Style {
+				SINGLE_QUOTES, DOUBLE_QUOTES, NO_QUOTES
+			}
+
+			public final String group;
+			public final int start;
+			public final int end;
+			public final Style style;
+
+			public MatchResult(Matcher matcher, int group, Style style) {
+				this.group = matcher.group(group);
+				this.start = matcher.start(group);
+				this.end = matcher.end(group);
+				this.style = style;
+				log.debug(this);
+			}
+
+			@Override
+			public String toString() {
+				return "MatchResult[start=" + start + ", end=" + end
+						+ ", group=" + group + ", style=" + style + "]";
+			}
+		}
+	}
 }

--- a/api/src/test/java/edu/cornell/mannlib/vitro/webapp/utils/configuration/ConfigurationBeanLoaderTest.java
+++ b/api/src/test/java/edu/cornell/mannlib/vitro/webapp/utils/configuration/ConfigurationBeanLoaderTest.java
@@ -2,12 +2,12 @@
 
 package edu.cornell.mannlib.vitro.webapp.utils.configuration;
 
-import static org.apache.jena.datatypes.xsd.XSDDatatype.XSDfloat;
-import static org.apache.jena.datatypes.xsd.XSDDatatype.XSDstring;
 import static edu.cornell.mannlib.vitro.testing.ModelUtilitiesTestHelper.dataProperty;
 import static edu.cornell.mannlib.vitro.testing.ModelUtilitiesTestHelper.objectProperty;
 import static edu.cornell.mannlib.vitro.testing.ModelUtilitiesTestHelper.typeStatement;
 import static edu.cornell.mannlib.vitro.webapp.utils.configuration.ConfigurationBeanLoader.toJavaUri;
+import static org.apache.jena.datatypes.xsd.XSDDatatype.XSDfloat;
+import static org.apache.jena.datatypes.xsd.XSDDatatype.XSDstring;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -19,18 +19,16 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
-import org.junit.Ignore;
-import org.junit.Test;
-
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.Statement;
+import org.junit.Ignore;
+import org.junit.Test;
 
 import edu.cornell.mannlib.vitro.webapp.modelaccess.ContextModelAccess;
 import edu.cornell.mannlib.vitro.webapp.modelaccess.RequestModelAccess;
 import edu.cornell.mannlib.vitro.webapp.utils.configuration.ConfigurationRdfParser.InvalidConfigurationRdfException;
 import edu.cornell.mannlib.vitro.webapp.utils.configuration.InstanceWrapper.InstanceWrapperException;
 import edu.cornell.mannlib.vitro.webapp.utils.configuration.PropertyType.PropertyTypeException;
-import edu.cornell.mannlib.vitro.webapp.utils.configuration.WrappedInstance.NoSuchPropertyMethodException;
 import edu.cornell.mannlib.vitro.webapp.utils.configuration.WrappedInstance.ResourceUnavailableException;
 
 /**
@@ -310,24 +308,6 @@ public class ConfigurationBeanLoaderTest extends
 	// --------------------------------------------
 
 	@Test
-	public void tripleHasUnrecognizedProperty_throwsException()
-			throws ConfigurationBeanLoaderException {
-		model.add(typeStatement(GENERIC_INSTANCE_URI,
-				toJavaUri(SimpleSuccess.class)));
-		model.add(dataProperty(GENERIC_INSTANCE_URI,
-				"http://bogus.property/name", "No place to put it."));
-
-		expectSimpleFailure(
-				SimpleSuccess.class,
-				throwable(ConfigurationBeanLoaderException.class,
-						"Failed to load"),
-				throwable(NoSuchPropertyMethodException.class,
-						"No property method"));
-	}
-
-	// --------------------------------------------
-
-	@Test
 	public void valueTypeDoesNotMatchArgumentOfPropertyMethod_throwsException()
 			throws ConfigurationBeanLoaderException {
 		model.add(typeStatement(GENERIC_INSTANCE_URI,
@@ -395,10 +375,26 @@ public class ConfigurationBeanLoaderTest extends
 		assertNotNull(instance);
 	}
 
+	/**
+	 * Ignores unexpected properties
+	 */
+	@Test
+	public void simpleSuccessIgnoringExtraProperties() throws ConfigurationBeanLoaderException {
+		model.add(typeStatement(SIMPLE_SUCCESS_INSTANCE_URI,
+				toJavaUri(SimpleSuccess.class)));
+		model.add(dataProperty(SIMPLE_SUCCESS_INSTANCE_URI,
+				"http://surprise.property/name", "No matching method."));
+
+		SimpleSuccess instance = loader.loadInstance(
+				SIMPLE_SUCCESS_INSTANCE_URI, SimpleSuccess.class);
+		
+		assertNotNull(instance);
+	}
+	
 	public static class SimpleSuccess {
 		// Nothing of interest.
 	}
-
+	
 	// --------------------------------------------
 
 	/**

--- a/api/src/test/java/edu/cornell/mannlib/vitro/webapp/utils/configuration/ConfigurationBeanLoader_NamespacesTest.java
+++ b/api/src/test/java/edu/cornell/mannlib/vitro/webapp/utils/configuration/ConfigurationBeanLoader_NamespacesTest.java
@@ -1,0 +1,111 @@
+/* $This file is distributed under the terms of the license in /doc/license.txt$ */
+
+package edu.cornell.mannlib.vitro.webapp.utils.configuration;
+
+import static edu.cornell.mannlib.vitro.testing.ModelUtilitiesTestHelper.typeStatement;
+import static edu.cornell.mannlib.vitro.webapp.utils.configuration.ConfigurationBeanLoader.toPossibleJavaUris;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
+
+import java.util.HashSet;
+import java.util.Random;
+import java.util.Set;
+
+import org.junit.Test;
+
+/**
+ * Assure that we can use "namespaces" for Java URIs. The namespace must end
+ * with a '#'.
+ */
+public class ConfigurationBeanLoader_NamespacesTest
+		extends ConfigurationBeanLoaderTestBase {
+
+	// ----------------------------------------------------------------------
+	// toPossibleJavaUris()
+	// ----------------------------------------------------------------------
+
+	@Test
+	public void possibleForJavaLangString() {
+		Set<String> expected = new HashSet<>();
+		expected.add("java:java.lang.String");
+		expected.add("java:java#lang.String");
+		expected.add("java:java.lang#String");
+		assertEquals(expected, toPossibleJavaUris(String.class));
+	}
+
+	// ----------------------------------------------------------------------
+	// loadAll()
+	// ----------------------------------------------------------------------
+
+	@Test
+	public void loadAllForJavaUtilRandom()
+			throws ConfigurationBeanLoaderException {
+		model.add(typeStatement("http://noPound", "java:java.util.Random"));
+		model.add(typeStatement("http://firstPound", "java:java#util.Random"));
+		model.add(typeStatement("http://secondPound", "java:java.util#Random"));
+		model.add(typeStatement("http://notARandom", "java:java.util.Set"));
+		Set<Random> instances = loader.loadAll(Random.class);
+		assertEquals(3, instances.size());
+	}
+
+	@Test
+	public void loadAlForCustomInnerClass()
+			throws ConfigurationBeanLoaderException {
+		Set<String> typeUris = toPossibleJavaUris(ExampleClassForLoadAll.class);
+		for (String typeUri : typeUris) {
+			model.add(typeStatement("http://testUri" + model.size(), typeUri));
+		}
+		Set<ExampleClassForLoadAll> instances = loader
+				.loadAll(ExampleClassForLoadAll.class);
+		assertEquals(typeUris.size(), instances.size());
+	}
+
+	public static class ExampleClassForLoadAll {
+		// Nothing of interest
+	}
+
+	// ----------------------------------------------------------------------
+	// loadInstance()
+	// ----------------------------------------------------------------------
+
+	@Test
+	public void loadInstanceVariationsForJavaUtilRandom()
+			throws ConfigurationBeanLoaderException {
+		model.add(typeStatement("http://noPound", "java:java.util.Random"));
+		model.add(typeStatement("http://firstPound", "java:java#util.Random"));
+		model.add(typeStatement("http://secondPound", "java:java.util#Random"));
+		model.add(typeStatement("http://notARandom", "java:java.util.Set"));
+
+		assertNotNull(loader.loadInstance("http://noPound", Random.class));
+		assertNotNull(loader.loadInstance("http://firstPound", Random.class));
+		assertNotNull(loader.loadInstance("http://secondPound", Random.class));
+
+		try {
+			loader.loadInstance("http://notARandom", Random.class);
+			fail("Should not be a Random");
+		} catch (Exception e) {
+			// Expected it
+		}
+	}
+
+	@Test
+	public void loadInstanceVariationsForCustomInnerClass()
+			throws ConfigurationBeanLoaderException {
+		Set<String> typeUris = toPossibleJavaUris(
+				ExampleClassForLoadInstance.class);
+		for (String typeUri : typeUris) {
+			model.add(typeStatement("http://testUri" + model.size(), typeUri));
+		}
+		for (int i = 0; i < model.size(); i++) {
+			String instanceUri = "http://testUri" + i;
+			assertNotNull("No instance for " + instanceUri, loader.loadInstance(
+					instanceUri, ExampleClassForLoadInstance.class));
+		}
+	}
+
+	public static class ExampleClassForLoadInstance {
+		// Nothing of interest
+	}
+
+}

--- a/api/src/test/java/edu/cornell/mannlib/vitro/webapp/utils/configuration/ConfigurationBeanLoader_ValidationTest.java
+++ b/api/src/test/java/edu/cornell/mannlib/vitro/webapp/utils/configuration/ConfigurationBeanLoader_ValidationTest.java
@@ -15,8 +15,8 @@ import edu.cornell.mannlib.vitro.webapp.utils.configuration.WrappedInstance.Vali
 /**
  * Test the @Validation annotation.
  */
-public class ConfigurationBeanLoader_ValidationTest extends
-		ConfigurationBeanLoaderTestBase {
+public class ConfigurationBeanLoader_ValidationTest
+		extends ConfigurationBeanLoaderTestBase {
 	// --------------------------------------------
 
 	@Test
@@ -25,8 +25,7 @@ public class ConfigurationBeanLoader_ValidationTest extends
 		model.add(typeStatement(GENERIC_INSTANCE_URI,
 				toJavaUri(ValidationMethodWithParameter.class)));
 
-		expectSimpleFailure(
-				ValidationMethodWithParameter.class,
+		expectSimpleFailure(ValidationMethodWithParameter.class,
 				throwable(ConfigurationBeanLoaderException.class,
 						"Failed to load"),
 				throwable(InstanceWrapperException.class,
@@ -49,11 +48,11 @@ public class ConfigurationBeanLoader_ValidationTest extends
 		model.add(typeStatement(GENERIC_INSTANCE_URI,
 				toJavaUri(ValidationMethodShouldReturnVoid.class)));
 
-		expectSimpleFailure(
-				ValidationMethodShouldReturnVoid.class,
+		expectSimpleFailure(ValidationMethodShouldReturnVoid.class,
 				throwable(ConfigurationBeanLoaderException.class,
 						"Failed to load"),
-				throwable(InstanceWrapperException.class, "should return void"));
+				throwable(InstanceWrapperException.class,
+						"should return void"));
 	}
 
 	public static class ValidationMethodShouldReturnVoid {
@@ -71,8 +70,7 @@ public class ConfigurationBeanLoader_ValidationTest extends
 		model.add(typeStatement(GENERIC_INSTANCE_URI,
 				toJavaUri(ValidationMethodIsPrivate.class)));
 
-		expectSimpleFailure(
-				ValidationMethodIsPrivate.class,
+		expectSimpleFailure(ValidationMethodIsPrivate.class,
 				throwable(ConfigurationBeanLoaderException.class,
 						"Failed to load"),
 				throwable(ValidationFailedException.class,
@@ -94,8 +92,7 @@ public class ConfigurationBeanLoader_ValidationTest extends
 		model.add(typeStatement(GENERIC_INSTANCE_URI,
 				toJavaUri(ValidationThrowsException.class)));
 
-		expectSimpleFailure(
-				ValidationThrowsException.class,
+		expectSimpleFailure(ValidationThrowsException.class,
 				throwable(ConfigurationBeanLoaderException.class,
 						"Failed to load"),
 				throwable(ValidationFailedException.class,
@@ -144,8 +141,7 @@ public class ConfigurationBeanLoader_ValidationTest extends
 		model.add(typeStatement(GENERIC_INSTANCE_URI,
 				toJavaUri(ValidationOverValidationSubclass.class)));
 
-		expectSimpleFailure(
-				ValidationOverValidationSubclass.class,
+		expectSimpleFailure(ValidationOverValidationSubclass.class,
 				throwable(ConfigurationBeanLoaderException.class,
 						"Failed to load"),
 				throwable(InstanceWrapperException.class,
@@ -158,8 +154,7 @@ public class ConfigurationBeanLoader_ValidationTest extends
 		model.add(typeStatement(GENERIC_INSTANCE_URI,
 				toJavaUri(PlainOverValidationSubclass.class)));
 
-		expectSimpleFailure(
-				PlainOverValidationSubclass.class,
+		expectSimpleFailure(PlainOverValidationSubclass.class,
 				throwable(ConfigurationBeanLoaderException.class,
 						"Failed to load"),
 				throwable(InstanceWrapperException.class,
@@ -182,8 +177,8 @@ public class ConfigurationBeanLoader_ValidationTest extends
 		// Just want to see that the superclass validation is run.
 	}
 
-	public static class AdditionalValidationSubclass extends
-			ValidationSuperclass {
+	public static class AdditionalValidationSubclass
+			extends ValidationSuperclass {
 		public boolean validatorSubHasRun = false;
 
 		@Validation
@@ -195,8 +190,8 @@ public class ConfigurationBeanLoader_ValidationTest extends
 		}
 	}
 
-	public static class ValidationOverValidationSubclass extends
-			EmptyValidationSubclass {
+	public static class ValidationOverValidationSubclass
+			extends EmptyValidationSubclass {
 		@Override
 		@Validation
 		public void validatorSuper() {
@@ -204,8 +199,8 @@ public class ConfigurationBeanLoader_ValidationTest extends
 		}
 	}
 
-	public static class PlainOverValidationSubclass extends
-			ValidationSuperclass {
+	public static class PlainOverValidationSubclass
+			extends ValidationSuperclass {
 		@Override
 		public void validatorSuper() {
 			// Should fail

--- a/api/src/test/java/edu/cornell/mannlib/vitro/webapp/web/templatemodels/TagsTest.java
+++ b/api/src/test/java/edu/cornell/mannlib/vitro/webapp/web/templatemodels/TagsTest.java
@@ -1,0 +1,248 @@
+package edu.cornell.mannlib.vitro.webapp.web.templatemodels;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.StringWriter;
+import java.lang.reflect.Field;
+
+import org.apache.log4j.Level;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import edu.cornell.mannlib.vitro.testing.AbstractTestClass;
+import edu.cornell.mannlib.vitro.webapp.controller.freemarker.UrlBuilder;
+import edu.cornell.mannlib.vitro.webapp.web.templatemodels.Tags.TagVersionInfo;
+import edu.cornell.mannlib.vitro.webapp.web.templatemodels.Tags.TagVersionInfo.MatchResult;
+import stubs.edu.cornell.mannlib.vitro.webapp.modules.ApplicationStub;
+import stubs.javax.servlet.ServletContextStub;
+
+public class TagsTest extends AbstractTestClass {
+    private ServletContextStub ctx;
+    private File resource;
+
+    @Before
+    public void setup() throws IOException {
+        resource = File.createTempFile("resource", "");
+
+        ctx = new ServletContextStub();
+        ctx.setRealPath("/base/sub/file.js", resource.getPath());
+        ctx.setRealPath("/base/sub/file.css", resource.getPath());
+
+        ApplicationStub.setup(ctx, null);
+
+        setContextPath("/context");
+    }
+
+    // ----------------------------------------------------------------------
+    // Parsing tests
+    //
+    // Reference for parsing attributes:
+    // https://www.w3.org/TR/html/syntax.html#elements-attributes
+    // ----------------------------------------------------------------------
+
+    @Test
+    public void noAttribute_failure() {
+        assertNoMatch("<div height='value'></div>");
+    }
+
+    @Test
+    public void singleQuote_noTerminator_failure() {
+        assertNoMatch("<link rel='stylesheet' href='problem></link>");
+    }
+
+    @Test
+    public void singleQuotes_embeddedSingleQuote_failure() {
+        assertNoMatch("<script src='value'problem'></script");
+    }
+
+    @Test
+    public void singleQuotes_embeddedDoubleQuote_success() {
+        assertMatch("<script src='value\"noproblem'></script",
+                "value\"noproblem");
+    }
+
+    @Test
+    public void doubleQuote_noTerminator_failure() {
+        assertNoMatch("<link rel=\"stylesheet\" href=\"problem ></link>");
+    }
+
+    @Test
+    public void doubleQuotes_embeddedDoubleQuote_failure() {
+        assertNoMatch("<link href=\"value\"problem\"></link>");
+    }
+
+    @Test
+    public void doubleQuotes_embeddedSingleQuote_success() {
+        assertMatch("<link href=\"value'noproblem\"></link>",
+                "value'noproblem");
+    }
+
+    @Test
+    public void unquotedBadTerminator_failure() {
+        assertNoMatch("<script src=problem");
+    }
+
+    @Test
+    public void unquoted_embeddedEquals_failure() {
+        assertNoMatch("<script src=value=problem>");
+    }
+
+    @Test
+    public void unquoted_embeddedSingleQuote_failure() {
+        assertNoMatch("<script src=value'problem>");
+    }
+
+    @Test
+    public void unquoted_embeddedDoubleQuote_failure() {
+        assertNoMatch("<script src=value\"problem>");
+    }
+
+    @Test
+    public void unquoted_embeddedBackTick_failure() {
+        assertNoMatch("<script src=value`problem>");
+    }
+
+    @Test
+    public void unquoted_embeddedLessThan_failure() {
+        assertNoMatch("<script src=value<problem>");
+    }
+
+    @Test
+    public void spacesBeforeEquals_success() {
+        assertMatch("<link href =value rel='stylesheet'>", "value");
+    }
+
+    @Test
+    public void spacesAfterEquals_success() {
+        assertMatch("<script src= 'value'></script>", "value");
+    }
+
+    @Test
+    public void noSpacesAroundEquals_success() {
+        assertMatch("<script src=\"value\" ></script>", "value");
+    }
+
+    // ----------------------------------------------------------------------
+    // Substitution tests
+    // ----------------------------------------------------------------------
+
+    @Test
+    public void noMatch_noChange() {
+        assertVersionNotAdded(
+                "<script junk='/context/base/sub/file.js' ></script>",
+                "no match");
+    }
+
+    @Test
+    public void alreadyHasQueryString_noChange() {
+        assertVersionNotAdded(
+                "<script src='/context/base/sub/file.js?why' ></script>",
+                "has query");
+    }
+
+    @Test
+    public void doesntStartWithContextPath_noChange() {
+        assertVersionNotAdded(
+                "<script src='/notContext/base/sub/file.js' ></script>",
+                "context path");
+    }
+
+    @Test
+    public void noRealPath_noChange() {
+        assertVersionNotAdded(
+                "<script src='/context/base/sub/nofile.js' ></script>",
+                "real path");
+    }
+
+    @Test
+    @Ignore
+    public void exception_noChange() {
+        fail("exception_noChange not implemented");
+    }
+
+    @Test
+    public void doubleQuotes_substitution() {
+        assertVersionAdded( //
+                "<link href=\"/context/base/sub/file.css\" rel=stylesheet></link>", //
+                "<link href=\"/context/base/sub/file.css?version=9999\" rel=stylesheet></link>");
+    }
+
+    @Test
+    public void singleQuotes_substitution() {
+        assertVersionAdded( //
+                "<script src='/context/base/sub/file.js' ></script>", //
+                "<script src='/context/base/sub/file.js?version=9999' ></script>");
+    }
+
+    @Test
+    public void unquoted_substitution() {
+        assertVersionAdded( //
+                "<script type=text/javascript src=/context/base/sub/file.js ></script>", //
+                "<script type=text/javascript src=/context/base/sub/file.js?version&eq;9999 ></script>");
+    }
+
+    // ----------------------------------------------------------------------
+    // Helper methods
+    // ----------------------------------------------------------------------
+
+    private void setContextPath(String contextPath) {
+        try {
+            Field f = UrlBuilder.class.getDeclaredField("contextPath");
+            f.setAccessible(true);
+            f.set(null, contextPath);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private void assertMatch(String tag, String expected) {
+        TagVersionInfo info = new TagVersionInfo(tag);
+
+        try {
+            Field f = TagVersionInfo.class.getDeclaredField("match");
+            f.setAccessible(true);
+            MatchResult match = (MatchResult) f.get(info);
+
+            assertEquals(expected, match.group);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+
+    }
+
+    private void assertNoMatch(String tag) {
+        TagVersionInfo info = new TagVersionInfo(tag);
+        assertFalse(info.hasVersion());
+    }
+
+    private void assertVersionAdded(String rawTag, String expected) {
+        String actual = createTag(rawTag);
+        String canonicalActual = actual.replaceAll("=[0-9a-f]{4}", "=9999")
+                .replaceAll("&eq;[0-9a-f]{4}", "&eq;9999");
+        assertEquals(expected, canonicalActual);
+    }
+
+    private void assertVersionNotAdded(String rawTag, String debugMessage) {
+        StringWriter writer = new StringWriter();
+        captureLogOutput(Tags.class, writer, true);
+        setLoggerLevel(Tags.class, Level.DEBUG);
+
+        String actual = createTag(rawTag);
+        assertEquals(rawTag, actual);
+        assertThat(writer.toString(), containsString(debugMessage));
+    }
+
+    private String createTag(String rawTag) {
+        Tags t = new Tags();
+        t.add(rawTag);
+        return t.list();
+    }
+
+}

--- a/home/src/main/resources/config/example.applicationSetup.n3
+++ b/home/src/main/resources/config/example.applicationSetup.n3
@@ -11,6 +11,7 @@
 # ------------------------------------------------------------------------------
 
 @prefix : <http://vitro.mannlib.cornell.edu/ns/vitro/ApplicationSetup#> .
+@prefix vitroWebapp: <java:edu.cornell.mannlib.vitro.webapp#> .
 
 # ----------------------------
 #
@@ -19,8 +20,8 @@
 # 
 
 :application 
-    a   <java:edu.cornell.mannlib.vitro.webapp.application.ApplicationImpl> ,
-        <java:edu.cornell.mannlib.vitro.webapp.modules.Application> ;
+    a   vitroWebapp:application.ApplicationImpl ,
+        vitroWebapp:modules.Application ;
     :hasSearchEngine              :instrumentedSearchEngineWrapper ;
     :hasSearchIndexer             :basicSearchIndexer ;
     :hasImageProcessor            :iioImageProcessor ;
@@ -35,8 +36,8 @@
 #
 
 :iioImageProcessor
-    a   <java:edu.cornell.mannlib.vitro.webapp.imageprocessor.imageio.IIOImageProcessor> ,
-        <java:edu.cornell.mannlib.vitro.webapp.modules.imageProcessor.ImageProcessor> .
+    a   vitroWebapp:imageprocessor.imageio.IIOImageProcessor ,
+        vitroWebapp:modules.imageProcessor.ImageProcessor .
 
 # ----------------------------
 #
@@ -46,8 +47,8 @@
 #
 
 :ptiFileStorage 
-    a   <java:edu.cornell.mannlib.vitro.webapp.filestorage.impl.FileStorageImplWrapper> ,
-        <java:edu.cornell.mannlib.vitro.webapp.modules.fileStorage.FileStorage> .
+    a   vitroWebapp:filestorage.impl.FileStorageImplWrapper ,
+        vitroWebapp:modules.fileStorage.FileStorage .
                
 # ----------------------------
 #
@@ -58,13 +59,13 @@
 #
 
 :instrumentedSearchEngineWrapper 
-    a   <java:edu.cornell.mannlib.vitro.webapp.searchengine.InstrumentedSearchEngineWrapper> , 
-        <java:edu.cornell.mannlib.vitro.webapp.modules.searchEngine.SearchEngine> ;
+    a   vitroWebapp:searchengine.InstrumentedSearchEngineWrapper , 
+        vitroWebapp:modules.searchEngine.SearchEngine ;
     :wraps :solrSearchEngine .
 
 :solrSearchEngine
-    a   <java:edu.cornell.mannlib.vitro.webapp.searchengine.solr.SolrSearchEngine> ,
-        <java:edu.cornell.mannlib.vitro.webapp.modules.searchEngine.SearchEngine> .
+    a   vitroWebapp:searchengine.solr.SolrSearchEngine ,
+        vitroWebapp:modules.searchEngine.SearchEngine .
 
 # ----------------------------
 #
@@ -74,8 +75,8 @@
 #
 
 :basicSearchIndexer
-    a   <java:edu.cornell.mannlib.vitro.webapp.searchindex.SearchIndexerImpl> ,
-        <java:edu.cornell.mannlib.vitro.webapp.modules.searchIndexer.SearchIndexer> ;
+    a   vitroWebapp:searchindex.SearchIndexerImpl ,
+        vitroWebapp:modules.searchIndexer.SearchIndexer ;
     :threadPoolSize "10" .
     
 # ----------------------------
@@ -89,26 +90,26 @@
 #
 
 :sdbContentTripleSource
-    a   <java:edu.cornell.mannlib.vitro.webapp.triplesource.impl.sdb.ContentTripleSourceSDB> ,
-        <java:edu.cornell.mannlib.vitro.webapp.modules.tripleSource.ContentTripleSource> .
+    a   vitroWebapp:triplesource.impl.sdb.ContentTripleSourceSDB ,
+        vitroWebapp:modules.tripleSource.ContentTripleSource .
 
 #:tdbContentTripleSource
-#    a   <java:edu.cornell.mannlib.vitro.webapp.triplesource.impl.tdb.ContentTripleSourceTDB> ,
-#        <java:edu.cornell.mannlib.vitro.webapp.modules.tripleSource.ContentTripleSource> ;
+#    a   vitroWebapp:triplesource.impl.tdb.ContentTripleSourceTDB ,
+#        vitroWebapp:modules.tripleSource.ContentTripleSource ;
 #    # May be an absolute path, or relative to the Vitro home directory.
 #    :hasTdbDirectory "tdbContentModels" .
 
 #:sparqlContentTripleSource
-#    a   <java:edu.cornell.mannlib.vitro.webapp.triplesource.impl.virtuoso.ContentTripleSourceSPARQL> ,
-#        <java:edu.cornell.mannlib.vitro.webapp.modules.tripleSource.ContentTripleSource> ;
+#    a   vitroWebapp:triplesource.impl.virtuoso.ContentTripleSourceSPARQL ,
+#        vitroWebapp:modules.tripleSource.ContentTripleSource ;
 #    # The URI of the SPARQL endpoint for your triple-store.
 #    :hasEndpointURI "PUT_YOUR_SPARQL_ENDPOINT_URI_HERE" ;
 #    # The URI to use for SPARQL UPDATE calls against your triple-store. 
 #    :hasUpdateEndpointURI "PUT_THE UPDATE_URI_HERE" .
 
 #:virtuosoContentTripleSource
-#    a   <java:edu.cornell.mannlib.vitro.webapp.triplesource.impl.virtuoso.ContentTripleSourceVirtuoso> ,
-#        <java:edu.cornell.mannlib.vitro.webapp.modules.tripleSource.ContentTripleSource> ;
+#    a   vitroWebapp:triplesource.impl.virtuoso.ContentTripleSourceVirtuoso ,
+#        vitroWebapp:modules.tripleSource.ContentTripleSource ;
 #    # The URI of Virtuoso's SPARQL endpoint.
 #    :hasEndpointURI "PUT_YOUR_VIRTUOSO_URI_HERE" ;
 #    # The URI to use for SPARQL UPDATE calls against Virtuoso. 
@@ -123,8 +124,8 @@
 #
 
 :tdbConfigurationTripleSource
-    a   <java:edu.cornell.mannlib.vitro.webapp.triplesource.impl.tdb.ConfigurationTripleSourceTDB> ,
-        <java:edu.cornell.mannlib.vitro.webapp.modules.tripleSource.ConfigurationTripleSource> .
+    a   vitroWebapp:triplesource.impl.tdb.ConfigurationTripleSourceTDB ,
+        vitroWebapp:modules.tripleSource.ConfigurationTripleSource .
         
 # ----------------------------
 #
@@ -134,5 +135,5 @@
 #
 
 :jfactTBoxReasonerModule
-    a   <java:edu.cornell.mannlib.vitro.webapp.tboxreasoner.impl.jfact.JFactTBoxReasonerModule> ,
-        <java:edu.cornell.mannlib.vitro.webapp.modules.tboxreasoner.TBoxReasonerModule> .
+    a   vitroWebapp:tboxreasoner.impl.jfact.JFactTBoxReasonerModule ,
+        vitroWebapp:modules.tboxreasoner.TBoxReasonerModule .

--- a/home/src/main/resources/rdf/display/everytime/searchIndexerConfigurationVitro.n3
+++ b/home/src/main/resources/rdf/display/everytime/searchIndexerConfigurationVitro.n3
@@ -1,6 +1,8 @@
 @prefix : <http://vitro.mannlib.cornell.edu/ns/vitro/ApplicationSetup#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix searchIndex: <java:edu.cornell.mannlib.vitro.webapp.searchindex#> .
+
 
 #
 # configure the SearchIndexer
@@ -8,8 +10,8 @@
 
 # Individuals with these types will be excluded from the search index
 :searchExcluder_typeExcluder
-    a   <java:edu.cornell.mannlib.vitro.webapp.searchindex.exclusions.ExcludeBasedOnType> ,
-        <java:edu.cornell.mannlib.vitro.webapp.searchindex.exclusions.SearchIndexExcluder> ;
+    a   searchIndex:exclusions.ExcludeBasedOnType ,
+        searchIndex:exclusions.SearchIndexExcluder ;
     :excludes
         "http://www.w3.org/2002/07/owl#AnnotationProperty" ,
         "http://www.w3.org/2002/07/owl#DatatypeProperty" ,
@@ -17,8 +19,8 @@
 
 # Individuals with types from these namespaces will be excluded from the search index.
 :searchExcluder_namespaceExcluder
-    a   <java:edu.cornell.mannlib.vitro.webapp.searchindex.exclusions.ExcludeBasedOnNamespace> ,
-        <java:edu.cornell.mannlib.vitro.webapp.searchindex.exclusions.SearchIndexExcluder> ;
+    a   searchIndex:exclusions.ExcludeBasedOnNamespace ,
+        searchIndex:exclusions.SearchIndexExcluder ;
     :excludes
         "http://vitro.mannlib.cornell.edu/ns/vitro/0.7#" ,
         "http://vitro.mannlib.cornell.edu/ns/vitro/public#" ,
@@ -27,38 +29,38 @@
 
 # Individuals with URIs in these namespaces will be excluded from the search index.
 :searchExcluder_typeNamespaceExcluder
-    a   <java:edu.cornell.mannlib.vitro.webapp.searchindex.exclusions.ExcludeBasedOnTypeNamespace> ,
-        <java:edu.cornell.mannlib.vitro.webapp.searchindex.exclusions.SearchIndexExcluder> ;
+    a   searchIndex:exclusions.ExcludeBasedOnTypeNamespace ,
+        searchIndex:exclusions.SearchIndexExcluder ;
     :excludes
         "http://vitro.mannlib.cornell.edu/ns/vitro/role#public" .
 
 :searchExcluder_syncingTypeExcluder
-    a   <java:edu.cornell.mannlib.vitro.webapp.searchindex.exclusions.SyncingExcludeBasedOnType> ,
-        <java:edu.cornell.mannlib.vitro.webapp.searchindex.exclusions.SearchIndexExcluder> .
+    a   searchIndex:exclusions.SyncingExcludeBasedOnType ,
+        searchIndex:exclusions.SearchIndexExcluder .
 
 # ------------------------------------
 
 :uriFinder_forDataProperties
-    a   <java:edu.cornell.mannlib.vitro.webapp.searchindex.indexing.IndexingUriFinder> ,
-        <java:edu.cornell.mannlib.vitro.webapp.searchindex.indexing.AdditionalURIsForDataProperties> .
+    a   searchIndex:indexing.IndexingUriFinder ,
+        searchIndex:indexing.AdditionalURIsForDataProperties .
 
 :uriFinder_forObjectProperties
-    a   <java:edu.cornell.mannlib.vitro.webapp.searchindex.indexing.IndexingUriFinder> ,
-        <java:edu.cornell.mannlib.vitro.webapp.searchindex.indexing.AdditionalURIsForObjectProperties> .
+    a   searchIndex:indexing.IndexingUriFinder ,
+        searchIndex:indexing.AdditionalURIsForObjectProperties .
 
 :uriFinder_forTypeStatements
-    a   <java:edu.cornell.mannlib.vitro.webapp.searchindex.indexing.IndexingUriFinder> ,
-        <java:edu.cornell.mannlib.vitro.webapp.searchindex.indexing.AdditionalURIsForTypeStatements> .
+    a   searchIndex:indexing.IndexingUriFinder ,
+        searchIndex:indexing.AdditionalURIsForTypeStatements .
 
 :uriFinder_forClassGroupChange
-    a   <java:edu.cornell.mannlib.vitro.webapp.searchindex.indexing.IndexingUriFinder> ,
-        <java:edu.cornell.mannlib.vitro.webapp.searchindex.indexing.URIsForClassGroupChange> .
+    a   searchIndex:indexing.IndexingUriFinder ,
+        searchIndex:indexing.URIsForClassGroupChange .
 
 # ------------------------------------
 
 :documentModifier_AllNames
-    a   <java:edu.cornell.mannlib.vitro.webapp.searchindex.documentBuilding.SelectQueryDocumentModifier> ,
-        <java:edu.cornell.mannlib.vitro.webapp.searchindex.documentBuilding.DocumentModifier> ;
+    a   searchIndex:documentBuilding.SelectQueryDocumentModifier ,
+        searchIndex:documentBuilding.DocumentModifier ;
     rdfs:label "All labels are added to name fields." ;
     :hasTargetField "nameRaw" ;
     :hasSelectQuery """
@@ -70,8 +72,8 @@
         """ .
     
 :documentModifier_NameFieldBooster
-    a   <java:edu.cornell.mannlib.vitro.webapp.searchindex.documentBuilding.FieldBooster> ,
-        <java:edu.cornell.mannlib.vitro.webapp.searchindex.documentBuilding.DocumentModifier> ;
+    a   searchIndex:documentBuilding.FieldBooster ,
+        searchIndex:documentBuilding.DocumentModifier ;
     :hasTargetField "nameRaw" ;
     :hasTargetField "nameLowercase" ;
     :hasTargetField "nameUnstemmed" ;
@@ -79,5 +81,5 @@
     :hasBoost "1.2"^^xsd:float .
 
 :documentModifier_thumbnailImageUrl
-    a   <java:edu.cornell.mannlib.vitro.webapp.searchindex.documentBuilding.ThumbnailImageURL> ,
-        <java:edu.cornell.mannlib.vitro.webapp.searchindex.documentBuilding.DocumentModifier> .
+    a   searchIndex:documentBuilding.ThumbnailImageURL ,
+        searchIndex:documentBuilding.DocumentModifier .


### PR DESCRIPTION
ConfigurationBeanLoader will permit the use of #-terminated namespaces in Java class URIs. Modify config files to use namespaces.

Relies on https://github.com/vivo-project/Vitro/pull/62