### PR TITLE
Update jenatools dependency to 1.2.0-SNAPSHOT

### DIFF
--- a/home/pom.xml
+++ b/home/pom.xml
@@ -69,13 +69,13 @@
         <dependency>
             <groupId>org.vivoweb</groupId>
             <artifactId>jena2tools</artifactId>
-            <version>1.1.1</version>
+            <version>1.2.0-SNAPSHOT</version>
             <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.vivoweb</groupId>
             <artifactId>jena3tools</artifactId>
-            <version>1.1.1</version>
+            <version>1.2.0-SNAPSHOT</version>
             <optional>true</optional>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -372,4 +372,19 @@
             <url>https://oss.sonatype.org/content/repositories/snapshots</url>
         </snapshotRepository>
     </distributionManagement>
+
+    <repositories>
+        <repository>
+            <id>sonatype-nexus-snapshots</id>
+            <name>Sonatype Nexus Snapshots</name>
+            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
+
 </project>


### PR DESCRIPTION
Related to: https://jira.duraspace.org/browse/VIVO-1520

# What does this pull request do?
Updates jenatools dependency to 1.2.0-SNAPSHOT

# How should this be tested?
- Build Vitro home assembly:
$ cd home
$ maven assembly:single

- Ensure build succeeded and include the correct version of jena2tools and jena3tools
https://github.com/fcrepo/fcrepo-specification/issues/373
$ cd target
$ tar xzvf vitro-home-1.10.0-SNAPSHOT.tar.gz 
$ cd bin/
$ jar xvf jena2tools.jar 
$ less META-INF/maven/org.vivoweb/jena2tools/pom.xml 

# Interested parties
@gneissone @roflinn @KitioFofack 
