### PR TITLE
Upgrade Jena version to 3.16.0

### DIFF
--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/EditLiteral.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/EditLiteral.java
@@ -132,6 +132,11 @@ public class EditLiteral implements Literal {
         throw new UnsupportedOperationException();
     }
 
+    @Override
+    public boolean isStmtResource() {
+        throw new UnsupportedOperationException();
+    }
+
     public Literal inModel(Model model) {
         throw new UnsupportedOperationException();
     }

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/rdfservice/adapters/AbstractModelDecorator.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/rdfservice/adapters/AbstractModelDecorator.java
@@ -326,6 +326,11 @@ public abstract class AbstractModelDecorator implements Model {
 	}
 
 	@Override
+	public boolean hasNoMappings() {
+		return inner.hasNoMappings();
+	}
+
+	@Override
 	public boolean samePrefixMappingAs(PrefixMapping other) {
 		return inner.samePrefixMappingAs(other);
 	}
@@ -682,6 +687,11 @@ public abstract class AbstractModelDecorator implements Model {
 	@Override
 	public Resource createResource(String uri) {
 		return inner.createResource(uri);
+	}
+
+	@Override
+	public Resource createResource(Statement statement) {
+		return inner.createResource(statement);
 	}
 
 	@Override

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/rdfservice/adapters/AbstractOntModelDecorator.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/rdfservice/adapters/AbstractOntModelDecorator.java
@@ -365,6 +365,11 @@ public abstract class AbstractOntModelDecorator implements OntModel {
 	}
 
 	@Override
+	public boolean hasNoMappings() {
+		return inner.hasNoMappings();
+	}
+
+	@Override
 	public boolean samePrefixMappingAs(PrefixMapping other) {
 		return inner.samePrefixMappingAs(other);
 	}
@@ -727,6 +732,11 @@ public abstract class AbstractOntModelDecorator implements OntModel {
 	@Override
 	public Resource createResource(String uri) {
 		return inner.createResource(uri);
+	}
+
+	@Override
+	public Resource createResource(Statement statement) {
+		return inner.createResource(statement);
 	}
 
 	@Override

--- a/api/src/test/java/stubs/org/apache/jena/rdf/model/LiteralStub.java
+++ b/api/src/test/java/stubs/org/apache/jena/rdf/model/LiteralStub.java
@@ -45,6 +45,11 @@ public class LiteralStub implements Literal {
 	}
 
 	@Override
+	public boolean isStmtResource() {
+		return false;
+	}
+
+	@Override
 	public boolean isURIResource() {
 		return false;
 	}

--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -176,7 +176,7 @@
         <dependency>
             <groupId>org.apache.jena</groupId>
             <artifactId>jena-arq</artifactId>
-            <version>3.11.0</version>
+            <version>3.16.0</version>
             <exclusions>
                 <!-- Exclude OSGi bundles from jsonld-java -->
                 <exclusion>
@@ -192,22 +192,32 @@
         <dependency>
             <groupId>org.apache.jena</groupId>
             <artifactId>jena-core</artifactId>
-            <version>3.11.0</version>
+            <version>3.16.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.jena</groupId>
             <artifactId>jena-sdb</artifactId>
-            <version>3.11.0</version>
+            <version>3.16.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.jena</groupId>
             <artifactId>jena-tdb</artifactId>
-            <version>3.11.0</version>
+            <version>3.16.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.solr</groupId>
             <artifactId>solr-solrj</artifactId>
             <version>7.4.0</version>
+        </dependency>
+        <dependency>
+            <groupId>commons-codec</groupId>
+            <artifactId>commons-codec</artifactId>
+            <version>1.15</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+            <version>1.7.26</version>
         </dependency>
         <dependency>
             <groupId>org.directwebremoting</groupId>


### PR DESCRIPTION
Related to: https://jira.lyrasis.org/browse/VIVO-1943

# What does this pull request do?
Upgrades Jena from 3.11.0 to 3.16.0

# What's new?
No functional change

# How should this be tested?
A successful build indicates success

# Additional Notes:
Based on the comment in the [jena-users](https://mail-archives.apache.org/mod_mbox/jena-users/201601.mbox/%3C568BA9FB.5090709@apache.org%3E), I do not expect this upgrade will fix the issue in [VIVO-1943](https://jira.lyrasis.org/browse/VIVO-1943). 
However, the upgrade should generally be useful. I am happy to follow-up with another commit that adds the patch mentioned in the ticket regarding the use of `Syntax.syntaxARQ`.

# Interested parties
@VIVO-project/vivo-committers
