### PR TITLE
[VIVO-1639] Improve display of search results -- remove class names

### DIFF
--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/searchindex/tasks/UpdateDocumentWorkUnit.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/searchindex/tasks/UpdateDocumentWorkUnit.java
@@ -176,8 +176,6 @@ public class UpdateDocumentWorkUnit implements Runnable {
 					classGroupUris.add(classGroupUri);
 				}
 
-				addToAlltext(doc, clz.getName());
-
 				Float boost = clz.getSearchBoost();
 				if (boost != null) {
 					doc.setDocumentBoost(doc.getDocumentBoost() + boost);


### PR DESCRIPTION
**[JIRA Issue [VIVO-1639] Improve display of search results -- remove class names](https://jira.duraspace.org/browse/VIVO-1639)**

# What does this pull request do?
It improves the search results by removing the list of classes names.

# What's new?
The line `addToAlltext(doc, clz.getName());` is being removed from [UpdateDocumentWorkUnit.java](https://github.com/vivo-project/Vitro/blob/1570f529571b924029b401fd918f43144e35afdf/api/src/main/java/edu/cornell/mannlib/vitro/webapp/searchindex/tasks/UpdateDocumentWorkUnit.java).

# Interested parties
@VIVO-project/vivo-committers