### PR TITLE
[VIVO-1925] i18n: Editing labels results in new label

### DIFF
--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/VTwo/MultiValueEditSubmission.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/VTwo/MultiValueEditSubmission.java
@@ -304,10 +304,12 @@ public class MultiValueEditSubmission {
 					String rangeLang = field.getRangeLang();  //UQAM  Default value
 					try {
 						if (_vreq != null ) {
-							if (editConfig.getLiteralsInScope().get("label").get(0).getLanguage() != "")
+							// if the language is set in the given Literal, this language-tag should be used and remain the same
+							// for example when you edit an label with an langauge-tag (no matter which language is selected globally)
+							if (!StringUtils.isBlank(editConfig.getLiteralsInScope().get("label").get(0).getLanguage()))
 							{
 								rangeLang = editConfig.getLiteralsInScope().get("label").get(0).getLanguage();
-							} else {
+							} else { // if the literal has no langauge-tag, use the language which is globally selected
 								rangeLang = _vreq.getLocale().getLanguage();
 								if (!_vreq.getLocale().getCountry().isEmpty()) {
 									rangeLang += "-" + _vreq.getLocale().getCountry();

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/VTwo/MultiValueEditSubmission.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/VTwo/MultiValueEditSubmission.java
@@ -304,9 +304,14 @@ public class MultiValueEditSubmission {
 					String rangeLang = field.getRangeLang();  //UQAM  Default value
 					try {
 						if (_vreq != null ) {
+							// only if the request comes from the rdfsLabelGenerator the language should be used
+							Boolean get_label_language = false;
+							if (!StringUtils.isBlank(editConfig.formUrl) && editConfig.formUrl.contains("RDFSLabelGenerator")) {
+								get_label_language = true;
+							}
 							// if the language is set in the given Literal, this language-tag should be used and remain the same
 							// for example when you edit an label with an langauge-tag (no matter which language is selected globally)
-							if (!StringUtils.isBlank(editConfig.getLiteralsInScope().get("label").get(0).getLanguage()))
+							if (!StringUtils.isBlank(editConfig.getLiteralsInScope().get("label").get(0).getLanguage()) && get_label_language)
 							{
 								rangeLang = editConfig.getLiteralsInScope().get("label").get(0).getLanguage();
 							} else { // if the literal has no langauge-tag, use the language which is globally selected

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/VTwo/MultiValueEditSubmission.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/VTwo/MultiValueEditSubmission.java
@@ -21,6 +21,7 @@ import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
 import org.apache.jena.rdf.model.ResourceFactory;
 import org.apache.jena.vocabulary.XSD;
+import org.apache.jena.vocabulary.RDF;
 
 import edu.cornell.mannlib.vitro.webapp.controller.VitroRequest;
 import edu.cornell.mannlib.vitro.webapp.edit.EditLiteral;
@@ -180,7 +181,7 @@ public class MultiValueEditSubmission {
 //				} catch (UnsupportedEncodingException e) {
 //					log.error(e, e);
 //				}
-			} else if ( XSD.xstring.getURI().equals(datatypeUri) ){
+			} else if ( XSD.xstring.getURI().equals(datatypeUri) || RDF.dtLangString.getURI().equals(datatypeUri) ){
 				if( lang != null && lang.length() > 0 )	return ResourceFactory.createLangLiteral(value, lang);
 			}
 			return literalCreationModel.createTypedLiteral(value, datatypeUri);
@@ -303,9 +304,14 @@ public class MultiValueEditSubmission {
 					String rangeLang = field.getRangeLang();  //UQAM  Default value
 					try {
 						if (_vreq != null ) {
-							rangeLang = _vreq.getLocale().getLanguage();
-							if (!_vreq.getLocale().getCountry().isEmpty()) {
-								rangeLang += "-" + _vreq.getLocale().getCountry();
+							if (editConfig.getLiteralsInScope().get("label").get(0).getLanguage() != "")
+							{
+								rangeLang = editConfig.getLiteralsInScope().get("label").get(0).getLanguage();
+							} else {
+								rangeLang = _vreq.getLocale().getLanguage();
+								if (!_vreq.getLocale().getCountry().isEmpty()) {
+									rangeLang += "-" + _vreq.getLocale().getCountry();
+								}
 							}
 						}
 

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/VTwo/MultiValueEditSubmission.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/VTwo/MultiValueEditSubmission.java
@@ -305,13 +305,13 @@ public class MultiValueEditSubmission {
 					try {
 						if (_vreq != null ) {
 							// only if the request comes from the rdfsLabelGenerator the language should be used
-							Boolean get_label_language = false;
+							Boolean getLabelLanguage = false;
 							if (!StringUtils.isBlank(editConfig.formUrl) && editConfig.formUrl.contains("RDFSLabelGenerator")) {
-								get_label_language = true;
+								getLabelLanguage = true;
 							}
 							// if the language is set in the given Literal, this language-tag should be used and remain the same
 							// for example when you edit an label with an langauge-tag (no matter which language is selected globally)
-							if (!StringUtils.isBlank(editConfig.getLiteralsInScope().get("label").get(0).getLanguage()) && get_label_language)
+							if (!StringUtils.isBlank(editConfig.getLiteralsInScope().get("label").get(0).getLanguage()) && getLabelLanguage)
 							{
 								rangeLang = editConfig.getLiteralsInScope().get("label").get(0).getLanguage();
 							} else { // if the literal has no langauge-tag, use the language which is globally selected

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/VTwo/ProcessRdfForm.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/VTwo/ProcessRdfForm.java
@@ -312,9 +312,14 @@ public class ProcessRdfForm {
             String lingCxt=null;
             //UQAM Taking into account the linguistic context in retract
             try {
+                // only if the request comes from the rdfsLabelGenerator the language should be used
+                Boolean get_label_language = false;
+                if (!StringUtils.isBlank(editConfig.formUrl) && editConfig.formUrl.contains("RDFSLabelGenerator")) {
+                    get_label_language = true;
+                }
                 // if the language is set in the given Literal, this language-tag should be used and remain the same
                 // for example when you edit an label with an langauge-tag (no matter which language is selected globally)
-                if (editConfig != null && !StringUtils.isBlank(editConfig.getLiteralsInScope().get("label").get(0).getLanguage())) {
+                if (editConfig != null && !StringUtils.isBlank(editConfig.getLiteralsInScope().get("label").get(0).getLanguage()) && get_label_language) {
                     lingCxt = editConfig.getLiteralsInScope().get("label").get(0).getLanguage();
                 } else { // if the literal has no langauge-tag, use the language which is globally selected
                     lingCxt = vreq.getLocale().getLanguage();

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/VTwo/ProcessRdfForm.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/VTwo/ProcessRdfForm.java
@@ -26,6 +26,7 @@ import org.apache.jena.rdf.model.Statement;
 import org.apache.jena.shared.Lock;
 import org.apache.jena.vocabulary.RDF;
 import org.apache.jena.vocabulary.XSD;
+import org.apache.commons.lang3.StringUtils;
 
 import edu.cornell.mannlib.vitro.webapp.controller.VitroRequest;
 import edu.cornell.mannlib.vitro.webapp.dao.InsertException;
@@ -311,9 +312,11 @@ public class ProcessRdfForm {
             String lingCxt=null;
             //UQAM Taking into account the linguistic context in retract
             try {
-                if (editConfig != null && editConfig.getLiteralsInScope().get("label").get(0).getLanguage() != "") {
+                // if the language is set in the given Literal, this language-tag should be used and remain the same
+                // for example when you edit an label with an langauge-tag (no matter which language is selected globally)
+                if (editConfig != null && !StringUtils.isBlank(editConfig.getLiteralsInScope().get("label").get(0).getLanguage())) {
                     lingCxt = editConfig.getLiteralsInScope().get("label").get(0).getLanguage();
-                } else {
+                } else { // if the literal has no langauge-tag, use the language which is globally selected
                     lingCxt = vreq.getLocale().getLanguage();
                     if (!vreq.getLocale().getCountry().isEmpty()) {
                         lingCxt += "-" + vreq.getLocale().getCountry();

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/VTwo/ProcessRdfForm.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/VTwo/ProcessRdfForm.java
@@ -313,13 +313,13 @@ public class ProcessRdfForm {
             //UQAM Taking into account the linguistic context in retract
             try {
                 // only if the request comes from the rdfsLabelGenerator the language should be used
-                Boolean get_label_language = false;
+                Boolean getLabelLanguage = false;
                 if (!StringUtils.isBlank(editConfig.formUrl) && editConfig.formUrl.contains("RDFSLabelGenerator")) {
-                    get_label_language = true;
+                    getLabelLanguage = true;
                 }
                 // if the language is set in the given Literal, this language-tag should be used and remain the same
                 // for example when you edit an label with an langauge-tag (no matter which language is selected globally)
-                if (editConfig != null && !StringUtils.isBlank(editConfig.getLiteralsInScope().get("label").get(0).getLanguage()) && get_label_language) {
+                if (editConfig != null && !StringUtils.isBlank(editConfig.getLiteralsInScope().get("label").get(0).getLanguage()) && getLabelLanguage) {
                     lingCxt = editConfig.getLiteralsInScope().get("label").get(0).getLanguage();
                 } else { // if the literal has no langauge-tag, use the language which is globally selected
                     lingCxt = vreq.getLocale().getLanguage();


### PR DESCRIPTION
**[JIRA Issue](https://jira.lyrasis.org/browse/VIVO-1925)**


# What does this pull request do?
Fixes a bug when you editing language labels.

# How should this be tested?
see [JIRA Issue](https://jira.lyrasis.org/browse/VIVO-1925)
**Bug description from JIRA Issue:
T**his bug can be seen when editing a label where the language of the label is different than the site language context.

For example, if the sample-data (https://github.com/vivo-project/sample-data/blob/master/sample-data.n3) is loaded, add a new label for "Rhetoric" while in a language context other than English (e.g. German).
http://localhost:8080/vivo/editRequestDispatch?subjectUri=http%3A%2F%2Fvivo.mydomain.edu%2Findividual%2Fn2854&editForm=edu.cornell.mannlib.vitro.webapp.edit.n3editing.configuration.generators.VIVOManageLabelsGenerator&predicateUri=http%3A%2F%2Fwww.w3.org%2F2000%2F01%2Frdf-schema%23label

Then, switch the site language context to English, and click on the "Edit" button next to the new, German label. Edit the value and save.

Notice the bug: the German label was not actually edited, but rather, a new label was added with an English langTag.

**And now with the fix, the selected label will be changed no matter which language is selected.**

