### PR TITLE
Move event listening to RDFServiceGraph level to avoid adding a new r…

### DIFF
--- a/api/src/test/java/edu/cornell/mannlib/vitro/webapp/dao/jena/RDFServiceGraphTest.java
+++ b/api/src/test/java/edu/cornell/mannlib/vitro/webapp/dao/jena/RDFServiceGraphTest.java
@@ -1,0 +1,62 @@
+package edu.cornell.mannlib.vitro.webapp.dao.jena;
+
+import static org.junit.Assert.assertEquals;
+
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.ModelFactory;
+import org.junit.Test;
+
+import edu.cornell.mannlib.vitro.testing.AbstractTestClass;
+import edu.cornell.mannlib.vitro.webapp.rdfservice.ChangeListener;
+import edu.cornell.mannlib.vitro.webapp.rdfservice.ModelChange;
+import edu.cornell.mannlib.vitro.webapp.rdfservice.RDFService;
+import edu.cornell.mannlib.vitro.webapp.rdfservice.RDFServiceException;
+import edu.cornell.mannlib.vitro.webapp.rdfservice.impl.jena.model.RDFServiceModel;
+
+
+public class RDFServiceGraphTest extends AbstractTestClass {
+
+    @Test
+    /**
+     * Test that creating a new model with the same underlying RDFServiceGraph
+     * does not result in a new listener registered on that graph.  No matter
+     * how many models have been created using a given RDFServiceGraph, an event
+     * sent to the last-created model should be heard only once by the 
+     * RDFService.
+     * @throws RDFServiceException
+     */
+    public void testEventListening() throws RDFServiceException {
+        Model m = ModelFactory.createDefaultModel();
+        RDFService rdfService = new RDFServiceModel(m);
+        EventsCounter counter = new EventsCounter();
+        rdfService.registerListener(counter);
+        RDFServiceGraph g = new RDFServiceGraph(rdfService);
+        Model model = null;
+        for (int i = 0; i < 100; i++) {
+            model = RDFServiceGraph.createRDFServiceModel(g);
+        }
+        model.notifyEvent("event");
+        assertEquals(1, counter.getCount());
+    }
+    
+    private class EventsCounter implements ChangeListener {
+
+        private int count = 0;
+        
+        public int getCount() {
+            return count;
+        }
+        
+        @Override
+        public void notifyModelChange(ModelChange modelChange) {
+            // TODO Auto-generated method stub            
+        }
+
+        @Override
+        public void notifyEvent(String graphURI, Object event) {
+            count++;
+        }
+        
+    }
+    
+}


### PR DESCRIPTION
…edundant listener each time a model is made for an existing RDFServiceGraph. Resolve https://jira.lyrasis.org/browse/VIVO-1976

**[JIRA Issue](https://jira.lyrasis.org/browse/VIVO-1976)**: (please link to issue)

this pull request do?
A brief description of what the intended result of the PR will be and/or what problem it solves.

- Removes registration of new listener from RDFServiceGraph.createRDFServiceModel()
- Adds event listening to anonymous subclass of SimpleEventManager in RDFServiceGraph.getEventManager().
- Adds unit test that creates multiple models from a single RDFServiceGraph and ensures that the RDFServiceGraph hears an event only once.

# How should this be tested?
Confirming that VIVO builds with a successful RDFServiceGraphTest should be sufficient.  Before applying the changes in RDFServiceGraph.java, RDFServiceGraphTest.java will fail because the RDFServiceGraph hears a single event 100 times.  After applying the rest of the PR's changes, it will hear it exactly once.

# Interested parties
@VIVO-project/vivo-committers
