### PR TITLE
Create initial format style enforcement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ utilities/sdb_to_tdb/.work
 **/.idea
 **/*.iml
 **/target
+*~
 
 **/overlays
 

--- a/checkstyle/pom.xml
+++ b/checkstyle/pom.xml
@@ -1,0 +1,7 @@
+<project>
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.vivoweb</groupId>
+  <artifactId>checkstyle</artifactId>
+  <version>1.11.0-SNAPSHOT</version>
+  <name>Vitro Checkstyle</name>
+</project>

--- a/checkstyle/src/main/resources/vitro-checkstyle/checkstyle-suppressions.xml
+++ b/checkstyle/src/main/resources/vitro-checkstyle/checkstyle-suppressions.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE suppressions PUBLIC
+    "-//Puppy Crawl//DTD Suppressions 1.1//EN"
+    "http://www.puppycrawl.com/dtds/suppressions_1_1.dtd">
+<suppressions>
+  <!-- Suppressions for Javadoc in Test classes -->
+  <suppress checks="JavadocMethod" files="src[/\\]test[/\\]java"/>
+  <suppress checks="JavadocType" files="src[/\\]test[/\\]java"/>
+
+  <!-- Suppressions for generated source files -->
+  <suppress checks=".*" files="[/\\]target[/\\]" />
+
+  <!-- Disables Javadoc requirement for all public methods. This suppression
+       is not recommended, but may be needed (temporarily) to allow checkstyle
+       to be applied to existing codebases. -->
+  <suppress checks="JavadocMethod" files="src[/\\]main[/\\]java"/>
+
+  <!-- No tab characters ('\t') allowed in the source code -->
+  <suppress checks="FileTabCharacter" files="src"/>
+
+  <!-- No Trailing Whitespace, except on lines that only have an asterisk (e.g. Javadoc comments) -->
+  <suppress checks="RegexpSingleline" files=".*\.java"/>
+
+  <!-- Maximum line length is 120 characters -->
+  <suppress checks="LineLength" files=".*\.java"/>
+
+  <!-- Highlight any TODO or FIXME comments in info messages -->
+  <suppress checks="TodoComment" files=".*\.java"/>
+
+  <!-- ##### Import statement requirements ##### -->
+  <!-- Star imports (e.g. import java.util.*) are NOT ALLOWED -->
+  <suppress checks="AvoidStarImport" files=".*\.java"/>
+  <!-- Redundant import statements are NOT ALLOWED -->
+  <suppress checks="RedundantImport" files=".*\.java"/>
+  <!-- Unused import statements are NOT ALLOWED -->
+  <suppress checks="UnusedImports" files=".*\.java"/>
+  <!-- Ensure imports appear alphabetically and grouped -->
+  <suppress checks="CustomImportOrder" files=".*\.java"/>
+
+
+  <!-- ##### Requirements for K&R Style braces ##### -->
+  <!-- Code blocks MUST HAVE braces, even single line statements (if, while, etc) -->
+  <suppress checks="NeedBraces" files=".*\.java"/>
+  <!-- Left braces should be at the end of current line (default value)-->
+  <suppress checks="LeftCurly" files=".*\.java"/>
+  <!-- Right braces should be on start of a new line (default value) -->
+  <suppress checks="RightCurly" files=".*\.java"/>
+
+  <!-- ##### Indentation / Whitespace requirements ##### -->
+  <!-- Require 4-space indentation (default value) -->
+  <suppress checks="Indentation" files=".*\.java"/>
+  <!-- Whitespace should exist around all major tokens -->
+  <suppress checks="WhitespaceAround" files=".*\.java"/>
+
+  <!-- Validate whitespace around Generics (angle brackets) per typical conventions
+       http://checkstyle.sourceforge.net/config_whitespace.html#GenericWhitespace -->
+  <suppress checks="GenericWhitespace" files=".*\.java"/>
+
+  <!-- ##### Blank line requirements ##### -->
+  <suppress checks="EmptyLineSeparator" files=".*\.java"/>
+
+  <!-- ##### Requirements for "switch" statements ##### -->
+  <!-- "switch" statements MUST have a "default" clause -->
+  <suppress checks="MissingSwitchDefault" files=".*\.java"/>
+  <!-- "case" clauses in switch statements MUST include break, return, throw or continue -->
+  <suppress checks="FallThrough" files=".*\.java"/>
+
+  <!-- ##### Other / Miscellaneous requirements ##### -->
+  <!-- Require utility classes do not have a public constructor -->
+  <suppress checks="HideUtilityClassConstructor" files=".*\.java"/>
+  <!-- Require each variable declaration is its own statement on its own line -->
+  <suppress checks="MultipleVariableDeclarations" files=".*\.java"/>
+  <!-- Each line of code can only include one statement -->
+  <suppress checks="OneStatementPerLine" files=".*\.java"/>
+  <!-- Require that "catch" statements are not empty (must at least contain a comment) -->
+  <suppress checks="EmptyCatchBlock" files=".*\.java"/>
+
+  <!-- Require that 'final' used on variables and parameters -->
+  <suppress checks="FinalLocalVariable" files=".*.java"/>
+  <suppress checks="FinalParameters" files=".*.java"/>
+</suppressions>

