### PR TITLE
[VIVO-1470] Cross-platform improvements for Maven

### DIFF
--- a/home/src/main/assembly/home.xml
+++ b/home/src/main/assembly/home.xml
@@ -11,7 +11,7 @@
     <fileSets>
         <fileSet>
             <directory>${project.basedir}</directory>
-            <outputDirectory>/</outputDirectory>
+            <outputDirectory>.</outputDirectory>
             <includes>
                 <include>README*</include>
                 <include>LICENSE*</include>
@@ -20,7 +20,7 @@
         </fileSet>
         <fileSet>
             <directory>${project.basedir}/src/main/resources</directory>
-            <outputDirectory>/</outputDirectory>
+            <outputDirectory>.</outputDirectory>
         </fileSet>
         <!-- fileSet>
             <directory>${project.build.directory}</directory>

--- a/installer/home/src/main/assembly/home.xml
+++ b/installer/home/src/main/assembly/home.xml
@@ -8,14 +8,14 @@
     <includeBaseDirectory>false</includeBaseDirectory>
     <dependencySets>
         <dependencySet>
-            <outputDirectory>/</outputDirectory>
+            <outputDirectory>.</outputDirectory>
             <unpack>true</unpack>
         </dependencySet>
     </dependencySets>
     <fileSets>
         <fileSet>
             <directory>${project.basedir}/src/main/resources</directory>
-            <outputDirectory>/</outputDirectory>
+            <outputDirectory>.</outputDirectory>
             <filtered>true</filtered>
         </fileSet>
     </fileSets>

--- a/installer/pom.xml
+++ b/installer/pom.xml
@@ -15,6 +15,7 @@
     <properties>
         <vitro-version>${project.version}</vitro-version>
         <maven-site-plugin.skip>true</maven-site-plugin.skip>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,7 @@
         <build.timestamp>${maven.build.timestamp}</build.timestamp>
         <maven-site-plugin.skip>false</maven-site-plugin.skip>
         <stagingBase>/</stagingBase>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <modules>


### PR DESCRIPTION
https://jira.duraspace.org/browse/VIVO-1470

# What does this pull request do?
Small corrections to the pom.xml and assembly.xml files to improve cross-platform support - remove Windows warnings and resource character set problems.

# What's new?
UTF-8 properties in pom files to set character set for resource filtering.
Altered assembly output directory to not use a Unix convention.

# How should this be tested?
Rebuild the application, and ensure that all artefacts are created and deployed normally (e.g. there should be no visible change, other than the warnings no longer appearing on Windows)

# Additional Notes:
No documentation, dependency changes or other impact.

# Interested parties
@VIVO-project/vivo-committers
