### PR TITLE
[Vivo 1918] i18n: Reload firsttime files on start-up if changed

### DIFF
--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/modelaccess/ModelNames.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/modelaccess/ModelNames.java
@@ -13,27 +13,27 @@ public class ModelNames {
 	public static final String ABOX_ASSERTIONS = "http://vitro.mannlib.cornell.edu/default/vitro-kb-2";
 	public static final String ABOX_INFERENCES = "http://vitro.mannlib.cornell.edu/default/vitro-kb-inf";
 	public static final String ABOX_UNION = "vitro:aboxOntModel";
-	public static final String ABOX_ASSERTIONS_FIRSTTIME = ABOX_ASSERTIONS + "Firsttime";
+	public static final String ABOX_ASSERTIONS_FIRSTTIME_BACKUP = ABOX_ASSERTIONS + "FirsttimeBackup";
 
 	public static final String TBOX_ASSERTIONS = "http://vitro.mannlib.cornell.edu/default/asserted-tbox";
 	public static final String TBOX_INFERENCES = "http://vitro.mannlib.cornell.edu/default/inferred-tbox";
 	public static final String TBOX_UNION = "vitro:tboxOntModel";
-	public static final String TBOX_ASSERTIONS_FIRSTTIME = TBOX_ASSERTIONS + "Firsttime";
+	public static final String TBOX_ASSERTIONS_FIRSTTIME_BACKUP = TBOX_ASSERTIONS + "FirsttimeBackup";
 
 	public static final String FULL_ASSERTIONS = "vitro:baseOntModel";
 	public static final String FULL_INFERENCES = "vitro:inferenceOntModel";
 	public static final String FULL_UNION = "vitro:jenaOntModel";
 
 	public static final String APPLICATION_METADATA = "http://vitro.mannlib.cornell.edu/default/vitro-kb-applicationMetadata";
-	public static final String APPLICATION_METADATA_FIRSTTIME = APPLICATION_METADATA + "Firsttime";
+	public static final String APPLICATION_METADATA_FIRSTTIME_BACKUP = APPLICATION_METADATA + "FirsttimeBackup";
 	public static final String USER_ACCOUNTS = "http://vitro.mannlib.cornell.edu/default/vitro-kb-userAccounts";
-	public static final String USER_ACCOUNTS_FIRSTTIME = USER_ACCOUNTS + "Firsttime";
+	public static final String USER_ACCOUNTS_FIRSTTIME_BACKUP = USER_ACCOUNTS + "FirsttimeBackup";
 	public static final String DISPLAY = "http://vitro.mannlib.cornell.edu/default/vitro-kb-displayMetadata";
-	public static final String DISPLAY_FIRSTTIME = DISPLAY + "Firsttime";
+	public static final String DISPLAY_FIRSTTIME_BACKUP = DISPLAY + "FirsttimeBackup";
 	public static final String DISPLAY_TBOX = "http://vitro.mannlib.cornell.edu/default/vitro-kb-displayMetadataTBOX";
-	public static final String DISPLAY_TBOX_FIRSTTIME = DISPLAY_TBOX + "Firsttime";
+	public static final String DISPLAY_TBOX_FIRSTTIME_BACKUP = DISPLAY_TBOX + "FirsttimeBackup";
 	public static final String DISPLAY_DISPLAY = "http://vitro.mannlib.cornell.edu/default/vitro-kb-displayMetadata-displayModel";
-	public static final String DISPLAY_DISPLAY_FIRSTTIME = DISPLAY_DISPLAY + "Firsttime";
+	public static final String DISPLAY_DISPLAY_FIRSTTIME_BACKUP = DISPLAY_DISPLAY + "FirsttimeBackup";
 
 	/**
 	 * A map of the URIS, keyed by their short names, intended only for display
@@ -46,24 +46,24 @@ public class ModelNames {
 		map.put("ABOX_ASSERTIONS", ABOX_ASSERTIONS);
 		map.put("ABOX_INFERENCES", ABOX_INFERENCES);
 		map.put("ABOX_UNION", ABOX_UNION);
-		map.put("ABOX_ASSERTIONS_FIRSTTIME", ABOX_ASSERTIONS_FIRSTTIME);
+		map.put("ABOX_ASSERTIONS_FIRSTTIME_BACKUP", ABOX_ASSERTIONS_FIRSTTIME_BACKUP);
 		map.put("TBOX_ASSERTIONS", TBOX_ASSERTIONS);
 		map.put("TBOX_INFERENCES", TBOX_INFERENCES);
 		map.put("TBOX_UNION", TBOX_UNION);
-		map.put("TBOX_ASSERTIONS_FIRSTTIME", TBOX_ASSERTIONS_FIRSTTIME);
+		map.put("TBOX_ASSERTIONS_FIRSTTIME_BACKUP", TBOX_ASSERTIONS_FIRSTTIME_BACKUP);
 		map.put("FULL_ASSERTIONS", FULL_ASSERTIONS);
 		map.put("FULL_INFERENCES", FULL_INFERENCES);
 		map.put("FULL_UNION", FULL_UNION);
 		map.put("APPLICATION_METADATA", APPLICATION_METADATA);
-		map.put("APPLICATION_METADATA_FIRSTTIME", APPLICATION_METADATA_FIRSTTIME);
+		map.put("APPLICATION_METADATA_FIRSTTIME_BACKUP", APPLICATION_METADATA_FIRSTTIME_BACKUP);
 		map.put("USER_ACCOUNTS", USER_ACCOUNTS);
-		map.put("USER_ACCOUNTS_FIRSTTIME", USER_ACCOUNTS_FIRSTTIME);
+		map.put("USER_ACCOUNTS_FIRSTTIME_BACKUP", USER_ACCOUNTS_FIRSTTIME_BACKUP);
 		map.put("DISPLAY", DISPLAY);
-		map.put("DISPLAY_FIRSTTIME", DISPLAY_FIRSTTIME);
+		map.put("DISPLAY_FIRSTTIME_BACKUP", DISPLAY_FIRSTTIME_BACKUP);
 		map.put("DISPLAY_TBOX", DISPLAY_TBOX);
-		map.put("DISPLAY_TBOX_FIRSTTIME", DISPLAY_TBOX_FIRSTTIME);
+		map.put("DISPLAY_TBOX_FIRSTTIME_BACKUP", DISPLAY_TBOX_FIRSTTIME_BACKUP);
 		map.put("DISPLAY_DISPLAY", DISPLAY_DISPLAY);
-		map.put("DISPLAY_DISPLAY_FIRSTTIME", DISPLAY_DISPLAY_FIRSTTIME);
+		map.put("DISPLAY_DISPLAY_FIRSTTIME_BACKUP", DISPLAY_DISPLAY_FIRSTTIME_BACKUP);
 		return Collections.unmodifiableMap(map);
 	}
 

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/modelaccess/ModelNames.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/modelaccess/ModelNames.java
@@ -27,9 +27,13 @@ public class ModelNames {
 	public static final String APPLICATION_METADATA = "http://vitro.mannlib.cornell.edu/default/vitro-kb-applicationMetadata";
 	public static final String APPLICATION_METADATA_FIRSTTIME = "vitro:applicationMetadataFirstime";
 	public static final String USER_ACCOUNTS = "http://vitro.mannlib.cornell.edu/default/vitro-kb-userAccounts";
+	public static final String USER_ACCOUNTS_FIRSTTIME = USER_ACCOUNTS + "Firsttime";
 	public static final String DISPLAY = "http://vitro.mannlib.cornell.edu/default/vitro-kb-displayMetadata";
+	public static final String DISPLAY_FIRSTTIME = DISPLAY + "Firsttime";
 	public static final String DISPLAY_TBOX = "http://vitro.mannlib.cornell.edu/default/vitro-kb-displayMetadataTBOX";
+	public static final String DISPLAY_TBOX_FIRSTTIME = DISPLAY_TBOX + "Firsttime";
 	public static final String DISPLAY_DISPLAY = "http://vitro.mannlib.cornell.edu/default/vitro-kb-displayMetadata-displayModel";
+	public static final String DISPLAY_DISPLAY_FIRSTTIME = DISPLAY_DISPLAY + "Firsttime";
 
 	/**
 	 * A map of the URIS, keyed by their short names, intended only for display
@@ -53,9 +57,13 @@ public class ModelNames {
 		map.put("APPLICATION_METADATA", APPLICATION_METADATA);
 		map.put("APPLICATION_METADATA_FIRSTTIME", APPLICATION_METADATA_FIRSTTIME);
 		map.put("USER_ACCOUNTS", USER_ACCOUNTS);
+		map.put("USER_ACCOUNTS_FIRSTTIME", USER_ACCOUNTS_FIRSTTIME);
 		map.put("DISPLAY", DISPLAY);
+		map.put("DISPLAY_FIRSTTIME", DISPLAY_FIRSTTIME);
 		map.put("DISPLAY_TBOX", DISPLAY_TBOX);
+		map.put("DISPLAY_TBOX_FIRSTTIME", DISPLAY_TBOX_FIRSTTIME);
 		map.put("DISPLAY_DISPLAY", DISPLAY_DISPLAY);
+		map.put("DISPLAY_DISPLAY_FIRSTTIME", DISPLAY_DISPLAY_FIRSTTIME);
 		return Collections.unmodifiableMap(map);
 	}
 

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/modelaccess/ModelNames.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/modelaccess/ModelNames.java
@@ -13,16 +13,19 @@ public class ModelNames {
 	public static final String ABOX_ASSERTIONS = "http://vitro.mannlib.cornell.edu/default/vitro-kb-2";
 	public static final String ABOX_INFERENCES = "http://vitro.mannlib.cornell.edu/default/vitro-kb-inf";
 	public static final String ABOX_UNION = "vitro:aboxOntModel";
+	public static final String ABOX_ASSERTIONS_FIRSTTIME = "vitro:aboxOntModelFirstime";
 
 	public static final String TBOX_ASSERTIONS = "http://vitro.mannlib.cornell.edu/default/asserted-tbox";
 	public static final String TBOX_INFERENCES = "http://vitro.mannlib.cornell.edu/default/inferred-tbox";
 	public static final String TBOX_UNION = "vitro:tboxOntModel";
+	public static final String TBOX_ASSERTIONS_FIRSTTIME = "vitro:tboxOntModelFirstime";
 
 	public static final String FULL_ASSERTIONS = "vitro:baseOntModel";
 	public static final String FULL_INFERENCES = "vitro:inferenceOntModel";
 	public static final String FULL_UNION = "vitro:jenaOntModel";
 
 	public static final String APPLICATION_METADATA = "http://vitro.mannlib.cornell.edu/default/vitro-kb-applicationMetadata";
+	public static final String APPLICATION_METADATA_FIRSTTIME = "vitro:applicationMetadataFirstime";
 	public static final String USER_ACCOUNTS = "http://vitro.mannlib.cornell.edu/default/vitro-kb-userAccounts";
 	public static final String DISPLAY = "http://vitro.mannlib.cornell.edu/default/vitro-kb-displayMetadata";
 	public static final String DISPLAY_TBOX = "http://vitro.mannlib.cornell.edu/default/vitro-kb-displayMetadataTBOX";
@@ -39,13 +42,16 @@ public class ModelNames {
 		map.put("ABOX_ASSERTIONS", ABOX_ASSERTIONS);
 		map.put("ABOX_INFERENCES", ABOX_INFERENCES);
 		map.put("ABOX_UNION", ABOX_UNION);
+		map.put("ABOX_ASSERTIONS_FIRSTTIME", ABOX_ASSERTIONS_FIRSTTIME);
 		map.put("TBOX_ASSERTIONS", TBOX_ASSERTIONS);
 		map.put("TBOX_INFERENCES", TBOX_INFERENCES);
 		map.put("TBOX_UNION", TBOX_UNION);
+		map.put("TBOX_ASSERTIONS_FIRSTTIME", TBOX_ASSERTIONS_FIRSTTIME);
 		map.put("FULL_ASSERTIONS", FULL_ASSERTIONS);
 		map.put("FULL_INFERENCES", FULL_INFERENCES);
 		map.put("FULL_UNION", FULL_UNION);
 		map.put("APPLICATION_METADATA", APPLICATION_METADATA);
+		map.put("APPLICATION_METADATA_FIRSTTIME", APPLICATION_METADATA_FIRSTTIME);
 		map.put("USER_ACCOUNTS", USER_ACCOUNTS);
 		map.put("DISPLAY", DISPLAY);
 		map.put("DISPLAY_TBOX", DISPLAY_TBOX);

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/modelaccess/ModelNames.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/modelaccess/ModelNames.java
@@ -13,19 +13,19 @@ public class ModelNames {
 	public static final String ABOX_ASSERTIONS = "http://vitro.mannlib.cornell.edu/default/vitro-kb-2";
 	public static final String ABOX_INFERENCES = "http://vitro.mannlib.cornell.edu/default/vitro-kb-inf";
 	public static final String ABOX_UNION = "vitro:aboxOntModel";
-	public static final String ABOX_ASSERTIONS_FIRSTTIME = "vitro:aboxOntModelFirstime";
+	public static final String ABOX_ASSERTIONS_FIRSTTIME = ABOX_ASSERTIONS + "Firsttime";
 
 	public static final String TBOX_ASSERTIONS = "http://vitro.mannlib.cornell.edu/default/asserted-tbox";
 	public static final String TBOX_INFERENCES = "http://vitro.mannlib.cornell.edu/default/inferred-tbox";
 	public static final String TBOX_UNION = "vitro:tboxOntModel";
-	public static final String TBOX_ASSERTIONS_FIRSTTIME = "vitro:tboxOntModelFirstime";
+	public static final String TBOX_ASSERTIONS_FIRSTTIME = TBOX_ASSERTIONS + "Firsttime";
 
 	public static final String FULL_ASSERTIONS = "vitro:baseOntModel";
 	public static final String FULL_INFERENCES = "vitro:inferenceOntModel";
 	public static final String FULL_UNION = "vitro:jenaOntModel";
 
 	public static final String APPLICATION_METADATA = "http://vitro.mannlib.cornell.edu/default/vitro-kb-applicationMetadata";
-	public static final String APPLICATION_METADATA_FIRSTTIME = "vitro:applicationMetadataFirstime";
+	public static final String APPLICATION_METADATA_FIRSTTIME = APPLICATION_METADATA + "Firsttime";
 	public static final String USER_ACCOUNTS = "http://vitro.mannlib.cornell.edu/default/vitro-kb-userAccounts";
 	public static final String USER_ACCOUNTS_FIRSTTIME = USER_ACCOUNTS + "Firsttime";
 	public static final String DISPLAY = "http://vitro.mannlib.cornell.edu/default/vitro-kb-displayMetadata";

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/modules/tripleSource/ConfigurationTripleSource.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/modules/tripleSource/ConfigurationTripleSource.java
@@ -6,6 +6,14 @@ import static edu.cornell.mannlib.vitro.webapp.modelaccess.ModelNames.DISPLAY;
 import static edu.cornell.mannlib.vitro.webapp.modelaccess.ModelNames.DISPLAY_DISPLAY;
 import static edu.cornell.mannlib.vitro.webapp.modelaccess.ModelNames.DISPLAY_TBOX;
 import static edu.cornell.mannlib.vitro.webapp.modelaccess.ModelNames.USER_ACCOUNTS;
+import static edu.cornell.mannlib.vitro.webapp.modelaccess.ModelNames.ABOX_ASSERTIONS_FIRSTTIME_BACKUP;
+import static edu.cornell.mannlib.vitro.webapp.modelaccess.ModelNames.TBOX_ASSERTIONS_FIRSTTIME_BACKUP;
+import static edu.cornell.mannlib.vitro.webapp.modelaccess.ModelNames.APPLICATION_METADATA_FIRSTTIME_BACKUP;
+import static edu.cornell.mannlib.vitro.webapp.modelaccess.ModelNames.USER_ACCOUNTS_FIRSTTIME_BACKUP;
+import static edu.cornell.mannlib.vitro.webapp.modelaccess.ModelNames.DISPLAY_FIRSTTIME_BACKUP;
+import static edu.cornell.mannlib.vitro.webapp.modelaccess.ModelNames.DISPLAY_TBOX_FIRSTTIME_BACKUP;
+import static edu.cornell.mannlib.vitro.webapp.modelaccess.ModelNames.DISPLAY_DISPLAY_FIRSTTIME_BACKUP;
+
 
 import org.apache.jena.rdf.model.ModelMaker;
 
@@ -18,7 +26,10 @@ public abstract class ConfigurationTripleSource implements TripleSource {
 	 * add memory-mapping.
 	 */
 	protected static final String[] CONFIGURATION_MODELS = { DISPLAY,
-			DISPLAY_TBOX, DISPLAY_DISPLAY, USER_ACCOUNTS };
+			DISPLAY_TBOX, DISPLAY_DISPLAY, USER_ACCOUNTS, ABOX_ASSERTIONS_FIRSTTIME_BACKUP,
+			TBOX_ASSERTIONS_FIRSTTIME_BACKUP, APPLICATION_METADATA_FIRSTTIME_BACKUP,
+			USER_ACCOUNTS_FIRSTTIME_BACKUP, DISPLAY_FIRSTTIME_BACKUP, 
+			DISPLAY_TBOX_FIRSTTIME_BACKUP, DISPLAY_DISPLAY_FIRSTTIME_BACKUP };
 
 	/**
 	 * These decorators are added to a Configuration ModelMaker, regardless of

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/servlet/setup/ConfigurationModelsSetup.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/servlet/setup/ConfigurationModelsSetup.java
@@ -229,11 +229,11 @@ public class ConfigurationModelsSetup implements ServletContextListener {
 						if (object.isLiteral() && object2.isLiteral()) {
 							// if the langauge tag is the same, remove this triple from the update list
 							if(object.asLiteral().getLanguage().equals(object2.asLiteral().getLanguage())) {
-								log.debug("This two triples changed UI and files: \n UI: " + stmt.toString() + " \n file: " +stmt2.toString());
+								log.debug("This two triples changed UI and files: \n UI: " + stmt + " \n file: " +stmt2);
 								changedInUIandFileStatements.add(stmt2);
 							}
 						} else {
-							log.debug("This two triples changed UI and files: \n UI: " + stmt.toString() + " \n file: " +stmt2.toString());
+							log.debug("This two triples changed UI and files: \n UI: " + stmt + " \n file: " +stmt2);
 							changedInUIandFileStatements.add(stmt2);
 						}
 					}

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/servlet/setup/ConfigurationModelsSetup.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/servlet/setup/ConfigurationModelsSetup.java
@@ -57,7 +57,7 @@ public class ConfigurationModelsSetup implements ServletContextListener {
 			if (ontModel.isEmpty()) {
 				loadFirstTimeFiles(ctx, modelPath, ontModel);
 				// backup firsttime files
-				OntModel baseModelFirsttime = ModelAccess.on(ctx).getOntModel(modelUri + "Firsttime");
+				OntModel baseModelFirsttime = ModelAccess.on(ctx).getOntModel(modelUri + "FirsttimeBackup");
 				baseModelFirsttime.add(ontModel);
 			} else {
 				// Check if the firsttime files have changed since the firsttime startup,
@@ -89,7 +89,7 @@ public class ConfigurationModelsSetup implements ServletContextListener {
 		boolean updatedFiles = false;
 
 		// get configuration models from the firsttime start up (backup state)
-		OntModel baseModelFirsttimeBackup = ModelAccess.on(ctx).getOntModel(modelUri + "Firsttime");
+		OntModel baseModelFirsttimeBackup = ModelAccess.on(ctx).getOntModel(modelUri + "FirsttimeBackup");
 
 		// compare firsttime files with configuration models
 		log.debug("compare firsttime files with configuration models (backup from first start) for " + modelPath);

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/servlet/setup/ConfigurationModelsSetup.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/servlet/setup/ConfigurationModelsSetup.java
@@ -222,11 +222,20 @@ public class ConfigurationModelsSetup implements ServletContextListener {
 					Property predicate2  = stmt2.getPredicate();    // get the predicate
 					RDFNode   object2    = stmt2.getObject();      // get the object
 
-					// if subject and predicate are equal but the object differs, do not update these triples
+					// if subject and predicate are equal but the object differs and the language tag is the same, do not update these triples
 					// this case indicates an change in the UI, which should not be overwriten from the firsttime files
-					if(subject.equals(subject2) && predicate.equals(predicate2) && !object.equals(object2)) {
-						log.debug("This two triples changed UI and files: \n UI: " + stmt.toString() + " \n file: " +stmt2.toString());
-						changedInUIandFileStatements.add(stmt2);
+					if(subject.equals(subject2) && predicate.equals(predicate2) && !object.equals(object2) ) {
+						// if object is an literal, check the language tag
+						if (object.isLiteral() && object2.isLiteral()) {
+							// if the langauge tag is the same, remove this triple from the update list
+							if(object.asLiteral().getLanguage().equals(object2.asLiteral().getLanguage())) {
+								log.debug("This two triples changed UI and files: \n UI: " + stmt.toString() + " \n file: " +stmt2.toString());
+								changedInUIandFileStatements.add(stmt2);
+							}
+						} else {
+							log.debug("This two triples changed UI and files: \n UI: " + stmt.toString() + " \n file: " +stmt2.toString());
+							changedInUIandFileStatements.add(stmt2);
+						}
 					}
 				}
 			}

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/servlet/setup/ConfigurationModelsSetup.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/servlet/setup/ConfigurationModelsSetup.java
@@ -13,7 +13,6 @@ import javax.servlet.ServletContextListener;
 
 import org.apache.jena.ontology.OntModel;
 import org.apache.jena.rdf.model.Model;
-import org.apache.jena.rdf.model.Property;
 import org.apache.jena.rdf.model.RDFNode;
 import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.rdf.model.Statement;
@@ -110,7 +109,12 @@ public class ConfigurationModelsSetup implements ServletContextListener {
 	}
 
 	/*
-	 * Double check the model difference for blank nodes and special cases and then apply the changes to the user models
+	 * This method is designed to compare configuration models (baseModel) with firsttime files (newModel):
+	 * if they are the same, stop
+	 * else, if they differ, compare values in configuration models (baseModel) with user's triplestore
+	 *     if they are the same, update user's triplestore with value in new firsttime files
+	 *     else, if they differ, leave user's triplestore statement alone
+	 * finally, overwrite the configuration models with content of the updated firstime files
 	 * 
 	 * @param baseModel The backup firsttime model (from the first startup)
 	 * @param newModel The current state of the firsttime files in the directory
@@ -126,7 +130,7 @@ public class ConfigurationModelsSetup implements ServletContextListener {
 		Model difNewOld = newModel.difference(baseModel);
 
 		// remove special case for display, problem with quickView -triple and blank nodes
-		if (modelIdString == "display") {
+		if (modelIdString.equals("display")) {
 
 			StmtIterator iter = difOldNew.listStatements();
 			List<Statement> removeStatement = new ArrayList<Statement>();

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/servlet/setup/ContentModelSetup.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/servlet/setup/ContentModelSetup.java
@@ -5,9 +5,9 @@ package edu.cornell.mannlib.vitro.webapp.servlet.setup;
 import static edu.cornell.mannlib.vitro.webapp.modelaccess.ModelNames.ABOX_ASSERTIONS;
 import static edu.cornell.mannlib.vitro.webapp.modelaccess.ModelNames.APPLICATION_METADATA;
 import static edu.cornell.mannlib.vitro.webapp.modelaccess.ModelNames.TBOX_ASSERTIONS;
-import static edu.cornell.mannlib.vitro.webapp.modelaccess.ModelNames.ABOX_ASSERTIONS_FIRSTTIME;
-import static edu.cornell.mannlib.vitro.webapp.modelaccess.ModelNames.TBOX_ASSERTIONS_FIRSTTIME;
-import static edu.cornell.mannlib.vitro.webapp.modelaccess.ModelNames.APPLICATION_METADATA_FIRSTTIME;
+import static edu.cornell.mannlib.vitro.webapp.modelaccess.ModelNames.ABOX_ASSERTIONS_FIRSTTIME_BACKUP;
+import static edu.cornell.mannlib.vitro.webapp.modelaccess.ModelNames.TBOX_ASSERTIONS_FIRSTTIME_BACKUP;
+import static edu.cornell.mannlib.vitro.webapp.modelaccess.ModelNames.APPLICATION_METADATA_FIRSTTIME_BACKUP;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -68,7 +68,7 @@ public class ContentModelSetup extends JenaDataSourceSetupBase
 			initializeApplicationMetadata(ctx, applicationMetadataModel);
 
 			// backup copy from firsttime files
-			OntModel applicationMetadataModelFirsttime = models.getOntModel(APPLICATION_METADATA_FIRSTTIME);
+			OntModel applicationMetadataModelFirsttime = models.getOntModel(APPLICATION_METADATA_FIRSTTIME_BACKUP);
 			applicationMetadataModelFirsttime.add(applicationMetadataModel);
             
 		} else {
@@ -84,7 +84,7 @@ public class ContentModelSetup extends JenaDataSourceSetupBase
             RDFFilesLoader.loadFirstTimeFiles(ctx, "abox", baseABoxModel, true);
 
             // backup copy from firsttime files
-            OntModel baseABoxModelFirsttime = models.getOntModel(ABOX_ASSERTIONS_FIRSTTIME);
+            OntModel baseABoxModelFirsttime = models.getOntModel(ABOX_ASSERTIONS_FIRSTTIME_BACKUP);
             baseABoxModelFirsttime.add(baseABoxModel);
         }
         RDFFilesLoader.loadEveryTimeFiles(ctx, "abox", baseABoxModel);
@@ -94,7 +94,7 @@ public class ContentModelSetup extends JenaDataSourceSetupBase
             RDFFilesLoader.loadFirstTimeFiles(ctx, "tbox", baseTBoxModel, true);
 
             // backup copy from firsttime files
-            OntModel baseTBoxModelFirsttime = models.getOntModel(TBOX_ASSERTIONS_FIRSTTIME);
+            OntModel baseTBoxModelFirsttime = models.getOntModel(TBOX_ASSERTIONS_FIRSTTIME_BACKUP);
             baseTBoxModelFirsttime.add(baseTBoxModel);
         }
         RDFFilesLoader.loadEveryTimeFiles(ctx, "tbox", baseTBoxModel);
@@ -219,11 +219,11 @@ public class ContentModelSetup extends JenaDataSourceSetupBase
      */
     private void applyFirstTimeChanges(ServletContext ctx) {
 
-        applyFirstTimeChanges(ctx, "applicationMetadata", APPLICATION_METADATA_FIRSTTIME, APPLICATION_METADATA);
+        applyFirstTimeChanges(ctx, "applicationMetadata", APPLICATION_METADATA_FIRSTTIME_BACKUP, APPLICATION_METADATA);
 
-        applyFirstTimeChanges(ctx, "abox", ABOX_ASSERTIONS_FIRSTTIME, ABOX_ASSERTIONS);
+        applyFirstTimeChanges(ctx, "abox", ABOX_ASSERTIONS_FIRSTTIME_BACKUP, ABOX_ASSERTIONS);
 
-        applyFirstTimeChanges(ctx, "tbox", TBOX_ASSERTIONS_FIRSTTIME, TBOX_ASSERTIONS);
+        applyFirstTimeChanges(ctx, "tbox", TBOX_ASSERTIONS_FIRSTTIME_BACKUP, TBOX_ASSERTIONS);
     }
 
 
