### PR TITLE
[VIVO-1909] Adjust SPARQL node logic so datatype not added if language tag included

### DIFF
--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/dao/jena/RDFServiceGraph.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/dao/jena/RDFServiceGraph.java
@@ -290,10 +290,10 @@ public class RDFServiceGraph implements GraphWithPerform {
             literalBuff.append("\"");
             pyString(literalBuff, node.getLiteralLexicalForm());
             literalBuff.append("\"");
-            if (node.getLiteralDatatypeURI() != null) {
-                literalBuff.append("^^<").append(node.getLiteralDatatypeURI()).append(">");
-            } else if (!StringUtils.isEmpty(node.getLiteralLanguage())) {
+            if (!StringUtils.isEmpty(node.getLiteralLanguage())) {
                 literalBuff.append("@").append(node.getLiteralLanguage());
+            } else if (node.getLiteralDatatypeURI() != null) {
+                literalBuff.append("^^<").append(node.getLiteralDatatypeURI()).append(">");
             }
             return literalBuff.toString();
         } else {

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/dao/jena/SparqlGraph.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/dao/jena/SparqlGraph.java
@@ -232,10 +232,10 @@ public class SparqlGraph implements GraphWithPerform {
             literalBuff.append("\"");
             pyString(literalBuff, node.getLiteralLexicalForm());
             literalBuff.append("\"");
-            if (node.getLiteralDatatypeURI() != null) {
-                literalBuff.append("^^<").append(node.getLiteralDatatypeURI()).append(">");
-            } else if (!StringUtils.isEmpty(node.getLiteralLanguage())) {
+            if (!StringUtils.isEmpty(node.getLiteralLanguage())) {
                 literalBuff.append("@").append(node.getLiteralLanguage());
+            } else if (node.getLiteralDatatypeURI() != null) {
+                literalBuff.append("^^<").append(node.getLiteralDatatypeURI()).append(">");
             }
             return literalBuff.toString();
         } else {

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/rdfservice/impl/RDFServiceImpl.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/rdfservice/impl/RDFServiceImpl.java
@@ -254,10 +254,10 @@ public abstract class RDFServiceImpl implements RDFService {
             literalBuff.append("\"");
             pyString(literalBuff, node.getLiteralLexicalForm());
             literalBuff.append("\"");
-            if (node.getLiteralDatatypeURI() != null) {
-                literalBuff.append("^^<").append(node.getLiteralDatatypeURI()).append(">");
-            } else if (node.getLiteralLanguage() != null && node.getLiteralLanguage().length() > 0) {
+            if (node.getLiteralLanguage() != null && node.getLiteralLanguage().length() > 0) {
                 literalBuff.append("@").append(node.getLiteralLanguage());
+            } else if (node.getLiteralDatatypeURI() != null) {
+                literalBuff.append("^^<").append(node.getLiteralDatatypeURI()).append(">");
             }
             return literalBuff.toString();
         } else {


### PR DESCRIPTION
**[VIVO-1909](https://jira.lyrasis.org/browse/VIVO-1909)**: 'Edit this Individual' form strips language tags and adds langString datatype

* Other Relevant Links (Mailing list discussion, related pull requests, etc.)
https://groups.google.com/u/2/g/vivo-tech/c/bjBcAJo8ldE/m/xgOfBPcZAwAJ?pli=1
Further discussion on #develop channel of Slack

# What does this pull request do?
Fixes a bug where labels edited via 'Edit this Individual' were being added with langString datatypes.

# What's new?
Flips logic in the rdf creation logic such that literals provided with a language tag keep a language tag and ditch the datatype. The behavior was previously the opposite. Following discussion at https://wiki.lyrasis.org/display/VIVODOC111x/Data+types+for+string+and+language strings and langStrings datatypes are assumed in RDF 1.1 and don't have to be explicitly stated.

# How should this be tested?
Confirm issue by editing a label via 'Edit this Individual' and observing that the langString datatype is added.

<img width="1392" alt="Screen Shot 2020-07-15 at 16 40 57" src="https://user-images.githubusercontent.com/10748475/87841670-51083a80-c864-11ea-81ca-d7e28dd65244.png">

Deploy with changes, and do the same. It should now add a language tag instead of a datatype. 

# Additional Notes:
The label editing available via the 'Edit this Individual' interface is problematic since it does not account for multiple languages. It displays a single label, even if there are many. If you update the label via this form it removes _all_ labels and replaces them with the new label, which is given the 'preferred' language tag, which is en-US. https://github.com/vivo-project/Vitro/blob/6d64d27fe4ad26bee7ffd10a852e71240f8ae903/api/src/main/java/edu/cornell/mannlib/vitro/webapp/dao/WebappDaoFactoryConfig.java#L22

An argument could be made for removing the 'Edit this Individual' editing interface completely, since I believe everything can be edited via the main UI anyway, and I don't think any of the i18n work touches it. 

# Interested parties
@hudajkhan @vivo-project/vivo-committers 
