### PR TITLE
Enable filtering of non-enabled i18n language files from being loaded…

### DIFF
--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/beans/ApplicationBean.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/beans/ApplicationBean.java
@@ -20,6 +20,7 @@ public class ApplicationBean {
     public final static int      VIVO_SEARCHBOX_SIZE         = 20;
 
     private final static String  DEFAULT_APPLICATION_NAME     = "Vitro";
+    private final static String  DEFAULT_APPLICATION_AVAILABLE_LANGS_FILE = "available-langs";
     private final static String  DEFAULT_ROOT_LOGOTYPE_IMAGE  = "";
     private final static int     DEFAULT_ROOT_LOGOTYPE_WIDTH  = 0;
     private final static int     DEFAULT_ROOT_LOGOTYPE_HEIGHT = 0;
@@ -33,6 +34,7 @@ public class ApplicationBean {
     private boolean   initialized             = false;
     private String    sessionIdStr            = null;
     private String    applicationName         = DEFAULT_APPLICATION_NAME;
+    private String    availableLangsFile      = DEFAULT_APPLICATION_AVAILABLE_LANGS_FILE;
 
     private String    rootLogotypeImage       = DEFAULT_ROOT_LOGOTYPE_IMAGE;
     private int       rootLogotypeWidth       = DEFAULT_ROOT_LOGOTYPE_WIDTH;
@@ -52,6 +54,7 @@ public class ApplicationBean {
         output += "  initialized from DB:    [" + initialized             + "]\n";
         output += "  session id:             [" + sessionIdStr            + "]\n";
         output += "  application name:       [" + applicationName         + "]\n";
+        output += "  available langs file:   [" + availableLangsFile      + "]\n";
         output += "  root logotype image:    [" + rootLogotypeImage       + "]\n";
         output += "  root logotype width:    [" + rootLogotypeWidth       + "]\n";
         output += "  root logotype height:   [" + rootLogotypeHeight      + "]\n";
@@ -175,6 +178,10 @@ public class ApplicationBean {
 
     public String getShortHand() {
     	return "";
+    }
+
+    public String getAvailableLangsFile() {
+        return availableLangsFile;
     }
 
     /**

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/servlet/setup/ConfigurationModelsSetup.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/servlet/setup/ConfigurationModelsSetup.java
@@ -52,12 +52,12 @@ public class ConfigurationModelsSetup implements ServletContextListener {
 
 	private void loadFirstTimeFiles(ServletContext ctx, String modelPath,
 			OntModel baseModel) {
-		RDFFilesLoader.loadFirstTimeFiles(modelPath, baseModel, baseModel.isEmpty());
+		RDFFilesLoader.loadFirstTimeFiles(ctx, modelPath, baseModel, baseModel.isEmpty());
 	}
 
 	private void loadEveryTimeFiles(ServletContext ctx, String modelPath,
 			OntModel memoryModel) {
-		RDFFilesLoader.loadEveryTimeFiles(modelPath, memoryModel);
+		RDFFilesLoader.loadEveryTimeFiles(ctx, modelPath, memoryModel);
 	}
 
 	@Override

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/servlet/setup/ContentModelSetup.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/servlet/setup/ContentModelSetup.java
@@ -67,15 +67,15 @@ public class ContentModelSetup extends JenaDataSourceSetupBase
 
         OntModel baseABoxModel = models.getOntModel(ABOX_ASSERTIONS);
         if (firstTimeStartup) {
-        	RDFFilesLoader.loadFirstTimeFiles("abox", baseABoxModel, true);
+            RDFFilesLoader.loadFirstTimeFiles(ctx, "abox", baseABoxModel, true);
         }
-        RDFFilesLoader.loadEveryTimeFiles("abox", baseABoxModel);
+        RDFFilesLoader.loadEveryTimeFiles(ctx, "abox", baseABoxModel);
 
         OntModel baseTBoxModel = models.getOntModel(TBOX_ASSERTIONS);
         if (firstTimeStartup) {
-        	RDFFilesLoader.loadFirstTimeFiles("tbox", baseTBoxModel, true);
+            RDFFilesLoader.loadFirstTimeFiles(ctx, "tbox", baseTBoxModel, true);
         }
-    	RDFFilesLoader.loadEveryTimeFiles("tbox", baseTBoxModel);
+        RDFFilesLoader.loadEveryTimeFiles(ctx, "tbox", baseTBoxModel);
     }
 
 	private long secondsSince(long startTime) {
@@ -94,7 +94,7 @@ public class ContentModelSetup extends JenaDataSourceSetupBase
 	private void initializeApplicationMetadata(ServletContext ctx,
 			Model applicationMetadataModel) {
 		OntModel temporaryAMModel = VitroModelFactory.createOntologyModel();
-    	RDFFilesLoader.loadFirstTimeFiles("applicationMetadata", temporaryAMModel, true);
+        RDFFilesLoader.loadFirstTimeFiles(ctx, "applicationMetadata", temporaryAMModel, true);
     	setPortalUriOnFirstTime(temporaryAMModel, ctx);
     	applicationMetadataModel.add(temporaryAMModel);
 	}

--- a/installer/webapp/pom.xml
+++ b/installer/webapp/pom.xml
@@ -45,11 +45,11 @@
                                     <type>war</type>
                                 </overlay>
                                 <!-- Overlays for multilingual support -->
-                                <!-- overlay>
+                                <overlay>
                                     <groupId>org.vivoweb</groupId>
-                                    <artifactId>vitro-languages-webapp</artifactId>
+                                    <artifactId>vitro-languages-webapp-core</artifactId>
                                     <type>war</type>
-                                </overlay -->
+                                </overlay>
                             </overlays>
                             <webResources>
                                 <resource>
@@ -148,12 +148,12 @@
             <type>war</type>
         </dependency>
         <!-- Dependency for multilingual support -->
-        <!-- dependency>
+        <dependency>
             <groupId>org.vivoweb</groupId>
-            <artifactId>vitro-languages-webapp</artifactId>
-            <version>[2.0.0,2.1.0)</version>
+            <artifactId>vitro-languages-webapp-core</artifactId>
+            <version>${project.version}</version>
             <type>war</type>
-        </dependency -->
+        </dependency>
 
         <dependency>
             <groupId>javax.servlet</groupId>


### PR DESCRIPTION
… into triple store

Define name of available language listing file (found in Vitro-languages)
Update RDFFilesLoader method interfaces to include ServletContext

Part of resolution to: https://jira.lyrasis.org/browse/VIVO-1836

# What does this pull request do?
This pull-request, in combination with the three other pull-requests noted below, does the following:
* Enable language Maven dependencies by default (they should not have to be turned off)
* Add logic that filters out language triples files from being loaded into the Vitro triple store
   - The logic is based on comparing the list of all available i18n languages with the languages that are enabled in the runtime.properties
   - If no languages are enabled (default case), then all languages except 'en_US' are omitted
   - The core of the pull-request is found in RDFFilesLoader.java

## Related pull-requests
* https://github.com/vivo-project/Vitro-languages/pull/18
* https://github.com/vivo-project/VIVO-languages/pull/41
* https://github.com/vivo-project/VIVO/pull/168

# How should this be tested?
To test the set of pull-requests,
1. Default case
   - build all four pull-requests
   - install VIVO like normal
   - observe that only U.S. English is enabled
1. Multi-language case
   - install VIVO with an updated runtime.properties that includes multiple languages
   - observe that VIVO has those language options in the i18n dropdown
1. Both cases above
   - observe the vivo.all.log for `info` messages detailing which RDF files are loaded and ignored

# Interested parties
@VIVO-project/vivo-committers , @MichelHeon
