### PR TITLE
Moved password encryption from MD5 to a salted and secure hash - 1448

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -54,6 +54,11 @@
 
     <dependencies>
         <dependency>
+            <groupId>de.mkammerer</groupId>
+            <artifactId>argon2-jvm</artifactId>
+            <version>2.4</version>
+        </dependency>
+        <dependency>
             <groupId>org.vivoweb</groupId>
             <artifactId>vitro-dependencies</artifactId>
             <version>2.0.0-SNAPSHOT</version>

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/auth/policy/PolicyHelper.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/auth/policy/PolicyHelper.java
@@ -102,7 +102,7 @@ public class PolicyHelper {
 			String uri = user.getUri();
 			log.debug("userAccount is '" + uri + "'");
 
-			if (!auth.isCurrentPassword(user, password)) {
+			if (!auth.isCurrentPasswordArgon2(user, password)) {
 				log.debug(String.format("UNAUTHORIZED, password not accepted "
 						+ "for %s, account URI: %s", email, uri));
 				return false;

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/auth/policy/RootUserPolicy.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/auth/policy/RootUserPolicy.java
@@ -67,6 +67,7 @@ public class RootUserPolicy implements PolicyIface {
 		private ServletContext ctx;
 		private StartupStatus ss;
 		private UserAccountsDao uaDao;
+		private ConfigurationProperties cp;
 		private String configuredRootUser;
 		private boolean configuredRootUserExists;
 		private TreeSet<String> otherRootUsers;
@@ -75,6 +76,7 @@ public class RootUserPolicy implements PolicyIface {
 		public void contextInitialized(ServletContextEvent sce) {
 			ctx = sce.getServletContext();
 			ss = StartupStatus.getBean(ctx);
+			cp = ConfigurationProperties.getBean(ctx);
 
 			try {
 				uaDao = ModelAccess.on(ctx).getWebappDaoFactory()
@@ -148,8 +150,8 @@ public class RootUserPolicy implements PolicyIface {
 			ua.setEmailAddress(configuredRootUser);
 			ua.setFirstName("root");
 			ua.setLastName("user");
-			ua.setMd5Password(Authenticator
-					.applyMd5Encoding(ROOT_USER_INITIAL_PASSWORD));
+			ua.setArgon2Password(Authenticator.applyArgon2iEncoding(cp,ROOT_USER_INITIAL_PASSWORD));
+			ua.setMd5Password("");
 			ua.setPasswordChangeRequired(true);
 			ua.setStatus(Status.ACTIVE);
 			ua.setRootUser(true);

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/beans/UserAccount.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/beans/UserAccount.java
@@ -48,6 +48,7 @@ public class UserAccount {
 	private String firstName = ""; // Never null.
 	private String lastName = ""; // Never null.
 
+	private String argon2Password = ""; //Never null.
 	private String md5Password = ""; // Never null.
 	private String oldPassword = ""; // Never null.
 	private long passwordLinkExpires = 0L; // Never negative.
@@ -104,6 +105,14 @@ public class UserAccount {
 		this.lastName = nonNull(lastName, "");
 	}
 
+	public String getArgon2Password() {
+		return argon2Password;
+	}
+
+	public void setArgon2Password(String argo2Password) {
+		this.argon2Password = nonNull(argo2Password, "");
+	}
+
 	public String getMd5Password() {
 		return md5Password;
 	}
@@ -125,8 +134,9 @@ public class UserAccount {
 	}
 
 	public String getPasswordLinkExpiresHash() {
-		return limitStringLength(8, Authenticator.applyMd5Encoding(String
+		return limitStringLength(8, Authenticator.applyArgon2iEncoding(String
 				.valueOf(passwordLinkExpires)));
+		//applyMd5Encoding
 	}
 
 	public void setPasswordLinkExpires(long passwordLinkExpires) {

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/accounts/UserAccountsSelector.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/accounts/UserAccountsSelector.java
@@ -246,6 +246,7 @@ public class UserAccountsSelector {
 			user.setFirstName(ifLiteralPresent(solution, "firstName", ""));
 			user.setLastName(ifLiteralPresent(solution, "lastName", ""));
 			user.setMd5Password(ifLiteralPresent(solution, "pwd", ""));
+			user.setArgon2Password(ifLiteralPresent(solution, "pwd", ""));
 			user.setPasswordLinkExpires(ifLongPresent(solution, "expire", 0L));
 			user.setLoginCount(ifIntPresent(solution, "count", 0));
 			user.setLastLoginTime(ifLongPresent(solution, "lastLogin", 0));

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/accounts/admin/UserAccountsAddPageStrategy.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/accounts/admin/UserAccountsAddPageStrategy.java
@@ -198,8 +198,8 @@ public abstract class UserAccountsAddPageStrategy extends UserAccountsPage {
 		@Override
 		protected void setAdditionalProperties(UserAccount u) {
 			if (!page.isExternalAuthOnly()) {
-				u.setMd5Password(Authenticator
-						.applyMd5Encoding(initialPassword));
+				u.setArgon2Password(Authenticator.applyArgon2iEncoding(initialPassword));
+				u.setMd5Password("");
 				u.setPasswordChangeRequired(true);
 			}
 			u.setStatus(Status.ACTIVE);

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/accounts/admin/UserAccountsEditPageStrategy.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/accounts/admin/UserAccountsEditPageStrategy.java
@@ -194,7 +194,8 @@ public abstract class UserAccountsEditPageStrategy extends UserAccountsPage {
 		@Override
 		protected void setAdditionalProperties(UserAccount u) {
 			if (!page.isExternalAuthOnly() && !newPassword.isEmpty()) {
-				u.setMd5Password(Authenticator.applyMd5Encoding(newPassword));
+				u.setArgon2Password(Authenticator.applyArgon2iEncoding(newPassword));
+				u.setMd5Password("");
 				u.setPasswordChangeRequired(true);
 			}
 		}

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/accounts/user/UserAccountsCreatePasswordPage.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/accounts/user/UserAccountsCreatePasswordPage.java
@@ -33,14 +33,14 @@ public class UserAccountsCreatePasswordPage extends
 	}
 
 	public void createPassword() {
-		userAccount.setMd5Password(Authenticator.applyMd5Encoding(newPassword));
+		userAccount.setArgon2Password(Authenticator.applyArgon2iEncoding(newPassword));
+		userAccount.setMd5Password("");
 		userAccount.setPasswordLinkExpires(0L);
 		userAccount.setPasswordChangeRequired(false);
 		userAccount.setStatus(Status.ACTIVE);
 		userAccountsDao.updateUserAccount(userAccount);
 		log.debug("Set password on '" + userAccount.getEmailAddress()
 				+ "' to '" + newPassword + "'");
-
 		notifyUser();
 	}
 

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/accounts/user/UserAccountsMyAccountPageStrategy.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/accounts/user/UserAccountsMyAccountPageStrategy.java
@@ -155,8 +155,8 @@ public abstract class UserAccountsMyAccountPageStrategy extends
 		@Override
 		public void setAdditionalProperties(UserAccount userAccount) {
 			if (!newPassword.isEmpty() && !page.isExternalAuthOnly()) {
-				userAccount.setMd5Password(Authenticator
-						.applyMd5Encoding(newPassword));
+				userAccount.setArgon2Password(Authenticator.applyArgon2iEncoding(newPassword));
+				userAccount.setMd5Password("");
 				userAccount.setPasswordChangeRequired(false);
 				userAccount.setPasswordLinkExpires(0L);
 			}

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/accounts/user/UserAccountsResetPasswordPage.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/accounts/user/UserAccountsResetPasswordPage.java
@@ -33,7 +33,8 @@ public class UserAccountsResetPasswordPage extends UserAccountsPasswordBasePage 
 	}
 
 	public void resetPassword() {
-		userAccount.setMd5Password(Authenticator.applyMd5Encoding(newPassword));
+		userAccount.setArgon2Password(Authenticator.applyArgon2iEncoding(newPassword));
+		userAccount.setMd5Password("");
 		userAccount.setPasswordLinkExpires(0L);
 		userAccount.setPasswordChangeRequired(false);
 		userAccount.setStatus(Status.ACTIVE);

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/api/VitroApiServlet.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/api/VitroApiServlet.java
@@ -54,7 +54,7 @@ public class VitroApiServlet extends HttpServlet {
 					+ "last names and a valid email address.");
 		}
 
-		if (!auth.isCurrentPassword(account, password)) {
+		if (!auth.isCurrentPasswordArgon2(account, password)) {
 			log.debug("Invalid: '" + email + "'/'" + password + "'");
 			throw new AuthException("email/password combination is not valid");
 		}

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/authenticate/AdminLoginController.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/authenticate/AdminLoginController.java
@@ -141,8 +141,12 @@ public class AdminLoginController extends FreemarkerHttpServlet {
 		}
 
 		private boolean newPasswordRequired() {
-			return auth.isCurrentPassword(userAccount, password)
-					&& (userAccount.isPasswordChangeRequired());
+			if(auth.md5HashIsNull(userAccount)) {
+				return auth.isCurrentPasswordArgon2(userAccount, password)
+						&& userAccount.isPasswordChangeRequired();
+			}
+			else
+				return auth.isCurrentPassword(userAccount, password);  // MD5 password should be changed anyway
 		}
 
 		private boolean isPasswordValidLength(String pw) {
@@ -151,8 +155,18 @@ public class AdminLoginController extends FreemarkerHttpServlet {
 		}
 
 		private boolean tryToLogin() {
-			if (!auth.isCurrentPassword(userAccount, password)) {
-				return false;
+			if(auth.md5HashIsNull(userAccount)) {
+				if (!auth.isCurrentPasswordArgon2(userAccount, password))
+					return false;
+			}
+			else {
+				if (!auth.isCurrentPassword(userAccount, password))
+					return false;
+				else {
+					userAccount.setPasswordChangeRequired(true);
+					userAccount.setMd5Password("");
+
+				}
 			}
 
 			try {

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/authenticate/BasicAuthenticator.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/authenticate/BasicAuthenticator.java
@@ -99,13 +99,38 @@ public class BasicAuthenticator extends Authenticator {
 	}
 
 	@Override
+	public boolean md5HashIsNull(UserAccount userAccount){
+		if(userAccount.getMd5Password().compareTo("")==0 || userAccount.getMd5Password()==null)
+			return  true;
+		else
+			return false;
+	}
+
+
+	@Override
+	public boolean isCurrentPasswordArgon2(UserAccount userAccount,
+									 String clearTextPassword) {
+		if (userAccount == null) {
+			return false;
+		}
+		if (clearTextPassword == null) {
+			return false;
+		}
+
+		return verifyArgon2iHash(userAccount.getArgon2Password(),clearTextPassword);
+	}
+
+
+
+	@Override
 	public void recordNewPassword(UserAccount userAccount,
 			String newClearTextPassword) {
 		if (userAccount == null) {
 			log.error("Trying to change password on null user.");
 			return;
 		}
-		userAccount.setMd5Password(applyMd5Encoding(newClearTextPassword));
+		userAccount.setArgon2Password((applyArgon2iEncoding(newClearTextPassword)));
+		userAccount.setMd5Password("");
 		userAccount.setPasswordChangeRequired(false);
 		userAccount.setPasswordLinkExpires(0L);
 		getUserAccountsDao().updateUserAccount(userAccount);

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/authenticate/ProgramLogin.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/authenticate/ProgramLogin.java
@@ -5,6 +5,7 @@ package edu.cornell.mannlib.vitro.webapp.controller.authenticate;
 import static edu.cornell.mannlib.vedit.beans.LoginStatusBean.AuthenticationSource.INTERNAL;
 import static edu.cornell.mannlib.vitro.webapp.beans.UserAccount.MAX_PASSWORD_LENGTH;
 import static edu.cornell.mannlib.vitro.webapp.beans.UserAccount.MIN_PASSWORD_LENGTH;
+import static edu.cornell.mannlib.vitro.webapp.controller.login.LoginProcessBean.MLevel.ERROR;
 
 import java.io.IOException;
 import java.io.PrintWriter;
@@ -158,7 +159,20 @@ public class ProgramLogin extends HttpServlet {
 		}
 
 		private boolean usernameAndPasswordAreValid() {
-			return auth.isCurrentPassword(userAccount, password);
+
+			if(auth.md5HashIsNull(userAccount)) {
+				if (!auth.isCurrentPasswordArgon2(userAccount, password))
+					return false;
+			}
+			else {
+				if (!auth.isCurrentPassword(userAccount, password))
+					return false;
+				else {
+					userAccount.setPasswordChangeRequired(true);
+				//	userAccount.setMd5Password("");
+				}
+			}
+			return true;
 		}
 
 		private boolean loginDisabled() {

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/authenticate/RestrictedAuthenticator.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/authenticate/RestrictedAuthenticator.java
@@ -77,6 +77,29 @@ public class RestrictedAuthenticator extends Authenticator {
 	}
 
 	@Override
+	public boolean md5HashIsNull(UserAccount userAccount){
+		if(userAccount.getMd5Password().compareTo("")==0 || userAccount.getMd5Password()==null)
+			return  true;
+		else
+			return false;
+	}
+
+
+	@Override
+	public boolean isCurrentPasswordArgon2(UserAccount userAccount,
+										   String clearTextPassword) {
+		if (userAccount == null) {
+			return false;
+		}
+		if (clearTextPassword == null) {
+			return false;
+		}
+
+		return verifyArgon2iHash(userAccount.getArgon2Password(),clearTextPassword);
+	}
+
+
+	@Override
 	public boolean isCurrentPassword(UserAccount userAccount,
 			String clearTextPassword) {
 		return auth.isCurrentPassword(userAccount, clearTextPassword);

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/edit/Authenticate.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/edit/Authenticate.java
@@ -331,15 +331,31 @@ public class Authenticate extends VitroHttpServlet {
 			return;
 		}
 
+
 		if (!getAuthenticator(request).isUserPermittedToLogin(user)) {
 			bean.setMessage(request, ERROR, "logins_disabled_for_maintenance");
 			return;
 		}
 
-		if (!getAuthenticator(request).isCurrentPassword(user, password)) {
-			bean.setMessage(request, ERROR, "error_incorrect_credentials");
-			return;
+
+		if(getAuthenticator(request).md5HashIsNull(user)) {
+			if (!getAuthenticator(request).isCurrentPasswordArgon2(user, password)) {
+				bean.setMessage(request, ERROR, "error_incorrect_credentials");
+				return;
+			}
 		}
+		else {
+				if (!getAuthenticator(request).isCurrentPassword(user, password)) {
+					bean.setMessage(request, ERROR, "error_incorrect_credentials");
+					return;
+				}
+				else {
+					 user.setPasswordChangeRequired(true);
+					 user.setMd5Password("");
+				}
+			}
+
+
 
 		// Username and password are correct. What next?
 		if (user.isPasswordChangeRequired()) {
@@ -401,7 +417,7 @@ public class Authenticate extends VitroHttpServlet {
 
 		UserAccount user = getAuthenticator(request).getAccountForInternalAuth(
 				username);
-		if (getAuthenticator(request).isCurrentPassword(user, newPassword)) {
+		if (getAuthenticator(request).isCurrentPasswordArgon2(user, newPassword)) {
 			bean.setMessage(request, ERROR, "error_previous_password");
 			return;
 		}

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/dao/VitroVocabulary.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/dao/VitroVocabulary.java
@@ -149,6 +149,7 @@ public class VitroVocabulary {
     public static final String USERACCOUNT_EMAIL_ADDRESS = VITRO_AUTH + "emailAddress";
     public static final String USERACCOUNT_FIRST_NAME = VITRO_AUTH + "firstName";
     public static final String USERACCOUNT_LAST_NAME = VITRO_AUTH + "lastName";
+    public static final String USERACCOUNT_ARGON2_PASSWORD = VITRO_AUTH + "argon2password";
     public static final String USERACCOUNT_MD5_PASSWORD = VITRO_AUTH + "md5password";
     public static final String USERACCOUNT_OLD_PASSWORD = VITRO_AUTH + "oldpassword";
     public static final String USERACCOUNT_LOGIN_COUNT = VITRO_AUTH + "loginCount";

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/dao/jena/JenaBaseDaoCon.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/dao/jena/JenaBaseDaoCon.java
@@ -112,6 +112,7 @@ public class JenaBaseDaoCon {
     protected  DatatypeProperty   USERACCOUNT_EMAIL_ADDRESS = _constModel.createDatatypeProperty(VitroVocabulary.USERACCOUNT_EMAIL_ADDRESS);
     protected  DatatypeProperty   USERACCOUNT_FIRST_NAME = _constModel.createDatatypeProperty(VitroVocabulary.USERACCOUNT_FIRST_NAME);
     protected  DatatypeProperty   USERACCOUNT_LAST_NAME = _constModel.createDatatypeProperty(VitroVocabulary.USERACCOUNT_LAST_NAME);
+    protected  DatatypeProperty   USERACCOUNT_ARGON2_PASSWORD = _constModel.createDatatypeProperty(VitroVocabulary.USERACCOUNT_ARGON2_PASSWORD);
     protected  DatatypeProperty   USERACCOUNT_MD5_PASSWORD = _constModel.createDatatypeProperty(VitroVocabulary.USERACCOUNT_MD5_PASSWORD);
     protected  DatatypeProperty   USERACCOUNT_OLD_PASSWORD = _constModel.createDatatypeProperty(VitroVocabulary.USERACCOUNT_OLD_PASSWORD);
     protected  DatatypeProperty   USERACCOUNT_LOGIN_COUNT = _constModel.createDatatypeProperty(VitroVocabulary.USERACCOUNT_LOGIN_COUNT);

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/dao/jena/UserAccountsDaoJena.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/dao/jena/UserAccountsDaoJena.java
@@ -93,6 +93,7 @@ public class UserAccountsDaoJena extends JenaBaseDao implements UserAccountsDao 
 					USERACCOUNT_EMAIL_ADDRESS));
 			u.setFirstName(getPropertyStringValue(r, USERACCOUNT_FIRST_NAME));
 			u.setLastName(getPropertyStringValue(r, USERACCOUNT_LAST_NAME));
+			u.setArgon2Password(getPropertyStringValue(r, USERACCOUNT_ARGON2_PASSWORD));
 			u.setMd5Password(getPropertyStringValue(r, USERACCOUNT_MD5_PASSWORD));
 			u.setOldPassword(getPropertyStringValue(r, USERACCOUNT_OLD_PASSWORD));
 			u.setPasswordLinkExpires(getPropertyLongValue(r,
@@ -225,6 +226,8 @@ public class UserAccountsDaoJena extends JenaBaseDao implements UserAccountsDao 
 					userAccount.getLastName(), model);
 			addPropertyStringValue(res, USERACCOUNT_MD5_PASSWORD,
 					userAccount.getMd5Password(), model);
+			addPropertyStringValue(res, USERACCOUNT_ARGON2_PASSWORD,
+					userAccount.getArgon2Password(), model);
 			addPropertyStringValue(res, USERACCOUNT_OLD_PASSWORD,
 					userAccount.getOldPassword(), model);
 			addPropertyLongValue(res, USERACCOUNT_PASSWORD_LINK_EXPIRES,
@@ -288,6 +291,8 @@ public class UserAccountsDaoJena extends JenaBaseDao implements UserAccountsDao 
 					userAccount.getLastName(), model);
 			updatePropertyStringValue(res, USERACCOUNT_MD5_PASSWORD,
 					userAccount.getMd5Password(), model);
+			updatePropertyStringValue(res, USERACCOUNT_ARGON2_PASSWORD,
+					userAccount.getArgon2Password(), model);
 			updatePropertyStringValue(res, USERACCOUNT_OLD_PASSWORD,
 					userAccount.getOldPassword(), model);
 			updatePropertyLongValue(res, USERACCOUNT_PASSWORD_LINK_EXPIRES,

--- a/api/src/test/java/edu/cornell/mannlib/vitro/webapp/controller/authenticate/AuthenticatorStub.java
+++ b/api/src/test/java/edu/cornell/mannlib/vitro/webapp/controller/authenticate/AuthenticatorStub.java
@@ -103,6 +103,32 @@ public class AuthenticatorStub extends Authenticator {
 	}
 
 	@Override
+	public boolean md5HashIsNull(UserAccount userAccount){
+		if(userAccount!=null) {
+			if (userAccount.getMd5Password().compareTo("") == 0 || userAccount.getMd5Password() == null)
+				return true;
+			else
+				return false;
+		}
+		return false;
+	}
+
+
+	@Override
+	public boolean isCurrentPasswordArgon2(UserAccount userAccount,
+										   String clearTextPassword) {
+		if (userAccount == null) {
+			return false;
+		}
+		if (clearTextPassword == null) {
+			return false;
+		}
+
+		return verifyArgon2iHash(userAccount.getArgon2Password(),clearTextPassword);
+	}
+
+
+	@Override
 	public boolean isCurrentPassword(UserAccount userAccount,
 			String clearTextPassword) {
 		if (userAccount == null) {

--- a/api/src/test/java/edu/cornell/mannlib/vitro/webapp/controller/authenticate/ProgramLoginTest.java
+++ b/api/src/test/java/edu/cornell/mannlib/vitro/webapp/controller/authenticate/ProgramLoginTest.java
@@ -98,7 +98,9 @@ public class ProgramLoginTest extends AbstractTestClass {
 		user.setUri(uri);
 		user.setPermissionSetUris(Collections
 				.singleton(PermissionSets.URI_DBA));
-		user.setMd5Password(Authenticator.applyMd5Encoding(password));
+		user.setArgon2Password(Authenticator.applyArgon2iEncodingStub(password));
+		user.setMd5Password("");
+		//user.setMd5Password(Authenticator.applyMd5Encoding(password));
 		user.setLoginCount(loginCount);
 		user.setPasswordChangeRequired(loginCount == 0);
 		return user;
@@ -179,12 +181,15 @@ public class ProgramLoginTest extends AbstractTestClass {
 			String newPassword) {
 		if (email != null) {
 			request.addParameter(PARAM_EMAIL_ADDRESS, email);
+			System.out.println("1");
 		}
 		if (password != null) {
 			request.addParameter(PARAM_PASSWORD, password);
+			System.out.println("2");
 		}
 		if (newPassword != null) {
 			request.addParameter(PARAM_NEW_PASSWORD, newPassword);
+			System.out.println("3");
 		}
 
 		try {

--- a/api/src/test/java/edu/cornell/mannlib/vitro/webapp/controller/edit/AuthenticateTest.java
+++ b/api/src/test/java/edu/cornell/mannlib/vitro/webapp/controller/edit/AuthenticateTest.java
@@ -191,7 +191,9 @@ public class AuthenticateTest extends AbstractTestClass {
 		user.setEmailAddress(userInfo.username);
 		user.setUri(userInfo.uri);
 		user.setPermissionSetUris(userInfo.permissionSetUris);
-		user.setMd5Password(Authenticator.applyMd5Encoding(userInfo.password));
+		user.setArgon2Password(Authenticator.applyArgon2iEncodingStub(userInfo.password));
+		user.setMd5Password("");
+	//	user.setMd5Password(Authenticator.applyMd5Encoding(userInfo.password));
 		user.setLoginCount(userInfo.loginCount);
 		user.setPasswordChangeRequired(userInfo.loginCount == 0);
 		return user;

--- a/api/src/test/java/edu/cornell/mannlib/vitro/webapp/dao/jena/UserAccountsDaoJenaTest.java
+++ b/api/src/test/java/edu/cornell/mannlib/vitro/webapp/dao/jena/UserAccountsDaoJenaTest.java
@@ -91,19 +91,19 @@ public class UserAccountsDaoJenaTest extends AbstractTestClass {
 	@Before
 	public void createUserAccountValues() {
 		user1 = userAccount(URI_USER1, "email@able.edu", "Zack", "Roberts",
-				"garbage", "", 0L, false, 5, 12345678L, Status.ACTIVE, "user1",
+				"garbage", "" ,"", 0L, false, 5, 12345678L, Status.ACTIVE, "user1",
 				false, collection(URI_ROLE1), false, EMPTY);
-		userNew = userAccount("", "email@here", "Joe", "Blow", "XXXX", "YYYY",
+		userNew = userAccount("", "email@here", "Joe", "Blow", "XXXX","", "YYYY",
 				0L, false, 1, 0L, Status.ACTIVE, "jblow", false, EMPTY, false,
 				EMPTY);
 
-		userA = userAccount("", "aahern@here", "Alf", "Ahern", "XXXX", "YYYY",
+		userA = userAccount("", "aahern@here", "Alf", "Ahern", "XXXX", "", "YYYY",
 				0L, false, 1, 0L, Status.ACTIVE, "aahern", false, EMPTY, false,
 				collection(URI_PROFILE1));
-		userB = userAccount("", "email@here", "Betty", "Boop", "XXXX", "YYYY",
+		userB = userAccount("", "email@here", "Betty", "Boop", "XXXX", "", "YYYY",
 				0L, false, 1, 0L, Status.ACTIVE, "bboop", false, EMPTY, false,
 				collection(URI_PROFILE1, URI_PROFILE2));
-		userC = userAccount("", "ccallas@here", "Charlie", "Callas", "XXXX",
+		userC = userAccount("", "ccallas@here", "Charlie", "Callas", "XXXX", "",
 				"YYYY", 0L, false, 1, 0L, Status.ACTIVE, "ccallas", false,
 				EMPTY, false, collection(URI_PROFILE2));
 	}
@@ -179,7 +179,7 @@ public class UserAccountsDaoJenaTest extends AbstractTestClass {
 	@Test
 	public void updateUserAccountSuccess() {
 		UserAccount orig = userAccount(URI_USER1, "updatedEmail@able.edu",
-				"Ezekiel", "Roberts", "differentHash", "oldHash", 1L, false,
+				"Ezekiel", "Roberts", "differentHash", "", "oldHash", 1L, false,
 				43, 1020304050607080L, Status.ACTIVE, "updatedUser1", false,
 				collection(URI_ROLE1, URI_ROLE3), false, EMPTY);
 
@@ -379,7 +379,7 @@ public class UserAccountsDaoJenaTest extends AbstractTestClass {
 	}
 
 	private UserAccount userAccount(String uri, String emailAddress,
-			String firstName, String lastName, String md5Password,
+			String firstName, String lastName, String argon2Password, String md5Password,
 			String oldPassword, long passwordLinkExpires,
 			boolean passwordChangeRequired, int loginCount, long lastLoginTime,
 			Status status, String externalAuthId, boolean externalAuthOnly,
@@ -390,7 +390,9 @@ public class UserAccountsDaoJenaTest extends AbstractTestClass {
 		ua.setEmailAddress(emailAddress);
 		ua.setFirstName(firstName);
 		ua.setLastName(lastName);
-		ua.setMd5Password(md5Password);
+		ua.setArgon2Password(argon2Password);
+		ua.setMd5Password("");
+		//ua.setMd5Password(md5Password);
 		ua.setOldPassword(oldPassword);
 		ua.setPasswordLinkExpires(passwordLinkExpires);
 		ua.setPasswordChangeRequired(passwordChangeRequired);
@@ -411,6 +413,7 @@ public class UserAccountsDaoJenaTest extends AbstractTestClass {
 		out.setEmailAddress(in.getEmailAddress());
 		out.setFirstName(in.getFirstName());
 		out.setLastName(in.getLastName());
+		out.setArgon2Password(in.getArgon2Password());
 		out.setMd5Password(in.getMd5Password());
 		out.setOldPassword(in.getOldPassword());
 		out.setPasswordLinkExpires(in.getPasswordLinkExpires());
@@ -433,7 +436,7 @@ public class UserAccountsDaoJenaTest extends AbstractTestClass {
 		assertEquals("email", e.getEmailAddress(), a.getEmailAddress());
 		assertEquals("first name", e.getFirstName(), a.getFirstName());
 		assertEquals("last name", e.getLastName(), a.getLastName());
-		assertEquals("password", e.getMd5Password(), a.getMd5Password());
+		assertEquals("password", e.getArgon2Password(), e.getArgon2Password());
 		assertEquals("old password", e.getOldPassword(), a.getOldPassword());
 		assertEquals("link expires", e.getPasswordLinkExpires(),
 				a.getPasswordLinkExpires());

--- a/home/src/main/resources/config/example.runtime.properties
+++ b/home/src/main/resources/config/example.runtime.properties
@@ -1,0 +1,154 @@
+# -----------------------------------------------------------------------------
+#
+# Vitro runtime properties
+#
+# This file is provided as example.runtime.properties.
+#
+# Save a copy of this file as runtime.properties in your Vitro home directory, 
+# and edit the properties as needed for your installation.
+#
+# -----------------------------------------------------------------------------
+
+# 
+# This namespace will be used when generating URIs for objects created in the 
+# editor. In order to serve linked data, the default namespace must be composed 
+# as follows (optional elements in parentheses):
+#
+# scheme + server_name (+ port) (+ servlet_context) + "/individual/"
+# 
+# For example, Cornell's default namespace is:
+#
+# http://vivo.cornell.edu/individual/
+#
+Vitro.defaultNamespace = http://vivo.mydomain.edu/individual/
+
+# 
+# URL of Solr context used in local Vitro search. This will usually consist of:
+#     scheme + server_name + port + vitro_webapp_name + "solr"
+# In the standard installation, the Solr context will be on the same server as Vitro,
+# and in the same Tomcat instance. The path will be the Vitro webapp.name (specified
+# above) + "solr"
+#   Example:
+#     vitro.local.solr.url = http://localhost:8080/vitrosolr
+vitro.local.solr.url = http://localhost:8080/vitrosolr
+
+#
+# Email parameters which VIVO can use to send mail. If these are left empty, 
+# the "Contact Us" form will be disabled and users will not be notified of
+# changes to their accounts.
+#
+email.smtpHost = smtp.my.domain.edu
+email.replyTo = vivoAdmin@my.domain.edu
+
+#
+# The basic parameters for a MySQL database connection. Change the end of the 
+# URL to reflect your database name (if it is not "vitro"). Change the username 
+# and password to match the authorized user you created in MySQL.
+#
+VitroConnection.DataSource.url = jdbc:mysql://localhost/vitro
+VitroConnection.DataSource.username = vitroweb
+VitroConnection.DataSource.password = vitrovitro
+
+#
+# The maximum number of active connections in the database connection pool.
+# Increase this value to support a greater number of concurrent page requests.
+#
+VitroConnection.DataSource.pool.maxActive = 40
+
+#
+# The maximum number of database connections that will be allowed
+# to remain idle in the connection pool.  Default is 25%
+# of the maximum number of active connections.
+#
+VitroConnection.DataSource.pool.maxIdle = 10
+
+#
+# Parameters to change in order to use VIVO with a database other than 
+# MySQL.
+#
+VitroConnection.DataSource.dbtype = MySQL
+VitroConnection.DataSource.driver = com.mysql.jdbc.Driver
+VitroConnection.DataSource.validationQuery = SELECT 1
+
+#
+# The email address of the root user for the VIVO application. The password 
+# for this user is initially set to "rootPassword", but you will be asked to 
+# change the password the first time you log in.
+#
+rootUser.emailAddress = root@myDomain.com
+
+#
+# Argon2 password hashing parameters for time, memory and parallelism required to compute a hash.
+#
+# A time cost defines the amount of computation realized and therefore the execution time, given in a number of iterations
+# A memory cost defines the memory usage, given in kibibytes
+# A parallelism degree defines the number of parallel threads
+# For determining the optimal values of the parameters for your setup please refer to the white paper section  9 -  https://github.com/P-H-C/phc-winner-argon2/blob/master/argon2-specs.pdf
+#
+# Warning: Please change the parameters only if you have installed a fresh installation of Vitro/Vivo and have not logged-in in the system yet.
+# If you already have user accounts encrypted through these parameters please do not change them otherwise the existing users would not be able to log-in.
+#
+argon2.parallism = 1
+argon2.memory = 1024
+argon2.time = 1000
+
+#
+# How is a logged-in user associated with a particular Individual? One way is 
+# for the Individual to have a property whose value is the username of the user.
+# This is the name of that property.
+#
+selfEditing.idMatchingProperty = http://vitro.mydomain.edu/ns#networkId
+
+#
+# If an external authentication system like Shibboleth or CUWebAuth is to be
+# used, these properties say how the login button should be labeled, and which
+# HTTP header will contain the user ID from the authentication system. If such
+# as system is not to be used, leave these commented out. Consult the 
+# installation instructions for more details. 
+#
+#externalAuth.buttonText = Log in using BearCat Shibboleth
+#externalAuth.netIdHeaderName = remote_userID 
+
+#
+# Types of individual for which we can create proxy editors.
+# If this is omitted, defaults to http://www.w3.org/2002/07/owl#Thing
+proxy.eligibleTypeList = http://www.w3.org/2002/07/owl#Thing
+
+#
+# Show only the most appropriate data values based on the Accept-Language 
+# header supplied by the browser.  Default is false if not set.
+#
+# RDFService.languageFilter = true
+
+#
+# Tell VIVO to generate HTTP headers on its responses to facilitate caching the 
+# profile pages that it creates. 
+#
+# For more information, see 
+# https://wiki.duraspace.org/display/VIVO/Use+HTTP+caching+to+improve+performance
+#
+# Developers will likely want to leave caching disabled, since a change to a
+# Freemarker template or to a Java class would not cause the page to be 
+# considered stale.
+#
+# http.createCacheHeaders = true
+
+#
+# Force VIVO to use a specific language or Locale instead of those 
+# specified by the browser. This affects RDF data retrieved from the model, 
+# if RDFService.languageFilter is true. This also affects the text of pages
+# that have been modified to support multiple languages. 
+#
+# languages.forceLocale = en_US
+
+#
+# A list of supported languages or Locales that the user may choose to
+# use instead of the one specified by the browser. Selection images must
+# be available in the i18n/images directory of the theme. This affects 
+# RDF data retrieved from the model, if RDFService.languageFilter is true.  
+# This also affects the text of pages that have been modified to support 
+# multiple languages. 
+#
+# This should not be used with languages.forceLocale, which will override it.
+#
+# languages.selectableLocales = en, es, fr

--- a/home/src/main/resources/config/example.runtime.properties
+++ b/home/src/main/resources/config/example.runtime.properties
@@ -88,7 +88,7 @@ rootUser.emailAddress = root@myDomain.com
 # Warning: Please change the parameters only if you have installed a fresh installation of Vitro/Vivo and have not logged-in in the system yet.
 # If you already have user accounts encrypted through these parameters please do not change them otherwise the existing users would not be able to log-in.
 #
-argon2.parallism = 1
+argon2.parallelism =1
 argon2.memory = 1024
 argon2.time = 1000
 

--- a/legacy/webapp/config/example.runtime.properties
+++ b/legacy/webapp/config/example.runtime.properties
@@ -78,6 +78,21 @@ VitroConnection.DataSource.validationQuery = SELECT 1
 rootUser.emailAddress = root@myDomain.com
 
 #
+# Argon2 password hashing parameters for time, memory and parallelism required to compute a hash.
+#
+# A time cost defines the amount of computation realized and therefore the execution time, given in a number of iterations
+# A memory cost defines the memory usage, given in kibibytes
+# A parallelism degree defines the number of parallel threads
+# For determining the optimal values of the parameters for your setup please refer to the white paper section  9 -  https://github.com/P-H-C/phc-winner-argon2/blob/master/argon2-specs.pdf
+#
+# Warning: Please change the parameters only if you have installed a fresh installation of Vitro/Vivo and have not logged-in in the system yet.
+# If you already have user accounts encrypted through these parameters please do not change them otherwise the existing users would not be able to log-in.
+#
+argon2.parallelism =1
+argon2.memory = 1024
+argon2.time = 1000
+
+#
 # How is a logged-in user associated with a particular Individual? One way is 
 # for the Individual to have a property whose value is the username of the user.
 # This is the name of that property.


### PR DESCRIPTION
https://jira.duraspace.org/browse/VIVO-1448

**What does this pull request do?**

It replaces the MD5 password hashing with a more secure and salted password hashing algorithm.

**What's new?**

MD5 hashing has been replaced by Argon2i hashing, which is salted and configurable in terms of memory, time and parallelism needed to compute a hash. https://github.com/phxql/argon2-jvm

MD5 hashing has not been completely eliminated and the users with MD5 hash as their passwords are asked by the system to renew their password once they log in.

The configurable parameters of the Argon2i algorithm are stored in the "runtime.properties" file.

**How should this be tested?**

- Copy the useraccounts (with Md5 passwords) from an already installed instance of Vivo/Vitro and place them in the home directory of vitro with Argon2i hashing and check if the system promotes you to renew your password after logging in.
- Login using API with root credentials.  (Could be done using a browser i.e, http://[server address e.g., localhost:8080]/[application name e.g., vitro]/api/sparqlQuery?email=[root email]&password=[root password])
- Create a new user and login
- Change your password and login
- Create an invite/user/create-user link
- Check external authentical
- Change the values for parallelism, memory and time in runtime.properties and login ( you should be still able to login but the time required to login should change)
- Restrict user accounts and login