### PR TITLE
VIVO-1694 Faceted browsing in browse and search page - Cineca custom

### DIFF
--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/dao/filtering/IndividualFiltering.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/dao/filtering/IndividualFiltering.java
@@ -565,5 +565,9 @@ public class IndividualFiltering implements Individual {
 	public void resolveAsFauxPropertyStatements(List<ObjectPropertyStatement> list) {
 		_innerIndividual.resolveAsFauxPropertyStatements(list);
 	}
+	
+    public Individual get_innerIndividual() {
+		return _innerIndividual;
+	}
 
 }

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/searchengine/base/BaseSearchInputField.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/searchengine/base/BaseSearchInputField.java
@@ -42,6 +42,14 @@ public class BaseSearchInputField implements SearchInputField {
 		valueList.addAll(values);
 	}
 
+	public void setValue(Object value) {
+		if(valueList.size()==1) {
+			valueList.set(0, value);
+		}else if(valueList.size()==0) {
+			valueList.add(value);
+		}
+	}
+	
 	@Override
 	public void setBoost(float boost) {
 		this.boost = boost;

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/searchindex/documentBuilding/FacetConfig.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/searchindex/documentBuilding/FacetConfig.java
@@ -1,0 +1,33 @@
+package edu.cornell.mannlib.vitro.webapp.searchindex.documentBuilding;
+
+import org.json.JSONObject;
+
+public class FacetConfig  {
+	
+	 public String configContextFor = null;
+	 public String qualifiedBy = null;
+	 public JSONObject pivotsIndexProperty = null;
+	 public String regexp = null;
+	 public String regexpreplace = null;
+	
+	 public FacetConfig(JSONObject jo) {
+
+		 if(jo.has("qualifiedBy")) {
+			 qualifiedBy = jo.getString("qualifiedBy");
+		 }
+		 if(jo.has("configContextFor")) {
+			 configContextFor = jo.getString("configContextFor");
+		 }
+		 if(jo.has("pivotsIndexProperty")) {
+		  pivotsIndexProperty = jo.getJSONObject("pivotsIndexProperty");
+		 }
+		 
+		 if(jo.has("regexp")) {
+			 regexp = jo.getString("regexp");
+		 }
+		 if(jo.has("regexpreplace")) {
+			 regexpreplace = jo.getString("regexpreplace");
+		 }
+		 
+ 	 } 
+}

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/searchindex/documentBuilding/JsonFacetsModifier.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/searchindex/documentBuilding/JsonFacetsModifier.java
@@ -1,0 +1,292 @@
+/* $This file is distributed under the terms of the license in LICENSE$ */
+
+package edu.cornell.mannlib.vitro.webapp.searchindex.documentBuilding;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import edu.cornell.mannlib.vitro.webapp.beans.Individual;
+import edu.cornell.mannlib.vitro.webapp.beans.ObjectProperty;
+import edu.cornell.mannlib.vitro.webapp.beans.ObjectPropertyStatement;
+import edu.cornell.mannlib.vitro.webapp.beans.VClass;
+import edu.cornell.mannlib.vitro.webapp.dao.filtering.IndividualFiltering;
+import edu.cornell.mannlib.vitro.webapp.dao.jena.IndividualSDB;
+import edu.cornell.mannlib.vitro.webapp.modules.searchEngine.SearchInputDocument;
+import edu.cornell.mannlib.vitro.webapp.modules.searchEngine.SearchInputField;
+import edu.cornell.mannlib.vitro.webapp.searchengine.base.BaseSearchInputField;
+import edu.cornell.mannlib.vitro.webapp.servlet.setup.JSONFilesLoader;
+
+public class JsonFacetsModifier implements DocumentModifier {
+	
+    private static final Log log = LogFactory.getLog(JsonFacetsModifier.class);
+
+    @Override
+    public void modifyDocument(Individual individual, SearchInputDocument doc) {
+        indexIndividual(individual, doc);
+    }
+
+    @Override
+    public void shutdown() {
+        // do nothing.
+    }
+
+    public static synchronized SearchInputDocument addFacetsOrder(String keyText, SearchInputDocument doc) {
+
+        if (keyText.contains("_facets")) {
+
+            String keyTextOrder = keyText.replace("_facets", "_facetsOrder");
+
+            Collection<Object> cc = doc.getField(keyText).getValues();
+
+            Object keyTextOrderValue = null;
+
+            if (cc.size() > 0) {
+                keyTextOrderValue = cc.iterator().next();
+            }
+
+            BaseSearchInputField searchInputFieldkeyTextOrder = (BaseSearchInputField) doc.getField(keyTextOrder);
+            if (searchInputFieldkeyTextOrder != null) {
+                searchInputFieldkeyTextOrder.setValue(keyTextOrderValue);
+                doc.addField(searchInputFieldkeyTextOrder);
+            } else {
+                doc.addField(keyTextOrder, (Object) keyTextOrderValue);
+            }
+
+        }
+
+        return doc;
+
+    }
+
+    public static synchronized SearchInputDocument addFacetsCount(String keyText, SearchInputDocument doc) {
+        String keyTextCount = keyText.replace("_facets", "_facetsCount");
+
+        Collection<Object> cc = doc.getField(keyText).getValues();
+        int keyTextSize = cc.size();
+
+        BaseSearchInputField searchInputFieldkeyTextCount = (BaseSearchInputField) doc.getField(keyTextCount);
+        if (searchInputFieldkeyTextCount != null) {
+            searchInputFieldkeyTextCount.setValue(keyTextSize);
+            doc.addField(searchInputFieldkeyTextCount);
+        } else {
+            doc.addField(keyTextCount, (Object) keyTextSize);
+        }
+
+        return doc;
+    }
+
+    public static SearchInputDocument indexIndividualFacet(String value, SearchInputDocument doc, String solr) {
+
+        String key = solr.replaceAll(" ", "-") + "_facets";
+
+        SearchInputField searchInputField = doc.getField(key);
+
+        boolean exists = false;
+        if (searchInputField != null) {
+            Collection<Object> solrdocValues = searchInputField.getValues();
+            for (Object s : solrdocValues) {
+                if (s.equals(value)) {
+                    exists = true;
+                }
+            }
+        }
+        if (!exists) {
+            doc.addField(key, value);
+            doc = addFacetsCount(key, doc);
+            doc = addFacetsOrder(key, doc);
+        }
+        return doc;
+    }
+
+    public static SearchInputDocument indexIndividualUriFacet(String valueUri, String prop, String value,
+            SearchInputDocument doc, String solr) {
+
+        String key = solr.replaceAll(" ", "-") + "_facets";
+        String keyUri = solr.replaceAll(" ", "-") + "_uri_facets";
+
+        // facets
+        SearchInputField searchInputField = doc.getField(keyUri);
+        boolean exists = false;
+        if (searchInputField != null) {
+            Collection<Object> solrdocValues = searchInputField.getValues();
+            for (Object s : solrdocValues) {
+                if (s.equals(value)) {
+                    exists = true;
+                }
+            }
+        }
+        if (!exists) {
+            doc.addField(key, value);
+            doc.addField(keyUri, valueUri);
+            doc = addFacetsCount(key, doc);
+            doc = addFacetsOrder(key, doc);
+        }
+
+        return doc;
+
+    }
+
+    public static SearchInputDocument indexIndividualData(Individual rootIndividual, Individual ind, String prop,
+            String regex, String regexreplace, SearchInputDocument doc, String solr) throws JSONException {
+
+        List<String> dataValues = ind.getDataValues(prop);
+
+        for (String value : dataValues) {
+
+            if (regex != null) {
+                Matcher m = Pattern.compile(regex).matcher(value);
+                if (m.matches()) {
+                    value = m.replaceAll(regexreplace);
+                }
+            }
+            log.debug("            solr doc: "+value);
+            if (rootIndividual.getURI().equals(ind.getURI())) {
+                doc = indexIndividualFacet(value, doc, solr);
+            } else {
+                doc = indexIndividualUriFacet(ind.getURI(), prop, value, doc, solr);
+            }
+
+        }
+
+        return doc;
+    }
+
+    public static SearchInputDocument indexIndividualRegexpUri(Individual rootIndividual, Individual ind, String prop,
+            String regex, String regexreplace, SearchInputDocument doc, String solr) throws JSONException {
+
+        Matcher m = Pattern.compile(regex).matcher(ind.getURI());
+        if (m.matches()) {
+            String value = m.replaceAll(regexreplace);
+            log.debug("            solr doc: "+value);
+            if (rootIndividual.getURI().equals(ind.getURI())) {
+                doc = indexIndividualFacet(value, doc, solr);
+            } else {
+                doc = indexIndividualUriFacet(ind.getURI(), ind.getURI(), value, doc, solr);
+            }
+        }
+
+        return doc;
+    }
+
+    public static List<Individual> getIndividualObjects(Individual ind, String propr, String qualifiedBy)
+            throws JSONException {
+
+        log.debug("    search for propr: " + propr + " qualifiedBy " + qualifiedBy);
+
+        List<ObjectPropertyStatement> objectPropertyStatements = ind.getObjectPropertyStatements(propr);
+        List<Individual> objectList = new ArrayList<Individual>();
+        for (ObjectPropertyStatement op : objectPropertyStatements) {
+
+            if (op.getProperty() instanceof ObjectProperty) {
+
+                Individual individual = op.getObject();
+
+                List<VClass> vclassL = individual.getVClasses();
+
+                boolean qualifiedByBoolean = false;
+                
+                if (qualifiedBy == null) {
+                    qualifiedByBoolean = true;
+                }else {
+                
+                for (VClass classiLev2 : vclassL) {
+                    if (classiLev2.getURI().equals(qualifiedBy)) {
+                        qualifiedByBoolean = true;
+                    }
+                }
+                
+                }
+
+                if (qualifiedByBoolean) {
+                    log.debug("        related ojb: " + op.getObjectURI());
+                    objectList.add(individual);
+                }
+
+            }
+        }
+
+        return objectList;
+    }
+
+    public static SearchInputDocument indexIndividualObjectOrData(Individual rootIndividual, Individual individual,
+            FacetConfig fLev1, SearchInputDocument doc, String solr) throws JSONException {
+
+        if (fLev1.pivotsIndexProperty == null) {
+            // no more nested props
+
+            if (fLev1.configContextFor != null) {
+                doc = indexIndividualData(rootIndividual, individual, fLev1.configContextFor, fLev1.regexp,
+                        fLev1.regexpreplace, doc, solr);
+            } else {
+
+                if (fLev1.regexp != null) {
+                    doc = indexIndividualRegexpUri(rootIndividual, individual, fLev1.configContextFor, fLev1.regexp,
+                            fLev1.regexpreplace, doc, solr);
+                } else {
+                    log.error("json config error ");
+                }
+            }
+
+        } else {
+
+            // get nested
+            List<Individual> objListLev1 = getIndividualObjects(individual, fLev1.configContextFor, fLev1.qualifiedBy);
+
+            for (Individual indsdbLev1 : objListLev1) {
+                FacetConfig fLev2 = new FacetConfig(fLev1.pivotsIndexProperty);
+                doc = indexIndividualObjectOrData(rootIndividual, indsdbLev1, fLev2, doc, solr);
+            }
+        }
+        return doc;
+    }
+
+    public static String getValue(JSONObject jo, String key) {
+        String value = null;
+        if (jo.has(key))
+            value = jo.getString(key);
+        return value;
+    }
+
+    public static SearchInputDocument indexIndividual(Individual ind, SearchInputDocument doc) throws JSONException {
+
+        JSONArray indxProp = JSONFilesLoader.pivotsIndexProperty;
+
+        for (int j = 0; j < indxProp.length(); j++) {
+
+            JSONObject jo = indxProp.getJSONObject(j);
+            String qualifiedByDomain = getValue(jo, "qualifiedByDomain");
+            String solr = getValue(jo, "solr");
+
+            FacetConfig fLev1 = new FacetConfig(jo);
+
+            IndividualSDB indsdb = ((IndividualSDB) ((IndividualFiltering) ind).get_innerIndividual());
+            List<VClass> vclassL = indsdb.getVClasses();
+
+            boolean qualifiedByDomainBoolean = false;
+
+            for (VClass classi : vclassL) {
+                if (classi.getURI().equals(qualifiedByDomain)) {
+                    qualifiedByDomainBoolean = true;
+                }
+            }
+
+            if (qualifiedByDomainBoolean) {
+                log.debug("\nJsonFacetsModifier, individual: " + ind.getURI() + ", Domain: " + qualifiedByDomain+ ", prop: "+fLev1.configContextFor);
+                doc = indexIndividualObjectOrData(indsdb, indsdb, fLev1, doc, solr);
+            }
+
+        }
+
+        return doc;
+    }
+
+}

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/searchindex/tasks/UpdateDocumentWorkUnit.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/searchindex/tasks/UpdateDocumentWorkUnit.java
@@ -38,6 +38,7 @@ import edu.cornell.mannlib.vitro.webapp.modules.searchEngine.SearchInputDocument
 import edu.cornell.mannlib.vitro.webapp.modules.searchIndexer.SearchIndexerUtils;
 import edu.cornell.mannlib.vitro.webapp.searchindex.documentBuilding.DocumentModifier;
 import edu.cornell.mannlib.vitro.webapp.searchindex.documentBuilding.DocumentModifierList;
+import edu.cornell.mannlib.vitro.webapp.searchindex.documentBuilding.JsonFacetsModifier;
 
 public class UpdateDocumentWorkUnit implements Runnable {
 	private static final Log log = LogFactory
@@ -95,7 +96,7 @@ public class UpdateDocumentWorkUnit implements Runnable {
 			this.list = Arrays.asList(new DocumentModifier[] {
 					new IdUriLabel(), new AddClasses(),
 					new AddMostSpecificTypes(), new AddObjectPropertyText(),
-					new AddDataPropertyText(), new AddEntityBoost() });
+					new AddDataPropertyText(), new AddEntityBoost(), new JsonFacetsModifier() });
 		}
 
 		public List<DocumentModifier> getList() {

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/servlet/setup/ConfigurationModelsSetup.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/servlet/setup/ConfigurationModelsSetup.java
@@ -31,6 +31,7 @@ public class ConfigurationModelsSetup implements ServletContextListener {
 			setupModel(ctx, DISPLAY_TBOX, "displayTbox");
 			setupModel(ctx, DISPLAY_DISPLAY, "displayDisplay");
 			setupModel(ctx, USER_ACCOUNTS, "auth");
+			new JSONFilesLoader();
 			ss.info(this,
 					"Set up the display models and the user accounts model.");
 		} catch (Exception e) {

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/servlet/setup/JSONFilesLoader.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/servlet/setup/JSONFilesLoader.java
@@ -1,0 +1,41 @@
+/* $This file is distributed under the terms of the license in LICENSE$ */
+
+package edu.cornell.mannlib.vitro.webapp.servlet.setup;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+import edu.cornell.mannlib.vitro.webapp.application.ApplicationUtils;
+
+public class JSONFilesLoader {
+	private static final Log log = LogFactory.getLog(JSONFilesLoader.class);
+
+	public static JSONArray pivotsIndexProperty = null;
+
+	public JSONFilesLoader() {
+		
+		String jsonconfig;
+		try {
+			
+			jsonconfig = new String(Files.readAllBytes(Paths.get(ApplicationUtils.instance().getHomeDirectory().getPath().toString() + "/json/config.json")));
+
+			JSONObject reader = new JSONObject(jsonconfig);
+			
+			if (reader.has("pivotsIndexProperty")) {
+				pivotsIndexProperty = reader.getJSONArray("pivotsIndexProperty");
+			} else {
+				log.warn("pivotsIndexProperty missing");
+			}
+
+		} catch (IOException e) {
+			log.error("jsonconfig error: "+e.toString());
+		}
+		
+	}
+
+}

--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -252,5 +252,12 @@
             <artifactId>javax.mail</artifactId>
             <version>1.6.0</version>
         </dependency>
+        
+        <dependency>
+          <groupId>org.json</groupId>
+          <artifactId>json</artifactId>
+          <version>20180813</version>
+        </dependency>
+
     </dependencies>
 </project>

--- a/home/src/main/resources/json/config.json
+++ b/home/src/main/resources/json/config.json
@@ -1,0 +1,72 @@
+
+{
+
+
+"pivotsIndexProperty": [
+		
+		{	
+			"solr":"author",
+			"qualifiedByDomain": "http://purl.org/ontology/bibo/Document",
+			"configContextFor": "http://vivoweb.org/ontology/core#relatedBy",
+			"qualifiedBy": "http://vivoweb.org/ontology/core#Authorship",
+				
+				"pivotsIndexProperty":{
+					"configContextFor": "http://vivoweb.org/ontology/core#relates",
+					    "qualifiedBy": "http://xmlns.com/foaf/0.1/Person",
+					    	"pivotsIndexProperty":{
+				            "configContextFor": "http://www.w3.org/2000/01/rdf-schema#label",
+				         },
+				},
+				
+	    },
+		
+		
+		{	
+			"solr":"authorContinent",
+			"qualifiedByDomain": "http://purl.org/ontology/bibo/Document",
+			"configContextFor": "http://vivoweb.org/ontology/core#relatedBy",
+			"qualifiedBy": "http://vivoweb.org/ontology/core#Authorship",
+				"pivotsIndexProperty":{
+					"configContextFor": "http://vivoweb.org/ontology/core#relates",
+					"qualifiedBy": "http://xmlns.com/foaf/0.1/Person",
+						"pivotsIndexProperty":{
+				             "configContextFor": "http://vivoweb.org/ontology/core#geographicFocus",
+				             "qualifiedBy": "http://vivoweb.org/ontology/core#Country",
+				                  "pivotsIndexProperty":{
+				                      "configContextFor": "http://aims.fao.org/aos/geopolitical.owl#isInGroup",
+				                      "qualifiedBy": "http://vivoweb.org/ontology/core#Continent",
+				                           "pivotsIndexProperty":{
+				                                "configContextFor": "http://www.w3.org/2000/01/rdf-schema#label",
+				                            }
+						          }
+				         },
+		        },		
+		},
+		
+		{	
+			"solr":"withStatus",
+			"qualifiedByDomain": "http://purl.org/ontology/bibo/Document",
+			"configContextFor": "http://purl.org/ontology/bibo/status",
+				"pivotsIndexProperty":{
+					"regexp":"^http://([a-zA-Z\\.]{1,50})/([a-zA-Z]{1,20})/([a-zA-Z]{1,20})/([a-zA-Z]{1,20})$",
+					"regexpreplace":"$4",
+				},
+		},
+		
+		
+		{
+			"solr":"articleYear",
+			"qualifiedByDomain": "http://purl.org/ontology/bibo/AcademicArticle",
+			"configContextFor": "http://vivoweb.org/ontology/core#dateTimeValue",
+			"qualifiedBy": "http://vivoweb.org/ontology/core#DateTimeValue",
+				"pivotsIndexProperty":{
+				 "configContextFor": "http://vivoweb.org/ontology/core#dateTime",
+				 "regexp":"^([0-9]{4,4})-.*$",
+				 "regexpreplace":"$1",
+				},
+		},
+		
+],
+
+
+}

--- a/home/src/main/resources/solr/conf/schema.xml
+++ b/home/src/main/resources/solr/conf/schema.xml
@@ -186,6 +186,11 @@
   <dynamicField name="*_tdate" type="tdate" indexed="true" stored="true" multiValued="true"/>
   <dynamicField name="*_tint" type="tint" indexed="true" stored="true" multiValued="true"/>
 
+  <dynamicField name="*_facets" type="string"  indexed="true"  stored="true" multiValued="true"/>
+  <dynamicField name="*_facetsCount" type="int"  indexed="true"  stored="true" multiValued="false"/>
+  <dynamicField name="*_facetsOrder" type="string"  indexed="true"  stored="true" multiValued="false"/>
+
+
    <!-- ****************************  End Dynamic Fields *************************** -->
 
 


### PR DESCRIPTION
**[JIRA Issue](https://jira.duraspace.org/projects/VIVO)**: https://jira.duraspace.org/browse/VIVO-1694

# What does this pull request do?
New document modifier "JsonFacetsModifier"
The Document modifier will create new fields searching for the properties described in the "config.json" file; starting from the Individual Object and going as deep into the data model as the recursive json config demands.

recoursive approach example:

        {    
            "solr":"authorContinent",
            "qualifiedByDomain": "http://purl.org/ontology/bibo/Document",
            "configContextFor": "http://vivoweb.org/ontology/core#relatedBy",
            "qualifiedBy": "http://vivoweb.org/ontology/core#Authorship",
                "pivotsIndexProperty":{
                    "configContextFor": "http://vivoweb.org/ontology/core#relates",
                    "qualifiedBy": "http://xmlns.com/foaf/0.1/Person",
                        "pivotsIndexProperty":{
                             "configContextFor": "http://vivoweb.org/ontology/core#geographicFocus",
                             "qualifiedBy": "http://vivoweb.org/ontology/core#Country",
                                  "pivotsIndexProperty":{
                                      "configContextFor": "http://aims.fao.org/aos/geopolitical.owl#isInGroup",
                                      "qualifiedBy": "http://vivoweb.org/ontology/core#Continent",
                                           "pivotsIndexProperty":{
                                                "configContextFor": "http://www.w3.org/2000/01/rdf-schema#label",
                                            }
                                  }
                         },
                },        
        },

It is also possible to apply a regexp on the literal value:
regexp example:

        {
            "solr":"articleYear",
            "qualifiedByDomain": "http://purl.org/ontology/bibo/AcademicArticle",
            "configContextFor": "http://vivoweb.org/ontology/core#dateTimeValue",
            "qualifiedBy": "http://vivoweb.org/ontology/core#DateTimeValue",
                "pivotsIndexProperty":{
                 "configContextFor": "http://vivoweb.org/ontology/core#dateTime",
                 "regexp":"^([0-9]{4,4})-.*$",
                 "regexpreplace":"$1",
                },
        },



The new fields on the search server:  
 "*_facets" , "*_facetsOrder" , "*_facetsCount" , "*_uri_facets"

We use these fields in our custom instance for the following improvements:

1) better performance and detalied infos on result lists (fetching data from solr into the browse and search templates) 
example:  
 "Article Name(j)" , < a "author link(i)" >Author(i) </ a>
 "Department Name(x)" - number of related Individuals

2) Customized browsing order based on configuration and "*_facetsOrder" fields
example:
 Browse "Research" by "publication date"
 
3) facets with pivot faceting query based on json configuration and "*_facets" fields
example:  
 ...&facet=true&facet.pivot=type,freetextKeyword_facets...

