### PR TITLE
[VIVO-1641] Replace afn:localname / afn:namespace with cross-platform equivalent

### DIFF
--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/dao/VitroVocabulary.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/dao/VitroVocabulary.java
@@ -32,8 +32,6 @@ public class VitroVocabulary {
     public static final String OWL = "http://www.w3.org/2002/07/owl#";
     public static final String OWL_ONTOLOGY = OWL+"Ontology";
     public static final String OWL_THING = OWL+"Thing";
-    
-    public static final String AFN = "http://jena.apache.org/ARQ/function#";
 
     public static final String label = vitroURI + "label";
     

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/dao/jena/JenaBaseDao.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/dao/jena/JenaBaseDao.java
@@ -1164,13 +1164,6 @@ public class JenaBaseDao extends JenaBaseDaoCon {
     	
     	String describeQueryStr =    "DESCRIBE <" + res.getURI() + ">" ;
     	
-//    	?	"PREFIX afn: <http://jena.apache.org/ARQ/function#> \n\n" +
-//    		"DESCRIBE ?bnode \n" +
-//    	    "WHERE { \n" +
-//    		"    FILTER(afn:bnode(?bnode) = \"" + res.getId().toString() + "\")\n" +
-//    		"    ?bnode ?p ?o \n" +
-//    	    "}"
-    	 
 	    Query describeQuery = QueryFactory.create(describeQueryStr, Syntax.syntaxARQ);
 		QueryExecution qe = QueryExecutionFactory.create(describeQuery, ontModel);
 		qe.execDescribe(temp);

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/dao/jena/JenaModelUtils.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/dao/jena/JenaModelUtils.java
@@ -258,8 +258,7 @@ public class JenaModelUtils {
         dataset.getLock().enterCriticalSection(Lock.READ);
         try {
             StringBuilder buff = new StringBuilder();
-            buff.append("PREFIX afn: <http://jena.apache.org/ARQ/function#> \n")
-                    .append("CONSTRUCT { \n").append("  ?res <").append(property.getURI()).append("> ?o } WHERE { \n");
+            buff.append("CONSTRUCT { \n").append("  ?res <").append(property.getURI()).append("> ?o } WHERE { \n");
             if (graphURI != null) {
                 buff.append("    GRAPH ").append(graphURI).append(" { \n");
             }
@@ -289,7 +288,6 @@ public class JenaModelUtils {
         
         StringBuilder describeQueryStrBuff = new StringBuilder()
             .append("PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> \n")
-            .append("PREFIX afn: <http://jena.apache.org/ARQ/function#> \n")
             .append("DESCRIBE ?res WHERE { \n");
             if (graphURI != null) {
                 describeQueryStrBuff.append("GRAPH ").append(graphURI).append("{ \n");
@@ -319,7 +317,7 @@ public class JenaModelUtils {
             // exclude resources in the Vitro internal namespace or in the 
             // OWL namespace, but allow all others
             buff
-            .append("    FILTER (afn:namespace(?res) != \"")
+            .append("    FILTER (REPLACE(STR(?res),\"^(.*)(#)(.*)$\", \"$1$2\") != \"")
             .append("http://www.w3.org/2002/07/owl#")
             .append("\") \n")
             .append("    FILTER (?res != <")

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/dao/jena/PropertyDaoJena.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/dao/jena/PropertyDaoJena.java
@@ -55,7 +55,6 @@ public class PropertyDaoJena extends JenaBaseDao implements PropertyDao {
 	protected static final String FAUX_PROPERTY_FLAG = "FAUX";
 	
     private static final Map<String, String> NAMESPACES = new HashMap<String, String>() {{
-        put("afn", VitroVocabulary.AFN);
         put("owl", VitroVocabulary.OWL);
         put("rdf", VitroVocabulary.RDF);
         put("rdfs", VitroVocabulary.RDFS);

--- a/webapp/src/main/webapp/config/listViewConfig-default.xml
+++ b/webapp/src/main/webapp/config/listViewConfig-default.xml
@@ -7,7 +7,7 @@
 
 <list-view-config>
     <query-select>    
-        PREFIX afn:  &lt;http://jena.apache.org/ARQ/function#&gt;
+        
         PREFIX rdfs: &lt;http://www.w3.org/2000/01/rdf-schema#&gt;  
         PREFIX vitro: &lt;http://vitro.mannlib.cornell.edu/ns/vitro/0.7#&gt;
         
@@ -17,7 +17,7 @@
                ?localName
         WHERE {
             ?subject ?property ?object .
-            LET (?localName := afn:localname(?object))
+            LET (?localName := REPLACE(STR(?object),"^.*(#)(.*)$", "$2"))
                 
             OPTIONAL {
                 <precise-subquery>?subject ?property ?object .</precise-subquery>
@@ -33,7 +33,7 @@
                 # Aug 9-10, 2011.
                 # ?subclass vitro:inClassGroup ?classgroup 
             } 
-            FILTER ( afn:namespace(?subclass) != "http://vitro.mannlib.cornell.edu/ns/vitro/0.7#" )   
+            FILTER ( REPLACE(STR(?subclass),"^(.*)(#)(.*)$", "$1$2") != "http://vitro.mannlib.cornell.edu/ns/vitro/0.7#" )   
             </collated>       
         
         } ORDER BY <collated> ?subclass </collated> ASC( ?label ) ASC( ?label ) ASC( ?localName )

--- a/webapp/src/main/webapp/config/listViewConfig-hasElement.xml
+++ b/webapp/src/main/webapp/config/listViewConfig-hasElement.xml
@@ -8,10 +8,10 @@
 <list-view-config>
     <query-select>
         PREFIX display: &lt;http://vitro.mannlib.cornell.edu/ontologies/display/1.1#&gt;
-        PREFIX afn:  &lt;http://jena.apache.org/ARQ/function#&gt;
+        
         
         SELECT ?menuItem
-               (afn:localname(?menuItem) AS ?menuItemName)
+               (REPLACE(STR(?menuItem),"^.*(#)(.*)$", "$2") AS ?menuItemName)
                ?linkText
                ?menuPosition
         WHERE {


### PR DESCRIPTION

**[JIRA Issue](https://jira.duraspace.org/projects/VIVO)**: https://jira.duraspace.org/browse/VIVO-1641

# What does this pull request do?
It avoids the exception from the "afn:localname" / "afn:namespace" function that Blazegraph does not know.

# What's new?
The built in function "afn:localname" / "afn:namespace" is replaced with a regular expression

# Interested parties
@VIVO-project/vivo-committers
