### PR TITLE
Vivo 1642 dependency updates

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -56,7 +56,7 @@
         <dependency>
             <groupId>de.mkammerer</groupId>
             <artifactId>argon2-jvm</artifactId>
-            <version>2.4</version>
+            <version>2.5</version>
         </dependency>
         <dependency>
             <groupId>org.vivoweb</groupId>
@@ -71,22 +71,22 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>javax.servlet</groupId>
+            <groupId>javax.servlet.jsp</groupId>
             <artifactId>jsp-api</artifactId>
-            <version>2.0</version>
+            <version>2.2</version>
             <scope>provided</scope>
         </dependency>
 
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.11</version>
+            <version>4.12</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.easymock</groupId>
             <artifactId>easymock</artifactId>
-            <version>3.5</version>
+            <version>4.0.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/api/src/test/resources/edu/cornell/mannlib/vitro/webapp/edit/n3editing/testEditConfig.json
+++ b/api/src/test/resources/edu/cornell/mannlib/vitro/webapp/edit/n3editing/testEditConfig.json
@@ -2,7 +2,7 @@
     "formUrl" : "${formUrl}",
     "editKey" : "${editKey}",
 
-    "subject"   : ["series",    "${subjectUriJson}", ],
+    "subject"   : ["series",    "${subjectUriJson}" ],
     "predicate" : ["predicate", "${predicateUriJson}" ],
     "object"    : ["talk", "${objectUriJson}", "URI" ],
 

--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -68,27 +68,27 @@
         <dependency>
             <groupId>com.ibm.icu</groupId>
             <artifactId>icu4j</artifactId>
-            <version>59.1</version>
+            <version>63.1</version>
         </dependency>
         <dependency>
             <groupId>com.twelvemonkeys.imageio</groupId>
             <artifactId>imageio-jpeg</artifactId>
-            <version>3.3.2</version>
+            <version>3.4.1</version>
         </dependency>
         <dependency>
             <groupId>com.twelvemonkeys.imageio</groupId>
             <artifactId>imageio-tiff</artifactId>
-            <version>3.3.2</version>
+            <version>3.4.1</version>
         </dependency>
         <dependency>
             <groupId>com.twelvemonkeys.servlet</groupId>
             <artifactId>servlet</artifactId>
-            <version>3.3.2</version>
+            <version>3.4.1</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-dbcp2</artifactId>
-            <version>2.1.1</version>
+            <version>2.5.0</version>
         </dependency>
         <dependency>
             <groupId>commons-fileupload</groupId>
@@ -98,23 +98,23 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.5</version>
+            <version>2.6</version>
         </dependency>
         <dependency>
             <!-- NB: 3.5 conflicts with Jena 3.1.1 -->
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.4</version>
+            <version>3.8.1</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-collections4</artifactId>
-            <version>4.1</version>
+            <version>4.2</version>
         </dependency>
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
-            <version>5.1.46</version>
+            <version>5.1.47</version>
         </dependency>
         <dependency>
             <groupId>net.sf.jga</groupId>
@@ -130,12 +130,12 @@
         <dependency>
             <groupId>net.sf.saxon</groupId>
             <artifactId>Saxon-HE</artifactId>
-            <version>9.8.0-4</version>
+            <version>9.9.0-2</version>
         </dependency>
         <dependency>
             <groupId>net.sourceforge.owlapi</groupId>
             <artifactId>jfact</artifactId>
-            <version>5.0.1</version>
+            <version>5.0.3</version>
             <!-- Exclude OWLAPI OSGi bundle and include separately -->
             <exclusions>
                 <exclusion>
@@ -149,12 +149,12 @@
         <dependency>
             <groupId>net.sourceforge.owlapi</groupId>
             <artifactId>owlapi-api</artifactId>
-            <version>5.1.1</version>
+            <version>5.1.8</version>
         </dependency>
         <dependency>
             <groupId>net.sourceforge.owlapi</groupId>
             <artifactId>owlapi-apibinding</artifactId>
-            <version>5.1.1</version>
+            <version>5.1.8</version>
             <!-- Exclude rio binding as we don't use Sesame -->
             <exclusions>
                 <exclusion>
@@ -166,12 +166,12 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
-            <version>4.5.3</version>
+            <version>4.5.6</version>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpmime</artifactId>
-            <version>4.5.3</version>
+            <version>4.5.6</version>
         </dependency>
         <dependency>
             <groupId>org.apache.jena</groupId>
@@ -217,17 +217,17 @@
         <dependency>
             <groupId>org.freemarker</groupId>
             <artifactId>freemarker</artifactId>
-            <version>2.3.23</version>
+            <version>2.3.28</version>
         </dependency>
         <dependency>
             <groupId>org.jsoup</groupId>
             <artifactId>jsoup</artifactId>
-            <version>1.10.3</version>
+            <version>1.11.3</version>
         </dependency>
         <dependency>
             <groupId>org.owasp.antisamy</groupId>
             <artifactId>antisamy</artifactId>
-            <version>1.5.6</version>
+            <version>1.5.7</version>
         </dependency>
 
         <!-- Used for JSP runtime -->
@@ -250,7 +250,7 @@
         <dependency>
             <groupId>com.sun.mail</groupId>
             <artifactId>javax.mail</artifactId>
-            <version>1.6.0</version>
+            <version>1.6.2</version>
         </dependency>
     </dependencies>
 </project>

--- a/installer/webapp/pom.xml
+++ b/installer/webapp/pom.xml
@@ -157,8 +157,8 @@
 
         <dependency>
             <groupId>javax.servlet</groupId>
-            <artifactId>servlet-api</artifactId>
-            <version>2.5</version>
+            <artifactId>javax.servlet-api</artifactId>
+            <version>3.1.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/solr/pom.xml
+++ b/solr/pom.xml
@@ -44,7 +44,7 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>jcl-over-slf4j</artifactId>
-            <version>1.6.1</version>
+            <version>1.7.25</version>
         </dependency>
         <dependency>
             <groupId>com.vividsolutions</groupId>
@@ -54,22 +54,22 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>jul-to-slf4j</artifactId>
-            <version>1.6.1</version>
+            <version>1.7.25</version>
         </dependency>
         <dependency>
             <groupId>log4j</groupId>
             <artifactId>log4j</artifactId>
-            <version>1.2.16</version>
+            <version>1.2.17</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>1.6.1</version>
+            <version>1.7.25</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
-            <version>1.6.1</version>
+            <version>1.7.25</version>
         </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
** Upgrade dependencies in Vitro **
* * *

**[VIVO-1642](https://jira.duraspace.org/browse/VIVO-1642)**: 

# What does this pull request do?
Based on a pass through all the .pom files in Vitro and a comparison with what's available on https://mvnrepository.com, these changes bring all the dependency versions to the highest possible without breaking the build.  This is half of the work for card VIVO-1642, the other half being upgrading the dependencies in VIVO itself.  Another PR will be made to the develop branch of the VIVO repository when that work is complete.

# How should this be tested?
Ensure the build still works, tests pass, and the VIVO app deploys with the updated Vitro dependencies.

# Interested parties
@awoods 