### PR TITLE
Fix errors preventing TPF server from working with TDB. Resolve https…

### DIFF
--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/rdfservice/impl/jena/tdb/RDFServiceTDB.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/rdfservice/impl/jena/tdb/RDFServiceTDB.java
@@ -13,6 +13,8 @@ import java.nio.file.Paths;
 import java.util.List;
 
 import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.RDFNode;
+
 import edu.cornell.mannlib.vitro.webapp.rdfservice.ResultSetConsumer;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.logging.Log;
@@ -232,6 +234,28 @@ public class RDFServiceTDB extends RDFServiceJena {
 		return isEquivalentGraph(graphURI, inStream, ModelSerializationFormat.NTRIPLE);
 	}
 
+	@Override
+    public long countTriples(RDFNode subject, RDFNode predicate, RDFNode object)
+            throws RDFServiceException {
+	    dataset.begin(ReadWrite.READ);
+        try {
+            return super.countTriples(subject, predicate, object);
+        } finally {
+            dataset.end();
+        }
+	}
+	
+	@Override
+    public Model getTriples(RDFNode subject, RDFNode predicate, RDFNode object, 
+            long limit, long offset) throws RDFServiceException {
+	    dataset.begin(ReadWrite.READ);
+	    try {
+	        return super.getTriples(subject, predicate, object, limit, offset);
+	    } finally {
+	        dataset.end();
+	    }	    
+	}
+	
 	/**
 	 * Convert all of the references to integer compatible type to "integer" in the serialized graph.
 	 *

--- a/home/src/main/resources/config/example.runtime.properties
+++ b/home/src/main/resources/config/example.runtime.properties
@@ -154,7 +154,15 @@ proxy.eligibleTypeList = http://www.w3.org/2002/07/owl#Thing
 #
 # languages.selectableLocales = en, es, fr
 
-# Triple pattern fragments is a very fast, very simple means for querying a triple store.
-# The triple pattern fragments API in VIVO puts little load on the server, providing a simple means for getting data from the triple store. The API has a web interface for manual use, can be used from the command line via curl, and can be used by programs.
-
+# Triple Pattern Fragments is a very fast, very simple means for querying a
+# triple store.  The Triple Pattern Fragments API in VIVO puts little load on
+# the server, providing a simple means for getting data from the triple store.
+# The API has a web interface for manual use, can be used from the command line
+# via curl, and can be used by programs.
+#
+# Vitro's Triple Pattern Fragments API does not require authentication and
+# makes the full RDF graph available regardless of display or publish levels
+# set on particular properties.  Enable Triple Pattern Fragments only if your
+# Vitro does not contain restricted data that should not be shared with others.
+#
 # tpf.activeFlag = true


### PR DESCRIPTION
…://jira.lyrasis.org/browse/VIVO-1615

**[JIRA Issue](https://jira.lyrasis.org/browse/VIVO-1615)**: (please link to issue)

Companion VIVO PR: https://github.com/vivo-project/VIVO/pull/236

# What does this pull request do?
- Overrides getTriples() and countTriples() in TDFServiceTDB to add transaction begin/end.
- Improves error handling in VitroLinkedDataFragmentServlet to log exceptions and to prevent the exception displayed to the user from being obscured by exceptions in error handling.
- Fixes erroneous runtime property displayed when TDF server is disabled.
- Removes unused code.
- Adds note to example.runtime.properties that TPF should not be enabled if Vitro contains restricted/sensitive data.

# How should this be tested?
Before applying PR:
- Set tpf.activeFlag = true in runtime.properties
- Request /tpf/core (e.g. http://localhost:8080/vivo/tpf/core).
- Confirm that error message is displayed ("Message freemarker.core.InvalidReferenceException: The following has evaluated to null or missing: ...").
After applying PR:
- Request /tpf/core (e.g. http://localhost:8080/vivo/tpf/core).
- Confirm that Linked Data Fragments Server interface is displayed

# Interested parties
@VIVO-project/vivo-committers
