### PR TITLE
Fixed DeletePropertyController.java - getting localname of property properly

### DIFF
--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/freemarker/DeletePropertyController.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/freemarker/DeletePropertyController.java
@@ -66,14 +66,14 @@ public class DeletePropertyController extends FreemarkerHttpServlet {
 
 
     private String getRedirectUrl(VitroRequest vreq) {
-		// TODO Auto-generated method stub
+    	// TODO Auto-generated method stub
     	String subjectUri = EditConfigurationUtils.getSubjectUri(vreq);
     	String predicateUri = EditConfigurationUtils.getPredicateUri(vreq);
-		Property prop = ResourceFactory.createProperty(predicateUri);
+    	Property prop = ResourceFactory.createProperty(predicateUri);
     	String localName = prop.getLocalName();
     	String redirectUrl =  "/entity?uri=" + URLEncoder.encode(subjectUri);
-		return redirectUrl + "#" + URLEncoder.encode(localName);
-	}
+    	return redirectUrl + "#" + URLEncoder.encode(localName);
+    }
 
 
 	private String handleErrors(VitroRequest vreq) {

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/freemarker/DeletePropertyController.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/freemarker/DeletePropertyController.java
@@ -10,6 +10,9 @@ import javax.servlet.http.HttpServletResponse;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
+import org.apache.jena.rdf.model.Property;
+import org.apache.jena.rdf.model.ResourceFactory;
+
 import edu.cornell.mannlib.vitro.webapp.auth.permissions.SimplePermission;
 import edu.cornell.mannlib.vitro.webapp.auth.requestedAction.AuthorizationRequest;
 import edu.cornell.mannlib.vitro.webapp.beans.DataProperty;
@@ -25,6 +28,8 @@ import edu.cornell.mannlib.vitro.webapp.edit.n3editing.VTwo.EditConfigurationUti
 import edu.cornell.mannlib.vitro.webapp.edit.n3editing.VTwo.N3EditUtils;
 import edu.cornell.mannlib.vitro.webapp.modelaccess.ModelAccess;
 import edu.cornell.mannlib.vitro.webapp.web.URLEncoder;
+
+
 /*
  * Custom deletion controller to which deletion requests from default property form are sent. May be replaced
  * later with additional features in process rdf form controller or alternative location.
@@ -64,8 +69,8 @@ public class DeletePropertyController extends FreemarkerHttpServlet {
 		// TODO Auto-generated method stub
     	String subjectUri = EditConfigurationUtils.getSubjectUri(vreq);
     	String predicateUri = EditConfigurationUtils.getPredicateUri(vreq);
-    	int hashIndex = predicateUri.lastIndexOf("#");
-    	String localName = predicateUri.substring(hashIndex + 1);
+		Property prop = ResourceFactory.createProperty(predicateUri);
+    	String localName = prop.getLocalName();
     	String redirectUrl =  "/entity?uri=" + URLEncoder.encode(subjectUri);
 		return redirectUrl + "#" + URLEncoder.encode(localName);
 	}


### PR DESCRIPTION




**[JIRA Issue] https://jira.lyrasis.org/browse/VIVO-1816


# What does this pull request do?
Fixed the way the localname of a property is determined by DeletePropertyController.java
