### PR TITLE
[VIVO-1718] RDF Delta patch messaging

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -83,6 +83,25 @@
         </dependency>
 
         <dependency>
+            <groupId>org.seaborne.rdf-delta</groupId>
+            <artifactId>rdf-delta-client</artifactId>
+            <version>0.7.0</version>
+        </dependency>
+
+        <dependency>
+            <groupId>javax.jms</groupId>
+            <artifactId>javax.jms-api</artifactId>
+            <version>2.0.1</version>
+        </dependency>
+
+        <!-- dependency to support ActiveMQ context, currently used only by JNDI lookup -->
+        <dependency>
+            <groupId>org.apache.activemq</groupId>
+            <artifactId>artemis-jms-client-all</artifactId>
+            <version>2.9.0</version>
+        </dependency>
+
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>4.11</version>

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/modules/Application.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/modules/Application.java
@@ -7,6 +7,8 @@ import javax.servlet.ServletContext;
 import edu.cornell.mannlib.vitro.webapp.application.VitroHomeDirectory;
 import edu.cornell.mannlib.vitro.webapp.modules.fileStorage.FileStorage;
 import edu.cornell.mannlib.vitro.webapp.modules.imageProcessor.ImageProcessor;
+import edu.cornell.mannlib.vitro.webapp.modules.messaging.JMSMessagingClient;
+import edu.cornell.mannlib.vitro.webapp.modules.rdfDelta.RDFDeltaDatasetFactory;
 import edu.cornell.mannlib.vitro.webapp.modules.searchEngine.SearchEngine;
 import edu.cornell.mannlib.vitro.webapp.modules.searchIndexer.SearchIndexer;
 import edu.cornell.mannlib.vitro.webapp.modules.tboxreasoner.TBoxReasonerModule;
