### PR TITLE
[VIVO-1539] Moved stream reset inside loop so that every listener gets same state

### DIFF
--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/rdfservice/impl/RDFServiceImpl.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/rdfservice/impl/RDFServiceImpl.java
@@ -141,8 +141,8 @@ public abstract class RDFServiceImpl implements RDFService {
     }
 	
     protected void notifyListeners(ModelChange modelChange) throws IOException {
-        modelChange.getSerializedModel().reset();
         for (ChangeListener listener : registeredListeners) {
+            modelChange.getSerializedModel().reset();
             listener.notifyModelChange(modelChange);
         }
         log.debug(registeredJenaListeners.size() + " registered Jena listeners");


### PR DESCRIPTION
**[VIVO-1539](https://jira.duraspace.org/browse/VIVO-1539)**:

# What does this pull request do?
Moves the resetting of the serialized changes from outside the loop that notifies listeners, to inside, so that listeners will always get a stream that is ready to use, regardless of how many have been configured or the order.

# How should this be tested?
The only existing listener is the one that controls inferencing.
Primary testing should be to submit a change to the data, and ensure that any inferences are written correctly.

# Interested parties
@VIVO-project/vivo-committers
