### PR TITLE
Change project version from 2.0.0-SNAPSHOT to 1.10.0-SNAPSHOT

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -7,13 +7,13 @@
 
     <groupId>org.vivoweb</groupId>
     <artifactId>vitro-api</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.10.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <parent>
         <groupId>org.vivoweb</groupId>
         <artifactId>vitro-project</artifactId>
-        <version>2.0.0-SNAPSHOT</version>
+        <version>1.10.0-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
 
@@ -56,7 +56,7 @@
         <dependency>
             <groupId>org.vivoweb</groupId>
             <artifactId>vitro-dependencies</artifactId>
-            <version>2.0.0-SNAPSHOT</version>
+            <version>1.10.0-SNAPSHOT</version>
             <type>pom</type>
         </dependency>
         <dependency>

--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -7,13 +7,13 @@
 
     <groupId>org.vivoweb</groupId>
     <artifactId>vitro-dependencies</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.10.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <parent>
         <groupId>org.vivoweb</groupId>
         <artifactId>vitro-project</artifactId>
-        <version>2.0.0-SNAPSHOT</version>
+        <version>1.10.0-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/home/pom.xml
+++ b/home/pom.xml
@@ -7,13 +7,13 @@
 
     <groupId>org.vivoweb</groupId>
     <artifactId>vitro-home</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.10.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <parent>
         <groupId>org.vivoweb</groupId>
         <artifactId>vitro-project</artifactId>
-        <version>2.0.0-SNAPSHOT</version>
+        <version>1.10.0-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/installer/home/pom.xml
+++ b/installer/home/pom.xml
@@ -7,13 +7,13 @@
 
     <groupId>org.vivoweb</groupId>
     <artifactId>vitro-installer-home</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.10.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <parent>
         <groupId>org.vivoweb</groupId>
         <artifactId>vitro-installer</artifactId>
-        <version>2.0.0-SNAPSHOT</version>
+        <version>1.10.0-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/installer/pom.xml
+++ b/installer/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>org.vivoweb</groupId>
     <artifactId>vitro-installer</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.10.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Vitro Installer</name>

--- a/installer/solr/pom.xml
+++ b/installer/solr/pom.xml
@@ -7,13 +7,13 @@
 
     <groupId>org.vivoweb</groupId>
     <artifactId>vitro-installer-solr</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.10.0-SNAPSHOT</version>
     <packaging>war</packaging>
 
     <parent>
         <groupId>org.vivoweb</groupId>
         <artifactId>vitro-installer</artifactId>
-        <version>2.0.0-SNAPSHOT</version>
+        <version>1.10.0-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/installer/webapp/pom.xml
+++ b/installer/webapp/pom.xml
@@ -7,13 +7,13 @@
 
     <groupId>org.vivoweb</groupId>
     <artifactId>vitro-installer-webapp</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.10.0-SNAPSHOT</version>
     <packaging>war</packaging>
 
     <parent>
         <groupId>org.vivoweb</groupId>
         <artifactId>vitro-installer</artifactId>
-        <version>2.0.0-SNAPSHOT</version>
+        <version>1.10.0-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>org.vivoweb</groupId>
     <artifactId>vitro-project</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.10.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Vitro</name>

--- a/solr/pom.xml
+++ b/solr/pom.xml
@@ -7,13 +7,13 @@
 
     <groupId>org.vivoweb</groupId>
     <artifactId>vitro-solr</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.10.0-SNAPSHOT</version>
     <packaging>war</packaging>
 
     <parent>
         <groupId>org.vivoweb</groupId>
         <artifactId>vitro-project</artifactId>
-        <version>2.0.0-SNAPSHOT</version>
+        <version>1.10.0-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/webapp/pom.xml
+++ b/webapp/pom.xml
@@ -7,13 +7,13 @@
 
     <groupId>org.vivoweb</groupId>
     <artifactId>vitro-webapp</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.10.0-SNAPSHOT</version>
     <packaging>war</packaging>
 
     <parent>
         <groupId>org.vivoweb</groupId>
         <artifactId>vitro-project</artifactId>
-        <version>2.0.0-SNAPSHOT</version>
+        <version>1.10.0-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
 
@@ -41,7 +41,7 @@
         <dependency>
             <groupId>org.vivoweb</groupId>
             <artifactId>vitro-api</artifactId>
-            <version>2.0.0-SNAPSHOT</version>
+            <version>1.10.0-SNAPSHOT</version>
         </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
Resolves: https://jira.duraspace.org/browse/VIVO-1479

# What does this pull request do?
Change project version from 2.0.0-SNAPSHOT to 1.10.0-SNAPSHOT

# How should this be tested?
This is only a Maven project version change. 
Success is if the project continues to build and deploy.

# Interested parties
@VIVO-project/vivo-committers
