### PR TITLE
VIVO-1929: patch authorizing create individual form

### DIFF
--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/VTwo/EditConfigurationUtils.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/VTwo/EditConfigurationUtils.java
@@ -62,6 +62,10 @@ public class EditConfigurationUtils {
         return vreq.getParameter("rangeUri");
     }
 
+    public static String getTypeOfNew(VitroRequest vreq) {
+        return vreq.getParameter("typeOfNew");
+    }
+
     public static VClass getRangeVClass(VitroRequest vreq) {
         WebappDaoFactory ctxDaoFact = ModelAccess.on(
                 vreq.getSession().getServletContext()).getWebappDaoFactory();

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/controller/EditRequestDispatchController.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/controller/EditRequestDispatchController.java
@@ -71,7 +71,7 @@ public class EditRequestDispatchController extends FreemarkerHttpServlet {
 
 	@Override
 	protected AuthorizationRequest requiredActions(VitroRequest vreq) {
-		// If request is for new individual for return simple do back end edition action permission
+		// If request is for new individual, return simple do back end editing action permission
 		if (StringUtils.isNoneEmpty(EditConfigurationUtils.getTypeOfNew(vreq))) {
 			return SimplePermission.DO_BACK_END_EDITING.ACTION;
 		}

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/controller/EditRequestDispatchController.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/controller/EditRequestDispatchController.java
@@ -11,6 +11,7 @@ import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.jena.ontology.OntModel;
@@ -68,9 +69,13 @@ public class EditRequestDispatchController extends FreemarkerHttpServlet {
     final String RDFS_LABEL_FORM = "edu.cornell.mannlib.vitro.webapp.edit.n3editing.configuration.generators.RDFSLabelGenerator";
     final String DEFAULT_DELETE_FORM = "edu.cornell.mannlib.vitro.webapp.edit.n3editing.configuration.generators.DefaultDeleteGenerator";
 
-    @Override
-    protected AuthorizationRequest requiredActions(VitroRequest vreq) {
-    	//Check if this statement can be edited here and return unauthorized if not
+	@Override
+	protected AuthorizationRequest requiredActions(VitroRequest vreq) {
+		// If request is for new individual for return simple do back end edition action permission
+		if (StringUtils.isNoneEmpty(EditConfigurationUtils.getTypeOfNew(vreq))) {
+			return SimplePermission.DO_BACK_END_EDITING.ACTION;
+		}
+		// Check if this statement can be edited here and return unauthorized if not
 		String subjectUri = EditConfigurationUtils.getSubjectUri(vreq);
 		String predicateUri = EditConfigurationUtils.getPredicateUri(vreq);
 		String objectUri = EditConfigurationUtils.getObjectUri(vreq);

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/controller/EditRequestDispatchController.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/controller/EditRequestDispatchController.java
@@ -72,7 +72,7 @@ public class EditRequestDispatchController extends FreemarkerHttpServlet {
 	@Override
 	protected AuthorizationRequest requiredActions(VitroRequest vreq) {
 		// If request is for new individual, return simple do back end editing action permission
-		if (StringUtils.isNoneEmpty(EditConfigurationUtils.getTypeOfNew(vreq))) {
+		if (StringUtils.isNotEmpty(EditConfigurationUtils.getTypeOfNew(vreq))) {
 			return SimplePermission.DO_BACK_END_EDITING.ACTION;
 		}
 		// Check if this statement can be edited here and return unauthorized if not


### PR DESCRIPTION
Resolves https://jira.lyrasis.org/browse/VIVO-1929

# What does this pull request do?
To authorize site admin, curator, and editor to create individual resources, edit request dispatch checks for query `typeOfNew` query parameter and returns simply do back end edition action permission to perform authorization.

# How should this be tested?
* create site admin user
* as site admin user, create new individual on site admin page

# Interested parties
@VIVO-project/vivo-committers
