### PR TITLE
[VIVO-1620] Improve AuthenticateTest performance

### DIFF
--- a/api/src/test/java/edu/cornell/mannlib/vitro/webapp/controller/edit/AuthenticateTest.java
+++ b/api/src/test/java/edu/cornell/mannlib/vitro/webapp/controller/edit/AuthenticateTest.java
@@ -163,10 +163,9 @@ public class AuthenticateTest extends AbstractTestClass {
 		
 		userAccountsDao = new UserAccountsDaoStub();
 		userAccountsDao.addPermissionSet(adminPermissionSet);
-		userAccountsDao.addUser(createUserFromUserInfo(NEW_DBA));
-		userAccountsDao.addUser(createUserFromUserInfo(OLD_DBA));
-		userAccountsDao.addUser(createUserFromUserInfo(OLD_SELF));
-		userAccountsDao.addUser(createUserFromUserInfo(OLD_STRANGER));
+		for (UserAccount account : userAccounts) {
+			userAccountsDao.addUser(account);
+		}
 
 		individualDao = new IndividualDaoStub();
 

--- a/api/src/test/java/edu/cornell/mannlib/vitro/webapp/controller/edit/AuthenticateTest.java
+++ b/api/src/test/java/edu/cornell/mannlib/vitro/webapp/controller/edit/AuthenticateTest.java
@@ -10,15 +10,18 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
 import org.apache.log4j.Level;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
 
@@ -119,16 +122,33 @@ public class AuthenticateTest extends AbstractTestClass {
 	private static final String NO_USER = "";
 	private static final String NO_MSG = "";
 
+	/**
+	 * Due to increased overhead of password hashing, create a list of UserAccount objects once
+	 * when the class is cloaded.
+	 *
+	 * These prepared user accounts will then be (re)used to populate the authenticator stubs prior to each test
+	 */
+	private static List<UserAccount> userAccounts = new ArrayList<>();
+
+	@BeforeClass
+	public static void prepareUserAccounts() {
+		userAccounts.add(createUserFromUserInfo(NEW_DBA));
+		userAccounts.add(createUserFromUserInfo(OLD_DBA));
+		userAccounts.add(createUserFromUserInfo(OLD_SELF));
+		userAccounts.add(createUserFromUserInfo(OLD_STRANGER));
+	}
+
 	@Before
 	public void setup() throws Exception {
 		I18nStub.setup();
 
 		authenticatorFactory = new AuthenticatorStub.Factory();
 		authenticator = authenticatorFactory.getInstance(request);
-		authenticator.addUser(createUserFromUserInfo(NEW_DBA));
-		authenticator.addUser(createUserFromUserInfo(OLD_DBA));
-		authenticator.addUser(createUserFromUserInfo(OLD_SELF));
-		authenticator.addUser(createUserFromUserInfo(OLD_STRANGER));
+
+		for (UserAccount account : userAccounts) {
+			authenticator.addUser(account);
+		}
+
 		authenticator.setAssociatedUri(OLD_SELF.username,
 				"old_self_associated_uri");
 
@@ -186,7 +206,7 @@ public class AuthenticateTest extends AbstractTestClass {
 				new HasPermissionFactory(servletContext));
 	}
 
-	private UserAccount createUserFromUserInfo(UserInfo userInfo) {
+	private static UserAccount createUserFromUserInfo(UserInfo userInfo) {
 		UserAccount user = new UserAccount();
 		user.setEmailAddress(userInfo.username);
 		user.setUri(userInfo.uri);


### PR DESCRIPTION
**[VIVO-1620](https://jira.duraspace.org/browse/VIVO-1620)**:

# What does this pull request do?
Improves the performance of the AuthenticateTest .

# What's new?
Instead of the user accounts being created - twice - prior to every single test method, this patch creates a list of user account objects once during the startup of the class, then prior to each test method it is this list of previously created user accounts that are used to populate the authenticator and user accounts dao.

In testing on Windows, this saves around 30-35 seconds of build time, because the Argon hashing is only done once per user account, rather multiple times as each user account is recreated on every single test.

No changes have been made to any of the tests themselves, only the initialisation code.

# How should this be tested?
Run the build with unit tests enabled - all of the unit tests should complete successfully, and the build time of the Vitro API should be reduced by around 30 seconds.

# Interested parties
@VIVO-project/vivo-committers
