### PR TITLE
[VIVO-1619] Create weblinks for data properties that have a range of anyURI and begin with http 

### DIFF
--- a/webapp/src/main/webapp/templates/freemarker/body/partials/individual/propStatement-dataDefault.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/body/partials/individual/propStatement-dataDefault.ftl
@@ -6,15 +6,19 @@
      is also used to generate the property statement during a deletion.  
  -->
 <#import "lib-datetime.ftl" as dt>
+<#import "lib-meta-tags.ftl" as lmt>
 <#if property.rangeDatatypeURI?? && property.rangeDatatypeURI?contains("#")>
 	<#assign datatype = property.rangeDatatypeURI?substring(property.rangeDatatypeURI?last_index_of("#")+1) />
 <#else>
 	<#assign datatype = "none" />
 </#if>
-<@showStatement statement datatype />
-
-<#macro showStatement statement datatype>
+<@showStatement statement property datatype />
+<#macro showStatement statement property datatype>
     <#assign theValue = statement.value />
+
+    <#if datatype == "anyURI" && theValue?starts_with("http")>
+	<#assign theValue = "<a href=\"" + statement.value + "\" target=\"_blank\">" + statement.value + "</a>" />
+    </#if>
 	
     <#if theValue?contains("<ul>") >
         <#assign theValue = theValue?replace("<ul>","<ul class='tinyMCEDisc'>") />
@@ -43,7 +47,8 @@
 	<#else>
     	${theValue} <#if !datatype?contains("none")> <@validateFormat theValue datatype/> </#if>
 	</#if>
-</#macro> 
+	<@lmt.addCitationMetaTag uri=(property.uri!) content=(theValue!) />
+</#macro>
 <#macro validateFormat value datatype >
 	<#if datatype?? >
 		<#switch datatype>

--- a/webapp/src/main/webapp/templates/freemarker/lib/lib-meta-tags.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/lib/lib-meta-tags.ftl
@@ -1,0 +1,4 @@
+<#-- $This file is distributed under the terms of the license in LICENSE$ -->
+
+<#macro addCitationMetaTag uri="" content="">
+</#macro>


### PR DESCRIPTION
[VIVO-1619](https://jira.duraspace.org/browse/VIVO-1619)

Corresponding VIVO pull request https://github.com/vivo-project/VIVO/pull/94
See VIVO pull request for discussion thread.

Upon approval of this pull request we will remove the propStatement-dataDefault.ftl file from the VIVO repo because it is a duplicate of this file in Vitro.

# What does this pull request do?
Identifiers that are data properties do not link to a URL even if the range is set to URL.
This change displays the data property value as a weblink IF it is of range URL AND it contains the string http.

# What's new?
Updated the propStatement-dataDefault.ftl file to test the range and value and create a weblink.
All data properties that have a range of URL AND have http in the value will display as a link.
There is no additional verification of the value. This validation should happen upstream in the VIVO ETL or as the user is entering the data.

Example:

Changes https://github.com/delsborg to a hyperlink
How should this be tested?
Deploy this change
Create a modify a data property and set the range to URL.
Add some data to the data property.
Verify that the data property is now a hyperlink.

# Additional Notes:
This has been tested in CU Boulders version 1.9.3 development instance.
Somebody still needs to test this in the latest Vitro/Vivo develop branch.
I would like to see if this can also be applied to a maintenance patch in version 1.9.3 such that we can update our local VIVO repo from that and keep things in sync.

# Example:

Documentation regarding linking to external sties should be updated. It is currently sparse and difficult to identify how to link to external sites.
Does this change add any new dependencies? NO
Does this change require any other modifications to be made to the repository? No
Could this change impact execution of existing code? NO
