### PR TITLE
[VIVO-1600] Add ElasticSmokeTest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ utilities/sdb_to_tdb/.work
 **/target
 
 **/overlays
+*~
 
 # Eclipse artifacts
 **/.settings

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/servlet/setup/ElasticSmokeTest.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/servlet/setup/ElasticSmokeTest.java
@@ -1,0 +1,128 @@
+/* $This file is distributed under the terms of the license in LICENSE$ */
+
+package edu.cornell.mannlib.vitro.webapp.servlet.setup;
+
+import edu.cornell.mannlib.vitro.webapp.config.ConfigurationProperties;
+import edu.cornell.mannlib.vitro.webapp.startup.StartupStatus;
+import edu.cornell.mannlib.vitro.webapp.utils.http.HttpClientFactory;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.http.HttpResponse;
+import org.apache.http.HttpStatus;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.util.EntityUtils;
+
+import javax.servlet.ServletContextEvent;
+import javax.servlet.ServletContextListener;
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+
+/**
+ * If we can't connect to ElasticSearch, add a Warning item to the StartupStatus.
+ */
+public class ElasticSmokeTest {
+
+    private static final Log log = LogFactory.getLog(ElasticSmokeTest.class);
+
+    private final ServletContextListener listener;
+
+    public ElasticSmokeTest(ServletContextListener listener) {
+        this.listener = listener;
+    }
+
+    public void doTest(ServletContextEvent sce) {
+        final StartupStatus ss = StartupStatus.getBean(sce.getServletContext());
+
+        String elasticUrlString = ConfigurationProperties.getBean(sce).getProperty("vitro.local.elastic.url", "");
+        if (elasticUrlString.isEmpty()) {
+            ss.fatal(listener, "Can't connect to ElasticSearch engine. "
+                    + "runtime.properties must contain a value for "
+                    + "vitro.local.elastic.url");
+            return;
+        }
+
+        URL elasticUrl = null;
+
+        try {
+            elasticUrl = new URL(elasticUrlString);
+        } catch (MalformedURLException e) {
+            ss.fatal(listener, "Can't connect to ElasticSearch engine. "
+                    + "The value for vitro.local.elastic.url "
+                    + "in runtime.properties is not a valid URL: '"
+                    + elasticUrlString + "'", e);
+        }
+
+        ss.info(listener, "Starting ElasticSearch test.");
+
+        checkConnection(elasticUrl, ss);
+    }
+
+    private void checkConnection(URL elasticUrl, StartupStatus ss) {
+        try {
+            new ElasticPinger(elasticUrl).ping();
+            reportGoodPing(ss);
+        } catch (ElasticProblemException e) {
+            reportPingProblem(ss, e);
+        }
+    }
+
+    private void reportGoodPing(StartupStatus ss) {
+        ss.info(listener, "The ElasticSearch server responded to a 'ping'.");
+    }
+
+    private void reportPingProblem(StartupStatus ss, ElasticProblemException e) {
+        ss.warning(listener, "The ElasticSearch engine did not respond to a 'ping' request", e);
+    }
+
+    /**
+     * Issue a "ping" to ElasticSearch. If we get here, we've already established
+     * contact, so any error is a fatal one.
+     */
+    private static class ElasticPinger {
+        private final URL elasticUrl;
+        private final HttpClient httpClient = HttpClientFactory.getHttpClient();
+
+        public ElasticPinger(URL elasticUrl) {
+            this.elasticUrl = elasticUrl;
+        }
+
+        public void ping() throws ElasticProblemException {
+            try {
+                HttpGet method = new HttpGet(elasticUrl.toExternalForm());
+                log.debug("Trying to ping ElasticSearch");
+                HttpResponse response = httpClient.execute(method);
+                try {
+                    log.debug("Finished pinging ElasticSearch");
+                    int statusCode = response.getStatusLine().getStatusCode();
+                    if (statusCode != HttpStatus.SC_OK) {
+                        throw new ElasticProblemException(statusCode);
+                    }
+                } finally {
+                    EntityUtils.consume(response.getEntity());
+                }
+            } catch (IOException e) {
+                throw new ElasticProblemException(e);
+            }
+        }
+    }
+
+    private static class ElasticProblemException extends Exception {
+        private final int statusCode;
+
+        ElasticProblemException(int statusCode) {
+            super("HTTP status code = " + statusCode);
+            this.statusCode = statusCode;
+        }
+
+        ElasticProblemException(Throwable cause) {
+            super(cause);
+            this.statusCode = 0;
+        }
+
+        int getStatusCode() {
+            return this.statusCode;
+        }
+    }
+}

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/servlet/setup/SearchEngineSmokeTest.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/servlet/setup/SearchEngineSmokeTest.java
@@ -1,0 +1,48 @@
+/* $This file is distributed under the terms of the license in LICENSE$ */
+
+package edu.cornell.mannlib.vitro.webapp.servlet.setup;
+
+import edu.cornell.mannlib.vitro.webapp.config.ConfigurationProperties;
+import edu.cornell.mannlib.vitro.webapp.startup.StartupStatus;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import javax.servlet.ServletContextEvent;
+import javax.servlet.ServletContextListener;
+
+/**
+ * Start up the appropriate search engine smoke test based on the configured URL property.
+ */
+public class SearchEngineSmokeTest implements ServletContextListener {
+
+    private static final Log log = LogFactory.getLog(SearchEngineSmokeTest.class);
+
+    @Override
+    public void contextInitialized(ServletContextEvent sce) {
+        final StartupStatus ss = StartupStatus.getBean(sce.getServletContext());
+
+        String solrUrlString = ConfigurationProperties.getBean(sce).getProperty("vitro.local.solr.url", "");
+        String elasticUrlString = ConfigurationProperties.getBean(sce).getProperty("vitro.local.elastic.url", "");
+
+        if (!solrUrlString.isEmpty() && !elasticUrlString.isEmpty()) {
+            ss.fatal(this, "More than one search engine is configured: " + solrUrlString + ", and " + elasticUrlString);
+
+        } else if (solrUrlString.isEmpty() && elasticUrlString.isEmpty()) {
+            ss.fatal(this, "No search engine is configured");
+
+        } else if (!solrUrlString.isEmpty()) {
+            log.debug("Initializing Solr: " + solrUrlString);
+            new SolrSmokeTest(this).doTest(sce);
+
+        } else {
+            log.debug("Initializing ElasticSearch: " + elasticUrlString);
+            new ElasticSmokeTest(this).doTest(sce);
+        }
+    }
+
+    @Override
+    public void contextDestroyed(ServletContextEvent sce) {
+        // nothing to tear down.
+    }
+
+}

