### PR TITLE
VIVO-1857: ftl function to capitalize group name affording override

### DIFF
--- a/webapp/src/main/webapp/templates/freemarker/body/partials/individual/individual-property-group-tabs.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/body/partials/individual/individual-property-group-tabs.ftl
@@ -20,11 +20,11 @@
     	    <#assign groupNameHtmlId = "${i18n().properties}" >
         </#if>
         <#if tabCount = 1 >
-            <li class="selectedGroupTab clickable" groupName="${groupNameHtmlId?replace("/","-")}">${groupName?capitalize}</li>
+            <li class="selectedGroupTab clickable" groupName="${groupNameHtmlId?replace("/","-")}">${p.capitalizeGroupName(groupName)}</li>
             <li class="groupTabSpacer">&nbsp;</li>
             <#assign tabCount = 2>
         <#else>
-            <li class="nonSelectedGroupTab clickable" groupName="${groupNameHtmlId?replace("/","-")}">${groupName?capitalize}</li>
+            <li class="nonSelectedGroupTab clickable" groupName="${groupNameHtmlId?replace("/","-")}">${p.capitalizeGroupName(groupName)}</li>
             <li class="groupTabSpacer">&nbsp;</li>
         </#if>
     </#if>
@@ -50,7 +50,7 @@
         <#if groupName?has_content>
 		    <#--the function replaces spaces in the name with underscores, also called for the property group menu-->
     	    <#assign groupNameHtmlId = p.createPropertyGroupHtmlId(groupName) >
-            <h2 id="${groupNameHtmlId?replace("/","-")}" pgroup="tabs" class="hidden">${groupName?capitalize}</h2>
+            <h2 id="${groupNameHtmlId?replace("/","-")}" pgroup="tabs" class="hidden">${p.capitalizeGroupName(groupName)}</h2>
         <#else>
             <h2 id="properties" pgroup="tabs" class="hidden">${i18n().properties_capitalized}</h2>
         </#if>

--- a/webapp/src/main/webapp/templates/freemarker/lib/lib-properties.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/lib/lib-properties.ftl
@@ -342,3 +342,6 @@ name will be used as the label. -->
     <#return groupName>
 </#function>
 
+<#function capitalizeGroupName propertyGroupName>
+    <#return propertyGroupName?capitalize>
+</#function>


### PR DESCRIPTION
https://jira.lyrasis.org/browse/VIVO-1857

https://github.com/vivo-project/VIVO-languages/pull/81
https://github.com/vivo-project/Vitro-languages/pull/35

# What does this pull request do?
Move freemarker group name capitalization into a function to afford overriding.

# How should this be tested?
As admin, go to individual and switch to French.

# Interested parties
@VIVO-project/vivo-committers