@@ -242,7 +242,7 @@ public class ContentModelSetup extends JenaDataSourceSetupBase
         RDFFilesLoader.loadFirstTimeFiles(ctx, modelPath, firsttimeFilesModel, true);
 
         // special initialization for application metadata model
-        if (firsttimeBackupModelUri.equals(APPLICATION_METADATA_FIRSTTIME)) {
+        if (firsttimeBackupModelUri.equals(APPLICATION_METADATA_FIRSTTIME_BACKUP)) {
             setPortalUriOnFirstTime(firsttimeFilesModel, ctx);
         }
 
@@ -260,7 +260,7 @@ public class ContentModelSetup extends JenaDataSourceSetupBase
 
     /*
 	 * This method is designed to compare configuration models (baseModel) with firsttime files (newModel):
-	 * if they are the same, stop
+	 * if they are the same, stopFirstTime
 	 * else, if they differ, compare values in configuration models (baseModel) with user's triplestore
 	 *     if they are the same, update user's triplestore with value in new firsttime files
 	 *     else, if they differ, leave user's triplestore statement alone

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/servlet/setup/ContentModelSetup.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/servlet/setup/ContentModelSetup.java
@@ -298,7 +298,7 @@ public class ContentModelSetup extends JenaDataSourceSetupBase
 
             if (!difOldNew.isEmpty()) {
                 difOldNew.write(out, "TTL"); 
-                log.debug("Difference for " + modelIdString + " (old -> new), these triples should be removed: " + out.toString());
+                log.debug("Difference for " + modelIdString + " (old -> new), these triples should be removed: " + out.toStringtoString());
 
                 // Check if the UI-changes Overlap with the changes made in the fristtime-files 
                 checkUiChangesOverlapWithFileChanges(baseModel, userModel, difOldNew);
@@ -317,7 +317,7 @@ public class ContentModelSetup extends JenaDataSourceSetupBase
             }
             if (!difNewOld.isEmpty()) {
                 difNewOld.write(out2, "TTL"); 
-                log.debug("Difference for " + modelIdString + " (new -> old), these triples should be added: " + out2.toString());
+                log.debug("Difference for " + modelIdString + " (new -> old), these triples should be added: " + out2);
 
                 // Check if the UI-changes Overlap with the changes made in the fristtime-files 
                 checkUiChangesOverlapWithFileChanges(baseModel, userModel, difNewOld);
@@ -381,11 +381,11 @@ public class ContentModelSetup extends JenaDataSourceSetupBase
                         if (object.isLiteral() && object2.isLiteral()) {
                             // if the langauge tag is the same, remove this triple from the update list
                             if(object.asLiteral().getLanguage().equals(object2.asLiteral().getLanguage())) {
-                                log.debug("This two triples changed UI and files: \n UI: " + stmt.toString() + " \n file: " +stmt2.toString());
+                                log.debug("This two triples changed UI and files: \n UI: " + stmt + " \n file: " +stmt2);
                                 changedInUIandFileStatements.add(stmt2);
                             }
                         } else {
-                            log.debug("This two triples changed UI and files: \n UI: " + stmt.toString() + " \n file: " +stmt2.toString());
+                            log.debug("This two triples changed UI and files: \n UI: " + stmt + " \n file: " +stmt2);
                             changedInUIandFileStatements.add(stmt2);
                         }
                     }

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/servlet/setup/ContentModelSetup.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/servlet/setup/ContentModelSetup.java
@@ -232,7 +232,7 @@ public class ContentModelSetup extends JenaDataSourceSetupBase
         log.debug("compare firsttime files with configuration models (backup from first start) for Application Metadata Model");
         OntModel testApplicationMetadataModel = VitroModelFactory.createOntologyModel();
         RDFFilesLoader.loadFirstTimeFiles(ctx, "applicationMetadata", testApplicationMetadataModel, true);
-        setPortalUriOnFirstTime(testApplicationMetadataModel, ctx); // muss das gemacht werden?
+        setPortalUriOnFirstTime(testApplicationMetadataModel, ctx);
     
         if ( applicationMetadataModel.isIsomorphicWith(testApplicationMetadataModel) ) {
             log.debug("They are the same, do nothing");
@@ -280,7 +280,12 @@ public class ContentModelSetup extends JenaDataSourceSetupBase
     }
 
     /*
-     * Double check the model difference for blank nodes and special cases and then apply the changes to the user models
+	 * This method is designed to compare configuration models (baseModel) with firsttime files (newModel):
+	 * if they are the same, stop
+	 * else, if they differ, compare values in configuration models (baseModel) with user's triplestore
+	 *     if they are the same, update user's triplestore with value in new firsttime files
+	 *     else, if they differ, leave user's triplestore statement alone
+	 * finally, overwrite the configuration models with content of the updated firstime files
      * 
      * @param baseModel The backup firsttime model (from the first startup)
      * @param newModel The current state of the firsttime files in the directory
@@ -295,7 +300,7 @@ public class ContentModelSetup extends JenaDataSourceSetupBase
         Model difNewOld = newModel.difference(baseModel);
 
         // special case for "rootTab" triple, do not need an update (is it still used in general? if not remove this case)
-        if("applicationMetadata" == modelIdString) {
+        if(modelIdString.equals("applicationMetadata")) {
             
             Property p = userModel.createProperty("http://vitro.mannlib.cornell.edu/ns/vitro/0.7#", "rootTab");
             difOldNew.removeAll(null, p, null);

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/servlet/setup/ContentModelSetup.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/servlet/setup/ContentModelSetup.java
@@ -374,11 +374,20 @@ public class ContentModelSetup extends JenaDataSourceSetupBase
                     Property predicate2  = stmt2.getPredicate();    // get the predicate
                     RDFNode   object2    = stmt2.getObject();      // get the object
 
-                    // if subject and predicate are equal but the object differs, do not update these triples
+                    // if subject and predicate are equal but the object differs and the language tag is the same, do not update these triples
                     // this case indicates an change in the UI, which should not be overwriten from the firsttime files
-                    if(subject.equals(subject2) && predicate.equals(predicate2) && !object.equals(object2)) {
-                        log.debug("This two triples changed UI and files: \n UI: " + stmt.toString() + " \n file: " +stmt2.toString());
-                        changedInUIandFileStatements.add(stmt2);
+                    if(subject.equals(subject2) && predicate.equals(predicate2) && !object.equals(object2) ) {
+                        // if object is an literal, check the language tag
+                        if (object.isLiteral() && object2.isLiteral()) {
+                            // if the langauge tag is the same, remove this triple from the update list
+                            if(object.asLiteral().getLanguage().equals(object2.asLiteral().getLanguage())) {
+                                log.debug("This two triples changed UI and files: \n UI: " + stmt.toString() + " \n file: " +stmt2.toString());
+                                changedInUIandFileStatements.add(stmt2);
+                            }
+                        } else {
+                            log.debug("This two triples changed UI and files: \n UI: " + stmt.toString() + " \n file: " +stmt2.toString());
+                            changedInUIandFileStatements.add(stmt2);
+                        }
                     }
                 }
             }

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/servlet/setup/ContentModelSetup.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/servlet/setup/ContentModelSetup.java
@@ -65,16 +65,16 @@ public class ContentModelSetup extends JenaDataSourceSetupBase
     	Model applicationMetadataModel = models.getOntModel(APPLICATION_METADATA);
 		if (applicationMetadataModel.isEmpty()) {
 			firstTimeStartup = true;
-            initializeApplicationMetadata(ctx, applicationMetadataModel);
-            
-            // backup copy from firsttime files
-            OntModel applicationMetadataModelFirsttime = models.getOntModel(APPLICATION_METADATA_FIRSTTIME);
-            applicationMetadataModelFirsttime.add(applicationMetadataModel);
+			initializeApplicationMetadata(ctx, applicationMetadataModel);
+
+			// backup copy from firsttime files
+			OntModel applicationMetadataModelFirsttime = models.getOntModel(APPLICATION_METADATA_FIRSTTIME);
+			applicationMetadataModelFirsttime.add(applicationMetadataModel);
             
 		} else {
-            // check if some of the firsttime files have changed since the first start up and
-            // if they changed, apply these changes to the user models
-            applyFirstTimeChanges(ctx);
+			// check if some of the firsttime files have changed since the first start up and
+			// if they changed, apply these changes to the user models
+			applyFirstTimeChanges(ctx);
 
         	checkForNamespaceMismatch( applicationMetadataModel, ctx );
 		}

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/servlet/setup/ContentModelSetup.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/servlet/setup/ContentModelSetup.java
@@ -298,7 +298,7 @@ public class ContentModelSetup extends JenaDataSourceSetupBase
 
             if (!difOldNew.isEmpty()) {
                 difOldNew.write(out, "TTL"); 
-                log.debug("Difference for " + modelIdString + " (old -> new), these triples should be removed: " + out.toStringtoString());
+                log.debug("Difference for " + modelIdString + " (old -> new), these triples should be removed: " + out);
 
                 // Check if the UI-changes Overlap with the changes made in the fristtime-files 
                 checkUiChangesOverlapWithFileChanges(baseModel, userModel, difOldNew);


### PR DESCRIPTION
**[JIRA Issue](https://jira.lyrasis.org/browse/VIVO-1918)**

# What does this pull request do?
This PR adds the functionality requested in the JIRA-Ticket
On the firsttime Start-Up a backup of the firsttime files is saved to a new model.
On every Start-Up these backup will be compared to the current state of the firsttime files. If the files have changed, try to apply
these changes to the user model. So if you activate a new language or change stuff in some firsttime files, you will no longer need to do a firsttime Start-Up of your system, with a normal restart the changes will be applied. 

# How should this be tested?
You need a fresh system (firsttime Start-Up) - for that, you can delete the tdb* directories in vivo_home (if you do not want to set up a whole new system)
Start the system so the new backup models will be created. After this, change some firsttime files and restart the system.
The changes should now be available without a new firsttime Start-Up. 

good examples:
- vivo_home_dir/rdf/i18n/en_US/tbox/firsttime/vitroAnnotations_en_US.n3
- vivo_home_dir/rdf/i18n/en_US/display/firsttime/menu_en_US.nt