### PR TITLE
Replace PR #99

### DIFF
--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/individual/IndividualResponseBuilder.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/individual/IndividualResponseBuilder.java
@@ -4,7 +4,9 @@ package edu.cornell.mannlib.vitro.webapp.controller.individual;
 
 import java.io.IOException;
 import java.sql.SQLException;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.apache.jena.rdf.model.RDFNode;
@@ -49,6 +51,16 @@ class IndividualResponseBuilder {
 	private static final Log log = LogFactory
 			.getLog(IndividualResponseBuilder.class);
 
+	public interface ExtendedResponse {
+	    void addOptions(VitroRequest vreq, Map<String, Object> body);
+    }
+
+    private static List<ExtendedResponse> extendedResponses = new ArrayList<>();
+
+    public static void registerExtendedResponse(ExtendedResponse extendedResponse) {
+        extendedResponses.add(extendedResponse);
+    }
+	
     private static final Map<String, String> namespaces = new HashMap<String, String>() {{
         put("display", VitroVocabulary.DISPLAY);
         put("vitro", VitroVocabulary.vitroURI);
@@ -85,8 +97,9 @@ class IndividualResponseBuilder {
 		body.put("profilePageTypesEnabled", getprofilePageTypesFlag());
 		body.put("verbosePropertySwitch", getVerbosePropertyValues());
 
-        addAltMetricOptions(body);
-        addPlumPrintOptions(body);
+		for (ExtendedResponse extendedResponse : extendedResponses) {
+		    extendedResponse.addOptions(vreq, body);
+        }
 
 		//Execute data getters that might apply to this individual, e.g. because of the class of the individual
 		try{
@@ -172,52 +185,6 @@ class IndividualResponseBuilder {
             }
         }
         return map;
-    }
-
-    private void addAltMetricOptions(Map<String, Object> body) {
-        ConfigurationProperties properties = ConfigurationProperties.getBean(vreq);
-
-        if (properties != null) {
-            String enabled        = properties.getProperty("resource.altmetric", "enabled");
-            String displayTo      = properties.getProperty("resource.altmetric.displayto", "right");
-            String badgeType      = properties.getProperty("resource.altmetric.badge-type", "donut");
-            String badgeHideEmpty = properties.getProperty("resource.altmetric.hide-no-mentions", "true");
-            String badgePopover   = properties.getProperty("resource.altmetric.badge-popover", "right");
-            String badgeDetails   = properties.getProperty("resource.altmetric.badge-details");
-
-            if (!"disabled".equalsIgnoreCase(enabled)) {
-                body.put("altmetricEnabled", true);
-
-                body.put("altmetricDisplayTo", displayTo);
-                body.put("altmetricBadgeType", badgeType);
-                if ("true".equalsIgnoreCase(badgeHideEmpty)) {
-                    body.put("altmetricHideEmpty", true);
-                }
-                body.put("altmetricPopover", badgePopover);
-                body.put("altmetricDetails", badgeDetails);
-            }
-        }
-    }
-
-    private void addPlumPrintOptions(Map<String, Object> body) {
-        ConfigurationProperties properties = ConfigurationProperties.getBean(vreq);
-
-        if (properties != null) {
-            String enabled = properties.getProperty("resource.plum-print", "enabled");
-            String displayTo = properties.getProperty("resource.plum-print.displayto", "right");
-            String printHideEmpty = properties.getProperty("resource.plum-print.hide-when-empty", "true");
-            String printPopover = properties.getProperty("resource.plum-print.popover", "right");
-            String printSize = properties.getProperty("resource.plum-print.size", "medium");
-
-            if (!"disabled".equalsIgnoreCase(enabled)) {
-                body.put("plumPrintEnabled", true);
-
-                body.put("plumPrintDisplayTo", displayTo);
-                body.put("plumPrintHideEmpty", "true".equalsIgnoreCase(printHideEmpty) ? "true" : "false");
-                body.put("plumPrintPopover", printPopover);
-                body.put("plumPrintSize", printSize);
-            }
-        }
     }
 
 	private boolean getTemporalVisualizationFlag() {


### PR DESCRIPTION
**[VIVO-1656](https://jira.duraspace.org/browse/VIVO-1656)**:

# What does this pull request do?
Adds an extension mechanism to the IndividualResponseBuilder that allows applications built on top of Vitro to register code to add extra parameters to be passed to the templates.

It also moves the Plum and AltMetrics extensions out of the Vitro code, as they are only applicable to VIVO. See the corresponding pull request in VIVO that uses the extension.

# What's new?
No change in functionality, this is an architectural improvement.

# How should this be tested?
Visit the page of any "individual" in Vitro. Should work exactly as it did before.

# Interested parties
@VIVO-project/vivo-committers
