### PR TITLE
[VIVO-1592] Upgrade Solr library to 7.4.0

### DIFF
--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/searchengine/solr/SolrConversionUtils.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/searchengine/solr/SolrConversionUtils.java
@@ -51,7 +51,6 @@ public class SolrConversionUtils {
 			SearchInputDocument doc) {
 		SolrInputDocument solrDoc = new SolrInputDocument(
 				convertToSolrInputFieldMap(doc.getFieldMap()));
-		solrDoc.setDocumentBoost(doc.getDocumentBoost());
 		return solrDoc;
 	}
 
@@ -81,11 +80,10 @@ public class SolrConversionUtils {
 			// No values, nothing to do.
 		} else if (values.size() == 1) {
 			// One value? Insure that it is accepted as such.
-			solrField.addValue(values.iterator().next(),
-					searchInputField.getBoost());
+			solrField.addValue(values.iterator().next());
 		} else {
 			// A collection of values? Add them.
-			solrField.addValue(values, searchInputField.getBoost());
+			solrField.addValue(values);
 		}
 
 		return solrField;
@@ -125,7 +123,6 @@ public class SolrConversionUtils {
 	 * Convert from a SearchQuery to a SolrQuery, so the Solr server may execute
 	 * it.
 	 */
-	@SuppressWarnings("deprecation")
 	static SolrQuery convertToSolrQuery(SearchQuery query) {
 		SolrQuery solrQuery = new SolrQuery(query.getQuery());
 		solrQuery.setStart(query.getStart());
@@ -141,7 +138,7 @@ public class SolrConversionUtils {
 
 		Map<String, Order> sortFields = query.getSortFields();
 		for (String sortField : sortFields.keySet()) {
-			solrQuery.addSortField(sortField,
+			solrQuery.addOrUpdateSort(sortField,
 					convertToSolrOrder(sortFields.get(sortField)));
 		}
 

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/servlet/setup/SolrSmokeTest.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/servlet/setup/SolrSmokeTest.java
@@ -235,7 +235,7 @@ public class SolrSmokeTest implements ServletContextListener {
 
 		private void tryToConnect() throws SolrProblemException {
 			try {
-				HttpGet method = new HttpGet(solrUrl.toExternalForm());
+				HttpGet method = new HttpGet(solrUrl.toExternalForm() + "/select");
 				SolrSmokeTest.log.debug("Trying to connect to Solr");
 				HttpResponse response = httpClient.execute(method);
 				try {

--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -207,7 +207,7 @@
         <dependency>
             <groupId>org.apache.solr</groupId>
             <artifactId>solr-solrj</artifactId>
-            <version>4.10.4</version>
+            <version>7.4.0</version>
         </dependency>
         <dependency>
             <groupId>org.directwebremoting</groupId>

--- a/installer/pom.xml
+++ b/installer/pom.xml
@@ -105,7 +105,7 @@
 
     <modules>
         <module>home</module>
-        <module>solr</module>
+        <!--<module>solr</module>-->
         <module>webapp</module>
     </modules>
 

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
         <module>api</module>
         <module>dependencies</module>
         <module>webapp</module>
-        <module>solr</module>
+        <!--<module>solr</module>-->
         <module>home</module>
     </modules>
 


### PR DESCRIPTION
Related to: https://jira.duraspace.org/browse/VIVO-1589

# What does this pull request do?
* Comments out the embedded solr modules
* Upgrades the Solr client library to 7.4.0

# What's new?
* This is an incremental step towards externalizing the Solr index
* Note: Search field `boost`s no longer appear to be supported in Solr7

# How should this be tested?
* Set up a stand-alone Solr7
* Create a "core" in the Solr7 web console
* Configure VIVO runtime.properties to point to the URL of the new core (note: omit the `#` in the URL)
* Enjoy!

# Interested parties
@hudajkhan , @roflinn 
