### PR TITLE
[VIVO-1736] - Bugfix for redirecting user to home page after login

### DIFF
--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/authenticate/LoginRedirector.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/authenticate/LoginRedirector.java
@@ -23,6 +23,7 @@ import edu.cornell.mannlib.vitro.webapp.beans.UserAccount;
 import edu.cornell.mannlib.vitro.webapp.controller.Controllers;
 import edu.cornell.mannlib.vitro.webapp.i18n.I18n;
 import edu.cornell.mannlib.vitro.webapp.i18n.I18nBundle;
+import edu.cornell.mannlib.vitro.webapp.controller.freemarker.UrlBuilder;
 
 /**
  * A user has just completed the login process. What page do we direct them to?
@@ -76,7 +77,7 @@ public class LoginRedirector {
 
 		if (!canSeeSiteAdminPage()) {
 			log.debug("User not recognized. Going to application home.");
-			return getApplicationHomePageUrl();
+			return UrlBuilder.getHomeUrl();
 		}
 
 		if (isLoginPage(afterLoginPage)) {
@@ -87,20 +88,20 @@ public class LoginRedirector {
 			return afterLoginPage;
 		} else {
 			log.debug("Don't know what to do. Go home.");
-			return getApplicationHomePageUrl();
+			return UrlBuilder.getHomeUrl();
 		}
 	}
 
 	public String getRedirectionUriForCancellingUser() {
 		if (isLoginPage(afterLoginPage)) {
 			log.debug("Coming from /login. Going to home.");
-			return getApplicationHomePageUrl();
+			return UrlBuilder.getHomeUrl();
 		} else if (null != afterLoginPage) {
 			log.debug("Returning to requested page: " + afterLoginPage);
 			return afterLoginPage;
 		} else {
 			log.debug("Don't know what to do. Go home.");
-			return getApplicationHomePageUrl();
+			return UrlBuilder.getHomeUrl();
 		}
 	}
 
@@ -108,10 +109,12 @@ public class LoginRedirector {
 			throws IOException {
 		try {
 			DisplayMessage.setMessage(request, assembleWelcomeMessage());
-			response.sendRedirect(getRedirectionUriForLoggedInUser());
+			String redirectUrl = getRedirectionUriForLoggedInUser();
+			log.debug("Sending redirect to path: " + redirectUrl);
+			response.sendRedirect(redirectUrl);
 		} catch (IOException e) {
 			log.debug("Problem with re-direction", e);
-			response.sendRedirect(getApplicationHomePageUrl());
+			response.sendRedirect(UrlBuilder.getHomeUrl());
 		}
 	}
 
@@ -143,7 +146,7 @@ public class LoginRedirector {
 			response.sendRedirect(getRedirectionUriForCancellingUser());
 		} catch (IOException e) {
 			log.debug("Problem with re-direction", e);
-			response.sendRedirect(getApplicationHomePageUrl());
+			response.sendRedirect(UrlBuilder.getHomeUrl());
 		}
 	}
 
@@ -173,23 +176,5 @@ public class LoginRedirector {
 		} catch (UnsupportedEncodingException e) {
 			throw new IllegalStateException("No UTF-8 encoding? Really?", e);
 		}
-	}
-
-	/**
-	 * The application home page can be overridden by an attribute in the
-	 * ServletContext. Further, it can either be an absolute URL, or it can be
-	 * relative to the application. Weird.
-	 */
-	private String getApplicationHomePageUrl() {
-		String contextRedirect = (String) session.getServletContext()
-				.getAttribute("postLoginRequest");
-		if (contextRedirect != null) {
-			if (contextRedirect.indexOf(":") == -1) {
-				return request.getContextPath() + contextRedirect;
-			} else {
-				return contextRedirect;
-			}
-		}
-		return request.getContextPath();
 	}
 }


### PR DESCRIPTION
**[JIRA Issue](https://jira.lyrasis.org/browse/VIVO-1736)**: VIVO-1736

# What does this pull request do?
Fixes an issue with external login redirects where they lead to an empty page in some situations.

# What's new?
Removes a method for determining the home page that didn't work. Replaced with a method defined elsewhere in the VIVO code. Also added a single line to the debug log that reports back the URL path that is being used for the redirect.

# How should this be tested?
1. Setup an external authentication scheme, such as Shibboleth or CAS. That's the hard part.
2. Login to VIVO using this external mechanism as a user that is not attached to a profile and that does not have elevated privileges (i.e. is a self-editor)
3. If the user has not logged in before, complete the information VIVO asks for, log out and log back in
4. Confirm upon login that a blank page is shown and the browser url shows /loginExternalAuthReturn.

To confirm fix, repeat above but user should be redirected to homepage as intended.

# Additional Notes:
Pure speculation, but this bug may be limited to VIVO installations where VIVO is served at Tomcat's root, and may be a result of how that was set up.

# Interested parties
@VIVO-project/vivo-committers
