### PR TITLE
Ensure 'other' in Individual->Teaching->advisees->type is translated

### DIFF
--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/VTwo/fields/ChildVClassesOptions.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/VTwo/fields/ChildVClassesOptions.java
@@ -7,6 +7,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
+import edu.cornell.mannlib.vitro.webapp.i18n.I18nBundle;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
@@ -40,7 +41,8 @@ public class ChildVClassesOptions implements FieldOptions {
     public Map<String, String> getOptions(
             EditConfigurationVTwo editConfig,
             String fieldName,
-            WebappDaoFactory wDaoFact) throws Exception{
+            WebappDaoFactory wDaoFact,
+            I18nBundle i18n) throws Exception{
         // now create an empty HashMap to populate and return
         HashMap <String,String> optionsMap = new LinkedHashMap<String,String>();
 

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/VTwo/fields/ChildVClassesWithParent.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/VTwo/fields/ChildVClassesWithParent.java
@@ -12,11 +12,9 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.jena.vocabulary.OWL;
 
 import edu.cornell.mannlib.vitro.webapp.beans.VClass;
-import edu.cornell.mannlib.vitro.webapp.controller.VitroRequest;
 import edu.cornell.mannlib.vitro.webapp.dao.VClassDao;
 import edu.cornell.mannlib.vitro.webapp.dao.WebappDaoFactory;
 import edu.cornell.mannlib.vitro.webapp.edit.n3editing.VTwo.EditConfigurationVTwo;
-import edu.cornell.mannlib.vitro.webapp.i18n.I18n;
 import edu.cornell.mannlib.vitro.webapp.i18n.I18nBundle;
 
 public class ChildVClassesWithParent implements FieldOptions {
@@ -25,7 +23,6 @@ public class ChildVClassesWithParent implements FieldOptions {
     String fieldName;
     String classUri;
     String defaultOptionLabel = null;
-    private  I18nBundle i18n;
 
     public ChildVClassesWithParent(String classUri) throws Exception {
         super();
@@ -49,9 +46,8 @@ public class ChildVClassesWithParent implements FieldOptions {
     public Map<String, String> getOptions(
             EditConfigurationVTwo editConfig,
             String fieldName,
-            VitroRequest vreq) throws Exception {
-//            WebappDaoFactory wDaoFact) throws Exception {
-    	this.i18n = I18n.bundle(vreq);
+            WebappDaoFactory wDaoFact,
+            I18nBundle i18n) throws Exception {
         HashMap <String,String> optionsMap = new LinkedHashMap<String,String>();
         // first test to see whether there's a default "leave blank" value specified with the literal options
         if ( ! StringUtils.isEmpty( defaultOptionLabel ) ){
@@ -60,7 +56,6 @@ public class ChildVClassesWithParent implements FieldOptions {
         String other_i18n = i18n.text("other");
         // first character in capital
         optionsMap.put(classUri, other_i18n.substring(0, 1).toUpperCase() + other_i18n.substring(1));
-        WebappDaoFactory wDaoFact = vreq.getWebappDaoFactory();
         VClassDao vclassDao = wDaoFact.getVClassDao();
         List<String> subClassList = vclassDao.getAllSubClassURIs(classUri);
         if (subClassList != null && subClassList.size() > 0) {
@@ -77,39 +72,5 @@ public class ChildVClassesWithParent implements FieldOptions {
     public Comparator<String[]> getCustomComparator() {
     	return null;
     }
-
-    /*
-     * (non-Javadoc)
-     * @see edu.cornell.mannlib.vitro.webapp.edit.n3editing.VTwo.fields.FieldOptions#getOptions(edu.cornell.mannlib.vitro.webapp.edit.n3editing.VTwo.EditConfigurationVTwo, java.lang.String, edu.cornell.mannlib.vitro.webapp.dao.WebappDaoFactory)
-     *  UQAM this version is a not internationalized use this method (see line below) more often
-     *  getOptions(EditConfigurationVTwo editConfig, String fieldName, VitroRequest vreq)
-     */
-    @Override
-    public Map<String, String> getOptions(
-            EditConfigurationVTwo editConfig,
-            String fieldName,
-            WebappDaoFactory wDaoFact) throws Exception {
-
-        HashMap <String,String> optionsMap = new LinkedHashMap<String,String>();
-        // first test to see whether there's a default "leave blank" value specified with the literal options
-        if ( ! StringUtils.isEmpty( defaultOptionLabel ) ){
-            optionsMap.put(LEFT_BLANK, defaultOptionLabel);
-        }
-
-        optionsMap.put(classUri, "Other");
-
-        VClassDao vclassDao = wDaoFact.getVClassDao();
-        List<String> subClassList = vclassDao.getAllSubClassURIs(classUri);
-        if (subClassList != null && subClassList.size() > 0) {
-            for (String subClassUri : subClassList) {
-                VClass subClass = vclassDao.getVClassByURI(subClassUri);
-                if (subClass != null && !OWL.Nothing.getURI().equals(subClassUri)) {
-                    optionsMap.put(subClassUri, subClass.getName().trim());
-                }
-            }
-        }
-       return optionsMap;
-    }
-
 
 }

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/VTwo/fields/ConstantFieldOptions.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/VTwo/fields/ConstantFieldOptions.java
@@ -10,6 +10,7 @@ import java.util.Map;
 
 import edu.cornell.mannlib.vitro.webapp.dao.WebappDaoFactory;
 import edu.cornell.mannlib.vitro.webapp.edit.n3editing.VTwo.EditConfigurationVTwo;
+import edu.cornell.mannlib.vitro.webapp.i18n.I18nBundle;
 
 public class ConstantFieldOptions implements FieldOptions {
 
@@ -54,7 +55,8 @@ public class ConstantFieldOptions implements FieldOptions {
     public Map<String, String> getOptions(
             EditConfigurationVTwo editConfig,
             String fieldName,
-            WebappDaoFactory wDaoFact) throws Exception {
+            WebappDaoFactory wDaoFact,
+            I18nBundle i18n) throws Exception {
         // originally not auto-sorted but sorted now, and empty values not removed or replaced
         HashMap <String,String> optionsMap = new LinkedHashMap<String,String>();
 

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/VTwo/fields/FieldOptions.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/VTwo/fields/FieldOptions.java
@@ -6,6 +6,7 @@ import java.util.Map;
 
 import edu.cornell.mannlib.vitro.webapp.dao.WebappDaoFactory;
 import edu.cornell.mannlib.vitro.webapp.edit.n3editing.VTwo.EditConfigurationVTwo;
+import edu.cornell.mannlib.vitro.webapp.i18n.I18nBundle;
 
 /**
  * Represents an object that can return a list of options
@@ -28,7 +29,8 @@ public interface FieldOptions {
     public Map<String,String> getOptions(
             EditConfigurationVTwo editConfig,
             String fieldName,
-            WebappDaoFactory wDaoFact) throws Exception;
+            WebappDaoFactory wDaoFact,
+            I18nBundle i18n) throws Exception;
 
     /*
      * Certain field options may have custom sorting requirements. If no sorting requirements exist,

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/VTwo/fields/IndividualsViaClassGroupOptions.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/VTwo/fields/IndividualsViaClassGroupOptions.java
@@ -6,6 +6,7 @@ import java.util.Map;
 
 import edu.cornell.mannlib.vitro.webapp.dao.WebappDaoFactory;
 import edu.cornell.mannlib.vitro.webapp.edit.n3editing.VTwo.EditConfigurationVTwo;
+import edu.cornell.mannlib.vitro.webapp.i18n.I18nBundle;
 
 public class IndividualsViaClassGroupOptions implements FieldOptions {
 
@@ -27,7 +28,8 @@ public class IndividualsViaClassGroupOptions implements FieldOptions {
     public Map<String, String> getOptions(
             EditConfigurationVTwo editConfig,
             String fieldName,
-            WebappDaoFactory wDaoFact) throws Exception {
+            WebappDaoFactory wDaoFact,
+            I18nBundle i18n) throws Exception {
         throw new Error("not implemented");
     }
 

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/VTwo/fields/IndividualsViaObjectPropetyOptions.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/VTwo/fields/IndividualsViaObjectPropetyOptions.java
@@ -11,6 +11,7 @@ import java.util.Map;
 
 import javax.servlet.http.HttpServletRequest;
 
+import edu.cornell.mannlib.vitro.webapp.i18n.I18nBundle;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
@@ -77,7 +78,8 @@ public class IndividualsViaObjectPropetyOptions implements FieldOptions {
     public Map<String, String> getOptions(
             EditConfigurationVTwo editConfig,
             String fieldName,
-            WebappDaoFactory wDaoFact) {
+            WebappDaoFactory wDaoFact,
+            I18nBundle i18n) {
         HashMap<String, String> optionsMap = new LinkedHashMap<String, String>();
         int optionsCount = 0;
 

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/VTwo/fields/IndividualsViaSearchQueryOptions.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/VTwo/fields/IndividualsViaSearchQueryOptions.java
@@ -8,6 +8,7 @@ import java.util.List;
 import java.util.ListIterator;
 import java.util.Map;
 
+import edu.cornell.mannlib.vitro.webapp.i18n.I18nBundle;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
@@ -90,7 +91,8 @@ public class IndividualsViaSearchQueryOptions extends IndividualsViaVClassOption
     public Map<String, String> getOptions(
             EditConfigurationVTwo editConfig,
             String fieldName,
-            WebappDaoFactory wDaoFact) throws Exception {
+            WebappDaoFactory wDaoFact,
+            I18nBundle i18n) throws Exception {
 
     	 Map<String, Individual> individualMap = new HashMap<String, Individual>();
 

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/VTwo/fields/IndividualsViaVClassOptions.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/VTwo/fields/IndividualsViaVClassOptions.java
@@ -8,6 +8,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import edu.cornell.mannlib.vitro.webapp.i18n.I18nBundle;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
@@ -48,7 +49,8 @@ public class IndividualsViaVClassOptions implements FieldOptions {
     public Map<String, String> getOptions(
             EditConfigurationVTwo editConfig,
             String fieldName,
-            WebappDaoFactory wDaoFact) throws Exception {
+            WebappDaoFactory wDaoFact,
+            I18nBundle i18n) throws Exception {
 
         Map<String, Individual> individualMap = new HashMap<String, Individual>();
 

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/VTwo/fields/RdfTypeOptions.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/VTwo/fields/RdfTypeOptions.java
@@ -9,6 +9,7 @@ import java.util.Map;
 import edu.cornell.mannlib.vitro.webapp.beans.VClass;
 import edu.cornell.mannlib.vitro.webapp.dao.WebappDaoFactory;
 import edu.cornell.mannlib.vitro.webapp.edit.n3editing.VTwo.EditConfigurationVTwo;
+import edu.cornell.mannlib.vitro.webapp.i18n.I18nBundle;
 
 public class RdfTypeOptions implements FieldOptions {
 
@@ -29,7 +30,8 @@ public class RdfTypeOptions implements FieldOptions {
     public Map<String, String> getOptions(
             EditConfigurationVTwo editConfig,
             String fieldName,
-            WebappDaoFactory wdf) {
+            WebappDaoFactory wdf,
+            I18nBundle i18n) {
         Map<String,String> uriToLabel = new HashMap<String,String>();
 
         for (String uri : typeURIs) {

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/VTwo/fields/SelectListGeneratorVTwo.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/VTwo/fields/SelectListGeneratorVTwo.java
@@ -11,6 +11,8 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
+import edu.cornell.mannlib.vitro.webapp.i18n.I18n;
+import edu.cornell.mannlib.vitro.webapp.i18n.I18nBundle;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
@@ -25,7 +27,8 @@ public class SelectListGeneratorVTwo {
     public static Map<String,String> getOptions(
             EditConfigurationVTwo editConfig,
             String fieldName,
-            WebappDaoFactory wDaoFact){
+            WebappDaoFactory wDaoFact,
+            I18nBundle i18n){
 
 
         if( editConfig == null ){
@@ -48,7 +51,7 @@ public class SelectListGeneratorVTwo {
         }
 
         try {
-            return field.getFieldOptions().getOptions(editConfig,fieldName,wDaoFact);
+            return field.getFieldOptions().getOptions(editConfig,fieldName,wDaoFact,i18n);
         } catch (Exception e) {
             log.error("Error runing getFieldOptionis()",e);
             return Collections.emptyMap();
@@ -56,6 +59,7 @@ public class SelectListGeneratorVTwo {
     }
 
     // UQAM Overcharge method for linguistic contexte processisng
+    // AWoods: This method appears to never be invoked.
 	public static Map<String,String> getOptions(
 			EditConfigurationVTwo editConfig,
 			String fieldName,
@@ -85,12 +89,7 @@ public class SelectListGeneratorVTwo {
 			//UQAM need vreq instead of WebappDaoFactory
 			Map<String, String> parentClass = Collections.emptyMap();
 			FieldOptions fieldOptions = field.getFieldOptions();
-			// UQAM TODO - Only internationalization of ChildVClassesWithParent are implemented. For TODO, implement the internationalization for the rest of instanceof "FieldOptions"
-			if (fieldOptions instanceof ChildVClassesWithParent ) {
-				return ((ChildVClassesWithParent)fieldOptions).getOptions(editConfig,fieldName,vreq);
-			} else {
-				return fieldOptions.getOptions(editConfig,fieldName,vreq.getWebappDaoFactory());
-			}
+			return fieldOptions.getOptions(editConfig,fieldName,vreq.getWebappDaoFactory(), I18n.bundle(vreq));
 		} catch (Exception e) {
 			log.error("Error runing getFieldOptionis()",e);
 			return Collections.emptyMap();

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/web/templatemodels/edit/EditConfigurationTemplateModel.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/web/templatemodels/edit/EditConfigurationTemplateModel.java
@@ -6,7 +6,6 @@ import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 import java.text.Collator;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -41,7 +40,6 @@ import edu.cornell.mannlib.vitro.webapp.i18n.I18n;
 import edu.cornell.mannlib.vitro.webapp.i18n.I18nBundle;
 import edu.cornell.mannlib.vitro.webapp.modelaccess.ModelAccess;
 import edu.cornell.mannlib.vitro.webapp.modelaccess.ModelAccess.LanguageOption;
-import edu.cornell.mannlib.vitro.webapp.modelaccess.ModelAccess.PolicyOption;
 import edu.cornell.mannlib.vitro.webapp.web.beanswrappers.ReadOnlyBeansWrapper;
 import edu.cornell.mannlib.vitro.webapp.web.templatemodels.BaseTemplateModel;
 import edu.cornell.mannlib.vitro.webapp.web.templatemodels.individual.ObjectPropertyStatementTemplateModel;
@@ -112,8 +110,7 @@ public class EditConfigurationTemplateModel extends BaseTemplateModel {
 		    	field.setOptions(new ConstantFieldOptions());
 		    }
 		    //UQAM-Optimization changing signature for including internationalization in scroll-down menu
-		    Map<String, String> optionsMap = SelectListGeneratorVTwo.getOptions(editConfig, fieldName, wdf);
-//		    Map<String, String> optionsMap = SelectListGeneratorVTwo.getOptions(editConfig, fieldName, vreq);
+		    Map<String, String> optionsMap = SelectListGeneratorVTwo.getOptions(editConfig, fieldName, wdf, I18n.bundle(vreq));
 		    optionsMap = SelectListGeneratorVTwo.getSortedMap(optionsMap, field.getFieldOptions().getCustomComparator(), vreq);
 		    if(pageData.containsKey(fieldName)) {
 		    	log.error("Check the edit configuration setup as pageData already contains " + fieldName + " and this will be overwritten now with empty collection");


### PR DESCRIPTION
Partial resolution to: https://jira.lyrasis.org/browse/VIVO-1881

# What does this pull request do?
Adds an I18NBundle parameter to `FieldOptions` so that drop-down lists may be translated.

# How should this be tested?
1. Go to person/individual
1. Select the "Teaching" tab
1. Select "advisees"
1. View "Advising Relationship Type" dropdown list
   - Verify the term "Other" is translated

# Related pull-request(s)
- https://github.com/vivo-project/VIVO/pull/177

# Interested parties
@VIVO-project/vivo-committers
