### PR TITLE
Implement nextBinding() method in FIlteredResultSet.

### DIFF
--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/rdfservice/filter/FilteredResultSet.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/rdfservice/filter/FilteredResultSet.java
@@ -9,6 +9,7 @@ import org.apache.jena.query.QuerySolution;
 import org.apache.jena.query.ResultSet;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.sparql.engine.binding.Binding;
+import org.apache.jena.sparql.engine.binding.BindingUtils;
 
 public class FilteredResultSet implements ResultSet {
 
@@ -53,7 +54,7 @@ public class FilteredResultSet implements ResultSet {
 
     @Override
     public Binding nextBinding() {
-        throw new UnsupportedOperationException("Can we ignore this?");
+        return BindingUtils.asBinding(nextSolution());
     }
 
     @Override


### PR DESCRIPTION
**[JIRA Issue](https://jira.lyrasis.org/browse/VIVO-1967)**: 
* Other Relevant Links (Mailing list discussion, related pull requests, etc.)

# What does this pull request do?
Implements FilteredResultSet's nextBinding() method so that exceptions are not thrown during certain iterations through FilteredResultSets.

# How should this be tested?
* Before applying this pull request, create or navigate to the profile page of a person with vCard first and last names.  Note that the QR code fails to appear under the profile picture and that the following appears in vivo.all.log:
ERROR [IndividualResponseBuilder] Data retrieval for individual lead to error java.lang.UnsupportedOperationException: Can we ignore this? at edu.cornell.mannlib.vitro.webapp.rdfservice.filter.FilteredResultSet.nextBinding(FilteredResultSet.java:56)
....
* Apply pull request
* Navigate to same individual
* Observe that QR code renders and error does not appear in logs.

# Interested parties
@VIVO-project/vivo-committers
