### PR TITLE
Maint rel 1.9 vivo 1639  - Vitro maint-rel-1.9 fix

### DIFF
--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/searchindex/tasks/UpdateDocumentWorkUnit.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/searchindex/tasks/UpdateDocumentWorkUnit.java
@@ -176,8 +176,6 @@ public class UpdateDocumentWorkUnit implements Runnable {
 					classGroupUris.add(classGroupUri);
 				}
 
-				addToAlltext(doc, clz.getName());
-
 				Float boost = clz.getSearchBoost();
 				if (boost != null) {
 					doc.setDocumentBoost(doc.getDocumentBoost() + boost);


### PR DESCRIPTION
JIRA Issue [VIVO-1639] Improve display of search results -- remove class names
This is the same code change that was merged to develop. Purpose is to apply this to the 1.9 branch.


What does this pull request do?
It improves the search results by removing the list of classes names.

How to test
Build
Rebuild the search index
Do a search -- class names in the search results should be gone.
What's new?
The line addToAlltext(doc, clz.getName()); is being removed from UpdateDocumentWorkUnit.java.

Interested parties
@vivo-project/vivo-committers