### PR TITLE
Sprint i18n/lang filtering model

### DIFF
--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/VTwo/EditConfigurationUtils.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/VTwo/EditConfigurationUtils.java
@@ -70,8 +70,9 @@ public class EditConfigurationUtils {
 
     public static VClass getLangAwardRangeVClass(VitroRequest vreq) {
         // UQAM-Linguistic-Management
-        WebappDaoFactory ctxDaoFact = ModelAccess.on(vreq).getWebappDaoFactory(LanguageOption.LANGUAGE_AWARE);
-        return ctxDaoFact.getVClassDao().getVClassByURI(getRangeUri(vreq));
+        WebappDaoFactory vreqDaoFact = ModelAccess.on(vreq).getWebappDaoFactory(
+                LanguageOption.LANGUAGE_AWARE);
+        return vreqDaoFact.getVClassDao().getVClassByURI(getRangeUri(vreq));
     }
     
     //get individual

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/VTwo/EditConfigurationUtils.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/VTwo/EditConfigurationUtils.java
@@ -63,11 +63,6 @@ public class EditConfigurationUtils {
     }
 
     public static VClass getRangeVClass(VitroRequest vreq) {
-
-        // This needs a WebappDaoFactory with no filtering/RDFService
-        // funny business because it needs to be able to retrieve anonymous union
-        // classes by their "pseudo-bnode URIs".
-        // Someday we'll need to figure out a different way of doing this.
         WebappDaoFactory ctxDaoFact = ModelAccess.on(
                 vreq.getSession().getServletContext()).getWebappDaoFactory();
         return ctxDaoFact.getVClassDao().getVClassByURI(getRangeUri(vreq));
@@ -75,17 +70,11 @@ public class EditConfigurationUtils {
 
     public static VClass getLangAwardRangeVClass(VitroRequest vreq) {
         // UQAM-Linguistic-Management
-        //
-
-        // This needs a WebappDaoFactory with linguistic context filtering/RDFService
-        // funny business because it needs to be able to retrieve anonymous union
-        // classes by their "pseudo-bnode URIs".
-        // Someday we'll need to figure out a different way of doing this.
         WebappDaoFactory ctxDaoFact = ModelAccess.on(vreq).getWebappDaoFactory(LanguageOption.LANGUAGE_AWARE);
         return ctxDaoFact.getVClassDao().getVClassByURI(getRangeUri(vreq));
     }
+    
     //get individual
-
     public static Individual getSubjectIndividual(VitroRequest vreq) {
     	Individual subject = null;
     	String subjectUri = getSubjectUri(vreq);

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/rdfservice/adapters/AbstractGraphDecorator.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/rdfservice/adapters/AbstractGraphDecorator.java
@@ -7,7 +7,6 @@ import org.apache.jena.graph.GraphStatisticsHandler;
 import org.apache.jena.graph.Node;
 import org.apache.jena.graph.TransactionHandler;
 import org.apache.jena.graph.Triple;
-import org.apache.jena.graph.impl.GraphWithPerform;
 import org.apache.jena.shared.AddDeniedException;
 import org.apache.jena.shared.DeleteDeniedException;
 import org.apache.jena.shared.PrefixMapping;
@@ -28,7 +27,7 @@ public abstract class AbstractGraphDecorator implements
 
     protected AbstractGraphDecorator(Graph g) {
         if (g == null) {
-            throw new NullPointerException("g may not be null.");
+            throw new IllegalArgumentException("g may not be null.");
         }
         this.inner = g;
     }

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/rdfservice/adapters/AbstractGraphDecorator.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/rdfservice/adapters/AbstractGraphDecorator.java
@@ -1,0 +1,137 @@
+package edu.cornell.mannlib.vitro.webapp.rdfservice.adapters;
+
+import org.apache.jena.graph.Capabilities;
+import org.apache.jena.graph.Graph;
+import org.apache.jena.graph.GraphEventManager;
+import org.apache.jena.graph.GraphStatisticsHandler;
+import org.apache.jena.graph.Node;
+import org.apache.jena.graph.TransactionHandler;
+import org.apache.jena.graph.Triple;
+import org.apache.jena.graph.impl.GraphWithPerform;
+import org.apache.jena.shared.AddDeniedException;
+import org.apache.jena.shared.DeleteDeniedException;
+import org.apache.jena.shared.PrefixMapping;
+import org.apache.jena.util.iterator.ExtendedIterator;
+
+import edu.cornell.mannlib.vitro.webapp.utils.logging.ToString;
+
+/**
+ * The base class for a delegating graph decorator.
+ *
+ * As implemented, all methods simply delegate to the inner graph. Subclasses
+ * should override selected methods to provide functionality.
+ */
+public abstract class AbstractGraphDecorator implements 
+        Graph {
+    
+    private final Graph inner;
+
+    protected AbstractGraphDecorator(Graph g) {
+        if (g == null) {
+            throw new NullPointerException("g may not be null.");
+        }
+        this.inner = g;
+    }
+
+    @Override
+    public String toString() {
+        return ToString.simpleName(this) + "[" + ToString.hashHex(this)
+                + ", inner=" + ToString.graphToString(inner) + "]";
+    }
+
+    @Override
+    public void add(Triple arg0) throws AddDeniedException {
+        inner.add(arg0);
+    }
+
+    @Override
+    public void clear() {
+        inner.clear();
+    }
+
+    @Override
+    public void close() {
+        inner.close();
+    }
+
+    @Override
+    public boolean contains(Triple arg0) {
+        return inner.contains(arg0);
+    }
+
+    @Override
+    public boolean contains(Node arg0, Node arg1, Node arg2) {
+        return inner.contains(arg0, arg1, arg2);
+    }
+
+    @Override
+    public void delete(Triple arg0) throws DeleteDeniedException {
+        inner.delete(arg0);
+    }
+
+    @Override
+    public boolean dependsOn(Graph arg0) {
+        return inner.dependsOn(arg0);
+    }
+
+    @Override
+    public ExtendedIterator<Triple> find(Triple arg0) {
+        return inner.find(arg0);
+    }
+
+    @Override
+    public ExtendedIterator<Triple> find(Node arg0, Node arg1, Node arg2) {
+        return inner.find(arg0, arg1, arg2);
+    }
+
+    @Override
+    public Capabilities getCapabilities() {
+        return inner.getCapabilities();
+    }
+
+    @Override
+    public GraphEventManager getEventManager() {
+        return inner.getEventManager();
+    }
+
+    @Override
+    public PrefixMapping getPrefixMapping() {
+        return inner.getPrefixMapping();
+    }
+
+    @Override
+    public GraphStatisticsHandler getStatisticsHandler() {
+        return inner.getStatisticsHandler();
+    }
+
+    @Override
+    public TransactionHandler getTransactionHandler() {
+        return inner.getTransactionHandler();
+    }
+
+    @Override
+    public boolean isClosed() {
+        return inner.isClosed();
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return inner.isEmpty();
+    }
+
+    @Override
+    public boolean isIsomorphicWith(Graph arg0) {
+        return inner.isIsomorphicWith(arg0);
+    }
+
+    @Override
+    public void remove(Node arg0, Node arg1, Node arg2) {
+        inner.remove(arg0, arg1, arg2);
+    }
+
+    @Override
+    public int size() {
+        return inner.size();
+    }
+    
+}

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/rdfservice/adapters/AbstractModelDecorator.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/rdfservice/adapters/AbstractModelDecorator.java
@@ -54,7 +54,7 @@ public abstract class AbstractModelDecorator implements Model {
 
 	protected AbstractModelDecorator(Model m) {
 		if (m == null) {
-			throw new NullPointerException("m may not be null.");
+			throw new IllegalArgumentException("m may not be null.");
 		}
 		this.inner = m;
 	}

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/rdfservice/filter/AcceptableLanguages.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/rdfservice/filter/AcceptableLanguages.java
@@ -13,11 +13,12 @@ import org.apache.commons.logging.LogFactory;
 public class AcceptableLanguages extends ArrayList<String>{
     
     private static final Log log = LogFactory.getLog(AcceptableLanguages.class);
+    
     /**
      * Construct a normalized list of acceptable language strings
      * from a set of raw language strings.  For any values of form 'aa-BB',
      * the base language ('aa') will be also added to the list. 
-     * @param rawLangs
+     * @param rawLangs may not be null
      */
     public AcceptableLanguages(List<String> rawLanguageStrs) {                
         log.debug("Raw language strings:" + rawLanguageStrs);

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/rdfservice/filter/AcceptableLanguages.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/rdfservice/filter/AcceptableLanguages.java
@@ -12,13 +12,14 @@ import org.apache.commons.logging.LogFactory;
  */
 public class AcceptableLanguages extends ArrayList<String>{
     
+    private static final long serialVersionUID = 1L;
     private static final Log log = LogFactory.getLog(AcceptableLanguages.class);
     
     /**
      * Construct a normalized list of acceptable language strings
      * from a set of raw language strings.  For any values of form 'aa-BB',
      * the base language ('aa') will be also added to the list. 
-     * @param rawLangs may not be null
+     * @param rawLanguageStrs may not be null
      */
     public AcceptableLanguages(List<String> rawLanguageStrs) {                
         log.debug("Raw language strings:" + rawLanguageStrs);

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/rdfservice/filter/AcceptableLanguages.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/rdfservice/filter/AcceptableLanguages.java
@@ -1,0 +1,34 @@
+package edu.cornell.mannlib.vitro.webapp.rdfservice.filter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+/**
+ * A normalized list of languages/locales acceptable in results
+ * returned by language-filtering RDFServices, graphs, models, etc.
+ */
+public class AcceptableLanguages extends ArrayList<String>{
+    
+    private static final Log log = LogFactory.getLog(AcceptableLanguages.class);
+    /**
+     * Construct a normalized list of acceptable language strings
+     * from a set of raw language strings.  For any values of form 'aa-BB',
+     * the base language ('aa') will be also added to the list. 
+     * @param rawLangs
+     */
+    public AcceptableLanguages(List<String> rawLanguageStrs) {                
+        log.debug("Raw language strings:" + rawLanguageStrs);
+        for (String lang : rawLanguageStrs) {
+            this.add(lang);
+            String baseLang = lang.split("-")[0];
+            if (!lang.equals(baseLang) && !this.contains(baseLang)) {
+                this.add(baseLang);
+            }
+        }
+        log.debug("Normalized language strings:" + this);
+    }
+
+}

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/rdfservice/filter/LangSort.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/rdfservice/filter/LangSort.java
@@ -1,0 +1,72 @@
+package edu.cornell.mannlib.vitro.webapp.rdfservice.filter;
+
+import java.util.List;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+/**
+ * A class for sorting language strings by acceptability according to a 
+ * supplied list of language preferences.  
+ * Refactored from LanguageFilteringRDFService for reuse by classes performing
+ * similar functions.
+ */
+public class LangSort {
+     
+    private static final Log log = LogFactory.getLog(LangSort.class);
+    
+    protected List<String> langs;
+    private int inexactMatchPenalty;
+    private int noLanguage;
+    private int noMatch;
+
+    /**
+     * Construct a language string sorter with a supplied list of preferred 
+     * language strings
+     * @param preferredLanguageStrings list of preferred languages of form
+     *                                 'en-US', 'es', 'fr-CA', etc.
+     */
+    public LangSort(List<String> preferredLanguageStrings) {
+        this.langs = preferredLanguageStrings;
+        this.inexactMatchPenalty = langs.size();
+        // no language is worse than any inexact match (if the preferred list does not include "").
+        this.noLanguage = 2 * inexactMatchPenalty;
+        // no match is worse than no language.
+        this.noMatch = noLanguage + 1;
+    }
+    
+    protected int compareLangs(String t1lang, String t2lang) {
+        return languageIndex(t1lang) - languageIndex(t2lang);
+    }
+
+    /**
+     * Return index of exact match, or index of partial match, or
+     * language-free, or no match.
+     */
+    private int languageIndex(String lang) {
+        if (lang == null) {
+            lang = "";
+        }
+
+        int index = langs.indexOf(lang);
+        if (index >= 0) {
+            log.debug("languageIndex for '" + lang + "' is " + index);
+            return index;
+        }
+
+        if (lang.length() > 2) {
+            index = langs.indexOf(lang.substring(0, 2));
+            if (index >= 0) {
+                log.debug("languageIndex for '" + lang + "' is " + index + inexactMatchPenalty);
+                return index + inexactMatchPenalty;
+            }
+        }
+
+        if (lang.isEmpty()) {
+            log.debug("languageIndex for '" + lang + "' is " + noLanguage);
+            return noLanguage;
+        }
+
+        return noMatch;
+    }
+}

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/rdfservice/filter/LangSort.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/rdfservice/filter/LangSort.java
@@ -24,7 +24,7 @@ public class LangSort {
      * Construct a language string sorter with a supplied list of preferred 
      * language strings
      * @param preferredLanguageStrings list of preferred languages of form
-     *                                 'en-US', 'es', 'fr-CA', etc.
+     *                                 'en-US', 'es', 'fr-CA'.  May not be null.
      */
     public LangSort(List<String> preferredLanguageStrings) {
         this.langs = preferredLanguageStrings;

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/rdfservice/filter/LanguageFilterModel.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/rdfservice/filter/LanguageFilterModel.java
@@ -12,10 +12,19 @@ import org.apache.jena.rdf.model.RDFNode;
 import org.apache.jena.rdf.model.Statement;
 import org.apache.jena.rdf.model.StmtIterator;
 
+/**
+ * A filter of literal statements from Models according to language preferences. 
+ */
 public class LanguageFilterModel {
 
     private static final Log log = LogFactory.getLog(LanguageFilterModel.class);
     
+    /**
+     * 
+     * @param m the model to filter. May not be null.
+     * @param langs list of strings of type 'en-US'. May not be null.
+     * @return model with language-inappropriate literal statements filtered out.
+     */
     public Model filterModel(Model m, List<String> langs) {
         log.debug("filterModel");
         List<Statement> retractions = new ArrayList<Statement>();

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/rdfservice/filter/LanguageFilterModel.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/rdfservice/filter/LanguageFilterModel.java
@@ -1,0 +1,95 @@
+package edu.cornell.mannlib.vitro.webapp.rdfservice.filter;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.List;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.RDFNode;
+import org.apache.jena.rdf.model.Statement;
+import org.apache.jena.rdf.model.StmtIterator;
+
+public class LanguageFilterModel {
+
+    private static final Log log = LogFactory.getLog(LanguageFilterModel.class);
+    
+    public Model filterModel(Model m, List<String> langs) {
+        log.debug("filterModel");
+        List<Statement> retractions = new ArrayList<Statement>();
+        StmtIterator stmtIt = m.listStatements();
+        while (stmtIt.hasNext()) {
+            Statement stmt = stmtIt.nextStatement();
+            if (stmt.getObject().isLiteral()) {
+                List<Statement> candidatesForRemoval = m.listStatements(
+                        stmt.getSubject(), stmt.getPredicate(), (RDFNode) null).toList();
+                if (candidatesForRemoval.size() == 1) {
+                    continue;
+                }
+                candidatesForRemoval.sort(new StatementSortByLang(langs));
+                log.debug("sorted statements: " + showSortedStatements(candidatesForRemoval));
+                Iterator<Statement> candIt = candidatesForRemoval.iterator();
+                String langRegister = null;
+                boolean chuckRemaining = false;
+                while(candIt.hasNext()) {
+                    Statement s = candIt.next();
+                    if (!s.getObject().isLiteral()) {
+                        continue;
+                    } else if (chuckRemaining) {
+                        retractions.add(s);
+                    }
+                    String lang = s.getObject().asLiteral().getLanguage();
+                    if (langRegister == null) {
+                        langRegister = lang;
+                    } else if (!langRegister.equals(lang)) {
+                        chuckRemaining = true;
+                        retractions.add(s);
+                    }
+                }
+            }
+
+        }
+        m.remove(retractions);
+        return m;
+    }
+    
+    private String showSortedStatements(List<Statement> candidatesForRemoval) {
+        List<String> langStrings = new ArrayList<String>();
+        for (Statement stmt: candidatesForRemoval) {
+            if (stmt == null) {
+                langStrings.add("null stmt");
+            } else {
+                RDFNode node = stmt.getObject();
+                if (!node.isLiteral()) {
+                    langStrings.add("not literal");
+                } else {
+                    langStrings.add(node.asLiteral().getLanguage());
+                }
+            }
+        }
+        return langStrings.toString();
+    }
+    
+    private class StatementSortByLang extends LangSort implements Comparator<Statement> {
+
+        public StatementSortByLang(List<String> langs) {
+            super(langs);
+        }
+        
+        public int compare(Statement s1, Statement s2) {
+            if (s1 == null || s2 == null) {
+                return 0;
+            } else if (!s1.getObject().isLiteral() || !s2.getObject().isLiteral()) {
+                return 0;
+            }
+
+            String s1lang = s1.getObject().asLiteral().getLanguage();
+            String s2lang = s2.getObject().asLiteral().getLanguage();
+
+            return compareLangs(s1lang, s2lang);
+        }
+    }
+    
+}

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/rdfservice/filter/LanguageFilteringGraph.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/rdfservice/filter/LanguageFilteringGraph.java
@@ -1,0 +1,67 @@
+package edu.cornell.mannlib.vitro.webapp.rdfservice.filter;
+
+import java.util.List;
+
+import org.apache.jena.graph.Graph;
+import org.apache.jena.graph.Node;
+import org.apache.jena.graph.Triple;
+import org.apache.jena.mem.GraphMem;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.ModelFactory;
+import org.apache.jena.util.iterator.ExtendedIterator;
+
+import edu.cornell.mannlib.vitro.webapp.rdfservice.adapters.AbstractGraphDecorator;
+import edu.cornell.mannlib.vitro.webapp.utils.logging.ToString;
+
+/**
+ * A graph decorator that filters find() results according to a list of 
+ * preferred language strings
+ */
+public class LanguageFilteringGraph extends AbstractGraphDecorator 
+        implements Graph {
+
+    private List<String> langs;
+    private LanguageFilterModel filterModel = new LanguageFilterModel();
+    private String toString;
+    
+    /**
+     * Return a graph wrapped in a decorator that will filter find() results
+     * according to the supplied list of acceptable languages  
+     * @param g the graph to wrap with language awareness
+     * @param preferredLanguages a list of preferred language strings
+     */
+    protected LanguageFilteringGraph(Graph g, List<String> preferredLanguages) {
+        super(g);
+        this.langs = preferredLanguages;
+        this.toString = "LanguageFilteringGraph[wrapping "
+                + ToString.graphToString(g) + "]";
+    }
+    
+    @Override 
+    public String toString() {
+        return this.toString;
+    }
+
+    @Override
+    public ExtendedIterator<Triple> find(Triple arg0) {
+        return filter(super.find(arg0));
+        
+    }
+
+    @Override
+    public ExtendedIterator<Triple> find(Node arg0, Node arg1, Node arg2) {
+        return filter(super.find(arg0, arg1, arg2));
+    }
+    
+    private ExtendedIterator<Triple> filter(ExtendedIterator<Triple> triples) {
+        Graph tmp = new GraphMem();
+        while(triples.hasNext()) {
+            Triple t = triples.next();
+            tmp.add(t);
+        }
+        Model filteredModel = filterModel.filterModel(
+                ModelFactory.createModelForGraph(tmp), langs);
+        return filteredModel.getGraph().find();
+    }
+
+}

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/rdfservice/filter/LanguageFilteringGraph.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/rdfservice/filter/LanguageFilteringGraph.java
@@ -27,8 +27,9 @@ public class LanguageFilteringGraph extends AbstractGraphDecorator
     /**
      * Return a graph wrapped in a decorator that will filter find() results
      * according to the supplied list of acceptable languages  
-     * @param g the graph to wrap with language awareness
-     * @param preferredLanguages a list of preferred language strings
+     * @param g the graph to wrap with language awareness. May not be null.
+     * @param preferredLanguages a list of preferred language strings. May not 
+     * be null.
      */
     protected LanguageFilteringGraph(Graph g, List<String> preferredLanguages) {
         super(g);

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/rdfservice/filter/LanguageFilteringGraph.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/rdfservice/filter/LanguageFilteringGraph.java
@@ -11,7 +11,6 @@ import org.apache.jena.rdf.model.ModelFactory;
 import org.apache.jena.util.iterator.ExtendedIterator;
 
 import edu.cornell.mannlib.vitro.webapp.rdfservice.adapters.AbstractGraphDecorator;
-import edu.cornell.mannlib.vitro.webapp.utils.logging.ToString;
 
 /**
  * A graph decorator that filters find() results according to a list of 
@@ -22,7 +21,6 @@ public class LanguageFilteringGraph extends AbstractGraphDecorator
 
     private List<String> langs;
     private LanguageFilterModel filterModel = new LanguageFilterModel();
-    private String toString;
     
     /**
      * Return a graph wrapped in a decorator that will filter find() results
@@ -34,13 +32,6 @@ public class LanguageFilteringGraph extends AbstractGraphDecorator
     protected LanguageFilteringGraph(Graph g, List<String> preferredLanguages) {
         super(g);
         this.langs = preferredLanguages;
-        this.toString = "LanguageFilteringGraph[wrapping "
-                + ToString.graphToString(g) + "]";
-    }
-    
-    @Override 
-    public String toString() {
-        return this.toString;
     }
 
     @Override

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/rdfservice/filter/LanguageFilteringUtils.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/rdfservice/filter/LanguageFilteringUtils.java
@@ -13,9 +13,6 @@ import org.apache.jena.ontology.OntModel;
 import org.apache.jena.ontology.OntModelSpec;
 import org.apache.jena.rdf.model.ModelFactory;
 
-import edu.cornell.mannlib.vitro.webapp.dao.jena.RDFServiceGraph;
-import edu.cornell.mannlib.vitro.webapp.rdfservice.impl.jena.model.RDFServiceModel;
-
 /**
  * Some methods that will come in handy when dealing with Language Filtering
  */

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/rdfservice/filter/LanguageFilteringUtils.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/rdfservice/filter/LanguageFilteringUtils.java
@@ -43,17 +43,14 @@ public class LanguageFilteringUtils {
 	}
 
 	/**
-	 * Add a Language Filtering layer to an OntModel by treating it as an RDFService.
+	 * Add a Language Filtering layer to an OntModel
 	 */
 	public static OntModel wrapOntModelInALanguageFilter(OntModel rawModel,
 			ServletRequest req) {
-		/** This is some nasty layering. Could we do this more easily? */
 		List<String> languages = localesToLanguages(req.getLocales());
 		return ModelFactory.createOntologyModel(OntModelSpec.OWL_MEM,
-				RDFServiceGraph.createRDFServiceModel(
-						new RDFServiceGraph(
-								new LanguageFilteringRDFService(
-										new RDFServiceModel(rawModel), languages))));
+		        ModelFactory.createModelForGraph(new LanguageFilteringGraph(
+		                rawModel.getGraph(), languages)));
 	}
 
 	private LanguageFilteringUtils() {

--- a/api/src/test/java/edu/cornell/mannlib/vitro/webapp/rdfservice/filter/LanguageFilteringRDFServiceTest.java
+++ b/api/src/test/java/edu/cornell/mannlib/vitro/webapp/rdfservice/filter/LanguageFilteringRDFServiceTest.java
@@ -282,12 +282,12 @@ public class LanguageFilteringRDFServiceTest extends AbstractTestClass {
 	private Comparator<Object> buildRowIndexedLiteralSortByLang() {
 		try {
 			Class<?> clazz = Class.forName(COLLATOR_CLASSNAME);
-			Class<?>[] argTypes = { LanguageFilteringRDFService.class };
-			Constructor<?> constructor = clazz.getDeclaredConstructor(argTypes);
+			Class<?>[] argTypes = { LanguageFilteringRDFService.class, List.class };
+			Constructor<?> constructor = clazz.getDeclaredConstructor(argTypes);						
 			constructor.setAccessible(true);
-
 			return (Comparator<Object>) constructor
-					.newInstance(filteringRDFService);
+					.newInstance(filteringRDFService, new AcceptableLanguages(
+					        preferredLanguages));
 		} catch (Exception e) {
 			throw new RuntimeException("Could not create a collator", e);
 		}


### PR DESCRIPTION
**[JIRA Issue](https://jira.lyrasis.org/browse/VIVO-1771)**

# What does this pull request do?
Applies language awareness directly to OntModels instead of filtering them through an additional language-aware RDFService.  This allows the same blank node identifiers found in the underlying model to be preserved through the filtering layer.

# What's new?
A LanguageFilteringGraph graph decorator class has been added to apply language filtering to a graph's find() methods.  The filtering behavior is refactored from LanguageFilteringRDFService so that RDFService construct/describe queries and graph finds are filtered identically.  Language awareness is applied to request-based OntModels by wrapping the original model's graph in a LanguageFilteringGraph.

# How should this be tested?
Before applying the pull request, as described in the JIRA issue, with languages filtering enabled in runtime.properties, attempting to add a "translator of" property to a person results in the erroneous class Thing being offered.  With the pull request applied, this will read "(Collection or Document)" (in English).  Other properties with union ranges will also show the applicable classes rather than Thing.

# Additional Notes:
With other language settings, the English word "or" will still appear as a separator between the class names even though the class names themselves will be translated (if a translated label exists).  This piece of the puzzle requires more careful architectural consideration, since the "or/and/not" text is generated within the VClassDao and access to I18n bundle properties requries access to a VitroRequest.

@VIVO-project/vivo-committers
