### PR TITLE
[VIVO-1458] Upgrade to Jena 3.6.0/Support FROM and FROM NAMED in SDB

### DIFF
--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/dao/jena/RDFServiceDataset.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/dao/jena/RDFServiceDataset.java
@@ -168,4 +168,9 @@ public class RDFServiceDataset implements Dataset {
 		return "RDFServiceDataset[" + ToString.hashHex(this) + ", " + g + "]";
 	}
 
+	@Override
+	public boolean isEmpty() {
+		return g.isEmpty();
+	}
+
 }

--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -176,7 +176,7 @@
         <dependency>
             <groupId>org.apache.jena</groupId>
             <artifactId>jena-arq</artifactId>
-            <version>3.4.0</version>
+            <version>3.6.0</version>
             <exclusions>
                 <!-- Exclude OSGi bundles from jsonld-java -->
                 <exclusion>
@@ -192,17 +192,17 @@
         <dependency>
             <groupId>org.apache.jena</groupId>
             <artifactId>jena-core</artifactId>
-            <version>3.4.0</version>
+            <version>3.6.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.jena</groupId>
             <artifactId>jena-sdb</artifactId>
-            <version>3.4.0</version>
+            <version>3.6.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.jena</groupId>
             <artifactId>jena-tdb</artifactId>
-            <version>3.4.0</version>
+            <version>3.6.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.solr</groupId>


### PR DESCRIPTION
**[JIRA Issue: [VIVO-1458]](https://jira.duraspace.org/browse/VIVO-1458)**

* Other Relevant Links (Mailing list discussion, related pull requests, etc.)
https://jira.duraspace.org/browse/VIVO-1373

# What does this pull request do?
Swaps Jena 3.4.0 with the latest and greatest, Jena 3.6.0
What it does NOT do is add new Jena functionality to VIVO (minus the lil' isEmpty method), e.g. TDB2 was released in Jena 3.5.0 but it is not implemented by this pull request

# What's new?
Upgrade to Jena 3.6.0 
Support FROM and FROM NAMED queries in SDB triplestores 

# How should this be tested?
You can reproduce the issue this addresses by attempting to run the below query on an instance running [VIVO 1.10.0 Beta 2 ](https://github.com/vivo-project/VIVO/releases/tag/rel-vivo-1.10.0-beta2) using SDB. You will receive a 500 error with the following message:
`org.apache.jena.sdb.SDBException: Queries with dataset descriptions (FROM/FROM NAMED) not supported`

You can confirm Jena has been upgraded by running this query in a VIVO using SDB
```
SELECT ?s ?p
FROM <http://vitro.mannlib.cornell.edu/default/vitro-kb-2>
WHERE
{
?s ?p ?o .
}
LIMIT 20
```
I have done basic testing on this. VIVO builds and starts, editing the database is possible, and SPARQL queries (including FROM and FROM NAMED) work.

# Additional Notes:
Harvester may need to be updated as well.

# Interested parties
@sarbajitdutta
@fereira 