### PR TITLE
[VIVO-1756] - Make data property richtext editor option selectable from UI

### DIFF
--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/edit/DatapropEditController.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/edit/DatapropEditController.java
@@ -42,7 +42,7 @@ public class DatapropEditController extends BaseEditController {
 
     	VitroRequest vreq = new VitroRequest(request);
 
-        final int NUM_COLS=18;
+        final int NUM_COLS=19;
 
         String datapropURI = request.getParameter("uri");
 
@@ -73,8 +73,9 @@ public class DatapropEditController extends BaseEditController {
         results.add("display tier");          // column 14
         results.add("display limit");         // column 15
         results.add("custom entry form");     // column 16
-        results.add("URI");                   // column 17
-        results.add("publish level");         // column 18
+        results.add("editing");               // column 17
+        results.add("URI");                   // column 18
+        results.add("publish level");         // column 19
 
         results.add(dp.getPickListName()); // column 1
         results.add(dp.getPublicName() == null ? "(no public label)" : dp.getPublicName()); // column 2
@@ -142,9 +143,10 @@ public class DatapropEditController extends BaseEditController {
         results.add(String.valueOf(dp.getDisplayTier()));  // column 14
         results.add(String.valueOf(dp.getDisplayLimit()));  // column 15
         results.add(dp.getCustomEntryForm() == null ? "(unspecified)" : dp.getCustomEntryForm());  // column 16
-        results.add(dp.getURI() == null ? "" : dp.getURI()); // column 17
+        results.add(dp.getEditing() == null ? "" : dp.getEditing()); // column 17
+        results.add(dp.getURI() == null ? "" : dp.getURI()); // column 18
 		results.add(dp.getHiddenFromPublishBelowRoleLevel() == null ? "(unspecified)"
-				: dp.getHiddenFromPublishBelowRoleLevel().getDisplayLabel()); // column 18
+				: dp.getHiddenFromPublishBelowRoleLevel().getDisplayLabel()); // column 19
         request.setAttribute("results",results);
         request.setAttribute("columncount",NUM_COLS);
         request.setAttribute("suppressquery","true");

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/edit/DatapropRetryController.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/edit/DatapropRetryController.java
@@ -168,13 +168,26 @@ public class DatapropRetryController extends BaseEditController {
         optionMap.put("ProhibitedFromUpdateBelowRoleLevelUsingRoleUri",RoleLevelOptionsSetup.getUpdateOptionsList(objectForEditing));
         optionMap.put("HiddenFromPublishBelowRoleLevelUsingRoleUri",RoleLevelOptionsSetup.getPublishOptionsList(objectForEditing));
 
+        // Set the value of the editing parameter (as defined in VitroVocabulary.java). 
+        // Use value to control form types as in defaultDataPropertyForm.ftl
+        String editingVal = objectForEditing.getEditing();
+        List<Option> editingOptList = new ArrayList<Option>();
+        editingOptList.add(0,new Option("","plaintext"));
+        editingOptList.add(1,new Option("HTML","rich text"));
+        for (Option val : editingOptList) {
+            if(editingVal != null && editingVal.equals(val.getValue())) {
+                val.setSelected(true);
+            }
+        }
+        optionMap.put("Editing", editingOptList);
+
         foo.setOptionLists(optionMap);
 
         request.setAttribute("functional",objectForEditing.getFunctional());
 
         //checkboxes are pretty annoying : we don't know if someone *unchecked* a box, so we have to default to false on updates.
         if (objectForEditing.getURI() != null) {
-        	objectForEditing.setFunctional(false);
+              objectForEditing.setFunctional(false);
         }
 
         foo.setErrorMap(epo.getErrMsgMap());

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/dao/jena/DataPropertyDaoJena.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/dao/jena/DataPropertyDaoJena.java
@@ -514,6 +514,7 @@ public class DataPropertyDaoJena extends PropertyDaoJena implements
             addPropertyStringValue(jDataprop, EXAMPLE, dtp.getExample(), ontModel);
             addPropertyStringValue(jDataprop, DESCRIPTION_ANNOT, dtp.getDescription(), ontModel);
             addPropertyStringValue(jDataprop, PUBLIC_DESCRIPTION_ANNOT, dtp.getPublicDescription(), ontModel);
+            addPropertyStringValue(jDataprop, EDITING, dtp.getEditing(), ontModel);
             addPropertyNonNegativeIntValue(jDataprop, DISPLAY_RANK_ANNOT, dtp.getDisplayTier(), ontModel);
             addPropertyNonNegativeIntValue(jDataprop, DISPLAY_LIMIT, dtp.getDisplayLimit(), ontModel);
             //addPropertyStringValue(jDataprop, HIDDEN_ANNOT, dtp.getHidden(), ontModel);
@@ -584,6 +585,7 @@ public class DataPropertyDaoJena extends PropertyDaoJena implements
             updatePropertyStringValue(jDataprop, EXAMPLE, dtp.getExample(), ontModel);
             updatePropertyStringValue(jDataprop, DESCRIPTION_ANNOT, dtp.getDescription(), ontModel);
             updatePropertyStringValue(jDataprop, PUBLIC_DESCRIPTION_ANNOT, dtp.getPublicDescription(), ontModel);
+            updatePropertyStringValue(jDataprop, EDITING, dtp.getEditing(), ontModel);
             updatePropertyNonNegativeIntValue(jDataprop, DISPLAY_RANK_ANNOT, dtp.getDisplayTier(), ontModel);
             updatePropertyNonNegativeIntValue(jDataprop, DISPLAY_LIMIT, dtp.getDisplayLimit(), ontModel);
 

--- a/webapp/src/main/webapp/templates/edit/specific/dataprop_retry.jsp
+++ b/webapp/src/main/webapp/templates/edit/specific/dataprop_retry.jsp
@@ -174,6 +174,12 @@
         </c:if>
     	</td>
 	</td>
+	<td valign="top" colspan="2">
+		<b>Rich text editing</b><br/>
+		<select name="Editing">
+		    <form:option name="Editing"/>
+		</select>
+	</td>
 </tr>
 <tr><td colspan="5"><hr class="formDivider"/></td></tr>
 


### PR DESCRIPTION
**[JIRA Issue](https://jira.lyrasis.org/browse/VIVO-1756)**: [VIVO-1756]

* Other Relevant Links (Mailing list discussion, related pull requests, etc.)
Follows up on comments in https://github.com/vivo-project/Vitro/pull/76

# What does this pull request do?
Makes the rich text editor for data properties selectable via the UI

# What's new?
Adds a drop down menu to the data property settings form. Selecting 'rich text' from this menu results in a triple being added for the data property in the form <data prop uri> <http://vitro.mannlib.cornell.edu/ns/vitro/0.7#editing> "HTML" .

# How should this be tested?
Add a new data property or edit an existing one.

![Screen Shot 2020-03-21 at 7 22 03 PM](https://user-images.githubusercontent.com/10748475/77240268-a2036d00-6ba9-11ea-9e03-1fd8a732fb23.png)

Add the bottom of the form, there should be a new option for enabling the rich text editor.

![Screen Shot 2020-03-21 at 7 22 16 PM](https://user-images.githubusercontent.com/10748475/77240276-b2b3e300-6ba9-11ea-8b17-42e9aa179ed3.png)

Select rich text and confirm that the value 'HTML' is populated 

![Screen Shot 2020-03-21 at 7 22 29 PM](https://user-images.githubusercontent.com/10748475/77240280-c7907680-6ba9-11ea-92f0-76162538679b.png)

Add or edit an instance of the property, confirm it uses the rich text editor.

![Screen Shot 2020-03-21 at 7 22 39 PM](https://user-images.githubusercontent.com/10748475/77240287-d70fbf80-6ba9-11ea-8fae-a2600fda4bb2.png)

Edit the property settings again to switch the editor back to the default. Confirm the rich text editor is no longer used.

![Screen Shot 2020-03-21 at 7 32 23 PM](https://user-images.githubusercontent.com/10748475/77240362-b72ccb80-6baa-11ea-834d-5f16e8d9ac01.png)

# Additional Notes:
'HTML' is currently the only value that has any effect, and it is hard coded into both the default form (https://github.com/vivo-project/Vitro/blob/master/webapp/src/main/webapp/templates/freemarker/edit/forms/defaultDataPropertyForm.ftl#L34) and the proposed DatapropRetryController.java here. Perhaps there's a more eloquent way to handle this but given the current situation it seemed sufficient. 

# Interested parties
@VIVO-project/vivo-committers