--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,7 @@
     </properties>
 
     <modules>
+        <module>checkstyle</module>
         <module>api</module>
         <module>dependencies</module>
         <module>webapp</module>
@@ -267,6 +268,54 @@
                     <skip>${maven-site-plugin.skip}</skip>
                     <stagingDirectory>${stagingBase}/vitro/${project.version}</stagingDirectory>
                 </configuration>
+            </plugin>
+
+            <!-- Used to validate all code style rules in source code using Checkstyle -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+                <version>3.0.0</version>
+                <executions>
+                    <execution>
+                        <id>verify-style</id>
+                        <!-- Bind to verify so it runs after package & unit tests, but before install -->
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <configLocation>
+                      duraspace-checkstyle/checkstyle.xml
+                    </configLocation>
+                    <suppressionsLocation>
+                      vitro-checkstyle/checkstyle-suppressions.xml
+                    </suppressionsLocation>
+                    <encoding>UTF-8</encoding>
+                    <consoleOutput>true</consoleOutput>
+                    <logViolationsToConsole>true</logViolationsToConsole>
+                    <failOnViolation>true</failOnViolation>
+                    <includeTestSourceDirectory>true</includeTestSourceDirectory>
+                </configuration>
+                <dependencies>
+                    <!-- Override dependencies to use latest version of checkstyle -->
+                    <dependency>
+                        <groupId>com.puppycrawl.tools</groupId>
+                        <artifactId>checkstyle</artifactId>
+                        <version>8.18</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.duraspace</groupId>
+                        <artifactId>codestyle</artifactId>
+                        <version>1.0.0</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.vivoweb</groupId>
+                        <artifactId>checkstyle</artifactId>
+                        <version>1.11.0-SNAPSHOT</version>
+                    </dependency>
+                </dependencies>
             </plugin>
         </plugins>
         <pluginManagement>


### PR DESCRIPTION
- All rules are initially suppressed

Resolves: https://jira.duraspace.org/browse/VIVO-1692

# What does this pull request do?
Adds checkstyle Maven tooling. Initially, the checkstyle rules are suppressed.

# How should this be tested?
The build should work as normal (no change).
However, in order to test that the checkstyle machinery works, you can comment out any of the suppression rules, such as:
https://github.com/vivo-project/Vitro/compare/develop...awoods:vivo-1692?expand=1#diff-d3455d71ca9aa05152222bc3d6ae20ddR19
..the build should fail with checkstyle errors.

# Interested parties
@VIVO-project/vivo-committers
