### PR TITLE
[VIVO-1755] - Better error handling when reasoner disabled

### DIFF
--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/freemarker/BaseSiteAdminController.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/freemarker/BaseSiteAdminController.java
@@ -209,7 +209,7 @@ public class BaseSiteAdminController extends FreemarkerHttpServlet {
                 }
             } catch (IllegalStateException e) {
                 error = "The inferencing engine is disabled.";
-                log.debug("Status of reasoner could not be determined.", e);
+                log.debug("Status of reasoner could not be determined. It is likely disabled.", e);
             }
 
             if (error != null) {

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/freemarker/BaseSiteAdminController.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/freemarker/BaseSiteAdminController.java
@@ -199,12 +199,18 @@ public class BaseSiteAdminController extends FreemarkerHttpServlet {
 
             String error = null;
             String explanation = null;
-            TBoxReasonerStatus status = ApplicationUtils.instance().getTBoxReasonerModule().getStatus();
-            if (!status.isConsistent()) {
-                error = "INCONSISTENT ONTOLOGY: reasoning halted.";
-                explanation = status.getExplanation();
-            } else if ( status.isInErrorState() ) {
-                error = "An error occurred during reasoning. Reasoning has been halted. See error log for details.";
+            try {
+                TBoxReasonerStatus status = ApplicationUtils.instance().getTBoxReasonerModule().getStatus();
+                if (!status.isConsistent()) {
+                    error = "INCONSISTENT ONTOLOGY: reasoning halted.";
+                    explanation = status.getExplanation();
+                } else if ( status.isInErrorState() ) {
+                    error = "An error occurred during reasoning. Reasoning has been halted. See error log for details.";
+                }
+            } catch (IllegalStateException e) {
+                error = "The inferencing engine is disabled.";
+                log.warn("Status of reasoner could not be determined.");
+                log.debug(e);
             }
 
             if (error != null) {

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/freemarker/BaseSiteAdminController.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/freemarker/BaseSiteAdminController.java
@@ -208,7 +208,7 @@ public class BaseSiteAdminController extends FreemarkerHttpServlet {
                     error = "An error occurred during reasoning. Reasoning has been halted. See error log for details.";
                 }
             } catch (IllegalStateException e) {
-                error = "The inferencing engine is disabled.";
+                error = "The inferencing engine is disabled. Data entered manually may exhibit unexpected behavior prior to inferencing.";
                 log.debug("Status of reasoner could not be determined. It is likely disabled.", e);
             }
 

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/freemarker/BaseSiteAdminController.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/freemarker/BaseSiteAdminController.java
@@ -209,8 +209,7 @@ public class BaseSiteAdminController extends FreemarkerHttpServlet {
                 }
             } catch (IllegalStateException e) {
                 error = "The inferencing engine is disabled.";
-                log.warn("Status of reasoner could not be determined.");
-                log.debug(e);
+                log.debug("Status of reasoner could not be determined.", e);
             }
 
             if (error != null) {

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/jena/JenaAdminActions.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/jena/JenaAdminActions.java
@@ -217,7 +217,7 @@ public class JenaAdminActions extends BaseEditController {
 			}
 		}
 		catch (IllegalStateException e) {
-			log.debug("Status of reasoner could not be determined. It is likely disabled", e);
+			log.warn("Status of reasoner could not be determined. It is likely disabled", e);
 		}
     }
 

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/jena/JenaAdminActions.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/jena/JenaAdminActions.java
@@ -192,29 +192,33 @@ public class JenaAdminActions extends BaseEditController {
 	}
 
     private void printRestrictions() {
-    	TBoxReasonerModule reasoner = ApplicationUtils.instance().getTBoxReasonerModule();
-    	for (Restriction rest : reasoner.listRestrictions() ) {
-    		if (rest.isAllValuesFromRestriction()) {
-    			log.trace("All values from: ");
-    			AllValuesFromRestriction avfr = rest.asAllValuesFromRestriction();
-    			Resource res = avfr.getAllValuesFrom();
-    			if (res.canAs(OntClass.class)) {
-    				OntClass resClass = res.as(OntClass.class);
-    				for (Resource inst : resClass.listInstances().toList() ) {
-    					log.trace("    -"+inst.getURI());
-    				}
-    			}
-    		} else if (rest.isSomeValuesFromRestriction()) {
-    			log.trace("Some values from: ");
-    		} else if (rest.isHasValueRestriction()) {
-    			log.trace("Has value: ");
-    		}
-    		log.trace("On property "+rest.getOnProperty().getURI());
-    		for (Resource inst : rest.listInstances().toList() ) {
-    			log.trace("     "+inst.getURI());
-    		}
-
-    	}
+		try {
+			TBoxReasonerModule reasoner = ApplicationUtils.instance().getTBoxReasonerModule();
+			for (Restriction rest : reasoner.listRestrictions() ) {
+				if (rest.isAllValuesFromRestriction()) {
+					log.trace("All values from: ");
+					AllValuesFromRestriction avfr = rest.asAllValuesFromRestriction();
+					Resource res = avfr.getAllValuesFrom();
+					if (res.canAs(OntClass.class)) {
+						OntClass resClass = res.as(OntClass.class);
+						for (Resource inst : resClass.listInstances().toList() ) {
+							log.trace("    -"+inst.getURI());
+						}
+					}
+				} else if (rest.isSomeValuesFromRestriction()) {
+					log.trace("Some values from: ");
+				} else if (rest.isHasValueRestriction()) {
+					log.trace("Has value: ");
+				}
+				log.trace("On property "+rest.getOnProperty().getURI());
+				for (Resource inst : rest.listInstances().toList() ) {
+					log.trace("     "+inst.getURI());
+				}
+			}
+		}
+		catch (IllegalStateException e) {
+			log.debug("Status of reasoner could not be determined. It is likely disabled", e);
+		}
     }
 
     private void removeLongLiterals() {

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/dao/jena/DataPropertyDaoJena.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/dao/jena/DataPropertyDaoJena.java
@@ -361,10 +361,10 @@ public class DataPropertyDaoJena extends PropertyDaoJena implements
 
     protected boolean reasoningAvailable() {
         try {
-    	TBoxReasonerStatus status = ApplicationUtils.instance().getTBoxReasonerModule().getStatus();
-        return status.isConsistent() && !status.isInErrorState();
+            TBoxReasonerStatus status = ApplicationUtils.instance().getTBoxReasonerModule().getStatus();
+            return status.isConsistent() && !status.isInErrorState();
         } catch (IllegalStateException e) {
-            log.debug("Status of reasoner could not be determined.", e);
+            log.debug("Status of reasoner could not be determined. It is likely disabled.", e);
             return false;
         }
     }

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/dao/jena/DataPropertyDaoJena.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/dao/jena/DataPropertyDaoJena.java
@@ -360,8 +360,13 @@ public class DataPropertyDaoJena extends PropertyDaoJena implements
     }
 
     protected boolean reasoningAvailable() {
+        try {
     	TBoxReasonerStatus status = ApplicationUtils.instance().getTBoxReasonerModule().getStatus();
-    	return status.isConsistent() && !status.isInErrorState();
+        return status.isConsistent() && !status.isInErrorState();
+        } catch (IllegalStateException e) {
+            log.debug("Status of reasoner could not be determined.", e);
+            return false;
+        }
     }
 
     private String getRequiredDatatypeURI(Individual individual, DataProperty dataprop, List<String> vclassURIs) {

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/VTwo/fields/IndividualsViaVClassOptions.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/VTwo/fields/IndividualsViaVClassOptions.java
@@ -110,10 +110,10 @@ public class IndividualsViaVClassOptions implements FieldOptions {
     	try {
             TBoxReasonerStatus status = ApplicationUtils.instance().getTBoxReasonerModule().getStatus();
             return status.isConsistent() && !status.isInErrorState();
-            } catch (IllegalStateException e) {
-                log.debug("Status of reasoner could not be determined.", e);
-                return false;
-            }
+        } catch (IllegalStateException e) {
+            log.debug("Status of reasoner could not be determined. It is likely disabled.", e);
+            return false;
+        }
     }
 
     protected Map<String, Individual> addWhenMissingInference( String classUri , WebappDaoFactory wDaoFact ){

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/VTwo/fields/IndividualsViaVClassOptions.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/VTwo/fields/IndividualsViaVClassOptions.java
@@ -8,6 +8,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
 import edu.cornell.mannlib.vitro.webapp.application.ApplicationUtils;
 import edu.cornell.mannlib.vitro.webapp.beans.Individual;
 import edu.cornell.mannlib.vitro.webapp.dao.IndividualDao;
@@ -16,6 +19,8 @@ import edu.cornell.mannlib.vitro.webapp.edit.n3editing.VTwo.EditConfigurationVTw
 import edu.cornell.mannlib.vitro.webapp.modules.tboxreasoner.TBoxReasonerStatus;
 
 public class IndividualsViaVClassOptions implements FieldOptions {
+
+    protected static final Log log = LogFactory.getLog(IndividualsViaVClassOptions.class.getName());
 
     public static final String LEFT_BLANK = "";
     protected List<String> vclassURIs;
@@ -102,8 +107,13 @@ public class IndividualsViaVClassOptions implements FieldOptions {
     }
 
     protected boolean isReasoningAvailable(){
-    	TBoxReasonerStatus status = ApplicationUtils.instance().getTBoxReasonerModule().getStatus();
-    	return status.isConsistent() && !status.isInErrorState();
+    	try {
+            TBoxReasonerStatus status = ApplicationUtils.instance().getTBoxReasonerModule().getStatus();
+            return status.isConsistent() && !status.isInErrorState();
+            } catch (IllegalStateException e) {
+                log.debug("Status of reasoner could not be determined.", e);
+                return false;
+            }
     }
 
     protected Map<String, Individual> addWhenMissingInference( String classUri , WebappDaoFactory wDaoFact ){


### PR DESCRIPTION
**[JIRA Issue](https://jira.lyrasis.org/browse/VIVO-1755)**: VIVO-1755

# What does this pull request do?
Fixes an issue that makes the site admin page inaccessible and the editor for data properties to break when the reasoner is disabled.

# What's new?
- Instead of throwing an error and stack trace up on the front end, the error is sent to the log. 
- An info box is displayed on the site admin page noting that the reasoner is disabled. The info box is already displayed when the reasoner status is abnormal, so I reused the functionality. 


# How should this be tested?
Reproduce the problem by commenting out these lines in tomcat/webapps/vivo/WEB-INF/resources/startup_listeners.txt

```
# edu.cornell.mannlib.vitro.webapp.application.ApplicationImpl$ReasonersSetup
# edu.cornell.mannlib.vitro.webapp.servlet.setup.SimpleReasonerSetup
```
Go to localhost:8080/vivo/siteAdmin.
You should get an error.

![Screen Shot 2020-03-20 at 12 45 51 PM](https://user-images.githubusercontent.com/10748475/77196350-cdeaf980-6aa8-11ea-80b6-5beef5b8038a.png)

Rebuild with changes. Site admin panel should work once again. Error should be printed to vivo.all.log, and stack trace should be printed to log if the log level is set to debug. 

![Screen Shot 2020-03-20 at 12 38 46 PM](https://user-images.githubusercontent.com/10748475/77196362-d5120780-6aa8-11ea-9381-f5c79033a81e.png)

Reproduce the data property editor error by turning reasoning off and trying to add a new record for a common data property, e.g. overview. An error will be thrown: java.lang.IllegalStateException: JFactTBoxReasonerModule has not been started. Rebuild with changes and you should be able to add the data property.

# Interested parties
@VIVO-project/vivo-committers
