### PR TITLE
[VIVO-1613] Fix menu ordering bug

### DIFF
--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/dao/jena/WebappDaoFactoryJena.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/dao/jena/WebappDaoFactoryJena.java
@@ -365,10 +365,8 @@ public class WebappDaoFactoryJena implements WebappDaoFactory {
     @Override
 	public ObjectPropertyStatementDao getObjectPropertyStatementDao() {
         if( objectPropertyStatementDao == null )
-            // TODO supply a valid RDFService as the first argument if we keep this
-            // implementation
             objectPropertyStatementDao = new ObjectPropertyStatementDaoJena(
-                    null, dwf, this);
+                    rdfService, dwf, this);
         return objectPropertyStatementDao;
     }
 


### PR DESCRIPTION
**[VIVO-1613](https://jira.duraspace.org/browse/VIVO-1613)**:

# What does this pull request do?
Fixes problem of a blank menu ordering page

# What's new?
None

# How should this be tested?
Visit the menu ordering page in site admin - it should be populated, and allow you to re-order the entries

# Additional Notes:
OK, here's the kicker.

The issue that this commit addresses was introduced in 2012(!), when the RDFService was being implemented, and it was never passed through to the ObjectPropertyStatementDAO.

This means that: for menu ordering to be working in prior releases, then something else must have changed to use this code path.

# Interested parties
@VIVO-project/vivo-committers
