### PR TITLE
[VIVO-1608] Fix node removal from the XML

### DIFF
--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/web/templatemodels/customlistview/CustomListViewConfigFile.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/web/templatemodels/customlistview/CustomListViewConfigFile.java
@@ -197,7 +197,12 @@ public class CustomListViewConfigFile {
 		 */
 		NodeList doomed = element.getElementsByTagName(tagName);
 		for (int i = doomed.getLength() - 1; i >= 0; i--) {
-			element.removeChild(doomed.item(i));
+			/*
+			 * As the node to be removed may be at an arbitrary depth in the DOM tree,
+			 * we need to get the parent of the node that we are trying to remove,
+			 * and then remove the child from there.
+			 */
+			doomed.item(i).getParentNode().removeChild(doomed.item(i));
 		}
 	}
 


### PR DESCRIPTION
**[VIVO-1608](https://jira.duraspace.org/browse/VIVO-1608)**:

# What does this pull request do?
Fixes the problem that filtering the list view config XML results in errors being logged when there are nested elements

# Interested parties
@gneissone 
