### PR TITLE
[VIVO-1525] Update YASQE to fix SPARQL query page freeze issue

### DIFF
--- a/webapp/src/main/webapp/templates/freemarker/body/admin/admin-sparqlQueryForm.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/body/admin/admin-sparqlQueryForm.ftl
@@ -31,6 +31,6 @@
     </form>
 </div><!-- content -->
 
-${stylesheets.add('<link rel="stylesheet" href="//cdn.jsdelivr.net/yasqe/2.6.1/yasqe.min.css" />')}
-${scripts.add('<script type="text/javascript" src="//cdn.jsdelivr.net/yasqe/2.6.1/yasqe.bundled.min.js"></script>',
+${stylesheets.add('<link rel="stylesheet" href="//cdn.jsdelivr.net/npm/yasgui-yasqe@2.11.22/dist/yasqe.min.css" />')}
+${scripts.add('<script type="text/javascript" src="//cdn.jsdelivr.net/npm/yasgui-yasqe@2.11.22/dist/yasqe.bundled.min.js"></script>',
 '<script type="text/javascript" src="${urls.base}/js/sparql/init-yasqe.js"></script>')}


### PR DESCRIPTION
**[JIRA Issue](https://jira.duraspace.org/browse/VIVO-1525)**: https://jira.duraspace.org/browse/VIVO-1525

* Other Relevant Links (Mailing list discussion, related pull requests, etc.)
[Issue and discussion on YASQE GitHub ](https://github.com/OpenTriply/YASGUI.YASQE/issues/135)

# What does this pull request do?
Fixes issue where SPARQL query page freezes if adding a new prefix in a certain situation by updating YASQE include to the latest version. 

# What's new?
Changes the javascript library include from 2.6.1 to 2.11.22

# How should this be tested?
* Reproduce the problem you are fixing (if applicable)
Create a SPARQL query where the last prefix in the query is on the same line as the beginning of the SELECT or CONSTRUCT statement. Then, try to add a new triple to the query containing a prefix not already in the prefixes list. The browser should lock up (tested using Chrome). For example, try adding (type, don't copy and paste) `?s a vivo:FacultyMember` beneath `?s a foaf:Person` on the following query:
```
PREFIX foaf: <http://xmlns.com/foaf/0.1/> SELECT * WHERE
{
  ?s a foaf:Person .
}
```

* Test that the pull request does what is intended.
Build with fix, write a similar SPARQL query as above. The new prefix should be appended to the top and the browser will not freeze.

# Interested parties
@VIVO-project/vivo-committers
