### PR TITLE
[VIVO-1667] Language filtering for CONSTRUCT queries

### DIFF
--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/rdfservice/filter/LanguageFilteringRDFService.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/rdfservice/filter/LanguageFilteringRDFService.java
@@ -22,6 +22,7 @@ import org.apache.jena.query.ResultSetFormatter;
 import org.apache.jena.rdf.model.Literal;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelChangedListener;
+import org.apache.jena.rdf.model.ModelFactory;
 import org.apache.jena.rdf.model.RDFNode;
 import org.apache.jena.rdf.model.Statement;
 import org.apache.jena.rdf.model.StmtIterator;
@@ -90,8 +91,15 @@ public class LanguageFilteringRDFService implements RDFService {
     @Override
     public void sparqlConstructQuery(String query, Model model)
             throws RDFServiceException {
-        s.sparqlConstructQuery(query, model);
-        filterModel(model);
+        if (model.isEmpty()) {
+            s.sparqlConstructQuery(query, model);
+            filterModel(model);
+        } else {
+            Model constructedModel = ModelFactory.createDefaultModel();
+            s.sparqlConstructQuery(query, constructedModel);
+            filterModel(constructedModel);
+            model.add(constructedModel);
+        }
     }
 
     @Override

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/rdfservice/filter/LanguageFilteringRDFService.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/rdfservice/filter/LanguageFilteringRDFService.java
@@ -91,6 +91,7 @@ public class LanguageFilteringRDFService implements RDFService {
     public void sparqlConstructQuery(String query, Model model)
             throws RDFServiceException {
         s.sparqlConstructQuery(query, model);
+        filterModel(model);
     }
 
     @Override


### PR DESCRIPTION
**[VIVO-1667](https://jira.duraspace.org/browse/VIVO-1667)**:

# What does this pull request do?
Corrects a bug where one of the construct query methods in Language filtering RDF Service does not 

# What's new?
Nothing

# How should this be tested?
Requires multi-lingual features to be enabled.

Original problem can be observed by having multiple labels on a VCard URL (attached as hasURL to contact info of a profile). The websites field will display multiple entries, despite there only be a single VCard URL attached.

When applied, this patch will correct this, and only a single entry for the website will be displayed.

# Interested parties
@VIVO-project/vivo-committers
