### PR TITLE
[VIVO-1915] i18n - Adding a label with language tag through the "new" manageLabelsForindividualAddForm.ftl does not take the setting for language tag

### DIFF
--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/VTwo/MultiValueEditSubmission.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/VTwo/MultiValueEditSubmission.java
@@ -21,7 +21,6 @@ import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
 import org.apache.jena.rdf.model.ResourceFactory;
 import org.apache.jena.vocabulary.XSD;
-import org.apache.jena.vocabulary.RDF;
 
 import edu.cornell.mannlib.vitro.webapp.controller.VitroRequest;
 import edu.cornell.mannlib.vitro.webapp.edit.EditLiteral;
@@ -181,7 +180,7 @@ public class MultiValueEditSubmission {
 //				} catch (UnsupportedEncodingException e) {
 //					log.error(e, e);
 //				}
-            } else if ( XSD.xstring.getURI().equals(datatypeUri) || RDF.dtLangString.getURI().equals(datatypeUri)){
+            } else if ( XSD.xstring.getURI().equals(datatypeUri) ){
 				if( lang != null && lang.length() > 0 )	return ResourceFactory.createLangLiteral(value, lang);
 			}
 			return literalCreationModel.createTypedLiteral(value, datatypeUri);

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/VTwo/MultiValueEditSubmission.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/VTwo/MultiValueEditSubmission.java
@@ -21,6 +21,7 @@ import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
 import org.apache.jena.rdf.model.ResourceFactory;
 import org.apache.jena.vocabulary.XSD;
+import org.apache.jena.vocabulary.RDF;
 
 import edu.cornell.mannlib.vitro.webapp.controller.VitroRequest;
 import edu.cornell.mannlib.vitro.webapp.edit.EditLiteral;
@@ -180,7 +181,7 @@ public class MultiValueEditSubmission {
 //				} catch (UnsupportedEncodingException e) {
 //					log.error(e, e);
 //				}
-			} else if ( XSD.xstring.getURI().equals(datatypeUri) ){
+            } else if ( XSD.xstring.getURI().equals(datatypeUri) || RDF.dtLangString.getURI().equals(datatypeUri)){
 				if( lang != null && lang.length() > 0 )	return ResourceFactory.createLangLiteral(value, lang);
 			}
 			return literalCreationModel.createTypedLiteral(value, datatypeUri);

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/VTwo/MultiValueEditSubmission.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/VTwo/MultiValueEditSubmission.java
@@ -21,6 +21,7 @@ import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
 import org.apache.jena.rdf.model.ResourceFactory;
 import org.apache.jena.vocabulary.XSD;
+import org.apache.jena.vocabulary.RDF;
 
 import edu.cornell.mannlib.vitro.webapp.controller.VitroRequest;
 import edu.cornell.mannlib.vitro.webapp.edit.EditLiteral;
@@ -180,7 +181,7 @@ public class MultiValueEditSubmission {
 //				} catch (UnsupportedEncodingException e) {
 //					log.error(e, e);
 //				}
-            } else if ( XSD.xstring.getURI().equals(datatypeUri) ){
+            } else if ( XSD.xstring.getURI().equals(datatypeUri) || RDF.dtLangString.getURI().equals(datatypeUri)){
 				if( lang != null && lang.length() > 0 )	return ResourceFactory.createLangLiteral(value, lang);
 			}
 			return literalCreationModel.createTypedLiteral(value, datatypeUri);

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/VTwo/MultiValueEditSubmission.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/VTwo/MultiValueEditSubmission.java
@@ -21,7 +21,6 @@ import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
 import org.apache.jena.rdf.model.ResourceFactory;
 import org.apache.jena.vocabulary.XSD;
-import org.apache.jena.vocabulary.RDF;
 
 import edu.cornell.mannlib.vitro.webapp.controller.VitroRequest;
 import edu.cornell.mannlib.vitro.webapp.edit.EditLiteral;
