### PR TITLE
Adds internationalization to the admin/sparql-query page

### DIFF
--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/admin/SparqlQueryController.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/admin/SparqlQueryController.java
@@ -17,6 +17,8 @@ import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import edu.cornell.mannlib.vitro.webapp.i18n.I18n;
+import edu.cornell.mannlib.vitro.webapp.i18n.I18nBundle;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -75,8 +77,8 @@ public class SparqlQueryController extends FreemarkerHttpServlet {
 	private static final String[] SAMPLE_QUERY = { //
 			"", //
 			"#", //
-			"# This example query gets 20 geographic locations", //
-			"# and (if available) their labels", //
+			"i18n:sparql_query_description_0", //
+			"i18n:sparql_query_description_1", //
 			"#", //
 			"SELECT ?geoLocation ?label", //
 			"WHERE", //
@@ -193,9 +195,11 @@ public class SparqlQueryController extends FreemarkerHttpServlet {
 
 	@Override
 	protected ResponseValues processRequest(VitroRequest vreq) throws Exception {
+		I18nBundle i18n = I18n.bundle(vreq);
+
 		Map<String, Object> bodyMap = new HashMap<>();
-		bodyMap.put("sampleQuery", buildSampleQuery(buildPrefixList(vreq)));
-		bodyMap.put("title", "SPARQL Query");
+		bodyMap.put("sampleQuery", buildSampleQuery(i18n, buildPrefixList(vreq)));
+		bodyMap.put("title", i18n.text("sparql_query_title"));
 		bodyMap.put("submitUrl", UrlBuilder.getUrl("admin/sparqlquery"));
 		return new TemplateResponseValues(TEMPLATE_NAME, bodyMap);
 	}
@@ -222,7 +226,7 @@ public class SparqlQueryController extends FreemarkerHttpServlet {
 		return prefixList;
 	}
 
-	private String buildSampleQuery(List<Prefix> prefixList) {
+	private String buildSampleQuery(I18nBundle i18n, List<Prefix> prefixList) {
 		StringWriter sw = new StringWriter();
 		PrintWriter writer = new PrintWriter(sw);
 
@@ -230,6 +234,10 @@ public class SparqlQueryController extends FreemarkerHttpServlet {
 			writer.println(p);
 		}
 		for (String line : SAMPLE_QUERY) {
+			if (line.startsWith("i18n:")) {
+			    // Get i18n translation
+				line =  i18n.text(line.substring("i18n:".length()));
+			}
 			writer.println(line);
 		}
 

--- a/webapp/src/main/webapp/templates/freemarker/body/admin/admin-sparqlQueryForm.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/body/admin/admin-sparqlQueryForm.ftl
@@ -29,7 +29,7 @@
 
 		<div class="options">
 			<input type="checkbox" id="download" name="download" value="true">
-			<label for="download"> Save results to file</label><br>		
+			<label for="download"> ${i18n().sparql_query_save_results}</label><br>
 		</div>
 
         <input class="submit" type="submit" value="Run Query" />

--- a/webapp/src/main/webapp/templates/freemarker/body/admin/admin-sparqlQueryForm.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/body/admin/admin-sparqlQueryForm.ftl
@@ -32,7 +32,7 @@
 			<label for="download"> ${i18n().sparql_query_save_results}</label><br>
 		</div>
 
-        <input class="submit" type="submit" value="Run Query" />
+        <input class="submit" type="submit" value="${i18n().sparql_query_run_query}" />
     </form>
 </div><!-- content -->
 

--- a/webapp/src/main/webapp/templates/freemarker/body/admin/admin-sparqlQueryForm.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/body/admin/admin-sparqlQueryForm.ftl
@@ -3,14 +3,14 @@
 <#-- Template that presents the SPARQL query form. -->
 
 <div id="content" class="sparqlform">
-    <h2>SPARQL Query</h2>
+    <h2>${i18n().sparql_query_title}</h2>
     <form action='${submitUrl}?posted' method="post">
-        <h3>Query:</h3>
+        <h3>${i18n().sparql_query_header}:</h3>
 
         <textarea name='query' rows='30' cols='100' class="span-23 maxWidth" id="query-area">${sampleQuery}</textarea>
 
         <div class="options">
-        	 <h3>Format for SELECT and ASK query results:</h3>
+			 <h3>${i18n().sparql_query_select_ask_results}:</h3>
         	 <label><input type='radio' name='resultFormat' value='text/plain' checked>RS_TEXT</label>
         	 <label><input type='radio' name='resultFormat' value='text/csv'>CSV</label>
         	 <label><input type='radio' name='resultFormat' value='text/tab-separated-values'>TSV</label>
@@ -19,7 +19,7 @@
         </div>
 
         <div class="options">
-        	 <h3>Format for CONSTRUCT and DESCRIBE query results:</h3>
+			 <h3>${i18n().sparql_query_construct_describe_results}:</h3>
         	 <label><input type='radio' name='rdfResultFormat' value='text/plain'>N-Triples</label>
         	 <label><input type='radio' name='rdfResultFormat' value='application/rdf+xml' checked>RDF/XML</label>
         	 <label><input type='radio' name='rdfResultFormat' value='text/n3'>N3</label>


### PR DESCRIPTION
Partial resolution of: https://jira.lyrasis.org/browse/VIVO-1873

# What does this pull request do?
Add i18n to admin/sparql-query page

# How should this be tested?
- Configure VIVO for multiple languages
- Log into VIVO as admin
- Navigate to siteAdmin >> SPARQL query
- Inspect the following elements for proper i18n translation (note: these are all still English until other translations are available)
   - Page title
   - Page heading
   - Section headings
   - Comment in sample query
- Change language context, and view correct translation (see note above regarding available translations)

# Interested parties
@VIVO-project/vivo-committers