--- a/webapp/src/main/webapp/WEB-INF/resources/startup_listeners.txt
+++ b/webapp/src/main/webapp/WEB-INF/resources/startup_listeners.txt
@@ -67,5 +67,5 @@ org.apache.commons.fileupload.servlet.FileCleanerCleanup
 #   and the PermissionRegistry must already be set up.
 edu.cornell.mannlib.vitro.webapp.dao.jena.VClassGroupCache$Setup
 
-# This should be near the end, because it will issue a warning if the connection to Solr times out.
-edu.cornell.mannlib.vitro.webapp.servlet.setup.SolrSmokeTest
+# This should be near the end, because it will issue a warning if the connection to Solr or ElasticSearch times out.
+edu.cornell.mannlib.vitro.webapp.servlet.setup.SearchEngineSmokeTest


### PR DESCRIPTION
Resolves: https://jira.duraspace.org/browse/VIVO-1600

# What does this pull request do?
This pull-request adds the ElasticSmokeTest, as well as a general "SearchEngine" listener that delegates the actual smoke test to either Elastic or Solr, depending on the configuration property used in runtime.properties.

# What's new?
A SmokeTest for ElasticSearch!

# How should this be tested?
In `runtime.properties`, run the following scenarios:
1. Use an internal or external Solr with `vitro.local.solr.url = <solr-url>`
   - This should be successful (inspect "startup status")
1. Use an external ElasticSearch with `vitro.local.elastic.url = <elastic-url>`
   - This should be successful (inspect "startup status")
1. Do not configure either property: `vitro.local.solr.url` nor `vitro.local.elastic.url`
   - This should fail (inspect "startup status")
1. Configure both properties: `vitro.local.solr.url` and `vitro.local.elastic.url`
   - This should fail (inspect "startup status")

# Interested parties
@VIVO-project/vivo-committers ...and Sprinters!
