### PR TITLE
Add usePreciseSubqueries property to example.runtime.properties.  Hav…

### DIFF
--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/rdfservice/impl/jena/tdb/RDFServiceTDB.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/rdfservice/impl/jena/tdb/RDFServiceTDB.java
@@ -93,6 +93,10 @@ public class RDFServiceTDB extends RDFServiceJena {
 		}
 	}
 
+        @Override
+        public boolean preferPreciseOptionals() {
+            return true;
+        }
 
 	@Override
 	public void close() {

--- a/home/src/main/resources/config/example.runtime.properties
+++ b/home/src/main/resources/config/example.runtime.properties
@@ -71,6 +71,18 @@ VitroConnection.DataSource.driver = com.mysql.jdbc.Driver
 VitroConnection.DataSource.validationQuery = SELECT 1
 
 #
+# Include sections between <precise-subquery></precise-subquery>
+# tags when executing 'list view' queries that retrieve data
+# for property lists on profile pages.
+#
+# Including these optional sections does not change the query
+# semantics, but may improve performance.
+#
+# Default is true if not set.
+#
+# listview.usePreciseSubquery = true
+
+#
 # The email address of the root user for the VIVO application. The password
 # for this user is initially set to "rootPassword", but you will be asked to
 # change the password the first time you log in.


### PR DESCRIPTION
…e RDFServiceTDB report a preference for precise optionals as does SDB.

**[JIRA Issue](https://jira.lyrasis.org/browse/VIVO-1974)**: 

Companion VIVO PR: https://github.com/vivo-project/VIVO/pull/233

https://wiki.lyrasis.org/display/VIVO/2021-03-23+-+VIVO+Development+IG

# What does this pull request do?
Has TDB also report a preference for precise optionals (as SDB already does) so that precise-subquery patterns in list views will be included.  Updates example.runtime.properties to show users how to set this behavior explicitly.

# How should this be tested?
* No functional changes.  Confirm that code still builds and runs normally.  Review text in properties file.  Additional testing of performance under both settings is welcome, though not expected at this stage (per developer discussion linked above.)

# Interested parties
@VIVO-project/vivo-committers
