### PR TITLE
[VIVO-1649] fix for RDFServiceSparql.executeUpdate method

### DIFF
--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/rdfservice/impl/sparql/RDFServiceSparql.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/rdfservice/impl/sparql/RDFServiceSparql.java
@@ -504,7 +504,7 @@ public class RDFServiceSparql extends RDFServiceImpl implements RDFService {
 				int statusCode = response.getStatusLine().getStatusCode();
 				if (statusCode > 399) {
 					log.error("response " + response.getStatusLine() + " to update. \n");
-					log.debug("update string: \n" + updateString);
+					//log.debug("update string: \n" + updateString);
 					throw new RDFServiceException("Unable to perform SPARQL UPDATE");
 				}
 			} finally {

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/rdfservice/impl/sparql/RDFServiceSparql.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/rdfservice/impl/sparql/RDFServiceSparql.java
@@ -19,6 +19,7 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.apache.http.Consts;
 import org.apache.http.HttpResponse;
 import org.apache.http.auth.AuthScope;
 import org.apache.http.auth.AuthenticationException;
@@ -495,21 +496,22 @@ public class RDFServiceSparql extends RDFServiceImpl implements RDFService {
 	protected void executeUpdate(String updateString) throws RDFServiceException {
 		try {
 			HttpPost meth = new HttpPost(updateEndpointURI);
-			meth.addHeader("Content-Type", "application/x-www-form-urlencoded");
-			meth.setEntity(new UrlEncodedFormEntity(Arrays.asList(new BasicNameValuePair("update", updateString))));
+			meth.addHeader("Content-Type", "application/x-www-form-urlencoded; charset="+Consts.UTF_8);
+			meth.setEntity(new UrlEncodedFormEntity(Arrays.asList(new BasicNameValuePair("update", updateString)),Consts.UTF_8));
 			HttpContext context = getContext(meth);
 			HttpResponse response = context != null ? httpClient.execute(meth, context) : httpClient.execute(meth);
 			try {
 				int statusCode = response.getStatusLine().getStatusCode();
 				if (statusCode > 399) {
 					log.error("response " + response.getStatusLine() + " to update. \n");
-					//log.debug("update string: \n" + updateString);
+					log.debug("update string: \n" + updateString);
 					throw new RDFServiceException("Unable to perform SPARQL UPDATE");
 				}
 			} finally {
 				EntityUtils.consume(response.getEntity());
 			}
 		} catch (Exception e) {
+			log.debug("update string: \n" + updateString);
 			throw new RDFServiceException("Unable to perform change set update", e);
 		}
 	}


### PR DESCRIPTION

**[JIRA Issue](https://jira.duraspace.org/projects/VIVO)**: https://jira.duraspace.org/browse/VIVO-1649

# What does this pull request do?
fix for  RDFServiceSparql.executeUpdate method;
the problem is an "Unable to perform change set update" exception uploading utf-8 data "geopolitical.abox.ver1.1-11-18-11.owl" on sparql blazegraph at startup. 

# What's new?
fixed specifying the encoding utf-8

# How should this be tested?
with a "test" namespace on a localhost blazegraph instance:

applicationSetup.n3 configuration:

:application 
    :hasContentTripleSource       :sparqlContentTripleSource ;

:sparqlContentTripleSource
    a   vitroWebapp:triplesource.impl.sparql.ContentTripleSourceSPARQL ,
        vitroWebapp:modules.tripleSource.ContentTripleSource ;
    # The URI of the SPARQL endpoint for your triple-store.
    :hasEndpointURI "http://localhost:9999/blazegraph/namespace/test/sparql" ;
    # The URI to use for SPARQL UPDATE calls against your triple-store. 
    :hasUpdateEndpointURI "http://localhost:9999/blazegraph/namespace/test/sparql" .

# Interested parties
@VIVO-project/vivo-committers