@@ -181,7 +180,7 @@ public class MultiValueEditSubmission {
 //				} catch (UnsupportedEncodingException e) {
 //					log.error(e, e);
 //				}
-            } else if ( XSD.xstring.getURI().equals(datatypeUri) || RDF.dtLangString.getURI().equals(datatypeUri)){
+			} else if ( XSD.xstring.getURI().equals(datatypeUri) ){
 				if( lang != null && lang.length() > 0 )	return ResourceFactory.createLangLiteral(value, lang);
 			}
 			return literalCreationModel.createTypedLiteral(value, datatypeUri);

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/VTwo/ProcessRdfForm.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/VTwo/ProcessRdfForm.java
@@ -214,7 +214,11 @@ public class ProcessRdfForm {
                     /*
                      * do it only if aLiteral are xstring datatype
                      */
-                    if (XSD.xstring.getURI().equals(aLiteratDT) || RDF.dtLangString.getURI().equals(aLiteratDT)) {
+
+                    if (RDF.dtLangString.getURI().equals(aLiteratDT) && !aLiteral.getLanguage().isEmpty()) {
+                        newLiteral = aLiteral;
+                    }
+                    else if (XSD.xstring.getURI().equals(aLiteratDT) || RDF.dtLangString.getURI().equals(aLiteratDT)) {
                         String lang = vreq.getLocale().getLanguage();
                         if (!vreq.getLocale().getCountry().isEmpty()) {
                             lang += "-" + vreq.getLocale().getCountry();

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/VTwo/ProcessRdfForm.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/VTwo/ProcessRdfForm.java
@@ -215,7 +215,10 @@ public class ProcessRdfForm {
                      * do it only if aLiteral are xstring datatype
                      */
 
-                    if (XSD.xstring.getURI().equals(aLiteratDT) || RDF.dtLangString.getURI().equals(aLiteratDT)) {
+                    if (RDF.dtLangString.getURI().equals(aLiteratDT) && !aLiteral.getLanguage().isEmpty()) {
+                        newLiteral = aLiteral;
+                    }
+                    else if (XSD.xstring.getURI().equals(aLiteratDT) || RDF.dtLangString.getURI().equals(aLiteratDT)) {
                         String lang = vreq.getLocale().getLanguage();
                         if (!vreq.getLocale().getCountry().isEmpty()) {
                             lang += "-" + vreq.getLocale().getCountry();

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/VTwo/ProcessRdfForm.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/VTwo/ProcessRdfForm.java
@@ -214,11 +214,7 @@ public class ProcessRdfForm {
                     /*
                      * do it only if aLiteral are xstring datatype
                      */
-
-                    if (RDF.dtLangString.getURI().equals(aLiteratDT) && !aLiteral.getLanguage().isEmpty()) {
-                        newLiteral = aLiteral;
-                    }
-                    else if (XSD.xstring.getURI().equals(aLiteratDT) || RDF.dtLangString.getURI().equals(aLiteratDT)) {
+                    if (XSD.xstring.getURI().equals(aLiteratDT) || RDF.dtLangString.getURI().equals(aLiteratDT)) {
                         String lang = vreq.getLocale().getLanguage();
                         if (!vreq.getLocale().getCountry().isEmpty()) {
                             lang += "-" + vreq.getLocale().getCountry();

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/ManageLabelsForIndividualGenerator.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/ManageLabelsForIndividualGenerator.java
@@ -224,6 +224,20 @@ public class ManageLabelsForIndividualGenerator extends BaseEditConfigurationGen
 		 config.addFormSpecificData("displayRemoveLink", (numberExistingLabels > 1));
 
 
+		// get current selected locale
+		String rangeLang = vreq.getLocale().getLanguage();
+		if (!vreq.getLocale().getCountry().isEmpty()) {
+			rangeLang += "-" + vreq.getLocale().getCountry();
+		}
+
+		// check if locale already has an entry (label)
+		boolean localeEntryExisting = true;
+		for (HashMap<String, String> tmp : availableLocalesForAdd) {
+			if (tmp.get("code").equals(rangeLang)) localeEntryExisting = false;
+		}
+		config.addFormSpecificData("localeEntryExisting", localeEntryExisting);
+		config.addFormSpecificData("currentSelectedLocale", rangeLang);
+
         //How do we edit? Will need to see
         config.addFormSpecificData("deleteWebpageUrl", "/edit/primitiveDelete");
 

--- a/webapp/src/main/webapp/js/individual/manageLabelsForIndividual.js
+++ b/webapp/src/main/webapp/js/individual/manageLabelsForIndividual.js
@@ -35,7 +35,6 @@ var manageLabels = {
     // Initial page setup. Called only at page load.
     initPage: function() {
 
-        //var disableSubmit = true;
         if(this.submissionErrorsExist == "false") {
         	//hide the form to add label
         	this.addLabelForm.hide();
@@ -44,7 +43,11 @@ var manageLabels = {
         	if(this.numberAvailableLocales == 0) {
             	manageLabels.showFormButtonWrapper.hide();
             	this.showCancelOnlyButton.show();
-        	} else {
+        	} else if(manageLabels.localeEntryExisting == "true") { 
+        		// if there is already an label for the selected langauge hide the add button 
+        		manageLabels.showFormButtonWrapper.hide();
+        		this.showCancelOnlyButton.show();
+        	} else{
         		//if the add label button is visible, don't need cancel only link
         		this.showCancelOnlyButton.hide();
         	}
@@ -53,38 +56,13 @@ var manageLabels = {
         	//Display the form
         	this.onShowAddForm();
 
-        	//Also make sure the save button is enabled in case there is a value selected for the drop down
-        	// if(this.labelLanguage.val() != "") {
-        	// 	disableSubmit = false;
-        	// }
-
         }
-
-
-
-        // if(disableSubmit) {
-        // 	//disable submit until user selects a language
-        //     this.submit.attr('disabled', 'disabled');
-        //     this.submit.addClass('disabledSubmit');
-        // }
 
         this.bindEventListeners();
 
     },
 
     bindEventListeners: function() {
-
-        // this.labelLanguage.change( function() {
-        // 	//if language selected, allow submission, otherwise disallow
-        // 	var selectedLanguage = manageLabels.labelLanguage.val();
-        // 	if(selectedLanguage != "") {
-        // 		manageLabels.submit.attr('disabled', false);
-        // 		manageLabels.submit.removeClass('disabledSubmit');
-        // 	} else {
-        // 		manageLabels.submit.attr('disabled', 'disabled');
-        // 		manageLabels.submit.addClass('disabledSubmit');
-        // 	}
-        // });
 
         //enable form to add label to be displayed or hidden
         this.showFormButton.click(function() {
@@ -123,9 +101,6 @@ var manageLabels = {
     clearAddForm:function() {
     	//clear inputs and select
     	manageLabels.addLabelForm.find("input[type='text'],select").val("");
-    	//set the button for save to be disabled again
-    	// manageLabels.submit.attr('disabled', 'disabled');
-		// manageLabels.submit.addClass('disabledSubmit');
     },
     onShowAddForm:function() {
     	manageLabels.addLabelForm.show();
@@ -226,12 +201,14 @@ var manageLabels = {
     	var availableLocalesList = [];
     	var listLen = selectLocalesFullList.length;
     	var i;
+    	var showAddButton = false;
     	for(i = 0; i < listLen; i++) {
     		var possibleLanguageInfo = selectLocalesFullList[i];
     		var possibleLanguageCode = possibleLanguageInfo["code"];
     		var possibleLangaugeLabel = possibleLanguageInfo["label"];
     		if(!(possibleLanguageCode in existingLanguages)) {
     			//manageLabels.addLanguageCode(possibleLanguageCode, possibleLanguageLabel);
+    			if (possibleLanguageCode == manageLabels.currentSelectedLocale) showAddButton = true;
     			availableLocalesList.push(possibleLanguageInfo);
     		}
     	}
@@ -242,8 +219,9 @@ var manageLabels = {
     	        var compB = b["label"];
     	        return compA < compB ? -1 : 1;
     	    });
+
     	 //Re-show the add button and the form if they were hidden before
-    	 if(availableLocalesList.length > 0 && manageLabels.showFormButtonWrapper.is(":hidden")) {
+    	 if(availableLocalesList.length > 0 && manageLabels.showFormButtonWrapper.is(":hidden") && showAddButton) {
     		 manageLabels.showFormButtonWrapper.show();
     		 //hide the cancel only button
     		 manageLabels.showCancelOnlyButton.hide();

--- a/webapp/src/main/webapp/js/individual/manageLabelsForIndividual.js
+++ b/webapp/src/main/webapp/js/individual/manageLabelsForIndividual.js
@@ -35,7 +35,7 @@ var manageLabels = {
     // Initial page setup. Called only at page load.
     initPage: function() {
 
-        var disableSubmit = true;
+        //var disableSubmit = true;
         if(this.submissionErrorsExist == "false") {
         	//hide the form to add label
         	this.addLabelForm.hide();
@@ -54,19 +54,19 @@ var manageLabels = {
         	this.onShowAddForm();
 
         	//Also make sure the save button is enabled in case there is a value selected for the drop down
-        	if(this.labelLanguage.val() != "") {
-        		disableSubmit = false;
-        	}
+        	// if(this.labelLanguage.val() != "") {
+        	// 	disableSubmit = false;
+        	// }
 
         }
 
 
 
-        if(disableSubmit) {
-        	//disable submit until user selects a language
-            this.submit.attr('disabled', 'disabled');
-            this.submit.addClass('disabledSubmit');
-        }
+        // if(disableSubmit) {
+        // 	//disable submit until user selects a language
+        //     this.submit.attr('disabled', 'disabled');
+        //     this.submit.addClass('disabledSubmit');
+        // }
 
         this.bindEventListeners();
 
@@ -74,17 +74,17 @@ var manageLabels = {
 
     bindEventListeners: function() {
 
-        this.labelLanguage.change( function() {
-        	//if language selected, allow submission, otherwise disallow
-        	var selectedLanguage = manageLabels.labelLanguage.val();
-        	if(selectedLanguage != "") {
-        		manageLabels.submit.attr('disabled', false);
-        		manageLabels.submit.removeClass('disabledSubmit');
-        	} else {
-        		manageLabels.submit.attr('disabled', 'disabled');
-        		manageLabels.submit.addClass('disabledSubmit');
-        	}
-        });
+        // this.labelLanguage.change( function() {
+        // 	//if language selected, allow submission, otherwise disallow
+        // 	var selectedLanguage = manageLabels.labelLanguage.val();
+        // 	if(selectedLanguage != "") {
+        // 		manageLabels.submit.attr('disabled', false);
+        // 		manageLabels.submit.removeClass('disabledSubmit');
+        // 	} else {
+        // 		manageLabels.submit.attr('disabled', 'disabled');
+        // 		manageLabels.submit.addClass('disabledSubmit');
+        // 	}
+        // });
 
         //enable form to add label to be displayed or hidden
         this.showFormButton.click(function() {
@@ -124,8 +124,8 @@ var manageLabels = {
     	//clear inputs and select
     	manageLabels.addLabelForm.find("input[type='text'],select").val("");
     	//set the button for save to be disabled again
-    	manageLabels.submit.attr('disabled', 'disabled');
-		manageLabels.submit.addClass('disabledSubmit');
+    	// manageLabels.submit.attr('disabled', 'disabled');
+		// manageLabels.submit.addClass('disabledSubmit');
     },
     onShowAddForm:function() {
     	manageLabels.addLabelForm.show();

--- a/webapp/src/main/webapp/templates/freemarker/body/individual/manageLabelsForIndividual.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/body/individual/manageLabelsForIndividual.ftl
@@ -31,6 +31,14 @@
 <#else>
 <h2>${i18n().manage_labels_capitalized}</h2>
 </#if>
+<#assign localeEntryExisting = true />
+<#if editConfiguration.pageData.localeEntryExisting?has_content>
+	<#assign localeEntryExisting = editConfiguration.pageData.localeEntryExisting />
+</#if>
+<#assign currentSelectedLocale =" " />
+<#if editConfiguration.pageData.currentSelectedLocale?has_content>
+	<#assign currentSelectedLocale = editConfiguration.pageData.currentSelectedLocale />
+</#if>
 
 
 
@@ -94,7 +102,9 @@ var customFormData = {
     individualUri: '${subjectUri!}',
     submissionErrorsExist: '${submissionErrorsExist}',
     selectLocalesFullList: selectLocalesFullList,
-    numberAvailableLocales:${availableLocalesNumber}
+    numberAvailableLocales:${availableLocalesNumber},
+    localeEntryExisting : '${localeEntryExisting?c}',
+    currentSelectedLocale: '${currentSelectedLocale}'
 };
 var i18nStrings = {
     errorProcessingLabels: '${i18n().error_processing_labels?js_string}',

--- a/webapp/src/main/webapp/templates/freemarker/body/individual/manageLabelsForIndividualAddForm.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/body/individual/manageLabelsForIndividualAddForm.ftl
@@ -6,19 +6,6 @@
   <label for="name">${i18n().name} ${requiredHint}</label>
   <input size="30"  type="text" id="label" name="label" value="" />
 </p>
-<label for="newLabelLanguage">${i18n().add_label_for_language}</label>
-<select  name="newLabelLanguage" id="newLabelLanguage" >
-<option value=""<#if !newLabelLanguageValue?has_content> selected="selected"</#if>>${i18n().select_locale}</option>
-<#if editConfiguration.pageData.selectLocale?has_content>
-	<#assign selectLocale = editConfiguration.pageData.selectLocale />
-	<#--Use the list of names because that is the order we want displayed-->
-
-	<#list selectLocale as locale>
-
- 	<option value="${locale.code}"<#if newLabelLanguageValue?has_content && locale.code == newLabelLanguageValue> selected="selected"</#if>>${locale.label}</option>
-	</#list>
-</#if>
- </select>
 
 <input type="hidden" name="editKey" id="editKey" value="${editKey}"/>
 


### PR DESCRIPTION
**[JIRA Issue](https://jira.lyrasis.org/browse/VIVO-1915)**

related PRs:
[1 PR ](https://github.com/vivo-project/VIVO/pull/190)
[2 PR](https://github.com/vivo-project/Vitro-languages/pull/31)

# What does this pull request do?
Fixes the bug when adding a label with language tag through manageLabelsForindivdualAddForm.
The selected language-tag was not used, in the end the parent language selection was used.

# How should this be tested?
With a fresh VIVO instanz and the given sample data (https://wiki.lyrasis.org/display/VIVODOC19x/Sample+Data) you can added a label/title to an instanz in an different language (f.e. german). Now you can click the button right of the label to "manage labels". You see the first initial english label and a german label.

If you try to add another label (the "main" language selection is set to english, upper right corner) with the button "Add Label" and you choose for example "French (Canada)" and click "Save". The Label will be listed as english (see images). And now, with the fix, the new label should have the selected language.

# Additional Notes:
I have also tested a few other places and found no problems but maybe someone with more experience in this area of the software should look at it and tell me if this is the right way to fix it.