### PR TITLE
[VIVO-1674] Improve quality of thumbnails created 

### DIFF
--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/imageprocessor/imageio/IIOImageProcessor.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/imageprocessor/imageio/IIOImageProcessor.java
@@ -15,14 +15,14 @@ import javax.imageio.ImageWriteParam;
 import javax.imageio.stream.ImageInputStream;
 import javax.imageio.stream.MemoryCacheImageInputStream;
 import javax.imageio.stream.MemoryCacheImageOutputStream;
-import java.awt.geom.AffineTransform;
-import java.awt.image.AffineTransformOp;
 import java.awt.image.BufferedImage;
+import java.awt.image.BufferedImageOp;
 import java.awt.image.ColorConvertOp;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import com.twelvemonkeys.image.ResampleOp;
 
 /**
  * Crop the main image as specified, and scale it to the correct size for a
@@ -151,11 +151,10 @@ public class IIOImageProcessor implements ImageProcessor {
 	}
 
 	private BufferedImage scaleImage(BufferedImage image, float scaleFactor) {
-		BufferedImage after = new BufferedImage(image.getWidth(), image.getHeight(), image.getType());
-		AffineTransform transform = AffineTransform.getScaleInstance(
-				scaleFactor, scaleFactor);
-		AffineTransformOp atoOp = new AffineTransformOp(transform, AffineTransformOp.TYPE_BICUBIC);
-		return atoOp.filter(image, after);
+		int newX = (int) (image.getWidth() * scaleFactor);
+		int newY = (int) (image.getHeight() * scaleFactor);
+		BufferedImageOp resampler = new ResampleOp(newX, newY, ResampleOp.FILTER_LANCZOS);
+		return resampler.filter(image, null);
 	}
 
 	private CropRectangle adjustCropRectangleToScaledImage(CropRectangle crop,


### PR DESCRIPTION
**[JIRA Issue](https://jira.duraspace.org/browse/VIVO-1674)**: VIVO-1674

# What does this pull request do?
Address issue with quality of thumbnails created when uploading an image 

# What's new?
Use Twelvemonkeys plugin for scaling thumbnails 
Adds additional logic to the jpg creation to allow us to set jpg compression level

# How should this be tested?
You can reproduce the issue by upload an image to VIVO. Observe the thumbnail that is created... it likely looks like it was cut out of a Norm's Diner menu in the 80s and somehow mimeographed onto the internet, i.e. not good. 
![thumbnail_harold_old](https://user-images.githubusercontent.com/10748475/52461122-d85b6580-2b2a-11e9-93ea-0d9f5f193907.jpg)

Build Vitro/VIVO with the changes. Thumbnails should now be much better looking.
![thumbnail_harold_new](https://user-images.githubusercontent.com/10748475/52461130-de514680-2b2a-11e9-9869-33eae45ae681.jpg)

# Additional Notes:
The twelvemonkeys plugin for ImageIO is already being included in [Vitro dependencies](https://github.com/vivo-project/Vitro/blob/f2656ba3d8ae67359567d5aecd92eb67ba743c62/dependencies/pom.xml#L74)

As always, improvements are welcome.

# Interested parties
@delsborg 