@@ -28,6 +30,10 @@ public interface Application {
 	ImageProcessor getImageProcessor();
 
 	FileStorage getFileStorage();
+
+	JMSMessagingClient getJMSMessagingClient();
+
+	RDFDeltaDatasetFactory getRDFDeltaDatasetFactory();
 
 	ContentTripleSource getContentTripleSource();
 

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/modules/messaging/JMSMessagingClient.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/modules/messaging/JMSMessagingClient.java
@@ -63,12 +63,12 @@ public class JMSMessagingClient {
 
     @Property(uri = "http://vitro.mannlib.cornell.edu/ns/vitro/ApplicationSetup#hasBrokerType", minOccurs = 1, maxOccurs = 1)
     public void setBrokerType(String type) {
-        this.brokerDestination = type;
+        this.brokerType = type;
     }
 
     @Property(uri = "http://vitro.mannlib.cornell.edu/ns/vitro/ApplicationSetup#hasBrokerDestination", minOccurs = 1, maxOccurs = 1)
     public void setBrokerDestination(String destination) {
-        this.brokerType = destination;
+        this.brokerDestination = destination;
     }
 
     @Property(uri = "http://vitro.mannlib.cornell.edu/ns/vitro/ApplicationSetup#hasBrokerUsername", minOccurs = 1, maxOccurs = 1)

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/modules/messaging/JMSMessagingClient.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/modules/messaging/JMSMessagingClient.java
@@ -1,0 +1,104 @@
+package edu.cornell.mannlib.vitro.webapp.modules.messaging;
+
+import java.util.Properties;
+
+import javax.jms.Connection;
+import javax.jms.ConnectionFactory;
+import javax.jms.Destination;
+import javax.jms.JMSException;
+import javax.jms.MessageProducer;
+import javax.jms.Session;
+import javax.jms.TextMessage;
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import edu.cornell.mannlib.vitro.webapp.modules.Application;
+import edu.cornell.mannlib.vitro.webapp.modules.ComponentStartupStatus;
+import edu.cornell.mannlib.vitro.webapp.utils.configuration.Property;
+
+public class JMSMessagingClient {
+
+    private static final Log log = LogFactory.getLog(JMSMessagingClient.class);
+
+    private String factoryInitial;
+
+    private String providerURL;
+
+    private String connectionFactory;
+
+    private String brokerDestination;
+
+    private String brokerUsername;
+
+    private String brokerPassword;
+
+    private Session session;
+
+    private MessageProducer producer;
+
+    @Property(uri = "http://vitro.mannlib.cornell.edu/ns/vitro/ApplicationSetup#hasFactoryInitial", minOccurs = 1, maxOccurs = 1)
+    public void setFactoryInitial(String factoryInitial) {
+        this.factoryInitial = factoryInitial;
+    }
+
+    @Property(uri = "http://vitro.mannlib.cornell.edu/ns/vitro/ApplicationSetup#hasProviderURL", minOccurs = 1, maxOccurs = 1)
+    public void setProviderURL(String providerURL) {
+        this.providerURL = providerURL;
+    }
+
+    @Property(uri = "http://vitro.mannlib.cornell.edu/ns/vitro/ApplicationSetup#hasConnectionFactory", minOccurs = 1, maxOccurs = 1)
+    public void setConnectionFactory(String connectionFactory) {
+        this.connectionFactory = connectionFactory;
+    }
+
+    @Property(uri = "http://vitro.mannlib.cornell.edu/ns/vitro/ApplicationSetup#hasBrokerDestination", minOccurs = 1, maxOccurs = 1)
+    public void setBrokerDestination(String destination) {
+        this.brokerDestination = destination;
+    }
+
+    @Property(uri = "http://vitro.mannlib.cornell.edu/ns/vitro/ApplicationSetup#hasBrokerUsername", minOccurs = 1, maxOccurs = 1)
+    public void setBrokerUsername(String username) {
+        this.brokerUsername = username;
+    }
+
+    @Property(uri = "http://vitro.mannlib.cornell.edu/ns/vitro/ApplicationSetup#hasBrokerPassword", minOccurs = 1, maxOccurs = 1)
+    public void setBrokerPassword(String password) {
+        this.brokerPassword = password;
+    }
+
+    public void startup(Application application, ComponentStartupStatus ss) {
+        Properties properties = new Properties();
+        properties.put("java.naming.factory.initial", factoryInitial);
+        properties.put("java.naming.provider.url", providerURL);
+
+        String[] destinationParts = brokerDestination.split("/");
+        String destinationBinding = String.format("%s.%s", destinationParts[0], brokerDestination);
+        String destinationName = destinationParts[1];
+        properties.put(destinationBinding, destinationName);
+
+        try {
+            InitialContext ic = new InitialContext(properties);
+            ConnectionFactory cf = (ConnectionFactory) ic.lookup(connectionFactory);
+
+            Destination destination = (Destination) ic.lookup(brokerDestination);
+            Connection connection = cf.createConnection(brokerUsername, brokerPassword);
+            session = connection.createSession(Session.AUTO_ACKNOWLEDGE);
+            producer = session.createProducer(destination);
+
+            ss.info(String.format("Message producer connected to %s at %s", brokerDestination, providerURL));
+        } catch (NamingException | JMSException e) {
+            ss.warning(e.getMessage(), e);
+        }
+
+    }
+
+    public void send(String payload) throws JMSException {
+        log.debug(String.format("Sending message to %s:\n%s", brokerDestination, payload));
+        TextMessage message = session.createTextMessage(payload);
+        producer.send(message);
+    }
+
+}

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/modules/messaging/JMSMessagingClient.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/modules/messaging/JMSMessagingClient.java
@@ -96,12 +96,13 @@ public class JMSMessagingClient {
                 session = connection.createSession(Session.AUTO_ACKNOWLEDGE);
                 producer = session.createProducer(destination);
     
-                ss.info(String.format("Message producer connected to %s at %s", brokerDestination, providerURL));
+                ss.info(String.format("Connected to %s at %s", brokerDestination, providerURL));
             } catch (NamingException | JMSException e) {
-                ss.warning(e.getMessage(), e);
+                ss.warning(String.format("Failed to connect to %s at %s", brokerDestination, providerURL), e);
             }
+        } else {
+            ss.warning(String.format("%s is not a valid broker destination", brokerDestination));
         }
-        ss.warning(String.format("%s is not a valid broker destination", brokerDestination));
     }
 
     public void send(String payload) throws JMSException {

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/modules/messaging/JMSMessagingClient.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/modules/messaging/JMSMessagingClient.java
@@ -34,6 +34,8 @@ public class JMSMessagingClient {
 
     private String connectionFactory;
 
+    private String brokerType;
+
     private String brokerDestination;
 
     private String brokerUsername;
@@ -59,9 +61,14 @@ public class JMSMessagingClient {
         this.connectionFactory = connectionFactory;
     }
 
+    @Property(uri = "http://vitro.mannlib.cornell.edu/ns/vitro/ApplicationSetup#hasBrokerType", minOccurs = 1, maxOccurs = 1)
+    public void setBrokerType(String type) {
+        this.brokerDestination = type;
+    }
+
     @Property(uri = "http://vitro.mannlib.cornell.edu/ns/vitro/ApplicationSetup#hasBrokerDestination", minOccurs = 1, maxOccurs = 1)
     public void setBrokerDestination(String destination) {
-        this.brokerDestination = destination;
+        this.brokerType = destination;
     }
 
     @Property(uri = "http://vitro.mannlib.cornell.edu/ns/vitro/ApplicationSetup#hasBrokerUsername", minOccurs = 1, maxOccurs = 1)
@@ -75,12 +82,11 @@ public class JMSMessagingClient {
     }
 
     public void startup(Application application, ComponentStartupStatus ss) {
-        Pattern pattern = Pattern.compile("^(topic|queues)/(.*)$");
+        Pattern pattern = Pattern.compile("^.*/(.*)$");
         Matcher matcher = pattern.matcher(brokerDestination);
         if (matcher.find()) {
-            String destinationType = matcher.group(1).equals("topic") ? "topic" : "queue";
-            String destinationName = matcher.group(2);
-            String destinationBinding = String.format("%s.%s", destinationType, brokerDestination);
+            String destinationName = matcher.group(1);
+            String destinationBinding = String.format("%s.%s", brokerType, brokerDestination);
 
             Properties properties = new Properties();
             properties.put(INITIAL_CONTEXT_FACTORY, factoryInitial);

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/modules/messaging/JMSMessagingClient.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/modules/messaging/JMSMessagingClient.java
@@ -1,5 +1,8 @@
 package edu.cornell.mannlib.vitro.webapp.modules.messaging;
 
+import static javax.naming.Context.INITIAL_CONTEXT_FACTORY;
+import static javax.naming.Context.PROVIDER_URL;
+
 import java.util.Properties;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -80,8 +83,8 @@ public class JMSMessagingClient {
             String destinationBinding = String.format("%s.%s", destinationType, brokerDestination);
 
             Properties properties = new Properties();
-            properties.put("java.naming.factory.initial", factoryInitial);
-            properties.put("java.naming.provider.url", providerURL);
+            properties.put(INITIAL_CONTEXT_FACTORY, factoryInitial);
+            properties.put(PROVIDER_URL, providerURL);
             properties.put(destinationBinding, destinationName);
 
             try {

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/modules/rdfDelta/RDFDeltaDatasetFactory.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/modules/rdfDelta/RDFDeltaDatasetFactory.java
@@ -59,7 +59,12 @@ public class RDFDeltaDatasetFactory {
 
     public Dataset wrap(String datasourceName, boolean shouldEmitMessage, Dataset dataset) {
         String datasourceURI = String.format("%s/%s", deltaServerURL, datasourceName);
-        Id dsRef = deltaLink.newDataSource(datasourceName, datasourceURI);
+        Id dsRef;
+        if (deltaLink.existsByName(datasourceName)) {
+            dsRef = deltaLink.getDataSourceDescriptionByName(datasourceName).getId();
+        } else {
+            dsRef = deltaLink.newDataSource(datasourceName, datasourceURI);
+        }
         deltaClient.attachExternal(dsRef, dataset.asDatasetGraph());
         // Connect using SyncPolicy.TXN_W for when a write-transaction starts, ignoring reads.
         // https://github.com/afs/rdf-delta/blob/master/rdf-delta-client/src/main/java/org/seaborne/delta/client/SyncPolicy.java

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/modules/rdfDelta/RDFDeltaDatasetFactory.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/modules/rdfDelta/RDFDeltaDatasetFactory.java
@@ -1,0 +1,89 @@
+package edu.cornell.mannlib.vitro.webapp.modules.rdfDelta;
+
+import javax.jms.JMSException;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.jena.atlas.lib.FileOps;
+import org.apache.jena.query.Dataset;
+import org.seaborne.delta.Id;
+import org.seaborne.delta.Version;
+import org.seaborne.delta.client.DeltaClient;
+import org.seaborne.delta.client.DeltaConnection;
+import org.seaborne.delta.client.DeltaLinkHTTP;
+import org.seaborne.delta.client.SyncPolicy;
+import org.seaborne.delta.client.Zone;
+import org.seaborne.delta.link.DeltaLink;
+import org.seaborne.delta.link.DeltaLinkListener;
+import org.seaborne.patch.RDFPatch;
+import org.seaborne.patch.RDFPatchOps;
+
+import edu.cornell.mannlib.vitro.webapp.modules.Application;
+import edu.cornell.mannlib.vitro.webapp.modules.ComponentStartupStatus;
+import edu.cornell.mannlib.vitro.webapp.modules.messaging.JMSMessagingClient;
+import edu.cornell.mannlib.vitro.webapp.utils.configuration.Property;
+
+public class RDFDeltaDatasetFactory {
+
+    private static final Log log = LogFactory.getLog(RDFDeltaDatasetFactory.class);
+
+    private String deltaServerURL;
+
+    private String deltaClientZone;
+
+    private DeltaLink deltaLink;
+
+    private DeltaClient deltaClient;
+
+    private JMSMessagingClient jmsMessagingClient;
+
+    @Property(uri = "http://vitro.mannlib.cornell.edu/ns/vitro/ApplicationSetup#hasDeltaServerURL", minOccurs = 1, maxOccurs = 1)
+    public void setDeltaServerURL(String url) {
+        this.deltaServerURL = url;
+    }
+
+    @Property(uri = "http://vitro.mannlib.cornell.edu/ns/vitro/ApplicationSetup#hasDeltaClientZone", minOccurs = 1, maxOccurs = 1)
+    public void setDeltaClientZone(String zone) {
+        this.deltaClientZone = zone;
+    }
+
+    public void startup(Application application, ComponentStartupStatus ss) {
+        FileOps.ensureDir(deltaClientZone);
+        FileOps.clearAll(deltaClientZone);
+        Zone zone = Zone.connect(deltaClientZone);
+        deltaLink = DeltaLinkHTTP.connect(deltaServerURL);
+        deltaClient = DeltaClient.create(zone, deltaLink);
+        jmsMessagingClient = application.getJMSMessagingClient();
+        ss.info(String.format("Delta client connected to Delta server at %s with zone %s", deltaServerURL, deltaClientZone));
+    }
+
+    public Dataset wrap(String datasourceName, boolean shouldEmitMessage, Dataset dataset) {
+        String datasourceURI = String.format("%s/%s", deltaServerURL, datasourceName);
+        Id dsRef = deltaLink.newDataSource(datasourceName, datasourceURI);
+        deltaClient.attachExternal(dsRef, dataset.asDatasetGraph());
+        // Connect using SyncPolicy.TXN_W for when a write-transaction starts, ignoring reads.
+        // https://github.com/afs/rdf-delta/blob/master/rdf-delta-client/src/main/java/org/seaborne/delta/client/SyncPolicy.java
+        deltaClient.connect(dsRef, SyncPolicy.TXN_W);
+        try (DeltaConnection dConn = deltaClient.get(dsRef)) {
+            if (shouldEmitMessage && jmsMessagingClient != null) {
+                dConn.addListener(new DeltaLinkListener() {
+                    @Override
+                    public void append(Id dsRef, Version version, RDFPatch patch) {
+                        try {
+                            jmsMessagingClient.send(RDFPatchOps.str(patch));
+                        } catch (JMSException e) {
+                            log.error(e, e);
+                        }
+                    }
+                });
+            } else {
+                if (jmsMessagingClient == null) {
+                    log.warn("Can not emit message without client");
+                }
+            }
+            log.info(String.format("Wrapped dataset using datasource %s with reference %s", datasourceName, dsRef));
+            return dConn.getDataset();
+        }
+    }
+
+}

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/rdfservice/impl/jena/tdb/RDFServiceTDB.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/rdfservice/impl/jena/tdb/RDFServiceTDB.java
@@ -7,9 +7,6 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.List;
 
 import org.apache.jena.rdf.model.Model;
@@ -20,7 +17,6 @@ import org.apache.commons.logging.LogFactory;
 
 import org.apache.jena.query.Dataset;
 import org.apache.jena.query.ReadWrite;
-import org.apache.jena.tdb.TDBFactory;
 
 import edu.cornell.mannlib.vitro.webapp.dao.jena.DatasetWrapper;
 import edu.cornell.mannlib.vitro.webapp.rdfservice.ChangeSet;
@@ -35,20 +31,8 @@ public class RDFServiceTDB extends RDFServiceJena {
 
 	private final Dataset dataset;
 
-	public RDFServiceTDB(String directoryPath) throws IOException {
-		Path tdbDir = Paths.get(directoryPath);
-
-		if (!Files.exists(tdbDir)) {
-			Path parentDir = tdbDir.getParent();
-			if (!Files.exists(parentDir)) {
-				throw new IllegalArgumentException(
-						"Cannot create TDB directory '" + tdbDir
-								+ "': parent directory does not exist.");
-			}
-			Files.createDirectory(tdbDir);
-		}
-
-		this.dataset = TDBFactory.createDataset(directoryPath);
+	public RDFServiceTDB(Dataset dataset) {
+		this.dataset = dataset;
 	}
 
 	@Override

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/triplesource/impl/tdb/ConfigurationTripleSourceTDB.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/triplesource/impl/tdb/ConfigurationTripleSourceTDB.java
@@ -3,11 +3,13 @@
 package edu.cornell.mannlib.vitro.webapp.triplesource.impl.tdb;
 
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 
 import org.apache.jena.query.Dataset;
 import org.apache.jena.rdf.model.ModelMaker;
 import org.apache.jena.tdb.TDB;
+import org.apache.jena.tdb.TDBFactory;
 
 import edu.cornell.mannlib.vitro.webapp.application.ApplicationUtils;
 import edu.cornell.mannlib.vitro.webapp.dao.jena.RDFServiceDataset;
@@ -51,12 +53,9 @@ public class ConfigurationTripleSourceTDB extends ConfigurationTripleSource {
 	public void startup(Application application, ComponentStartupStatus ss) {
 		configureTDB();
 
-		Path vitroHome = ApplicationUtils.instance().getHomeDirectory()
-				.getPath();
-		String tdbPath = vitroHome.resolve(DIRECTORY_TDB).toString();
-
 		try {
-			this.rdfService = new RDFServiceTDB(tdbPath);
+			String tdbPath = resolveTdbPath();
+			this.rdfService = new RDFServiceTDB(TDBFactory.createDataset(tdbPath));
 			this.rdfServiceFactory = createRDFServiceFactory();
 			this.unclosableRdfService = this.rdfServiceFactory.getRDFService();
 			this.dataset = new RDFServiceDataset(this.unclosableRdfService);
@@ -70,6 +69,12 @@ public class ConfigurationTripleSourceTDB extends ConfigurationTripleSource {
 
 	private void configureTDB() {
 		TDB.getContext().setTrue(TDB.symUnionDefaultGraph);
+	}
+
+	private String resolveTdbPath() throws IOException {
+		Path tdbPath = ApplicationUtils.instance().getHomeDirectory().getPath().resolve(DIRECTORY_TDB);
+		Files.createDirectories(tdbPath);
+		return tdbPath.toString();
 	}
 
 	private RDFServiceFactory createRDFServiceFactory() {

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/triplesource/impl/tdb/ContentTripleSourceTDB.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/triplesource/impl/tdb/ContentTripleSourceTDB.java
@@ -92,8 +92,7 @@ public class ContentTripleSourceTDB extends ContentTripleSource {
 			checkForFirstTimeStartup();
 			ss.info("Initialized the RDF source for TDB");
 		} catch (IOException e) {
-			throw new RuntimeException(
-					"Failed to set up the RDF source for TDB", e);
+			throw new RuntimeException("Failed to set up the RDF source for TDB", e);
 		}
 	}
 
@@ -108,19 +107,16 @@ public class ContentTripleSourceTDB extends ContentTripleSource {
 	}
 
 	private RDFServiceFactory createRDFServiceFactory() {
-		return new LoggingRDFServiceFactory(new RDFServiceFactorySingle(
-				this.rdfService));
+		return new LoggingRDFServiceFactory(new RDFServiceFactorySingle(this.rdfService));
 	}
 
 	private ModelMaker createModelMaker() {
-		return addContentDecorators(new ModelMakerWithPersistentEmptyModels(
-				new MemoryMappingModelMaker(new RDFServiceModelMaker(
-						this.unclosableRdfService), SMALL_CONTENT_MODELS)));
+		return addContentDecorators(new ModelMakerWithPersistentEmptyModels(new MemoryMappingModelMaker(
+				new RDFServiceModelMaker(this.unclosableRdfService), SMALL_CONTENT_MODELS)));
 	}
 
 	private void checkForFirstTimeStartup() {
-		if (this.dataset.getNamedModel(ModelNames.TBOX_ASSERTIONS).getGraph()
-				.isEmpty()) {
+		if (this.dataset.getNamedModel(ModelNames.TBOX_ASSERTIONS).getGraph().isEmpty()) {
 			JenaDataSourceSetupBase.thisIsFirstStartup();
 		}
 	}
@@ -146,8 +142,7 @@ public class ContentTripleSourceTDB extends ContentTripleSource {
 	}
 
 	@Override
-	public OntModelCache getShortTermOntModels(RDFService shortTermRdfService,
-			OntModelCache longTermOntModelCache) {
+	public OntModelCache getShortTermOntModels(RDFService shortTermRdfService, OntModelCache longTermOntModelCache) {
 		// No need to use short-term models.
 		return longTermOntModelCache;
 	}

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/triplesource/impl/tdb/ContentTripleSourceTDB.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/triplesource/impl/tdb/ContentTripleSourceTDB.java
@@ -3,11 +3,15 @@
 package edu.cornell.mannlib.vitro.webapp.triplesource.impl.tdb;
 
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 
 import org.apache.jena.query.Dataset;
 import org.apache.jena.rdf.model.ModelMaker;
 import org.apache.jena.tdb.TDB;
+import org.apache.jena.tdb.TDBFactory;
 
+import edu.cornell.mannlib.vitro.webapp.application.ApplicationUtils;
 import edu.cornell.mannlib.vitro.webapp.dao.jena.RDFServiceDataset;
 import edu.cornell.mannlib.vitro.webapp.dao.jena.RDFServiceModelMaker;
 import edu.cornell.mannlib.vitro.webapp.modelaccess.ModelNames;
@@ -16,6 +20,7 @@ import edu.cornell.mannlib.vitro.webapp.modelaccess.adapters.ModelMakerWithPersi
 import edu.cornell.mannlib.vitro.webapp.modelaccess.ontmodels.OntModelCache;
 import edu.cornell.mannlib.vitro.webapp.modules.Application;
 import edu.cornell.mannlib.vitro.webapp.modules.ComponentStartupStatus;
+import edu.cornell.mannlib.vitro.webapp.modules.rdfDelta.RDFDeltaDatasetFactory;
 import edu.cornell.mannlib.vitro.webapp.modules.tripleSource.ContentTripleSource;
 import edu.cornell.mannlib.vitro.webapp.rdfservice.RDFService;
 import edu.cornell.mannlib.vitro.webapp.rdfservice.RDFServiceFactory;
@@ -42,6 +47,10 @@ import edu.cornell.mannlib.vitro.webapp.utils.logging.ToString;
 public class ContentTripleSourceTDB extends ContentTripleSource {
 	private String tdbPath;
 
+	private String rdfDeltaDatasource;
+
+	private boolean emitPatches = false;
+
 	private volatile RDFService rdfService;
 	private RDFServiceFactory rdfServiceFactory;
 	private RDFService unclosableRdfService;
@@ -53,11 +62,29 @@ public class ContentTripleSourceTDB extends ContentTripleSource {
 		tdbPath = path;
 	}
 
+	@Property(uri = "http://vitro.mannlib.cornell.edu/ns/vitro/ApplicationSetup#hasRDFDeltaDatasource", minOccurs = 0, maxOccurs = 1)
+	public void setRDFDeltaDatasource(String deltaDatasource) {
+		rdfDeltaDatasource = deltaDatasource;
+	}
+
+	@Property(uri = "http://vitro.mannlib.cornell.edu/ns/vitro/ApplicationSetup#shouldEmitPatches", minOccurs = 0, maxOccurs = 1)
+	public void setShouldEmitPatches(String emitPatches) {
+		this.emitPatches = Boolean.parseBoolean(emitPatches);
+	}
+
 	@Override
 	public void startup(Application application, ComponentStartupStatus ss) {
 		configureTDB();
 		try {
-			this.rdfService = new RDFServiceTDB(resolveTdbPath(application));
+			String tdbPath = resolveTdbPath();
+			Dataset dataset = TDBFactory.createDataset(tdbPath);
+			if (rdfDeltaDatasource != null) {
+				RDFDeltaDatasetFactory rdfDeltaDatasetFactory = application.getRDFDeltaDatasetFactory();
+				if (rdfDeltaDatasetFactory != null) {
+					dataset = rdfDeltaDatasetFactory.wrap(rdfDeltaDatasource, emitPatches, dataset);
+				}
+			}
+			this.rdfService = new RDFServiceTDB(dataset);
 			this.rdfServiceFactory = createRDFServiceFactory();
 			this.unclosableRdfService = this.rdfServiceFactory.getRDFService();
 			this.dataset = new RDFServiceDataset(this.unclosableRdfService);
@@ -70,13 +97,14 @@ public class ContentTripleSourceTDB extends ContentTripleSource {
 		}
 	}
 
-	private String resolveTdbPath(Application application) {
-		return application.getHomeDirectory().getPath().resolve(tdbPath)
-				.toString();
-	}
-
 	private void configureTDB() {
 		TDB.getContext().setTrue(TDB.symUnionDefaultGraph);
+	}
+
+	private String resolveTdbPath() throws IOException {
+		Path tdbPath = ApplicationUtils.instance().getHomeDirectory().getPath().resolve(this.tdbPath);
+		Files.createDirectories(tdbPath);
+		return tdbPath.toString();
 	}
 
 	private RDFServiceFactory createRDFServiceFactory() {

--- a/api/src/test/java/stubs/edu/cornell/mannlib/vitro/webapp/modules/ApplicationStub.java
+++ b/api/src/test/java/stubs/edu/cornell/mannlib/vitro/webapp/modules/ApplicationStub.java
@@ -12,6 +12,8 @@ import edu.cornell.mannlib.vitro.webapp.application.VitroHomeDirectory;
 import edu.cornell.mannlib.vitro.webapp.modules.Application;
 import edu.cornell.mannlib.vitro.webapp.modules.fileStorage.FileStorage;
 import edu.cornell.mannlib.vitro.webapp.modules.imageProcessor.ImageProcessor;
+import edu.cornell.mannlib.vitro.webapp.modules.messaging.JMSMessagingClient;
+import edu.cornell.mannlib.vitro.webapp.modules.rdfDelta.RDFDeltaDatasetFactory;
 import edu.cornell.mannlib.vitro.webapp.modules.searchEngine.SearchEngine;
 import edu.cornell.mannlib.vitro.webapp.modules.searchIndexer.SearchIndexer;
 import edu.cornell.mannlib.vitro.webapp.modules.tboxreasoner.TBoxReasonerModule;
@@ -86,7 +88,18 @@ public class ApplicationStub implements Application {
 	public ImageProcessor getImageProcessor() {
 		throw new RuntimeException(
 				"ApplicationStub.getImageProcessor() not implemented.");
+	}
 
+	@Override
+	public JMSMessagingClient getJMSMessagingClient() {
+		throw new RuntimeException(
+				"ApplicationStub.getJMSMessagingClient() not implemented.");
+	}
+
+	@Override
+	public RDFDeltaDatasetFactory getRDFDeltaDatasetFactory() {
+		throw new RuntimeException(
+				"ApplicationStub.getRDFDeltaDatasetFactory() not implemented.");
 	}
 
 	@Override

--- a/home/src/main/resources/config/example.applicationSetup.n3
+++ b/home/src/main/resources/config/example.applicationSetup.n3
@@ -164,6 +164,7 @@
 #    :hasProviderURL "tcp://localhost:61616?type=TOPIC_CF" ;
 #    :hasConnectionFactory "TopicConnectionFactory" ;
 #    :hasBrokerDestination "topic/rdf-delta-patch" ;
+#    :hasBrokerType "topic" ;
 #    :hasBrokerUsername "artemis" ;
 #    :hasBrokerPassword "artemis" .
 

--- a/home/src/main/resources/config/example.applicationSetup.n3
+++ b/home/src/main/resources/config/example.applicationSetup.n3
@@ -151,6 +151,9 @@
 # ----------------------------
 #
 # JMS Messaging Client Module:
+#    JNDI implementation of a messaging client used to publish messages
+#    to a broker. Requires an external message broker. Has been tested
+#    against Artemis ActiveMQ topic. https://activemq.apache.org/components/artemis/
 #
 
 #:jmsMessagingClient

--- a/home/src/main/resources/config/example.applicationSetup.n3
+++ b/home/src/main/resources/config/example.applicationSetup.n3
@@ -99,6 +99,14 @@
 #    # May be an absolute path, or relative to the Vitro home directory.
 #    :hasTdbDirectory "tdbContentModels" .
 
+#:tdbRDFDeltaMessagingContentTripleSource
+#    a   vitroWebapp:triplesource.impl.tdb.ContentTripleSourceTDB ,
+#        vitroWebapp:modules.tripleSource.ContentTripleSource ;
+#    # May be an absolute path, or relative to the Vitro home directory.
+#    :hasTdbDirectory "/opt/vivo/vivo-data" ;
+#    :hasRDFDeltaDatasource "vivo-data" ;
+#    :shouldEmitPatches "true" .
+
 #:sparqlContentTripleSource
 #    a   vitroWebapp:triplesource.impl.virtuoso.ContentTripleSourceSPARQL ,
 #        vitroWebapp:modules.tripleSource.ContentTripleSource ;
@@ -137,3 +145,30 @@
 :jfactTBoxReasonerModule
     a   vitroWebapp:tboxreasoner.impl.jfact.JFactTBoxReasonerModule ,
         vitroWebapp:modules.tboxreasoner.TBoxReasonerModule .
+
+# ----------------------------
+#
+# JMS Messaging Client Module:
+#
+
+#:jmsMessagingClient
+#    a   vitroWebapp:modules.messaging.JMSMessagingClient ;
+#    # JNDI property java.naming.factory.initial
+#    :hasFactoryInitial "org.apache.activemq.artemis.jndi.ActiveMQInitialContextFactory" ;
+#    # JNDI property java.naming.provider.url
+#    :hasProviderURL "tcp://localhost:61616?type=TOPIC_CF" ;
+#    :hasConnectionFactory "TopicConnectionFactory" ;
+#    :hasBrokerDestination "topic/rdf-delta-patch" ;
+#    :hasBrokerUsername "artemis" ;
+#    :hasBrokerPassword "artemis" .
+
+# ----------------------------
+#
+# RDF Delta Dataset Factory Module:
+#
+
+#:rdfDeltaDatasetFactory
+#    a   vitroWebapp:modules.rdfDelta.RDFDeltaDatasetFactory ;
+#    # becomes an absolute path
+#    :hasDeltaServerURL "http://localhost:1066/" ;
+#    :hasDeltaClientZone "/opt/vivo/Zone" .

--- a/home/src/main/resources/config/example.applicationSetup.n3
+++ b/home/src/main/resources/config/example.applicationSetup.n3
@@ -104,7 +104,9 @@
 #        vitroWebapp:modules.tripleSource.ContentTripleSource ;
 #    # May be an absolute path, or relative to the Vitro home directory.
 #    :hasTdbDirectory "/opt/vivo/vivo-data" ;
-#    :hasRDFDeltaDatasource "vivo-data" ;
+#    # Name of the RDF Delta Patch Log Datasource
+#    :hasRDFDeltaDatasource "vivo-patches" ;
+#    # Whether or not a triple change should be published, requires jmsMessagingClient
 #    :shouldEmitPatches "true" .
 
 #:sparqlContentTripleSource

--- a/home/src/main/resources/config/example.applicationSetup.n3
+++ b/home/src/main/resources/config/example.applicationSetup.n3
@@ -170,6 +170,11 @@
 # ----------------------------
 #
 # RDF Delta Dataset Factory Module:
+#    Dataset factory implementation in which connects to an external RDF Delta Patch Log service
+#    and affords wrapping TDB datasets. The returned dataset produces RDF Delta Patch Logs for
+#    each write to the triplestore. These patches can be read from the logs or used to emit
+#    the change event.
+#    https://afs.github.io/rdf-delta/
 #
 
 #:rdfDeltaDatasetFactory

--- a/home/src/main/resources/config/example.rdf.messaging.applicationSetup.n3
+++ b/home/src/main/resources/config/example.rdf.messaging.applicationSetup.n3
@@ -26,7 +26,9 @@
     :hasSearchIndexer             :basicSearchIndexer ;
     :hasImageProcessor            :iioImageProcessor ;
     :hasFileStorage               :ptiFileStorage ;
-    :hasContentTripleSource       :sdbContentTripleSource ;
+    :hasRDFDeltaDatasetFactory    :rdfDeltaDatasetFactory ;
+    :hasJMSMessagingClient        :jmsMessagingClient ;
+    :hasContentTripleSource       :tdbRDFDeltaMessagingContentTripleSource ;
     :hasConfigurationTripleSource :tdbConfigurationTripleSource ;
     :hasTBoxReasonerModule        :jfactTBoxReasonerModule .
 
@@ -89,15 +91,25 @@
 #    endpoint, or a Virtuoso endpoint, with parameters as shown.
 #
 
-:sdbContentTripleSource
-    a   vitroWebapp:triplesource.impl.sdb.ContentTripleSourceSDB ,
-        vitroWebapp:modules.tripleSource.ContentTripleSource .
+#:sdbContentTripleSource
+#    a   vitroWebapp:triplesource.impl.sdb.ContentTripleSourceSDB ,
+#        vitroWebapp:modules.tripleSource.ContentTripleSource .
 
 #:tdbContentTripleSource
 #    a   vitroWebapp:triplesource.impl.tdb.ContentTripleSourceTDB ,
 #        vitroWebapp:modules.tripleSource.ContentTripleSource ;
 #    # May be an absolute path, or relative to the Vitro home directory.
 #    :hasTdbDirectory "tdbContentModels" .
+
+:tdbRDFDeltaMessagingContentTripleSource
+    a   vitroWebapp:triplesource.impl.tdb.ContentTripleSourceTDB ,
+        vitroWebapp:modules.tripleSource.ContentTripleSource ;
+    # May be an absolute path, or relative to the Vitro home directory.
+    :hasTdbDirectory "/opt/vivo/vivo-data" ;
+    # Name of the RDF Delta Patch Log Datasource
+    :hasRDFDeltaDatasource "vivo-patches" ;
+    # Whether or not a triple change should be published, requires jmsMessagingClient
+    :shouldEmitPatches "true" .
 
 #:sparqlContentTripleSource
 #    a   vitroWebapp:triplesource.impl.virtuoso.ContentTripleSourceSPARQL ,
@@ -137,3 +149,39 @@
 :jfactTBoxReasonerModule
     a   vitroWebapp:tboxreasoner.impl.jfact.JFactTBoxReasonerModule ,
         vitroWebapp:modules.tboxreasoner.TBoxReasonerModule .
+
+# ----------------------------
+#
+# JMS Messaging Client Module:
+#    JNDI implementation of a messaging client used to publish messages
+#    to a broker. Requires an external message broker. Has been tested
+#    against Artemis ActiveMQ topic. https://activemq.apache.org/components/artemis/
+#
+
+:jmsMessagingClient
+    a   vitroWebapp:modules.messaging.JMSMessagingClient ;
+    # JNDI property java.naming.factory.initial
+    :hasFactoryInitial "org.apache.activemq.artemis.jndi.ActiveMQInitialContextFactory" ;
+    # JNDI property java.naming.provider.url
+    :hasProviderURL "tcp://localhost:61616?type=TOPIC_CF" ;
+    :hasConnectionFactory "TopicConnectionFactory" ;
+    :hasBrokerDestination "topic/rdf-delta-patch" ;
+    :hasBrokerType "topic" ;
+    :hasBrokerUsername "artemis" ;
+    :hasBrokerPassword "artemis" .
+
+# ----------------------------
+#
+# RDF Delta Dataset Factory Module:
+#    Dataset factory implementation in which connects to an external RDF Delta Patch Log service
+#    and affords wrapping TDB datasets. The returned dataset produces RDF Delta Patch Logs for
+#    each write to the triplestore. These patches can be read from the logs or used to emit
+#    the change event.
+#    https://afs.github.io/rdf-delta/
+#
+
+:rdfDeltaDatasetFactory
+    a   vitroWebapp:modules.rdfDelta.RDFDeltaDatasetFactory ;
+    # becomes an absolute path
+    :hasDeltaServerURL "http://localhost:1066/" ;
+    :hasDeltaClientZone "/opt/vivo/Zone" .


### PR DESCRIPTION
**[VIVO-1718](https://jira.duraspace.org/browse/VIVO-1718)**

[RDF Delta](https://afs.github.io/rdf-delta/)
[RDF Delta Github](https://github.com/afs/rdf-delta)
[ActiveMQ Artemis](https://activemq.apache.org/components/artemis/)

# What does this pull request do?

This PR is to introduce ability to wrap TDB dataset with a RDF Delta Client connection. This will send all triplestore changes to a [RDF Delta Server](https://github.com/afs/rdf-delta/tree/master/rdf-delta-server) in the form of [RDF Delta Patches](https://afs.github.io/rdf-delta/rdf-patch.html). In addition provide the ability to connect and publish RDF Delta Patches to a message broker topic or queue.

# What's new?
* Added RDF Delta Dataset Factory to produce datasets wrapped with a RDF Delta client from an existing TDB dataset
* Added JMS Messaging Client to be able to send a message to a configured destination
* Added initialization of RDF Delta Dataset Factory based on configuration
* Added initialization of JMS Messaging Client based on configuration
* Wrap configuration TDB triplestore with RDF Delta Client connection
* Wrap content TDB triplestore with RDF Delta Client connection

# How should this be tested?

Can be tested using [VIVO vagrant](https://github.com/TAMULib/vivo-vagrant/tree/rdf-delta-messaging).

Additions to the vagrant:
- RDF Delta server, http://localhost:1066
- Artemis ActiveMQ, http://localhost:8161
- Simple Message Consumer, http://localhost:9000/actuator/logfile

After logging into VIVO, http://localhost:8080/vivo, as `vivo_root@school.edu` with password `rootPassword` and updating the password you will be able to make changes that are logged and published as RDF Delta patches. These messages will be consumed and logged by the simple message consumer.

# Additional Notes:

* rdf-delta-client dependency
* javax.jms-api dependency
* artemis-jms-client-all dependency

# Interested parties
@awoods @mconlon17 @roflinn 
