### PR TITLE
[VIVO-1697] Add sanitization to fix SPARQL injection vulnerability

### DIFF
--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/dao/jena/IndividualSDB.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/dao/jena/IndividualSDB.java
@@ -118,6 +118,12 @@ public class IndividualSDB extends IndividualImpl implements Individual {
     	this.dwf = datasetWrapperFactory;
 		this.webappDaoFactory = wadf;
 
+		// Check that individualURI is valid. (Prevent SPARQL injection attack.)
+		// Valid syntax is defined here: https://www.w3.org/TR/rdf-sparql-query/#rIRI_REF
+		if (!individualURI.matches("[^<>\"{}|^`\\\\\u0000-\u0020]*")) {
+			throw new IndividualNotFoundException();
+		}
+
     	if (skipInitialization) {
             OntModel ontModel = ModelFactory.createOntologyModel(
                     OntModelSpec.OWL_MEM);


### PR DESCRIPTION
There is a SPARQL query injection vulnerability in VIVO. Below is an example of a request that triggers the vulnerability:

```
curl http://172.18.0.10:8080/vivo/individual?uri=http%3A%2F%2Fvivoweb.org%2Fontology%2Fcore%23FacultyMember%3E%20%3Fp%20%3Fo%20.%20FILTER%20regex%28%22aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa%21%22%2C%20%22%28.%2Aa%29%7B50%7D%22%29%20%7D%20%23%20
```

I sent an email to info@duraspace.org on 2019-01-21 to report this vulnerability. Nobody replied so I am posting this pull request to fix the issue.

I have written up the reproduction steps in more detail [here](https://github.com/kevinbackhouse/SecurityExploits/tree/b443c7044406857cefaa3e3715cf085070fa100d/vivo-project).

There are numerous places in the code that look like similar bugs, but I have not investigated whether any of the others are exploitable. I would recommend that you add sanitization to all of them though. You can see the list of source locations that should be fixed here:

https://lgtm.com/query/6380177318884151820/

I will apply for a CVE for this vulnerability.