### PR TITLE
VIVO-1696 - fix for OutOfMemoryError with large file upload in RDFServiceGraph flush()

### DIFF
--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/api/SparqlUpdateApiController.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/api/SparqlUpdateApiController.java
@@ -32,6 +32,7 @@ import edu.cornell.mannlib.vitro.webapp.auth.requestedAction.AuthorizationReques
 import edu.cornell.mannlib.vitro.webapp.controller.VitroRequest;
 import edu.cornell.mannlib.vitro.webapp.dao.jena.RDFServiceDataset;
 import edu.cornell.mannlib.vitro.webapp.modules.searchIndexer.SearchIndexer;
+import edu.cornell.mannlib.vitro.webapp.searchindex.SearchIndexerImpl;
 
 /**
  * Process SPARQL Updates, as an API.
@@ -60,9 +61,17 @@ public class SparqlUpdateApiController extends VitroApiServlet {
 			throws ServletException, IOException {
 		log.debug("Starting update");
 		try {
+			if("s".equals(req.getParameter("firstime"))) {
+				log.info("disablePendingStatements");
+				SearchIndexerImpl.disablePendingStatements();
+			}
 			confirmAuthorization(req, REQUIRED_ACTIONS);
 			UpdateRequest parsed = parseUpdateString(req);
 			executeUpdate(req, parsed);
+			if("s".equals(req.getParameter("firstime"))) {
+				log.info("enablePendingStatements");
+				SearchIndexerImpl.enablePendingStatements();
+			}
 			do200response(resp);
 		} catch (AuthException e) {
 			do403response(resp, e);

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/api/SparqlUpdateApiController.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/api/SparqlUpdateApiController.java
@@ -107,7 +107,7 @@ public class SparqlUpdateApiController extends VitroApiServlet {
 	    try {
 	        if(indexer != null) {
 	            indexer.pause();
-	            if("s".equals(req.getParameter("firstime"))) {
+	            if("s".equals(req.getParameter("firsttime"))) {
 					IndexingChangeListener.enabled = false;
 				}
 	        }
@@ -122,7 +122,7 @@ public class SparqlUpdateApiController extends VitroApiServlet {
 		    }
 			if(indexer != null) {
 			    indexer.unpause();
-				if("s".equals(req.getParameter("firstime"))) {
+				if("s".equals(req.getParameter("firsttime"))) {
 					IndexingChangeListener.enabled = true;
 					indexer.rebuildIndex();
 				}

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/dao/jena/RDFServiceGraph.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/dao/jena/RDFServiceGraph.java
@@ -96,104 +96,60 @@ public class RDFServiceGraph implements GraphWithPerform {
         return sb;
     }
     
-    private String serialize(Triple t) {
-        StringBuffer sb = new StringBuffer();
-        sb.append(sparqlNodeUpdate(t.getSubject(), "")).append(" ") 
-               .append(sparqlNodeUpdate(t.getPredicate(), "")).append(" ") 
-               .append(sparqlNodeUpdate(t.getObject(), "")).append(" .");
-        return sb.toString();
-    }
-
     private synchronized void flush() {
-        ChangeSet changeSet = rdfService.manufactureChangeSet();
         try {
             if(!removalsGraph.isEmpty()) {
-                flushGraph(removalsGraph,graphURI,changeSet,rdfService,false);
+                flushGraph(removalsGraph,rdfService,false);
             }
             if(!additionsGraph.isEmpty()) {
-                flushGraph(additionsGraph,graphURI,changeSet,rdfService,true);
+                flushGraph(additionsGraph,rdfService,true);
             }
         } catch (RDFServiceException rdfse) {
             throw new RuntimeException(rdfse);
         }
     }
     
-    
-    private static int maxStringSize = 10000000;
-    
-    private synchronized void flushGraph(Graph graph,String graphURI,ChangeSet changeSet,RDFService rdfService,boolean add) throws RDFServiceException {
+    private synchronized void flushGraph(Graph graph, RDFService rdfService,boolean add) throws RDFServiceException {
         
-        Runtime runtime = Runtime.getRuntime();
-
-        StringBuilder sb = new StringBuilder(maxStringSize+(10000000/10));
+        int maxStringSize = 10000000;
+        StringBuilder sb = new StringBuilder(maxStringSize);
         Iterator<Triple> tripIt = graph.find(null, null, null);
         
         while(tripIt.hasNext()) {
-
-            sb.append(" \n").append(serialize(tripIt.next()));
-           
+            sb.append(" \n");
+            serialize(sb,tripIt.next());
             if(sb.length()>maxStringSize) {
-               
-               String triples = sb.toString();
-               
-              InputStream tripleInputStream = RDFServiceUtils.toInputStream(triples);
-               
-              if(add) {
-                   changeSet.addAddition(tripleInputStream,RDFService.ModelSerializationFormat.N3, graphURI);
-              }else {
-                  changeSet.addRemoval(tripleInputStream,RDFService.ModelSerializationFormat.N3, graphURI);
-              }
-              
-               triples = null;
-               
-               rdfService.changeSetUpdate(changeSet);
-                
-               changeSet = rdfService.manufactureChangeSet();
-
-               if(tripleInputStream!=null) {
-                    try {
-                        tripleInputStream.close();
-                    } catch (IOException e) {
-                        throw new RuntimeException();
-                    }
-               }
-               
-               runtime.gc();
-               
-               sb = new StringBuilder(maxStringSize+(10000000/10));
-               
+            	flushTriples(sb, rdfService, add);
+                sb = new StringBuilder(maxStringSize);
            }
         }
-        
-        String triples = sb.toString();
-        sb = null;
-        
-        InputStream tripleInputStream = RDFServiceUtils.toInputStream(triples);
-       
-        if(add) {
-            changeSet.addAddition(tripleInputStream, RDFService.ModelSerializationFormat.N3, graphURI);
-        }else {
-        changeSet.addRemoval(tripleInputStream,RDFService.ModelSerializationFormat.N3, graphURI);
-      }
-        
-        triples = null;
+        flushTriples(sb, rdfService, add);
         graph.clear();
-        
-        rdfService.changeSetUpdate(changeSet);
-        
-        if(tripleInputStream!=null) {
-                try {
-                    tripleInputStream.close();
-                } catch (IOException e) {
-                    throw new RuntimeException();
-                }
-        }
-        
-        changeSet = null;
-        runtime.gc();
-       
     }    
     
+    
+    private synchronized void flushTriples(StringBuilder sbTriples,RDFService rdfService,boolean add) throws RDFServiceException {
+    
+        String triples = sbTriples.toString();
+        sbTriples = null;
+        ChangeSet changeSet = rdfService.manufactureChangeSet();
+    
+        try (InputStream tripleInputStream = RDFServiceUtils.toInputStream(triples)) {
+            if(add) {
+                changeSet.addAddition(tripleInputStream, RDFService.ModelSerializationFormat.N3, graphURI);
+            }else {
+                changeSet.addRemoval(tripleInputStream,RDFService.ModelSerializationFormat.N3, graphURI);
+            }
+            triples = null;
+            rdfService.changeSetUpdate(changeSet);
+            tripleInputStream.close();
+            changeSet = null;
+        } catch (IOException e) {
+            throw new RuntimeException();
+        } 
+    }
+    
+   
     @Override
     public void performAdd(Triple t) {
         if(inTransaction) {
@@ -570,12 +526,12 @@ public class RDFServiceGraph implements GraphWithPerform {
 	};
 
 	private final TransactionHandler transactionHandler = new TransactionHandler() {
-    @Override
-    public synchronized void abort() {
-        inTransaction = false;
-        removalsGraph.clear();
-        additionsGraph.clear();
-    }
+        @Override
+	    public synchronized void abort() {
+	        inTransaction = false;
+	        removalsGraph.clear();
+	        additionsGraph.clear();
+	    }
 
         @Override
         public synchronized void begin() {

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/searchindex/IndexingChangeListener.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/searchindex/IndexingChangeListener.java
@@ -58,6 +58,7 @@ public class IndexingChangeListener extends StatementListener
 	private final Ticker ticker;
 	private volatile boolean rebuildScheduled;
     private final Model defaultModel;
+    public static volatile boolean enabled = true;
 
 	/** All access to the list must be synchronized. */
 	private final List<Statement> changes;
