### PR TITLE
Add subject to reindex in AdditionalURIsForObjectProperties

### DIFF
--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/searchindex/indexing/AdditionalURIsForObjectProperties.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/searchindex/indexing/AdditionalURIsForObjectProperties.java
@@ -59,16 +59,16 @@ public class AdditionalURIsForObjectProperties implements IndexingUriFinder, Con
     public void endIndexing() { /* nothing to do */ }
 
     protected List<String> doObjectPropertyStmt(Statement stmt) {
-        // Only need to consider the object since the subject
-        // will already be updated in search index as part of
-        // SearchReindexingListener.
-
         // Also, context nodes are not handled here. They are
         // taken care of in AdditionalURIsForContextNodex.
-        if( stmt.getObject().isURIResource() )
-            return Collections.singletonList( stmt.getObject().as(Resource.class).getURI() );
-        else
-            return Collections.emptyList();
+        List<String> uris = new ArrayList<String>();
+        if( stmt.getObject().isURIResource() ) {
+          uris.add(stmt.getObject().as(Resource.class).getURI() );
+        }
+        if( stmt.getSubject().isURIResource() ) {
+          uris.add(stmt.getSubject().as(Resource.class).getURI() );
+        }
+        return uris;
     }
 
     protected List<String> doDataPropertyStmt(Statement stmt) {

--- a/api/src/test/java/edu/cornell/mannlib/vitro/webapp/searchindex/indexing/AdditionalURIsForObjectPropertiesTest.java
+++ b/api/src/test/java/edu/cornell/mannlib/vitro/webapp/searchindex/indexing/AdditionalURIsForObjectPropertiesTest.java
@@ -90,13 +90,14 @@ public class AdditionalURIsForObjectPropertiesTest {
         Assert.assertTrue("uris was empty", uris.size() > 0 );
 
         Assert.assertTrue("uris didn't not contain test:cheese", uris.contains(testNS+"cheese"));
+        Assert.assertTrue("uris didn't not contain test:bob", uris.contains(testNS+"bob"));
 
         Assert.assertTrue("uris contained test:Person", !uris.contains(testNS+"Person"));
         Assert.assertTrue("uris contained owl:Thing", !uris.contains( OWL.Thing.getURI() ));
         Assert.assertTrue("uris contained test:onions", !uris.contains(testNS+"onions"));
         Assert.assertTrue("uris contained test:icecream", !uris.contains(testNS+"icecream"));
 
-        Assert.assertEquals(1, uris.size());
+        Assert.assertEquals(2, uris.size());
     }
 
     @Test


### PR DESCRIPTION
**[JIRA Issue](https://jira.lyrasis.org/browse/VIVO-1966)**

# What does this pull request do?
Adds subject to reindex list after adding or removing object property.

# How should this be tested?
1. Enable debugging for AdditionalURIsForObjectProperties
2. Create two persons
3. Add object property Person1 sameAs Person2
4. In logs AdditionalURIsForObjectProperties should find both persons to reindex.

# Interested parties
@VIVO-project/vivo-committers
