### PR TITLE
Allow site admins to edit pages in page management. Resolve https://j…

### DIFF
--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/controller/EditRequestDispatchController.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/controller/EditRequestDispatchController.java
@@ -68,12 +68,15 @@ public class EditRequestDispatchController extends FreemarkerHttpServlet {
     //TODO: Create this generator
     final String RDFS_LABEL_FORM = "edu.cornell.mannlib.vitro.webapp.edit.n3editing.configuration.generators.RDFSLabelGenerator";
     final String DEFAULT_DELETE_FORM = "edu.cornell.mannlib.vitro.webapp.edit.n3editing.configuration.generators.DefaultDeleteGenerator";
-
+    final String MANAGE_MENUS_FORM = "edu.cornell.mannlib.vitro.webapp.edit.n3editing.configuration.generators.ManagePageGenerator";
+    
 	@Override
 	protected AuthorizationRequest requiredActions(VitroRequest vreq) {
 		// If request is for new individual, return simple do back end editing action permission
 		if (StringUtils.isNotEmpty(EditConfigurationUtils.getTypeOfNew(vreq))) {
 			return SimplePermission.DO_BACK_END_EDITING.ACTION;
+		} else if(MANAGE_MENUS_FORM.equals(vreq.getParameter("editForm"))) {
+		    return SimplePermission.MANAGE_MENUS.ACTION;
 		}
 		// Check if this statement can be edited here and return unauthorized if not
 		String subjectUri = EditConfigurationUtils.getSubjectUri(vreq);


### PR DESCRIPTION
…ira.lyrasis.org/browse/VIVO-1973

**[JIRA Issue](https://jira.lyrasis.org/browse/VIVO-1973)**: (please link to issue)

Editing an existing page is the only page CRUD action that goes through EditRequestDispatch.  In line with other recent changes, this pull request adds a special case to EditRequestDispatch where if the edit form is the page management form, the MANAGE_MENUS SimplePermission is checked.

# How should this be tested?
Log in as a user with role Site Admin.  Go to page management and click the pencil to edit an existing page.  The page should now be editable.

# Interested parties
@VIVO-project/vivo-committers