@@ -103,15 +104,19 @@ public class IndexingChangeListener extends StatementListener
 
 	@Override
 	public void addedStatement(Statement stmt) {
-		if (!rebuildScheduled) {
-			noteChange(stmt);
+		if (enabled) {
+		    if (!rebuildScheduled) {
+		    	noteChange(stmt);
+		    }
 		}
 	}
 
 	@Override
 	public void removedStatement(Statement stmt) {
-		if (!rebuildScheduled) {
-			noteChange(stmt);
+		if (enabled) {
+		    if (!rebuildScheduled) {
+		    	noteChange(stmt);
+		    }
 		}
 	}
 

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/searchindex/SearchIndexerImpl.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/searchindex/SearchIndexerImpl.java
@@ -102,6 +102,7 @@ public class SearchIndexerImpl implements SearchIndexer {
 	private boolean rebuildOnUnpause = false;
 
 	private volatile int paused = 0;
+	private static volatile boolean enabled = true;
 
 	private List<Statement> pendingStatements = new ArrayList<Statement>();
 	private Collection<String> pendingUris = new ArrayList<String>();
@@ -168,6 +169,14 @@ public class SearchIndexerImpl implements SearchIndexer {
 		modifiers.addAll(new UpdateDocumentWorkUnit.MinimalDocumentModifiers()
 				.getList());
 		modifiers.addAll(beanLoader.loadAll(DocumentModifier.class));
+	}
+	
+	public static synchronized void enablePendingStatements() {
+		enabled = true;
+	}
+	
+	public static synchronized void disablePendingStatements() {
+		enabled = false;
 	}
 
 	@Override
@@ -280,7 +289,9 @@ public class SearchIndexerImpl implements SearchIndexer {
 
 	private synchronized boolean addToPendingStatements(List<Statement> changes) {
 		if (paused > 0) {
-			pendingStatements.addAll(changes);
+			if(enabled) {
+			    pendingStatements.addAll(changes);
+			}
 			return true;
 		}
 

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/searchindex/SearchIndexerImpl.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/searchindex/SearchIndexerImpl.java
@@ -102,7 +102,6 @@ public class SearchIndexerImpl implements SearchIndexer {
 	private boolean rebuildOnUnpause = false;
 
 	private volatile int paused = 0;
-	private static volatile boolean enabled = true;
 
 	private List<Statement> pendingStatements = new ArrayList<Statement>();
 	private Collection<String> pendingUris = new ArrayList<String>();
@@ -169,14 +168,6 @@ public class SearchIndexerImpl implements SearchIndexer {
 		modifiers.addAll(new UpdateDocumentWorkUnit.MinimalDocumentModifiers()
 				.getList());
 		modifiers.addAll(beanLoader.loadAll(DocumentModifier.class));
-	}
-	
-	public static synchronized void enablePendingStatements() {
-		enabled = true;
-	}
-	
-	public static synchronized void disablePendingStatements() {
-		enabled = false;
 	}
 
 	@Override
@@ -289,9 +280,7 @@ public class SearchIndexerImpl implements SearchIndexer {
 
 	private synchronized boolean addToPendingStatements(List<Statement> changes) {
 		if (paused > 0) {
-			if(enabled) {
-			    pendingStatements.addAll(changes);
-			}
+			pendingStatements.addAll(changes);
 			return true;
 		}
 


### PR DESCRIPTION
**[JIRA Issue](https://jira.duraspace.org/projects/VIVO)**: (https://jira.duraspace.org/browse/VIVO-1696)

# What does this pull request do?
fix OutOfMemoryError on large upload files to api/sparqlUpdate in RDFServiceGraph flush() method

# What's new?
- avoids exceeding the string limit size
- keep memory low

# How should this be tested?
- use a big nt input file , about 1.5GB.
- upload the file to the api/sparqlUpdate on a tomcat with  -Xmx6000m or more


example:
curl "http://server/webapp/api/sparqlUpdate" -d "email=root@email" -d "password=rootPassword" -d "update=LOAD <http://server/bigfile.nt> into graph <http://vitro.mannlib.cornell.edu/default/vitro-kb-2>"


# Interested parties
@VIVO-project/vivo-committers
