### PR TITLE
Use same fallback locale used by RDFFilesLoader when setting locale o…

### DIFF
--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/i18n/selection/SelectedLocale.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/i18n/selection/SelectedLocale.java
@@ -91,7 +91,9 @@ public abstract class SelectedLocale {
 			}
 		}
 
-		return null;
+		Locale fallbackLocale = getFallbackLocale();
+        log.debug("Using fallback locale as default: " + fallbackLocale);
+        return fallbackLocale;
 	}
 
 	/**
@@ -134,7 +136,17 @@ public abstract class SelectedLocale {
 			return preferredLocal;
 		}
 
-		return null;
+		Locale fallbackLocale = getFallbackLocale();
+		log.debug("Using fallback locale as default: " + fallbackLocale);
+		return fallbackLocale;
+	}
+	
+	/**
+	 * @return a default locale to use if no other criteria for selecting a 
+	 * different one exist.
+	 */
+	public static Locale getFallbackLocale() {
+	    return new Locale("en", "US");
 	}
 
 	/**

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/servlet/setup/RDFFilesLoader.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/servlet/setup/RDFFilesLoader.java
@@ -132,9 +132,9 @@ public class RDFFilesLoader {
 			enabledLocales.add(locale.toLanguageTag().replace('-', '_'));
 		}
 
-		// If no languages were enabled in runtime.properties, add 'en_US' as the default
+		// If no languages were enabled in runtime.properties, add a fallback as the default
 		if (enabledLocales.isEmpty()) {
-			enabledLocales.add("en_US");
+			enabledLocales.add(SelectedLocale.getFallbackLocale().toString());
 		}
 
 		return enabledLocales;


### PR DESCRIPTION
…n request. Resolves https://jira.lyrasis.org/browse/VIVO-1959

**[JIRA Issue](https://jira.lyrasis.org/browse/VIVO-1959)**: 

# What does this pull request do?
Uses the same fallback locale (currently "en_US") used by the RDFFilesLoader to set the request's locale if there is no list of selectable locales from which to obtain a default.

# What's new?
"en_US" fallback is refactored to SelectedLocale.java.  RDFFilesLoader uses this fallback, as does SelectedLocale.getOverridingLocale().

# How should this be tested?
* Before installing pull request:
* Install VIVO with all language-related properties in runtime.properties commented out (standard monolingual VIVO with no explicit forced locale).
* Set your browser's language preference list (wherever it provides the list of languages/countries that can be moved up and down) so that the topmost locale is something unrecognized by VIVO (e.g. "ro-RO").
* Observe that each i18n property usage on the page displays an error message ("Text bundle 'all' not found").
* Install pull request.
* English-US i18n text should appear on the page instead of the error messages.

# Interested parties
@VIVO-project/vivo-committers
