### PR TITLE
[VIVO-1543] Removing non existing flash.html file inclusion in page.ftl template

### DIFF
--- a/webapp/src/main/webapp/templates/freemarker/page/page.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/page/page.ftl
@@ -24,7 +24,7 @@
         <hr class="hidden" />
 
         <div id="contentwrap">
-  
+			<#include "flash.ftl">
             <div id="content">                      
                 ${body}
             </div> <!-- content -->

--- a/webapp/src/main/webapp/templates/freemarker/page/page.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/page/page.ftl
@@ -24,8 +24,7 @@
         <hr class="hidden" />
 
         <div id="contentwrap">
-            <#include "flash.html">
-
+  
             <div id="content">                      
                 ${body}
             </div> <!-- content -->

--- a/webapp/src/main/webapp/templates/freemarker/page/page.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/page/page.ftl
@@ -24,7 +24,8 @@
         <hr class="hidden" />
 
         <div id="contentwrap">
-			<#include "flash.ftl">
+            <#include "flash.ftl">
+
             <div id="content">                      
                 ${body}
             </div> <!-- content -->


### PR DESCRIPTION
The PR removes non existing flash.html file inclusion in page.ftl template

**[JIRA Issue]: https://jira.duraspace.org/browse/VIVO-1543

# What does this pull request do?
It just removes an inclusion to non existent file

# How should this be tested?
A description of what steps someone could take to:

* Reproduce the problem you are fixing (if applicable)
Switch to develop branch 
Rename the page.ftl template (to page.ftl.bak for instance) in your preferred theme. 
Run VIVO with that theme
You will get a 500 error on pages different from the home page 

* Test that the pull request does what is intended.
Rename the page.ftl (to page.ftl.bak for instance) template in your preferred theme.
Run the application, it should work properly (no  500 error)

# Interested parties
@gneissone, @mconlon17, @awoods, @VIVO-project/vivo-committers
