### PR TITLE
VIVO-1475 Add Data Distribution API

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -252,5 +252,11 @@
             <artifactId>javax.mail</artifactId>
             <version>1.6.0</version>
         </dependency>
+        
+        <dependency>
+            <groupId>edu.cornell.library.scholars</groupId>
+            <artifactId>data-distribution-api-vivo_1_10</artifactId>
+            <version>1.1.1</version>
+        </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
**[JIRA Issue](https://jira.duraspace.org/projects/VIVO)**: https://jira.duraspace.org/browse/VIVO-1475

* Other Relevant Links 
    * [API Documentation](https://cul-it.github.io/vivo-data-distribution-api/index.html)

# What does this pull request do?
Adds the Data Distribution API (developed by Scholars@Cornell) to the VIVO distribution.

# What's new?
Allows the site administrator to configure data distributors - named, parameterized requests for data from VIVO.

# How should this be tested?
1. Bare API:
    * Install and start VIVO
    * Point browser to `http://localhost:8080/vivo/api/dataRequest`
        * Response is `'action' path was not provided.`
    * Point browser to `http://localhost:8080/vivo/api/dataRequest/hello?name=World`
        * Response is `Did not find a DataDistributor for 'hello'`
2. Configure a distributor:
    * Create a configuration file, as described in [Using in VIVO 1.10](https://cul-it.github.io/vivo-data-distribution-api/install_vivo_1_10.html)
    * Install and start VIVO
    * Point browser to `http://localhost:8080/vivo/api/dataRequest/hello?name=World`
        * Response is `Hello, World!`

# Interested parties
@VIVO-project/vivo-committers
