### PR TITLE
[VIVO-1737] Update Error Prone

### DIFF
--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/beans/IndividualImpl.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/beans/IndividualImpl.java
@@ -20,6 +20,7 @@ import edu.cornell.mannlib.vitro.webapp.filestorage.model.ImageInfo;
 /**
  * Represents a single entity record.
 */
+@SuppressWarnings("ComparableType")
 public class IndividualImpl extends BaseResourceBean implements Individual, Comparable<Individual> {
 	/**
 	 * This can be used as a "not initialized" indicator for a property that

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/grefine/JSONReconcileServlet.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/grefine/JSONReconcileServlet.java
@@ -469,7 +469,7 @@ public class JSONReconcileServlet extends VitroHttpServlet {
         return queryStr.replaceAll("\\s+", "\\\\ ");
     }
 
-    public class SearchResult implements Comparable<Object> {
+    public class SearchResult implements Comparable<SearchResult> {
         private String label;
         private String uri;
 
@@ -493,7 +493,7 @@ public class JSONReconcileServlet extends VitroHttpServlet {
             return map;
         }
 
-        public int compareTo(Object o) throws ClassCastException {
+        public int compareTo(SearchResult o) throws ClassCastException {
             if ( !(o instanceof SearchResult) ) {
                 throw new ClassCastException("Error in SearchResult.compareTo(): expected SearchResult object.");
             }

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/search/controller/AutocompleteController.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/search/controller/AutocompleteController.java
@@ -311,7 +311,7 @@ public class AutocompleteController extends VitroAjaxController {
 		return RDFServiceUtils.getRDFService(new VitroRequest(req));
 	}
 
-    public class SearchResult implements Comparable<Object> {
+    public class SearchResult implements Comparable<SearchResult> {
         private String label;
         private String uri;
         private String msType;
@@ -375,7 +375,7 @@ public class AutocompleteController extends VitroAjaxController {
         	return jsonObj;
         }
 
-        public int compareTo(Object o) throws ClassCastException {
+        public int compareTo(SearchResult o) throws ClassCastException {
             if ( !(o instanceof SearchResult) ) {
                 throw new ClassCastException("Error in SearchResult.compareTo(): expected SearchResult object.");
             }

--- a/pom.xml
+++ b/pom.xml
@@ -217,6 +217,34 @@
                 </plugins>
             </build>
         </profile>
+        <profile>
+            <!-- Profile for Error Prone plugin -->
+            <id>errorprone</id>
+            <activation>
+                <jdk>[1.8,12)</jdk>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-compiler-plugin</artifactId>
+                        <configuration>
+                            <fork>true</fork>
+                            <compilerArgs combine.children="append">
+                                <arg>-Xplugin:ErrorProne</arg>
+                            </compilerArgs>
+                            <annotationProcessorPaths>
+                                <path>
+                                    <groupId>com.google.errorprone</groupId>
+                                    <artifactId>error_prone_core</artifactId>
+                                    <version>2.3.4</version>
+                                </path>
+                            </annotationProcessorPaths>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
     </profiles>
 
     <build>
@@ -230,15 +258,7 @@
                     <encoding>UTF-8</encoding>
                     <compilerArgs>
                         <arg>-XDcompilePolicy=simple</arg>
-                        <arg>-Xplugin:ErrorProne</arg>
                     </compilerArgs>
-                    <annotationProcessorPaths>
-                        <path>
-                            <groupId>com.google.errorprone</groupId>
-                            <artifactId>error_prone_core</artifactId>
-                            <version>2.3.2</version>
-                        </path>
-                    </annotationProcessorPaths>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
**[VIVO-1737](https://jira.lyrasis.org/browse/VIVO-1737)**:

# What does this pull request do?

Updates the Error Prone plugin to for compile time analysis to the latest release, and moves the configuration to a profile that is enabled for JDK 1.8 - 11.

Builds with Error Prone fail when using JDK 12+, so by not enabling on those JDKs enables people to use them for their environment - Vitro/VIVO builds on JDK 13, but it is not tested.

This also allows developers to disable the Error Prone plugin from the command line, however I would not recommend this in general as it quickly and easily catches bad code.

# What's new?
Nothing specific, although the Error Prone plugin is now faster and includes some extra checks

# How should this be tested?
Run mvn clean install - build should complete.
Ideally, test with multiple JDK versions

# Interested parties
@VIVO-project/vivo-committers