4) overrides on edismax qf to boost search results on "*_facets" fields
example:  
 .. &qf=freetextKeyword_facets^5...


# How should this be tested?

To install the document modifier on your existing VIVO instance:

- create a json folder in the install dir and copy the config.json configuration file inside.
example:  
 home\rdf\
 home\json\config.json
- update the \solr\conf\schema.xml configuration with the new dynamic Fields
- maven update

Example:

To test this "config.json" demo file you should have at least an  Academic Article  with 1 or more author (with a Geographic Focus Country) ,  a publication date and a status.

Force the update on the SOLR Server,  log in and edit the Academic Article title.

Open the solr console and search for the modified document, you should see something like this:
Modified Article document  - example:

"author_uri_facets":["http://irises.unimi.it/individual/n3196"],
"author_facets":["auth name"],
"author_facetsCount":1,
"author_facetsOrder":"auth name",

"authorContinent_uri_facets":["http://aims.fao.org/aos/geopolitical.owl#Europe"],
"authorContinent_facets":["Europe"],
"authorContinent_facetsCount":1,
"authorContinent_facetsOrder": "Europe"

"withStatus_facetsOrder": "accepted",
"withStatus_facets": [ "accepted" ],
"withStatus_facetsCount": 1,
"withStatus_uri_facets": [ "http://purl.org/ontology/bibo/accepted" ]
  
"articleYear_uri_facets": [  "http://irises.unimi.it/individual/n3966"   ],
"articleYear_facets": [  "2025"  ],
"articleYear_facetsOrder": "2025",
"articleYear_facetsCount": 1


# Interested parties
@VIVO-project/vivo-committers