### PR TITLE
[VIVO-1900] i18n: added empty check for getCountry, fixing bug with spanish label (es)

### DIFF
--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/freemarker/FreemarkerHttpServlet.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/freemarker/FreemarkerHttpServlet.java
@@ -281,7 +281,10 @@ public class FreemarkerHttpServlet extends VitroHttpServlet  {
 
         templateDataModel.put("body", bodyString);
 
-        String lang = vreq.getLocale().getLanguage() + "-"+vreq.getLocale().getCountry();
+        String lang = vreq.getLocale().getLanguage();
+        if (!vreq.getLocale().getCountry().isEmpty()) {
+            lang += "-" + vreq.getLocale().getCountry();
+        }
         templateDataModel.put("country", lang);
 
         // Tell the template and any directives it uses that we're processing a page template.

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/json/GetRandomSearchIndividualsByVClass.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/json/GetRandomSearchIndividualsByVClass.java
@@ -76,9 +76,9 @@ public class GetRandomSearchIndividualsByVClass extends GetSearchIndividualsByVC
 				IndividualTemplateModelBuilder.build(individual, vreq));
 		modelMap.put("vclass", vclassName);
 		String langCtx = vreq.getLocale().getLanguage();  //UQAM-Linguistic-Management build the linguistic context
-        if (!vreq.getLocale().getCountry().isEmpty()) {
-            langCtx += "-" + vreq.getLocale().getCountry();
-        }
+		if (!vreq.getLocale().getCountry().isEmpty()) {
+			langCtx += "-" + vreq.getLocale().getCountry();
+		}
 		modelMap.put("langCtx", langCtx); // UQAM-Linguistic-Management add the linguistic context to map
 		ShortViewService svs = ShortViewServiceSetup.getService(ctx);
 		return svs.renderShortView(individual, ShortViewContext.BROWSE,

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/json/GetRandomSearchIndividualsByVClass.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/json/GetRandomSearchIndividualsByVClass.java
@@ -75,7 +75,10 @@ public class GetRandomSearchIndividualsByVClass extends GetSearchIndividualsByVC
 		modelMap.put("individual",
 				IndividualTemplateModelBuilder.build(individual, vreq));
 		modelMap.put("vclass", vclassName);
-		String langCtx = vreq.getLocale().getLanguage() + "-"+vreq.getLocale().getCountry();  //UQAM-Linguistic-Management build the linguistic context
+		String langCtx = vreq.getLocale().getLanguage();  //UQAM-Linguistic-Management build the linguistic context
+        if (!vreq.getLocale().getCountry().isEmpty()) {
+            langCtx += "-" + vreq.getLocale().getCountry();
+        }
 		modelMap.put("langCtx", langCtx); // UQAM-Linguistic-Management add the linguistic context to map
 		ShortViewService svs = ShortViewServiceSetup.getService(ctx);
 		return svs.renderShortView(individual, ShortViewContext.BROWSE,

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/VTwo/MultiValueEditSubmission.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/VTwo/MultiValueEditSubmission.java
@@ -303,7 +303,7 @@ public class MultiValueEditSubmission {
 					String rangeLang = field.getRangeLang();  //UQAM  Default value
 					try {
 						if (_vreq != null ) {
-							rangeLang	= _vreq.getLocale().getLanguage();
+							rangeLang = _vreq.getLocale().getLanguage();
 							if (!_vreq.getLocale().getCountry().isEmpty()) {
 								rangeLang += "-" + _vreq.getLocale().getCountry();
 							}

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/VTwo/MultiValueEditSubmission.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/VTwo/MultiValueEditSubmission.java
@@ -303,7 +303,10 @@ public class MultiValueEditSubmission {
 					String rangeLang = field.getRangeLang();  //UQAM  Default value
 					try {
 						if (_vreq != null ) {
-							rangeLang	= _vreq.getLocale().getLanguage() + "-"+_vreq.getLocale().getCountry();
+                            rangeLang	= _vreq.getLocale().getLanguage();
+                            if (!_vreq.getLocale().getCountry().isEmpty()) {
+                                rangeLang += "-" + _vreq.getLocale().getCountry();
+                            }
 						}
 
 					} catch (Exception e) {

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/VTwo/MultiValueEditSubmission.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/VTwo/MultiValueEditSubmission.java
@@ -303,10 +303,10 @@ public class MultiValueEditSubmission {
 					String rangeLang = field.getRangeLang();  //UQAM  Default value
 					try {
 						if (_vreq != null ) {
-                            rangeLang	= _vreq.getLocale().getLanguage();
-                            if (!_vreq.getLocale().getCountry().isEmpty()) {
-                                rangeLang += "-" + _vreq.getLocale().getCountry();
-                            }
+							rangeLang	= _vreq.getLocale().getLanguage();
+							if (!_vreq.getLocale().getCountry().isEmpty()) {
+								rangeLang += "-" + _vreq.getLocale().getCountry();
+							}
 						}
 
 					} catch (Exception e) {

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/VTwo/ProcessRdfForm.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/VTwo/ProcessRdfForm.java
@@ -309,7 +309,7 @@ public class ProcessRdfForm {
             String lingCxt=null;
             //UQAM Taking into account the linguistic context in retract
             try {
-                lingCxt	= vreq.getLocale().getLanguage();
+                lingCxt = vreq.getLocale().getLanguage();
                 if (!vreq.getLocale().getCountry().isEmpty()) {
                     lingCxt += "-" + vreq.getLocale().getCountry();
                 }

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/VTwo/ProcessRdfForm.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/VTwo/ProcessRdfForm.java
@@ -307,14 +307,14 @@ public class ProcessRdfForm {
         List<Model> retracts = new ArrayList<Model>();
         if( requiredDels != null && optionalDels != null ){
             String lingCxt=null;
-    		//UQAM Taking into account the linguistic context in retract
-    		try {
-                    lingCxt	= vreq.getLocale().getLanguage();
-                    if (!vreq.getLocale().getCountry().isEmpty()) {
-                        lingCxt += "-" + vreq.getLocale().getCountry();
-                    }
-    		} catch (Exception e) {
-    		}
+            //UQAM Taking into account the linguistic context in retract
+            try {
+                lingCxt	= vreq.getLocale().getLanguage();
+                if (!vreq.getLocale().getCountry().isEmpty()) {
+                    lingCxt += "-" + vreq.getLocale().getCountry();
+                }
+            } catch (Exception e) {
+            }
             retracts.addAll( parseN3ToRDF(requiredDels, REQUIRED, lingCxt) );
             retracts.addAll( parseN3ToRDF(optionalDels, OPTIONAL, lingCxt) );
         }

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/VTwo/ProcessRdfForm.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/VTwo/ProcessRdfForm.java
@@ -216,7 +216,10 @@ public class ProcessRdfForm {
                      */
 
                     if (XSD.xstring.getURI().equals(aLiteratDT) || RDF.dtLangString.getURI().equals(aLiteratDT)) {
-                        String lang = vreq.getLocale().getLanguage() + "-" + vreq.getLocale().getCountry();
+                        String lang = vreq.getLocale().getLanguage();
+                        if (!vreq.getLocale().getCountry().isEmpty()) {
+                            lang += "-" + vreq.getLocale().getCountry();
+                        }
                         newLiteral = ResourceFactory.createLangLiteral(aText, lang);
                     } else {
                         newLiteral = ResourceFactory.createTypedLiteral(aText, aLiteral.getDatatype());
@@ -306,7 +309,10 @@ public class ProcessRdfForm {
             String lingCxt=null;
     		//UQAM Taking into account the linguistic context in retract
     		try {
-    				lingCxt	= vreq.getLocale().getLanguage() + "-"+vreq.getLocale().getCountry();
+                    lingCxt	= vreq.getLocale().getLanguage();
+                    if (!vreq.getLocale().getCountry().isEmpty()) {
+                        lingCxt += "-" + vreq.getLocale().getCountry();
+                    }
     		} catch (Exception e) {
     		}
             retracts.addAll( parseN3ToRDF(requiredDels, REQUIRED, lingCxt) );

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/services/shortview/FakeApplicationOntologyService.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/services/shortview/FakeApplicationOntologyService.java
@@ -494,7 +494,10 @@ public class FakeApplicationOntologyService {
 			this.individualUri = individualUri;
 			this.vreq = vreq;
 			this.ctx = vreq.getSession().getServletContext();
-			this.langCtx =  vreq.getLocale().getLanguage() + "-"+vreq.getLocale().getCountry(); // UQAM-Optimization add the linguistic context
+			this.langCtx =  vreq.getLocale().getLanguage(); // UQAM-Optimization add the linguistic context
+            if (!vreq.getLocale().getCountry().isEmpty()) {
+                this.langCtx += "-" + vreq.getLocale().getCountry();
+            }
 		}
 
 		@Override

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/services/shortview/FakeApplicationOntologyService.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/services/shortview/FakeApplicationOntologyService.java
@@ -495,9 +495,9 @@ public class FakeApplicationOntologyService {
 			this.vreq = vreq;
 			this.ctx = vreq.getSession().getServletContext();
 			this.langCtx =  vreq.getLocale().getLanguage(); // UQAM-Optimization add the linguistic context
-            if (!vreq.getLocale().getCountry().isEmpty()) {
-                this.langCtx += "-" + vreq.getLocale().getCountry();
-            }
+			if (!vreq.getLocale().getCountry().isEmpty()) {
+				this.langCtx += "-" + vreq.getLocale().getCountry();
+			}
 		}
 
 		@Override


### PR DESCRIPTION
**[JIRA Issue](https://jira.lyrasis.org/browse/VIVO-1900)**

[2nd PR](https://github.com/vivo-project/VIVO/pull/182)

# What does this pull request do?
This PR adds an check for empty Country language tags. Most tags are like this "en-US" or "de-DE" but the spanish one is just "es". The language tag consists of two parts and if the second part (Country) is empty the spanish label looked like this "es-" and caused an error.

I have corrected not only the part that causes this error but all the ones I have found which could also lead to this or similar errors.

# What's new?
Check for empty country language tag.

# How should this be tested?
With a fresh VIVO instanz and the given sample data (https://wiki.lyrasis.org/display/VIVODOC19x/Sample+Data) i tried to add an spanish label to an article. Go to the article, edit label with language set to spanish ( you do not need to edit it) and click "Editar etiqueta" (Edit Label). After that an error  occurred. If this does not happen and the label is set, it should be fine.