### PR TITLE
Change Model writer lang from "N3-PP" to "N3"

### DIFF
--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/VTwo/AdditionsAndRetractions.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/VTwo/AdditionsAndRetractions.java
@@ -57,7 +57,7 @@ public class AdditionsAndRetractions {
         str += "\nadditions:[";
         if( getAdditions() != null ) {
            StringWriter writer = new StringWriter();
-           getAdditions().write(writer, "N3-PP");
+           getAdditions().write(writer, "N3");
            str += "\n" + writer.toString() + "\n";
         }
         str += "],\n";
@@ -65,7 +65,7 @@ public class AdditionsAndRetractions {
         str += "\nretractions:[";
         if( getRetractions() != null ) {
            StringWriter writer = new StringWriter();
-           getRetractions().write(writer, "N3-PP");
+           getRetractions().write(writer, "N3");
            str += "\n" + writer.toString() + "\n";
         }
         str += "],\n";

--- a/api/src/test/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/VTwo/AdditionsAndRetractionsTest.java
+++ b/api/src/test/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/VTwo/AdditionsAndRetractionsTest.java
@@ -1,0 +1,39 @@
+package edu.cornell.mannlib.vitro.webapp.edit.n3editing.VTwo;
+
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.ModelFactory;
+import org.junit.Assert;
+import org.junit.Test;
+
+import static org.apache.jena.rdf.model.ResourceFactory.createProperty;
+import static org.apache.jena.rdf.model.ResourceFactory.createResource;
+import static org.apache.jena.rdf.model.ResourceFactory.createStatement;
+import static org.apache.jena.rdf.model.ResourceFactory.createStringLiteral;
+
+/**
+ * @author awoods
+ * @since 2020-04-01
+ */
+public class AdditionsAndRetractionsTest {
+
+    @Test
+    public void testToString() {
+        Model additions = ModelFactory.createDefaultModel();
+        additions.add(createStatement(
+                createResource("test:add"),
+                createProperty("test:prop"),
+                createStringLiteral("new")));
+
+        Model retractions = ModelFactory.createDefaultModel();
+        retractions.add(createStatement(
+                createResource("test:retract"),
+                createProperty("test:prop"),
+                createStringLiteral("old")));
+        AdditionsAndRetractions aar = new AdditionsAndRetractions(additions, retractions);
+
+        final String s = aar.toString();
+        Assert.assertNotNull(s);
+        Assert.assertTrue(s.contains("test:add"));
+        Assert.assertTrue(s.contains("test:retract"));
+    }
+}


### PR DESCRIPTION
Resolves: https://jira.lyrasis.org/browse/VIVO-1761

# What does this pull request do?
This pull-request changes the writer lang in AdditionsAndRetractions.toString() from "N3-PP" to "N3".
This was the only instance in the VIVO/Vitro codebase that was using "N3-PP".
A new unit test was added that fails without the update, and passes with it.

# How should this be tested?
A successful build indicates the code is working.

# Interested parties
@VIVO-project/vivo-committers
