### PR TITLE
[VIVO-1872] - Add download option to SPARQL Query page

### DIFF
--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/admin/SparqlQueryController.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/admin/SparqlQueryController.java
@@ -123,7 +123,7 @@ public class SparqlQueryController extends FreemarkerHttpServlet {
 			if (download) {	
 				String extension = getFilenameExtension(req, query, format);
 				resp.setHeader("Content-Transfer-Encoding", "binary");
-				resp.setHeader("Content-disposition", "attachment; filename=sparqlquery." + extension);
+				resp.setHeader("Content-disposition", "attachment; filename=query-results." + extension);
 			}
 
 			core.executeAndFormat(resp.getOutputStream());

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/admin/SparqlQueryController.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/admin/SparqlQueryController.java
@@ -118,14 +118,14 @@ public class SparqlQueryController extends FreemarkerHttpServlet {
 			String format = interpretRequestedFormats(req, query);
 			SparqlQueryApiExecutor core = SparqlQueryApiExecutor.instance(
 					rdfService, queryString, format);
+			resp.setContentType(core.getMediaType());
+
 			if (download) {	
 				String extension = getFilenameExtension(req, query, format);
 				resp.setHeader("Content-Transfer-Encoding", "binary");
 				resp.setHeader("Content-disposition", "attachment; filename=sparqlquery." + extension);
 			}
-			else {
-				resp.setContentType(core.getMediaType());
-			}
+
 			core.executeAndFormat(resp.getOutputStream());
 		} catch (InvalidQueryTypeException e) {
 			do400BadRequest("Query type is not SELECT, ASK, CONSTRUCT, "

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/api/sparqlquery/RdfResultMediaType.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/api/sparqlquery/RdfResultMediaType.java
@@ -12,17 +12,17 @@ import java.util.Map;
  * and DESCRIBE).
  */
 public enum RdfResultMediaType {
-	TEXT("text/plain", true, "NTRIPLE", "N-TRIPLE"),
+	TEXT("text/plain", true, "NTRIPLE", "N-TRIPLE", "nt"),
 
-	RDF_XML("application/rdf+xml", true, "RDFXML", "RDF/XML"),
+	RDF_XML("application/rdf+xml", true, "RDFXML", "RDF/XML", "rdf"),
 
-	N3("text/n3", true, "N3", "N3"),
+	N3("text/n3", true, "N3", "N3", "n3"),
 
-	TTL("text/turtle", false, "N3", "TTL"),
+	TTL("text/turtle", false, "N3", "TTL", "ttl"),
 
-	JSON("application/json", false, "N3", "JSON"),
+	JSON("application/json", false, "N3", "JSON", "json"),
 
-	JSON_LD("application/ld+json", false, "N3", "JSON");
+	JSON_LD("application/ld+json", false, "N3", "JSON", "json");
 
 	// ----------------------------------------------------------------------
 	// Keep a map of content types, for easy conversion back and forth
@@ -79,12 +79,18 @@ public enum RdfResultMediaType {
 	 */
 	private final String jenaResponseFormat;
 
+	/**
+	 * What extension should be used if file is downloaded?
+	 */
+	private final String extension;
+
 	private RdfResultMediaType(String contentType, boolean nativeFormat,
-			String serializationFormat, String jenaResponseFormat) {
+			String serializationFormat, String jenaResponseFormat, String extension) {
 		this.contentType = contentType;
 		this.nativeFormat = nativeFormat;
 		this.serializationFormat = serializationFormat;
 		this.jenaResponseFormat = jenaResponseFormat;
+		this.extension = extension;
 	}
 
 	public String getContentType() {
@@ -101,6 +107,10 @@ public enum RdfResultMediaType {
 
 	public String getJenaResponseFormat() {
 		return jenaResponseFormat;
+	}
+
+	public String getExtension() {
+		return extension;
 	}
 
 }

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/api/sparqlquery/RdfResultMediaType.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/api/sparqlquery/RdfResultMediaType.java
@@ -22,7 +22,7 @@ public enum RdfResultMediaType {
 
 	JSON("application/json", false, "N3", "JSON", "json"),
 
-	JSON_LD("application/ld+json", false, "N3", "JSON", "json");
+	JSON_LD("application/ld+json", false, "N3", "JSON", "jsonld");
 
 	// ----------------------------------------------------------------------
 	// Keep a map of content types, for easy conversion back and forth

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/api/sparqlquery/ResultSetMediaType.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/api/sparqlquery/ResultSetMediaType.java
@@ -12,15 +12,15 @@ import java.util.Map;
  * SELECT and ASK).
  */
 public enum ResultSetMediaType {
-	TEXT("text/plain", true, "TEXT", null),
+	TEXT("text/plain", true, "TEXT", null, "txt"),
 
-	CSV("text/csv", true, "CSV", null),
+	CSV("text/csv", true, "CSV", null, "csv"),
 
-	TSV("text/tab-separated-values", false, "CSV", "tsv"),
+	TSV("text/tab-separated-values", false, "CSV", "tsv", "tsv"),
 
-	XML("application/sparql-results+xml", true, "XML", null),
+	XML("application/sparql-results+xml", true, "XML", null, "xml"),
 
-	JSON("application/sparql-results+json", true, "JSON", null);
+	JSON("application/sparql-results+json", true, "JSON", null, "json");
 
 	// ----------------------------------------------------------------------
 	// Keep a map of content types, for easy conversion back and forth
@@ -78,12 +78,18 @@ public enum ResultSetMediaType {
 	 */
 	private final String jenaResponseFormat;
 
+	/**
+	 * What extension should be used if file is downloaded?
+	 */
+	private final String extension;
+
 	private ResultSetMediaType(String contentType, boolean nativeFormat,
-			String rdfServiceFormat, String jenaResponseFormat) {
+			String rdfServiceFormat, String jenaResponseFormat, String extension) {
 		this.contentType = contentType;
 		this.nativeFormat = nativeFormat;
 		this.rdfServiceFormat = rdfServiceFormat;
 		this.jenaResponseFormat = jenaResponseFormat;
+		this.extension = extension;
 	}
 
 	public String getContentType() {
@@ -100,6 +106,10 @@ public enum ResultSetMediaType {
 
 	public String getJenaResponseFormat() {
 		return jenaResponseFormat;
+	}
+
+	public String getExtension() {
+		return extension;
 	}
 
 }

--- a/webapp/src/main/webapp/templates/freemarker/body/admin/admin-sparqlQueryForm.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/body/admin/admin-sparqlQueryForm.ftl
@@ -29,7 +29,7 @@
 
 		<div class="options">
 			<input type="checkbox" id="download" name="download" value="true">
-			<label for="download"> Force download of results</label><br>		
+			<label for="download"> Save results to file</label><br>		
 		</div>
 
         <input class="submit" type="submit" value="Run Query" />

--- a/webapp/src/main/webapp/templates/freemarker/body/admin/admin-sparqlQueryForm.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/body/admin/admin-sparqlQueryForm.ftl
@@ -27,6 +27,11 @@
         	 <label><input type='radio' name='rdfResultFormat' value='application/json'>JSON-LD</label>
         </div>
 
+		<div class="options">
+			<input type="checkbox" id="download" name="download" value="true">
+			<label for="download"> Force download of results</label><br>		
+		</div>
+
         <input class="submit" type="submit" value="Run Query" />
     </form>
 </div><!-- content -->


### PR DESCRIPTION
**[JIRA Issue](https://jira.lyrasis.org/browse/VIVO-1872)**: VIVO-1872

# What does this pull request do?
Adds a new 'force download' check box to the SPARQL query page.

<img width="619" alt="Screen Shot 2020-05-20 at 4 39 53 PM" src="https://user-images.githubusercontent.com/10748475/82504720-4d04aa00-9ab9-11ea-9d71-d117e7e7f369.png">


# What's new?

- Adds new 'force download' checkbox to page
- Changes response headers to force a file download
- Adds an extension to the file based on the format selected 

# How should this be tested?

1. Build with changes. 
2. Go to Site Admin -> SPARQL query.
3. Verify new button is present.
4. Check 'force download' box.
5. Try different formats. Confirm file is downloaded and has the correct filename extension.
6. Uncheck box. 
7. Confirm file does not download (NOTE: this is dependent on your browser support for the requested format. For example, my browser doesn't support RDF/XML so this format is downloaded regardless of whether the 'force download' box is checked)

# Additional Notes:
The motivation for this PR was frustration with very large SPARQL query results causing my browser to hang. 

I don't think this has any implications for SPARQL queries submitted via API, though it would be worth checking. I did test the API and my query was successful. 

# Interested parties
@VIVO-project/vivo-committers
