### PR TITLE
[VIVO-1851] - Add 'remove' option to named graph management page

### DIFF
--- a/webapp/src/main/webapp/jenaIngest/listModels.jsp
+++ b/webapp/src/main/webapp/jenaIngest/listModels.jsp
@@ -56,7 +56,7 @@ function init(){
                 <input type="hidden" name="action" value="loadRDFData"/>
                 <input type="hidden" name="modelName" value="${modelName}"/>
                 <input type="hidden" name="modelType" value="${modelType}"/>
-                <input type="submit" name="submit" value="load RDF data"/>
+                <input type="submit" name="submit" value="add/remove RDF data"/>
             </form>
             </td>
             <td>

--- a/webapp/src/main/webapp/jenaIngest/loadRDFData.jsp
+++ b/webapp/src/main/webapp/jenaIngest/loadRDFData.jsp
@@ -16,8 +16,8 @@
 <p><input type="file" name="filePath" /></p>
 
 <ul style="list-style-type:none;">
-	<li><input type="radio" name="mode" value="directAddABox" checked="checked"/>add instance data</li>
-	<li><input type="radio" name="mode" value="remove"/>remove instance data</li>
+	<li><input type="radio" name="mode" value="directAddABox" checked="checked"/>add RDF data</li>
+	<li><input type="radio" name="mode" value="remove"/>remove RDF data</li>
 </ul>
 
 <select name="language">

--- a/webapp/src/main/webapp/jenaIngest/loadRDFData.jsp
+++ b/webapp/src/main/webapp/jenaIngest/loadRDFData.jsp
@@ -15,6 +15,11 @@
 <p>Or upload a file from your computer:</p>
 <p><input type="file" name="filePath" /></p>
 
+<ul style="list-style-type:none;">
+	<li><input type="radio" name="mode" value="directAddABox" checked="checked"/>add instance data</li>
+	<li><input type="radio" name="mode" value="remove"/>remove instance data</li>
+</ul>
+
 <select name="language">
 	<option value="RDF/XML">RDF/XML</option>
 	<option value="N3">N3</option>


### PR DESCRIPTION
**[JIRA Issue](https://jira.lyrasis.org/browse/VIVO-1851)**: VIVO-1851

# What does this pull request do?
The VIVO UI provides a way to add data to named graphs via

Site Admin > Ingest tools > Manage Jena Models > load RDF data

This pull request adds brings the RDF upload form for named graphs in line with the primary add/remove RDF form in site admin that works on the kb-2 graph by adding a 'remove' option.

# What's new?

- Adds 'remove' option to named graph upload RDF form
- Changes text in a couple places to reflect new 'remove' option

# How should this be tested?

1. Navigate to the 'Manage Jena Models' page. 
2. Create a new named graph to test by clicking 'Create Model' near the top. Call it anything you like. 
3. Next, click the newly renamed 'add/remove RDF data' button for that named graph. 
4. Add some RDF. I'm attaching some sample RDF for convenience. 

[example.txt](https://github.com/vivo-project/Vitro/files/4561878/example.txt)

![Screen Shot 2020-04-30 at 5 43 48 PM](https://user-images.githubusercontent.com/10748475/80769359-2aaaec80-8b0a-11ea-8a5e-08b4e94dac59.png)

5. Confirm RDF was added to the named graph.

![Screen Shot 2020-04-30 at 5 41 50 PM](https://user-images.githubusercontent.com/10748475/80769284-f8998a80-8b09-11ea-86fa-27e4c0818b4e.png)

6. Repeat procedure, except check the 'remove' option when uploading the RDF. Confirm RDF was removed from the named graph.

![Screen Shot 2020-04-30 at 5 42 20 PM](https://user-images.githubusercontent.com/10748475/80769323-11a23b80-8b0a-11ea-9970-ce0a8ce938f5.png)




# Additional Notes:
This has bothered me for a long time. I've been working around it by uploading the data intended for deletion to a temporary graph, then using the 'subtract one graph from another' function. 

# Interested parties
@VIVO-project/vivo-committers
