### PR TITLE
VIVO-1478 mysql driver throws exception

### DIFF
--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/triplesource/impl/sdb/SDBConnectionSmokeTests.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/triplesource/impl/sdb/SDBConnectionSmokeTests.java
@@ -52,6 +52,10 @@ public class SDBConnectionSmokeTests {
 					+ PROPERTY_DB_URL + "'");
 			return;
 		}
+		
+		// Get the full URL, with options.
+		url = SDBDataSource.getJdbcUrl(props);
+		
 		String username = props.getProperty(PROPERTY_DB_USERNAME);
 		if (username == null || username.isEmpty()) {
 			ss.fatal("runtime.properties does not contain a value for '"

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/triplesource/impl/sdb/SDBDataSource.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/triplesource/impl/sdb/SDBDataSource.java
@@ -2,8 +2,6 @@
 
 package edu.cornell.mannlib.vitro.webapp.triplesource.impl.sdb;
 
-import java.beans.PropertyVetoException;
-
 import javax.servlet.ServletContext;
 
 import org.apache.commons.lang3.StringUtils;
@@ -51,7 +49,7 @@ public class SDBDataSource {
 	public BasicDataSource getDataSource() {
 		BasicDataSource cpds = new BasicDataSource();
 		cpds.setDriverClassName(getDbDriverClassName());
-		cpds.setUrl(getJdbcUrl());
+		cpds.setUrl(getJdbcUrl(configProps));
 		cpds.setUsername(configProps.getProperty(PROPERTY_DB_USERNAME));
 		cpds.setPassword(configProps.getProperty(PROPERTY_DB_PASSWORD));
 		cpds.setMaxTotal(getMaxActive());
@@ -73,41 +71,6 @@ public class SDBDataSource {
 	private String getDbDriverClassName() {
 		return configProps.getProperty(PROPERTY_DB_DRIVER_CLASS_NAME,
 				DEFAULT_DRIVER_CLASS);
-	}
-
-	private String getDbType() {
-		return configProps.getProperty(PROPERTY_DB_TYPE, DEFAULT_TYPE);
-	}
-
-	private String getJdbcUrl() {
-		String url = configProps.getProperty(PROPERTY_DB_URL);
-
-		// Ensure that MySQL handles unicode properly, else all kinds of
-		// horrible nastiness ensues.
-		if (DEFAULT_TYPE.equals(getDbType())) {
-			if (!url.contains("?")) {
-				url += "?useUnicode=yes&characterEncoding=utf8&nullNamePatternMatchesAll=true&cachePrepStmts=true&useServerPrepStmts=true";
-			} else {
-				String urlLwr = url.toLowerCase();
-				if (!urlLwr.contains("useunicode")) {
-					url += "&useUnicode=yes";
-				}
-				if (!urlLwr.contains("characterencoding")) {
-					url += "&characterEncoding=utf8";
-				}
-				if (!urlLwr.contains("nullnamepatternmatchesall")) {
-					url += "&nullNamePatternMatchesAll=true";
-				}
-				if (!urlLwr.contains("cacheprepstmts")) {
-					url += "&cachePrepStmts=true";
-				}
-				if (!urlLwr.contains("useserverprepstmts")) {
-					url += "&useServerPrepStmts=true";
-				}
-			}
-		}
-
-		return url;
 	}
 
 	private String getValidationQuery() {
@@ -167,4 +130,49 @@ public class SDBDataSource {
 			return defaultValue;
 		}
 	}
+	
+	/**
+	 * Get the JDBC URL, perhaps with special MySQL options.
+	 * 
+	 * This must be static and package-accessible so SDBConnectionSmokeTests can
+	 * use the same options.
+	 */
+	static String getJdbcUrl(ConfigurationProperties props) {
+		String url = props.getProperty(PROPERTY_DB_URL);
+
+		// Ensure that MySQL handles unicode properly, else all kinds of
+		// horrible nastiness ensues. Also, set some other handy options.
+		if (DEFAULT_TYPE.equals(getDbType(props))) {
+			if (!url.contains("?")) {
+				url += "?useUnicode=yes&characterEncoding=utf8&nullNamePatternMatchesAll=true&cachePrepStmts=true&useServerPrepStmts=true&serverTimezone=UTC";
+			} else {
+				String urlLwr = url.toLowerCase();
+				if (!urlLwr.contains("useunicode")) {
+					url += "&useUnicode=yes";
+				}
+				if (!urlLwr.contains("characterencoding")) {
+					url += "&characterEncoding=utf8";
+				}
+				if (!urlLwr.contains("nullnamepatternmatchesall")) {
+					url += "&nullNamePatternMatchesAll=true";
+				}
+				if (!urlLwr.contains("cacheprepstmts")) {
+					url += "&cachePrepStmts=true";
+				}
+				if (!urlLwr.contains("useserverprepstmts")) {
+					url += "&useServerPrepStmts=true";
+				}
+				if (!urlLwr.contains("servertimezone")) {
+					url += "serverTimezone=UTC";
+				}
+			}
+		}
+		return url;
+	}
+
+	private static String getDbType(ConfigurationProperties props) {
+		return props.getProperty(PROPERTY_DB_TYPE, DEFAULT_TYPE);
+	}
+	
+
 }

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/triplesource/impl/sdb/SDBDataSource.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/triplesource/impl/sdb/SDBDataSource.java
@@ -163,7 +163,7 @@ public class SDBDataSource {
 					url += "&useServerPrepStmts=true";
 				}
 				if (!urlLwr.contains("servertimezone")) {
-					url += "serverTimezone=UTC";
+					url += "&serverTimezone=UTC";
 				}
 			}
 		}

--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -114,7 +114,7 @@
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
-            <version>6.0.6</version>
+            <version>5.1.46</version>
         </dependency>
         <dependency>
             <groupId>net.sf.jga</groupId>

--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -114,7 +114,7 @@
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
-            <version>5.1.46</version>
+            <version>8.0.11</version>
         </dependency>
         <dependency>
             <groupId>net.sf.jga</groupId>

--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -114,7 +114,7 @@
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
-            <version>8.0.11</version>
+            <version>5.1.46</version>
         </dependency>
         <dependency>
             <groupId>net.sf.jga</groupId>


### PR DESCRIPTION
**Thank you for submitting a pull request! Title this pull request with a brief description of what the pull request fixes/improves/changes. Please describe the pull request in detail using the template below.**
* * *

**[JIRA Issue](https://jira.duraspace.org/projects/VIVO)**: https://jira.duraspace.org/browse/VIVO-1478

* Other Relevant Links (Mailing list discussion, related pull requests, etc.)

# What does this pull request do?
Upgrading to a newer MySQL driver caused an exception unless `serverTimezone` was specified in the JDBC URL. This request causes VIVO to specify `serverTimeZone=UTC` as a default option on the URL. It also uses the most recent version of the MySQL driver.

# What's new?
* Changes mysql-connector-java artifact from version 6.0.6 (February, 2017) to version 5.1.46 (April, 2018)

# How should this be tested?
* To reproduce the problem, 
    * Install VIVO
    * Start VIVO
    * Observe InvalidConnectionAttributeException in the log
    * VIVO presents a fatal error page
* To test the fix,
    1. user provides no options on JDBC URL
        * Merge the fix, repeat installation and start VIVO
        * Log contains no InvalidConnectionAttributeException
        * VIVO operates normally
    2. user provides options on JDBC URL
        * As above, but add an innocuous option to the JDBC URL in `runtime.properties`
            * e.g., `VitroConnection.DataSource.url = jdbc:mysql://localhost/vitrodb?useUnicode=yes`
        * Start VIVO
        * Log contains no InvalidConnectionAttributeException
        * VIVO operates normally

# Interested parties
@VIVO-project/vivo-committers
