### PR TITLE
Added code for deleting individuals

### DIFF
--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/freemarker/DeleteIndividualController.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/freemarker/DeleteIndividualController.java
@@ -36,6 +36,7 @@ import edu.cornell.mannlib.vitro.webapp.controller.freemarker.responsevalues.Tem
 import static edu.cornell.mannlib.vitro.webapp.dao.DisplayVocabulary.HAS_DELETE_QUERY;
 
 import edu.cornell.mannlib.vitro.webapp.dao.jena.event.BulkUpdateEvent;
+import edu.cornell.mannlib.vitro.webapp.modelaccess.ModelAccess;
 import edu.cornell.mannlib.vitro.webapp.modelaccess.ModelNames;
 import edu.cornell.mannlib.vitro.webapp.rdfservice.ChangeSet;
 import edu.cornell.mannlib.vitro.webapp.rdfservice.RDFService;
@@ -170,7 +171,7 @@ public class DeleteIndividualController extends FreemarkerHttpServlet {
 			Query queryForTypeSpecificDeleteQuery = QueryFactory.create(deleteQuery);
 			QuerySolutionMap bindings = new QuerySolutionMap();
 			bindings.add(INDIVIDUAL_URI, ResourceFactory.createResource(targetIndividual));
-			Model ontModel = vreq.getJenaOntModel();
+			Model ontModel = ModelAccess.on(vreq).getOntModelSelector().getABoxModel();
 			QueryExecution qexec = QueryExecutionFactory.create(queryForTypeSpecificDeleteQuery, ontModel, bindings);
 			Model results = qexec.execConstruct();
 			return results;

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/freemarker/DeleteIndividualController.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/freemarker/DeleteIndividualController.java
@@ -102,8 +102,8 @@ public class DeleteIndividualController extends FreemarkerHttpServlet {
 		if (uri == null) {
 			return "Individual uri is null. No object to delete.";
 		}
-		if (uri.contains(">")) {
-			return "Individual uri shouldn't contain >";
+		if (uri.contains("<") || uri.contains(">")) {
+			return "Individual IRI shouldn't contain '<' or '>";
 		}
 		return "";
 	}
@@ -189,7 +189,7 @@ public class DeleteIndividualController extends FreemarkerHttpServlet {
 			StringWriter sw = new StringWriter();
 			model.write(sw, "N3");
 			log.error("Got " + e.getClass().getSimpleName() + " while removing\n" + sw.toString());
-			e.printStackTrace();
+			log.error(e,e);
 			throw new RuntimeException(e);
 		}
 	}

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/freemarker/DeleteIndividualController.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/freemarker/DeleteIndividualController.java
@@ -31,7 +31,9 @@ import edu.cornell.mannlib.vitro.webapp.controller.VitroRequest;
 import edu.cornell.mannlib.vitro.webapp.controller.freemarker.responsevalues.RedirectResponseValues;
 import edu.cornell.mannlib.vitro.webapp.controller.freemarker.responsevalues.ResponseValues;
 import edu.cornell.mannlib.vitro.webapp.controller.freemarker.responsevalues.TemplateResponseValues;
-import edu.cornell.mannlib.vitro.webapp.dao.DisplayVocabulary;
+import static edu.cornell.mannlib.vitro.webapp.dao.DisplayVocabulary.HAS_DELETE_QUERY;
+import static edu.cornell.mannlib.vitro.webapp.dao.VitroVocabulary.MOST_SPECIFIC_TYPE;
+
 import edu.cornell.mannlib.vitro.webapp.dao.jena.event.BulkUpdateEvent;
 import edu.cornell.mannlib.vitro.webapp.modelaccess.ModelNames;
 import edu.cornell.mannlib.vitro.webapp.rdfservice.ChangeSet;
@@ -46,10 +48,14 @@ public class DeleteIndividualController extends FreemarkerHttpServlet {
 	private static final boolean BEGIN = true;
 	private static final boolean END = !BEGIN;
 
-	private static String TYPE_QUERY = "" + "PREFIX vitro:    <http://vitro.mannlib.cornell.edu/ns/vitro/0.7#>"
-			+ "SELECT ?type " + "WHERE" + "{ ?individualURI vitro:mostSpecificType ?type ." + "}";
-	private static String queryForDeleteQuery = "PREFIX display: <" + DisplayVocabulary.DISPLAY_NS + "> \n"
-			+ "SELECT ?deleteQueryText WHERE { ?associatedURI display:hasDeleteQuery ?deleteQueryText }";
+	private static String TYPE_QUERY = ""
+			+ "SELECT ?type WHERE { "
+			+ "?individualURI <" + MOST_SPECIFIC_TYPE + "> ?type ." 
+			+ "}";
+	private static String queryForDeleteQuery = ""
+			+ "SELECT ?deleteQueryText WHERE { "
+			+ "?associatedURI <" + HAS_DELETE_QUERY + "> ?deleteQueryText ."
+			+ "}";
 
 	private static final String DEFAULT_DELETE_QUERY_TEXT = "DESCRIBE ?individualURI";
 
@@ -67,8 +73,8 @@ public class DeleteIndividualController extends FreemarkerHttpServlet {
 		String type = getObjectMostSpecificType(individualUri, vreq);
 		Model displayModel = vreq.getDisplayModel();
 
-		String delteQueryText = getDeleteQueryForType(type, displayModel);
-		Model toRemove = getIndividualsToDelete(individualUri, delteQueryText, vreq);
+		String deleteQueryText = getDeleteQueryForType(type, displayModel);
+		Model toRemove = getIndividualsToDelete(individualUri, deleteQueryText, vreq);
 		if (toRemove.size() > 0) {
 			deleteIndividuals(toRemove, vreq);
 		}
@@ -127,7 +133,7 @@ public class DeleteIndividualController extends FreemarkerHttpServlet {
 		if (!deleteQueryText.equals(DEFAULT_DELETE_QUERY_TEXT)) {
 			log.debug("For " + typeURI + " found delete query \n" + deleteQueryText);
 		} else {
-			log.debug("For " + typeURI + " delete query not found. Using defalut query \n" + deleteQueryText);
+			log.debug("For " + typeURI + " delete query not found. Using default query \n" + deleteQueryText);
 		}
 		return deleteQueryText;
 	}

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/freemarker/DeleteIndividualController.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/freemarker/DeleteIndividualController.java
@@ -3,7 +3,9 @@ package edu.cornell.mannlib.vitro.webapp.controller.freemarker;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
-import java.nio.charset.StandardCharsets;
+import java.io.PipedInputStream;
+import java.io.PipedOutputStream;
+import java.io.StringWriter;
 import java.util.HashMap;
 
 import javax.servlet.annotation.WebServlet;
@@ -19,6 +21,7 @@ import org.apache.jena.query.QuerySolution;
 import org.apache.jena.query.QuerySolutionMap;
 import org.apache.jena.query.ResultSet;
 import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.ModelFactory;
 import org.apache.jena.rdf.model.ResourceFactory;
 import org.apache.jena.shared.Lock;
 
@@ -29,172 +32,167 @@ import edu.cornell.mannlib.vitro.webapp.controller.freemarker.responsevalues.Red
 import edu.cornell.mannlib.vitro.webapp.controller.freemarker.responsevalues.ResponseValues;
 import edu.cornell.mannlib.vitro.webapp.controller.freemarker.responsevalues.TemplateResponseValues;
 import edu.cornell.mannlib.vitro.webapp.dao.DisplayVocabulary;
-import edu.cornell.mannlib.vitro.webapp.dao.jena.QueryUtils;
 import edu.cornell.mannlib.vitro.webapp.dao.jena.event.BulkUpdateEvent;
 import edu.cornell.mannlib.vitro.webapp.modelaccess.ModelNames;
 import edu.cornell.mannlib.vitro.webapp.rdfservice.ChangeSet;
 import edu.cornell.mannlib.vitro.webapp.rdfservice.RDFService;
-import edu.cornell.mannlib.vitro.webapp.rdfservice.RDFServiceException;
 import edu.cornell.mannlib.vitro.webapp.rdfservice.impl.RDFServiceUtils;
 
-@WebServlet(name="DeleteIndividualController",urlPatterns="/deleteIndividualController")
-public class DeleteIndividualController extends FreemarkerHttpServlet{
-	
-  private static final Log log = LogFactory.getLog(DeleteIndividualController.class);
-  private static final boolean BEGIN = true;
-  private static final boolean END = !BEGIN;
-	
-  private static String TYPE_QUERY = ""
-      + "PREFIX vitro:    <http://vitro.mannlib.cornell.edu/ns/vitro/0.7#>"
-      + "SELECT ?type "
-      + "WHERE"
-      + "{ ?individualURI vitro:mostSpecificType ?type ." 
-      +	"}";
-  private static String queryForDeleteQuery = 
- 		    "PREFIX display: <" + DisplayVocabulary.DISPLAY_NS +"> \n" +
-        "SELECT ?deleteQueryText WHERE { ?associatedURI display:hasDeleteQuery ?deleteQueryText }";
+@WebServlet(name = "DeleteIndividualController", urlPatterns = "/deleteIndividualController")
+public class DeleteIndividualController extends FreemarkerHttpServlet {
 
-  private static final String DEFAULT_DELETE_QUERY_TEXT = "DESCRIBE ?individualURI";
+	private static final long serialVersionUID = 1L;
+	private static final Log log = LogFactory.getLog(DeleteIndividualController.class);
+	private static final boolean BEGIN = true;
+	private static final boolean END = !BEGIN;
 
-  @Override
-  protected AuthorizationRequest requiredActions(VitroRequest vreq) {
-    return SimplePermission.DO_FRONT_END_EDITING.ACTION;
-  }
-	
-  protected ResponseValues processRequest(VitroRequest vreq) {
-    String errorMessage = handleErrors(vreq);
-    if (!errorMessage.isEmpty()) {
-      return prepareErrorMessage(errorMessage);
-    }
-    String individualUri = vreq.getParameter("individualUri");
-    String type = getObjectMostSpecificType(individualUri, vreq);
-    Model displayModel = vreq.getDisplayModel();
+	private static String TYPE_QUERY = "" + "PREFIX vitro:    <http://vitro.mannlib.cornell.edu/ns/vitro/0.7#>"
+			+ "SELECT ?type " + "WHERE" + "{ ?individualURI vitro:mostSpecificType ?type ." + "}";
+	private static String queryForDeleteQuery = "PREFIX display: <" + DisplayVocabulary.DISPLAY_NS + "> \n"
+			+ "SELECT ?deleteQueryText WHERE { ?associatedURI display:hasDeleteQuery ?deleteQueryText }";
 
-    String delteQueryText = getDeleteQueryForType(type, displayModel);
-    byte[] toRemove = getIndividualsToDelete(individualUri, delteQueryText, vreq);
-    if (toRemove.length > 0) {
-      deleteIndividuals(toRemove, vreq);
-    }
-    String redirectUrl = getRedirectUrl(vreq);
+	private static final String DEFAULT_DELETE_QUERY_TEXT = "DESCRIBE ?individualURI";
 
-    return new RedirectResponseValues(redirectUrl, HttpServletResponse.SC_SEE_OTHER);
-  }
-	
-  private String getRedirectUrl(VitroRequest vreq) {
-    String redirectUrl = vreq.getParameter("redirectUrl");
-    if (redirectUrl != null) {
-      return redirectUrl;
-    }
-    return "/";
-  }
+	@Override
+	protected AuthorizationRequest requiredActions(VitroRequest vreq) {
+		return SimplePermission.DO_FRONT_END_EDITING.ACTION;
+	}
 
+	protected ResponseValues processRequest(VitroRequest vreq) {
+		String errorMessage = handleErrors(vreq);
+		if (!errorMessage.isEmpty()) {
+			return prepareErrorMessage(errorMessage);
+		}
+		String individualUri = vreq.getParameter("individualUri");
+		String type = getObjectMostSpecificType(individualUri, vreq);
+		Model displayModel = vreq.getDisplayModel();
 
-  private TemplateResponseValues prepareErrorMessage(String errorMessage) {
-    HashMap<String, Object> map = new HashMap<String, Object>();
-    map.put("errorMessage", errorMessage);
-    return new TemplateResponseValues("error-message.ftl", map);
-  }
-	
-  private String handleErrors(VitroRequest vreq) {
-    String uri = vreq.getParameter("individualUri");
-    if (uri == null) {
-      return "Individual uri is null. No object to delete.";
-    }
-    if (uri.contains(">")) {
-      return "Individual uri shouldn't contain >";
-    }
-    return "";
-  }
+		String delteQueryText = getDeleteQueryForType(type, displayModel);
+		Model toRemove = getIndividualsToDelete(individualUri, delteQueryText, vreq);
+		if (toRemove.size() > 0) {
+			deleteIndividuals(toRemove, vreq);
+		}
+		String redirectUrl = getRedirectUrl(vreq);
 
-  private static String getDeleteQueryForType(String typeURI, Model displayModel) {
-    String deleteQueryText = DEFAULT_DELETE_QUERY_TEXT;
-    Query queryForTypeSpecificDeleteQuery = QueryFactory.create(queryForDeleteQuery);
-    QuerySolutionMap initialBindings = new QuerySolutionMap();
-    initialBindings.add("associatedURI", ResourceFactory.createResource(typeURI));
-    displayModel.enterCriticalSection(Lock.READ);
-    try {
-      QueryExecution qexec = QueryExecutionFactory.create(queryForTypeSpecificDeleteQuery, displayModel, initialBindings);
-      try {
-        ResultSet results = qexec.execSelect();
-        while (results.hasNext()) {
-          QuerySolution solution = results.nextSolution();
-          deleteQueryText = solution.get("deleteQueryText").toString();
-        }
-      } finally {
-        qexec.close();
-      }
-    } finally {
-      displayModel.leaveCriticalSection();
-    }
+		return new RedirectResponseValues(redirectUrl, HttpServletResponse.SC_SEE_OTHER);
+	}
 
-    if (!deleteQueryText.equals(DEFAULT_DELETE_QUERY_TEXT)) {
-      log.debug("For " + typeURI + " found delete query \n" + deleteQueryText);
-    } else {
-      log.debug("For " + typeURI + " delete query not found. Using defalut query \n" + deleteQueryText);
-    }
-    return deleteQueryText;
-  }
-	
-  private String getObjectMostSpecificType(String individualURI, VitroRequest vreq) {
-    String type = "";
-    try {
-      Query typeQuery = QueryFactory.create(TYPE_QUERY);
-      QuerySolutionMap bindings = new QuerySolutionMap();
-      bindings.add("individualURI", ResourceFactory.createResource(individualURI));
-      Model ontModel = vreq.getJenaOntModel();
-      QueryExecution qexec = QueryExecutionFactory.create(typeQuery, ontModel, bindings);
-      ResultSet results = qexec.execSelect();
-      while (results.hasNext()) {
-        QuerySolution solution = results.nextSolution();
-        type = solution.get("type").toString();
-        log.debug(type);
-      }
-    } catch (Exception e) {
-      log.error("Failed to get type for individual URI " + individualURI);
-      log.error(e, e);
-    }
-    return type;
-  }
-  
-  private byte[] getIndividualsToDelete(String targetIndividual, String deleteQuery, VitroRequest vreq) {
-    ByteArrayOutputStream out = new ByteArrayOutputStream();
-    try {
-    	Query queryForTypeSpecificDeleteQuery = QueryFactory.create(deleteQuery);
-    	QuerySolutionMap bindings = new QuerySolutionMap();
-    	bindings.add("individualURI", ResourceFactory.createResource(targetIndividual));
-    	Model ontModel = vreq.getJenaOntModel();
-      QueryExecution qexec = QueryExecutionFactory.create(queryForTypeSpecificDeleteQuery, ontModel, bindings);
-      Model results = qexec.execDescribe();
-      results.write(out, "N3");
+	private String getRedirectUrl(VitroRequest vreq) {
+		String redirectUrl = vreq.getParameter("redirectUrl");
+		if (redirectUrl != null) {
+			return redirectUrl;
+		}
+		return "/";
+	}
 
-    } catch (Exception e) {
-      log.error("Query raised an error \n" + deleteQuery);
-      log.error(e, e);
-    }
-    return out.toByteArray();
-  }
+	private TemplateResponseValues prepareErrorMessage(String errorMessage) {
+		HashMap<String, Object> map = new HashMap<String, Object>();
+		map.put("errorMessage", errorMessage);
+		return new TemplateResponseValues("error-message.ftl", map);
+	}
 
-  private void deleteIndividuals(byte[] toRemove, VitroRequest vreq) {
-    String removingString = new String(toRemove, StandardCharsets.UTF_8);
-    RDFService rdfService = vreq.getRDFService();
-    ChangeSet cs = makeChangeSet(rdfService);
-    InputStream in = new ByteArrayInputStream(toRemove);
-    cs.addRemoval(in, RDFServiceUtils.getSerializationFormatFromJenaString("N3"), ModelNames.ABOX_ASSERTIONS);
-    try {
-      rdfService.changeSetUpdate(cs);
-    } catch (RDFServiceException e) {
-      log.error("Got error while removing\n" + removingString);
-      throw new RuntimeException(e);
-    }
-  }
-	
-  private ChangeSet makeChangeSet(RDFService rdfService) {
-    ChangeSet cs = rdfService.manufactureChangeSet();
-    cs.addPreChangeEvent(new BulkUpdateEvent(null, BEGIN));
-    cs.addPostChangeEvent(new BulkUpdateEvent(null, END));
-    return cs;
-  }
-  
-	
-  
+	private String handleErrors(VitroRequest vreq) {
+		String uri = vreq.getParameter("individualUri");
+		if (uri == null) {
+			return "Individual uri is null. No object to delete.";
+		}
+		if (uri.contains(">")) {
+			return "Individual uri shouldn't contain >";
+		}
+		return "";
+	}
+
+	private static String getDeleteQueryForType(String typeURI, Model displayModel) {
+		String deleteQueryText = DEFAULT_DELETE_QUERY_TEXT;
+		Query queryForTypeSpecificDeleteQuery = QueryFactory.create(queryForDeleteQuery);
+		QuerySolutionMap initialBindings = new QuerySolutionMap();
+		initialBindings.add("associatedURI", ResourceFactory.createResource(typeURI));
+		displayModel.enterCriticalSection(Lock.READ);
+		try {
+			QueryExecution qexec = QueryExecutionFactory.create(queryForTypeSpecificDeleteQuery, displayModel,
+					initialBindings);
+			try {
+				ResultSet results = qexec.execSelect();
+				if (results.hasNext()) {
+					QuerySolution solution = results.nextSolution();
+					deleteQueryText = solution.get("deleteQueryText").toString();
+				}
+			} finally {
+				qexec.close();
+			}
+		} finally {
+			displayModel.leaveCriticalSection();
+		}
+
+		if (!deleteQueryText.equals(DEFAULT_DELETE_QUERY_TEXT)) {
+			log.debug("For " + typeURI + " found delete query \n" + deleteQueryText);
+		} else {
+			log.debug("For " + typeURI + " delete query not found. Using defalut query \n" + deleteQueryText);
+		}
+		return deleteQueryText;
+	}
+
+	private String getObjectMostSpecificType(String individualURI, VitroRequest vreq) {
+		String type = "";
+		try {
+			Query typeQuery = QueryFactory.create(TYPE_QUERY);
+			QuerySolutionMap bindings = new QuerySolutionMap();
+			bindings.add("individualURI", ResourceFactory.createResource(individualURI));
+			Model ontModel = vreq.getJenaOntModel();
+			QueryExecution qexec = QueryExecutionFactory.create(typeQuery, ontModel, bindings);
+			ResultSet results = qexec.execSelect();
+			while (results.hasNext()) {
+				QuerySolution solution = results.nextSolution();
+				type = solution.get("type").toString();
+				log.debug(type);
+			}
+		} catch (Exception e) {
+			log.error("Failed to get type for individual URI " + individualURI);
+			log.error(e, e);
+		}
+		return type;
+	}
+
+	private Model getIndividualsToDelete(String targetIndividual, String deleteQuery, VitroRequest vreq) {
+		try {
+			Query queryForTypeSpecificDeleteQuery = QueryFactory.create(deleteQuery);
+			QuerySolutionMap bindings = new QuerySolutionMap();
+			bindings.add("individualURI", ResourceFactory.createResource(targetIndividual));
+			Model ontModel = vreq.getJenaOntModel();
+			QueryExecution qexec = QueryExecutionFactory.create(queryForTypeSpecificDeleteQuery, ontModel, bindings);
+			Model results = qexec.execDescribe();
+			return results;
+
+		} catch (Exception e) {
+			log.error("Query raised an error \n" + deleteQuery);
+			log.error(e, e);
+		}
+		return ModelFactory.createDefaultModel();
+	}
+
+	private void deleteIndividuals(Model model, VitroRequest vreq) {
+		RDFService rdfService = vreq.getRDFService();
+		ChangeSet cs = makeChangeSet(rdfService);
+		try {
+			ByteArrayOutputStream out = new ByteArrayOutputStream();
+			model.write(out, "N3");
+			InputStream in = new ByteArrayInputStream(out.toByteArray());
+			cs.addRemoval(in, RDFServiceUtils.getSerializationFormatFromJenaString("N3"), ModelNames.ABOX_ASSERTIONS);
+			rdfService.changeSetUpdate(cs);
+		} catch (Exception e) {
+			StringWriter sw = new StringWriter();
+			model.write(sw, "N3");
+			log.error("Got " + e.getClass().getSimpleName() + " while removing\n" + sw.toString());
+			e.printStackTrace();
+			throw new RuntimeException(e);
+		}
+	}
+
+	private ChangeSet makeChangeSet(RDFService rdfService) {
+		ChangeSet cs = rdfService.manufactureChangeSet();
+		cs.addPreChangeEvent(new BulkUpdateEvent(null, BEGIN));
+		cs.addPostChangeEvent(new BulkUpdateEvent(null, END));
+		return cs;
+	}
+
 }

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/freemarker/DeleteIndividualController.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/freemarker/DeleteIndividualController.java
@@ -1,0 +1,200 @@
+package edu.cornell.mannlib.vitro.webapp.controller.freemarker;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServletResponse;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.jena.query.Query;
+import org.apache.jena.query.QueryExecution;
+import org.apache.jena.query.QueryExecutionFactory;
+import org.apache.jena.query.QueryFactory;
+import org.apache.jena.query.QuerySolution;
+import org.apache.jena.query.QuerySolutionMap;
+import org.apache.jena.query.ResultSet;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.ResourceFactory;
+import org.apache.jena.shared.Lock;
+
+import edu.cornell.mannlib.vitro.webapp.auth.permissions.SimplePermission;
+import edu.cornell.mannlib.vitro.webapp.auth.requestedAction.AuthorizationRequest;
+import edu.cornell.mannlib.vitro.webapp.controller.VitroRequest;
+import edu.cornell.mannlib.vitro.webapp.controller.freemarker.responsevalues.RedirectResponseValues;
+import edu.cornell.mannlib.vitro.webapp.controller.freemarker.responsevalues.ResponseValues;
+import edu.cornell.mannlib.vitro.webapp.controller.freemarker.responsevalues.TemplateResponseValues;
+import edu.cornell.mannlib.vitro.webapp.dao.DisplayVocabulary;
+import edu.cornell.mannlib.vitro.webapp.dao.jena.QueryUtils;
+import edu.cornell.mannlib.vitro.webapp.dao.jena.event.BulkUpdateEvent;
+import edu.cornell.mannlib.vitro.webapp.modelaccess.ModelNames;
+import edu.cornell.mannlib.vitro.webapp.rdfservice.ChangeSet;
+import edu.cornell.mannlib.vitro.webapp.rdfservice.RDFService;
+import edu.cornell.mannlib.vitro.webapp.rdfservice.RDFServiceException;
+import edu.cornell.mannlib.vitro.webapp.rdfservice.impl.RDFServiceUtils;
+
+@WebServlet(name="DeleteIndividualController",urlPatterns="/deleteIndividualController")
+public class DeleteIndividualController extends FreemarkerHttpServlet{
+	
+  private static final Log log = LogFactory.getLog(DeleteIndividualController.class);
+  private static final boolean BEGIN = true;
+  private static final boolean END = !BEGIN;
+	
+  private static String TYPE_QUERY_START = ""
+      + "PREFIX vitro:    <http://vitro.mannlib.cornell.edu/ns/vitro/0.7#>"
+      + "SELECT ?type "
+      + "WHERE"
+      + "{ <";
+  private static String TYPE_QUERY_END = "> vitro:mostSpecificType ?type ." 
+      +	"}";
+  private static String queryForDeleteQuery = 
+ 		    "PREFIX display: <" + DisplayVocabulary.DISPLAY_NS +"> \n" +
+        "SELECT ?deleteQueryText WHERE { ?associatedURI display:hasDeleteQuery ?deleteQueryText }";
+
+  private static final String DEFAULT_DELETE_QUERY_TEXT = "DESCRIBE ?individualURI";
+
+  @Override
+  protected AuthorizationRequest requiredActions(VitroRequest vreq) {
+    return SimplePermission.DO_FRONT_END_EDITING.ACTION;
+  }
+	
+  protected ResponseValues processRequest(VitroRequest vreq) {
+    String errorMessage = handleErrors(vreq);
+    if (!errorMessage.isEmpty()) {
+      return prepareErrorMessage(errorMessage);
+    }
+    String individualUri = vreq.getParameter("individualUri");
+    String type = getObjectMostSpecificType(individualUri, vreq);
+    Model displayModel = vreq.getDisplayModel();
+
+    String delteQueryText = getDeleteQueryForType(type, displayModel);
+    byte[] toRemove = getIndividualsToDelete(individualUri, delteQueryText, vreq);
+    if (toRemove.length > 0) {
+      deleteIndividuals(toRemove, vreq);
+    }
+    String redirectUrl = getRedirectUrl(vreq);
+
+    return new RedirectResponseValues(redirectUrl, HttpServletResponse.SC_SEE_OTHER);
+  }
+	
+  private String getRedirectUrl(VitroRequest vreq) {
+    String redirectUrl = vreq.getParameter("redirectUrl");
+    if (redirectUrl != null) {
+      return redirectUrl;
+    }
+    return "/";
+  }
+
+
+  private TemplateResponseValues prepareErrorMessage(String errorMessage) {
+    HashMap<String, Object> map = new HashMap<String, Object>();
+    map.put("errorMessage", errorMessage);
+    return new TemplateResponseValues("error-message.ftl", map);
+  }
+	
+  private String handleErrors(VitroRequest vreq) {
+    String uri = vreq.getParameter("individualUri");
+    if (uri == null) {
+      return "Individual uri is null. No object to delete.";
+    }
+    if (uri.contains(">")) {
+      return "Individual uri shouldn't contain >";
+    }
+    return "";
+  }
+
+  private static String getDeleteQueryForType(String typeURI, Model displayModel) {
+    String deleteQueryText = DEFAULT_DELETE_QUERY_TEXT;
+    Query queryForTypeSpecificDeleteQuery = QueryFactory.create(queryForDeleteQuery);
+    QuerySolutionMap initialBindings = new QuerySolutionMap();
+    initialBindings.add("associatedURI", ResourceFactory.createResource(typeURI));
+    displayModel.enterCriticalSection(Lock.READ);
+    try {
+      QueryExecution qexec = QueryExecutionFactory.create(queryForTypeSpecificDeleteQuery, displayModel, initialBindings);
+      try {
+        ResultSet results = qexec.execSelect();
+        while (results.hasNext()) {
+          QuerySolution solution = results.nextSolution();
+          deleteQueryText = solution.get("deleteQueryText").toString();
+        }
+      } finally {
+        qexec.close();
+      }
+    } finally {
+      displayModel.leaveCriticalSection();
+    }
+
+    if (!deleteQueryText.equals(DEFAULT_DELETE_QUERY_TEXT)) {
+      log.debug("For " + typeURI + " found delete query \n" + deleteQueryText);
+    } else {
+      log.debug("For " + typeURI + " delete query not found. Using defalut query \n" + deleteQueryText);
+    }
+    return deleteQueryText;
+  }
+	
+  private String getObjectMostSpecificType(String individualURI, VitroRequest vreq) {
+    String type = "";
+    try {
+      ResultSet results = QueryUtils.getLanguageNeutralQueryResults(makeTypeQuery(individualURI), vreq);
+      while (results.hasNext()) {
+        QuerySolution solution = results.nextSolution();
+        type = solution.get("type").toString();
+        log.debug(type);
+      }
+    } catch (Exception e) {
+      log.error("Failed to get type for individual URI " + individualURI);
+      log.error(e, e);
+    }
+    return type;
+  }
+  
+  private byte[] getIndividualsToDelete(String targetIndividual, String deleteQuery, VitroRequest vreq) {
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    Query queryForTypeSpecificDeleteQuery = QueryFactory.create(deleteQuery);
+    QuerySolutionMap initialBindings = new QuerySolutionMap();
+    initialBindings.add("individualURI", ResourceFactory.createResource(targetIndividual));
+    Model ontModel = vreq.getJenaOntModel();
+    try {
+      QueryExecution qexec = QueryExecutionFactory.create(queryForTypeSpecificDeleteQuery, ontModel, initialBindings);
+      Model results = qexec.execDescribe();
+      results.write(out, "N3");
+
+    } catch (Exception e) {
+      log.error("Query raised an error \n" + deleteQuery);
+      log.error(e, e);
+    }
+    return out.toByteArray();
+  }
+
+  private String makeTypeQuery(String objectURI) {
+    return TYPE_QUERY_START + objectURI + TYPE_QUERY_END;
+  }
+	
+  private void deleteIndividuals(byte[] toRemove, VitroRequest vreq) {
+    String removingString = new String(toRemove, StandardCharsets.UTF_8);
+    RDFService rdfService = vreq.getRDFService();
+    ChangeSet cs = makeChangeSet(rdfService);
+    InputStream in = new ByteArrayInputStream(toRemove);
+    cs.addRemoval(in, RDFServiceUtils.getSerializationFormatFromJenaString("N3"), ModelNames.ABOX_ASSERTIONS);
+    try {
+      rdfService.changeSetUpdate(cs);
+    } catch (RDFServiceException e) {
+      log.error("Got error while removing\n" + removingString);
+      throw new RuntimeException(e);
+    }
+  }
+	
+  private ChangeSet makeChangeSet(RDFService rdfService) {
+    ChangeSet cs = rdfService.manufactureChangeSet();
+    cs.addPreChangeEvent(new BulkUpdateEvent(null, BEGIN));
+    cs.addPostChangeEvent(new BulkUpdateEvent(null, END));
+    return cs;
+  }
+  
+	
+  
+}

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/dao/DisplayVocabulary.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/dao/DisplayVocabulary.java
@@ -53,6 +53,8 @@ public class DisplayVocabulary {
     //specific case for internal class, value is true or false
     public static final String 	RESTRICT_RESULTS_BY_INTERNAL = NS + "restrictResultsByInternalClass";
 
+    public static final String HAS_DELETE_QUERY = NS + "hasDeleteQuery";
+
 
     /* Data Properties */
     public static final DatatypeProperty URL_MAPPING = m_model.createDatatypeProperty(NS + "urlMapping");

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/DefaultDeleteGenerator.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/DefaultDeleteGenerator.java
@@ -2,8 +2,6 @@
 
 package edu.cornell.mannlib.vitro.webapp.edit.n3editing.configuration.generators;
 
-import java.util.HashMap;
-
 import javax.servlet.http.HttpSession;
 
 import org.apache.commons.logging.Log;
@@ -21,15 +19,15 @@ import edu.cornell.mannlib.vitro.webapp.edit.n3editing.VTwo.EditConfigurationVTw
  */
 public class DefaultDeleteGenerator extends BaseEditConfigurationGenerator implements EditConfigurationGenerator {
 
-	private Log log = LogFactory.getLog(DefaultObjectPropertyFormGenerator.class);
+	private static final Log log = LogFactory.getLog(DefaultObjectPropertyFormGenerator.class);
+	private static final String PROPERTY_TEMPLATE = "confirmDeletePropertyForm.ftl";
+	private static final String INDIVIDUAL_TEMPLATE = "confirmDeleteIndividualForm.ftl";
+
 	private String subjectUri = null;
 	private String predicateUri = null;
 	private String objectUri = null;
 	private Integer dataHash = 0;
 	private DataPropertyStatement dps = null;
-	private String dataLiteral = null;
-  private String propertyTemplate = "confirmDeletePropertyForm.ftl";
-  private String individualTemplate = "confirmDeleteIndividualForm.ftl";
 
 
 	//In this case, simply return the edit configuration currently saved in session
@@ -48,10 +46,10 @@ public class DefaultDeleteGenerator extends BaseEditConfigurationGenerator imple
     	//prepare update?
     	prepare(vreq, editConfiguration);
     	if (editConfiguration.getPredicateUri() == null && editConfiguration.getSubjectUri() == null) {
-    		editConfiguration.setTemplate(individualTemplate);
+    		editConfiguration.setTemplate(INDIVIDUAL_TEMPLATE);
     		addDeleteParams(vreq, editConfiguration);
     	}else {
-    		editConfiguration.setTemplate(propertyTemplate);
+    		editConfiguration.setTemplate(PROPERTY_TEMPLATE);
     	}
     	return editConfiguration;
     }
@@ -75,7 +73,7 @@ public class DefaultDeleteGenerator extends BaseEditConfigurationGenerator imple
 		EditConfigurationVTwo editConfiguration = new EditConfigurationVTwo();
 		initProcessParameters(vreq, session, editConfiguration);
 		//set edit key for this as well
-		editConfiguration.setEditKey(editConfiguration.newEditKey(session));
+		editConfiguration.setEditKey(EditConfigurationVTwo.newEditKey(session));
 		return editConfiguration;
 
 	}

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/DefaultDeleteGenerator.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/DefaultDeleteGenerator.java
@@ -47,21 +47,29 @@ public class DefaultDeleteGenerator extends BaseEditConfigurationGenerator imple
     	}
     	//prepare update?
     	prepare(vreq, editConfiguration);
-      if (editConfiguration.getPredicateUri() == null && editConfiguration.getSubjectUri() == null) {
-        editConfiguration.setTemplate(individualTemplate);
-        addRedirectUrl(vreq, editConfiguration);
-      } else {
-        editConfiguration.setTemplate(propertyTemplate);
-      }
+    	if (editConfiguration.getPredicateUri() == null && editConfiguration.getSubjectUri() == null) {
+    		editConfiguration.setTemplate(individualTemplate);
+    		addDeleteParams(vreq, editConfiguration);
+    	}else {
+    		editConfiguration.setTemplate(propertyTemplate);
+    	}
     	return editConfiguration;
     }
 
-  private void addRedirectUrl(VitroRequest vreq, EditConfigurationVTwo editConfiguration) {
-    String redirectUrl = vreq.getParameter("redirectUrl");
-    if (redirectUrl != null) {
-      editConfiguration.addFormSpecificData("redirectUrl", redirectUrl);
-    }
-  }
+	private void addDeleteParams(VitroRequest vreq, EditConfigurationVTwo editConfiguration) {
+		String redirectUrl = vreq.getParameter("redirectUrl");
+		if (redirectUrl != null) {
+			editConfiguration.addFormSpecificData("redirectUrl", redirectUrl);
+		}
+		String individualName = vreq.getParameter("individualName");
+		if (redirectUrl != null) {
+			editConfiguration.addFormSpecificData("individualName", individualName);
+		}
+		String individualType = vreq.getParameter("individualType");
+		if (redirectUrl != null) {
+			editConfiguration.addFormSpecificData("individualType", individualType);
+		}
+	}
 
 	private EditConfigurationVTwo  setupEditConfiguration(VitroRequest vreq, HttpSession session) {
 		EditConfigurationVTwo editConfiguration = new EditConfigurationVTwo();

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/DefaultDeleteGenerator.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/DefaultDeleteGenerator.java
@@ -28,7 +28,9 @@ public class DefaultDeleteGenerator extends BaseEditConfigurationGenerator imple
 	private Integer dataHash = 0;
 	private DataPropertyStatement dps = null;
 	private String dataLiteral = null;
-	private String template = "confirmDeletePropertyForm.ftl";
+  private String propertyTemplate = "confirmDeletePropertyForm.ftl";
+  private String individualTemplate = "confirmDeleteIndividualForm.ftl";
+
 
 	//In this case, simply return the edit configuration currently saved in session
 	//Since this is forwarding from another form, an edit configuration should already exist in session
@@ -43,11 +45,23 @@ public class DefaultDeleteGenerator extends BaseEditConfigurationGenerator imple
     	if(editConfiguration == null) {
     		editConfiguration = setupEditConfiguration(vreq, session);
     	}
-    	editConfiguration.setTemplate(template);
     	//prepare update?
     	prepare(vreq, editConfiguration);
+      if (editConfiguration.getPredicateUri() == null && editConfiguration.getSubjectUri() == null) {
+        editConfiguration.setTemplate(individualTemplate);
+        addRedirectUrl(vreq, editConfiguration);
+      } else {
+        editConfiguration.setTemplate(propertyTemplate);
+      }
     	return editConfiguration;
     }
+
+  private void addRedirectUrl(VitroRequest vreq, EditConfigurationVTwo editConfiguration) {
+    String redirectUrl = vreq.getParameter("redirectUrl");
+    if (redirectUrl != null) {
+      editConfiguration.addFormSpecificData("redirectUrl", redirectUrl);
+    }
+  }
 
 	private EditConfigurationVTwo  setupEditConfiguration(VitroRequest vreq, HttpSession session) {
 		EditConfigurationVTwo editConfiguration = new EditConfigurationVTwo();

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/controller/EditRequestDispatchController.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/controller/EditRequestDispatchController.java
@@ -363,7 +363,7 @@ public class EditRequestDispatchController extends FreemarkerHttpServlet {
          String predicateUri = EditConfigurationUtils.getPredicateUri(vreq);
          String formParam = getFormParam(vreq);
          //if no form parameter, then predicate uri and subject uri must both be populated
-    	if (formParam == null || "".equals(formParam)) {
+         if ((formParam == null || "".equals(formParam)) && !isDeleteForm(vreq)) {
             if ((predicateUri == null || predicateUri.trim().length() == 0)) {
             	return true;
             }

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/controller/EditRequestDispatchController.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/controller/EditRequestDispatchController.java
@@ -78,6 +78,9 @@ public class EditRequestDispatchController extends FreemarkerHttpServlet {
 		} else if(MANAGE_MENUS_FORM.equals(vreq.getParameter("editForm"))) {
 		    return SimplePermission.MANAGE_MENUS.ACTION;
 		}
+		if (isIndividualDeletion(vreq)) {
+			return SimplePermission.DO_BACK_END_EDITING.ACTION;
+		}
 		// Check if this statement can be edited here and return unauthorized if not
 		String subjectUri = EditConfigurationUtils.getSubjectUri(vreq);
 		String predicateUri = EditConfigurationUtils.getPredicateUri(vreq);
@@ -104,6 +107,16 @@ public class EditRequestDispatchController extends FreemarkerHttpServlet {
 				or(objectPropertyAction));
 
 		return isAuthorized? SimplePermission.DO_FRONT_END_EDITING.ACTION: AuthorizationRequest.UNAUTHORIZED;
+	}
+
+	private boolean isIndividualDeletion(VitroRequest vreq) {
+		String subjectUri = EditConfigurationUtils.getSubjectUri(vreq);
+		String predicateUri = EditConfigurationUtils.getPredicateUri(vreq);
+		String objectUri = EditConfigurationUtils.getObjectUri(vreq);
+		if (objectUri != null && subjectUri == null && predicateUri == null && isDeleteForm(vreq)) {
+			return true;
+		}
+		return false;
 	}
 
 	@Override

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/web/templatemodels/edit/EditConfigurationTemplateModel.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/web/templatemodels/edit/EditConfigurationTemplateModel.java
@@ -718,6 +718,10 @@ public class EditConfigurationTemplateModel extends BaseTemplateModel {
     	return vreq.getContextPath() + "/deletePropertyController";
     }
 
+    public String getDeleteIndividualProcessingUrl() {
+      return vreq.getContextPath() + "/deleteIndividualController";
+    }
+
     //TODO: Check if this logic is correct and delete prohibited does not expect a specific value
     public boolean isDeleteProhibited() {
     	String deleteProhibited = vreq.getParameter("deleteProhibited");

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/web/templatemodels/individual/BaseIndividualTemplateModel.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/web/templatemodels/individual/BaseIndividualTemplateModel.java
@@ -7,6 +7,7 @@ import static edu.cornell.mannlib.vitro.webapp.auth.requestedAction.RequestedAct
 import static edu.cornell.mannlib.vitro.webapp.auth.requestedAction.RequestedAction.SOME_URI;
 
 import java.util.Collection;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
@@ -27,6 +28,7 @@ import edu.cornell.mannlib.vitro.webapp.beans.VClass;
 import edu.cornell.mannlib.vitro.webapp.config.ConfigurationProperties;
 import edu.cornell.mannlib.vitro.webapp.controller.VitroRequest;
 import edu.cornell.mannlib.vitro.webapp.controller.freemarker.UrlBuilder;
+import edu.cornell.mannlib.vitro.webapp.controller.freemarker.UrlBuilder.ParamMap;
 import edu.cornell.mannlib.vitro.webapp.controller.freemarker.UrlBuilder.Route;
 import edu.cornell.mannlib.vitro.webapp.dao.ObjectPropertyStatementDao;
 import edu.cornell.mannlib.vitro.webapp.dao.VClassDao;
@@ -37,6 +39,7 @@ import edu.cornell.mannlib.vitro.webapp.web.templatemodels.BaseTemplateModel;
 public abstract class BaseIndividualTemplateModel extends BaseTemplateModel {
 
     private static final Log log = LogFactory.getLog(BaseIndividualTemplateModel.class);
+    private static final String EDIT_PATH = "editRequestDispatch";
 
     protected final Individual individual;
     protected final LoginStatusBean loginStatusBean;
@@ -147,6 +150,22 @@ public abstract class BaseIndividualTemplateModel extends BaseTemplateModel {
 
     public String getName() {
         return individual.getName();
+    }
+    
+    public String getDeleteUrl() {
+      Collection<String> types = getMostSpecificTypes();
+      ParamMap params = new ParamMap(
+          "objectUri", individual.getURI(), 
+          "cmd", "delete", 
+          "statement_label", getNameStatement().getValue(), 
+          "statement_object", individual.getURI());
+      Iterator<String> typesIterator = types.iterator();
+      if (types.iterator().hasNext()) {
+        String type = typesIterator.next();
+        params.put("statement_type", type);
+      }
+
+      return UrlBuilder.getUrl(EDIT_PATH, params);
     }
 
     public Collection<String> getMostSpecificTypes() {

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/web/templatemodels/individual/BaseIndividualTemplateModel.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/web/templatemodels/individual/BaseIndividualTemplateModel.java
@@ -153,20 +153,20 @@ public abstract class BaseIndividualTemplateModel extends BaseTemplateModel {
     }
     
     public String getDeleteUrl() {
-      Collection<String> types = getMostSpecificTypes();
-      ParamMap params = new ParamMap(
-          "objectUri", individual.getURI(), 
-          "cmd", "delete", 
-          "statement_label", getNameStatement().getValue(), 
-          "statement_object", individual.getURI());
-      Iterator<String> typesIterator = types.iterator();
-      if (types.iterator().hasNext()) {
-        String type = typesIterator.next();
-        params.put("statement_type", type);
-      }
+    	Collection<String> types = getMostSpecificTypes();
+    	ParamMap params = new ParamMap(
+          "objectUri", individual.getURI(),
+          "cmd", "delete",
+          "individualName",getNameStatement().getValue()
+          );
+    	Iterator<String> typesIterator = types.iterator();
+    	if (types.iterator().hasNext()) {
+				String type = typesIterator.next();
+				params.put("individualType", type);
+			}
 
-      return UrlBuilder.getUrl(EDIT_PATH, params);
-    }
+			return UrlBuilder.getUrl(EDIT_PATH, params);
+		}
 
     public Collection<String> getMostSpecificTypes() {
         ObjectPropertyStatementDao opsDao = vreq.getWebappDaoFactory().getObjectPropertyStatementDao();

--- a/home/src/main/resources/rdf/display/firsttime/application.owl
+++ b/home/src/main/resources/rdf/display/firsttime/application.owl
@@ -128,6 +128,7 @@
 <owl:ObjectProperty rdf:about="&display;restrictResultsByClass"/>
 <owl:ObjectProperty rdf:about="&display;getIndividualsForClass"/>
 <owl:ObjectProperty rdf:about="&display;hasDataGetter"/>
+<owl:DataProperty rdf:about="&display;hasDeleteQuery"/>
  <owl:ObjectProperty rdf:about="&display;requiresAction">
 
   </owl:ObjectProperty>

--- a/home/src/main/resources/rdf/displayTbox/everytime/displayTBOX.n3
+++ b/home/src/main/resources/rdf/displayTbox/everytime/displayTBOX.n3
@@ -204,6 +204,9 @@ vitro:additionalLink
 display:hasElement
       a       owl:ObjectProperty .
 
+display:hasDeleteQuery
+      a       owl:DataProperty .
+
 display:excludeClass
       a       owl:ObjectProperty .
 

--- a/webapp/src/main/webapp/templates/freemarker/body/individual/individual-vitro.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/body/individual/individual-vitro.ftl
@@ -49,7 +49,9 @@
                 <h1 class="fn" itemprop="name">
                     <#-- Label -->
                     <@p.label individual editable labelCount localesCount languageCount/>
-
+                    <#if editable>
+                        <@p.deleteIndividualLink individual />
+                    </#if>
                     <#--  Most-specific types -->
                     <@p.mostSpecificTypes individual />
                     <span id="iconControlsVitro"><img id="uriIcon" title="${individual.uri}" class="middle" src="${urls.images}/individual/uriIcon.gif" alt="uri icon"/></span>

--- a/webapp/src/main/webapp/templates/freemarker/edit/forms/confirmDeleteIndividualForm.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/edit/forms/confirmDeleteIndividualForm.ftl
@@ -1,11 +1,14 @@
 <#-- $This file is distributed under the terms of the license in LICENSE$ -->
-<#assign statement = editConfiguration.objectStatementDisplay />
-<#assign deletionTemplateName = editConfiguration.deleteTemplate/>
-
 <#if editConfiguration.pageData.redirectUrl??>
 	<#assign redirectUrl = editConfiguration.pageData.redirectUrl />
 <#else>
 	<#assign redirectUrl = "/" />
+</#if>
+<#if editConfiguration.pageData.individualName??>
+	<#assign individualName = editConfiguration.pageData.individualName />
+</#if>
+<#if editConfiguration.pageData.individualType??>
+	<#assign individualType = editConfiguration.pageData.individualType />
 </#if>
 
 <form action="${editConfiguration.deleteIndividualProcessingUrl}" method="get">
@@ -13,10 +16,14 @@
 
     <input type="hidden" name="individualUri"    value="${editConfiguration.objectUri}" role="input" />
     <input type="hidden" name="redirectUrl"    value="${redirectUrl}" role="input" />
-  
-    <#if statement?has_content>
-       <#include deletionTemplateName />
-    </#if>
+    <p>
+      <#if individualType??>
+       ${individualType}
+      </#if>
+      <#if individualName??>
+       ${individualName} 
+      </#if>
+    </p>
    <br />
     <p class="submit">
         <input type="submit" id="submit" value="${i18n().delete_button}" role="button"/>

--- a/webapp/src/main/webapp/templates/freemarker/edit/forms/confirmDeleteIndividualForm.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/edit/forms/confirmDeleteIndividualForm.ftl
@@ -1,0 +1,26 @@
+<#-- $This file is distributed under the terms of the license in LICENSE$ -->
+<#assign statement = editConfiguration.objectStatementDisplay />
+<#assign deletionTemplateName = editConfiguration.deleteTemplate/>
+
+<#if editConfiguration.pageData.redirectUrl??>
+	<#assign redirectUrl = editConfiguration.pageData.redirectUrl />
+<#else>
+	<#assign redirectUrl = "/" />
+</#if>
+
+<form action="${editConfiguration.deleteIndividualProcessingUrl}" method="get">
+    <h2>${i18n().confirm_individual_deletion} </h2>
+
+    <input type="hidden" name="individualUri"    value="${editConfiguration.objectUri}" role="input" />
+    <input type="hidden" name="redirectUrl"    value="${redirectUrl}" role="input" />
+  
+    <#if statement?has_content>
+       <#include deletionTemplateName />
+    </#if>
+   <br />
+    <p class="submit">
+        <input type="submit" id="submit" value="${i18n().delete_button}" role="button"/>
+        or
+        <a class="cancel" title="${i18n().cancel_title}" href="${editConfiguration.cancelUrl}">${i18n().cancel_link}</a>
+    </p>
+</form>

--- a/webapp/src/main/webapp/templates/freemarker/lib/lib-properties.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/lib/lib-properties.ftl
@@ -203,6 +203,16 @@ name will be used as the label. -->
     <a class="edit-${propertyLocalName}" href="${url}" title="${i18n().edit_entry}"><img class="edit-individual" data-range="${rangeUri}" src="${urls.images}/individual/editIcon.gif" alt="${i18n().edit_entry}" /></a>
 </#macro>
 
+<#macro deleteIndividualLink individual redirectUrl="/">
+    <#local url = individual.deleteUrl + "&redirectUrl=" + "${redirectUrl}">
+    <@showDeleteIndividualLink url />
+</#macro>
+
+
+<#macro showDeleteIndividualLink url>
+	<a class="delete-individual" href="${url}" title="${i18n().delete_entry}"><img  class="delete-individual" src="${urls.images}/individual/deleteIcon.gif" alt="${i18n().delete_entry}" /></a>
+</#macro>
+
 <#macro deleteLink propertyLocalName propertyName statement rangeUri="">
     <#local url = statement.deleteUrl>
     <#if url?has_content>


### PR DESCRIPTION
**[JIRA Issue](https://jira.lyrasis.org/browse/VIVO-1962)**
[Vitro-languages PR](https://github.com/vivo-project/Vitro-languages/pull/44)


# What does this pull request do?
Adds functionality to delete individuals and specify SPARQL Query to also delete individual dependant objects.
Require documentation update to provide examples with such queries.
# What's new?
DeleteIndividualController to execute deletion
Display data property display:hasDeleteQuery to specify CONSTRUCT SPARQL query for a class to get all dependant object at deletion phase. 
If class has no associated delete query, then default will be used.

# How should this be tested?
Add <@p.deleteIndividualLink individual /> to individual page to create a link for individual deletion. Use link to delete individual. 
Write CONSTRUCT query in format <class> display:hasDeleteQuery """ construct query text """ . 
and save it to rdf/display/everytime/ 


# Interested parties
Tag (@ mention) interested parties or, if unsure, @VIVO-project/vivo-committers
