### PR TITLE
[VIVO-1736] - Bugfix for redirecting user to home page after login

### DIFF
--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/authenticate/LoginRedirector.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/authenticate/LoginRedirector.java
@@ -108,7 +108,9 @@ public class LoginRedirector {
 			throws IOException {
 		try {
 			DisplayMessage.setMessage(request, assembleWelcomeMessage());
-			response.sendRedirect(getRedirectionUriForLoggedInUser());
+			String redirectUrl = getRedirectionUriForLoggedInUser();
+			log.debug("Sending redirect to path: " + redirectUrl);
+			response.sendRedirect(redirectUrl);
 		} catch (IOException e) {
 			log.debug("Problem with re-direction", e);
 			response.sendRedirect(getApplicationHomePageUrl());

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/authenticate/LoginRedirector.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/authenticate/LoginRedirector.java
@@ -177,10 +177,6 @@ public class LoginRedirector {
 		}
 	}
 
-	/**
-	 * The application home page can either be an absolute URL, or it can be
-	 * relative to the application. Weird.
-	 */
 	private String getApplicationHomePageUrl() {
 		String contextPath = request.getContextPath();
 		if (contextPath.equals("")) {

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/authenticate/LoginRedirector.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/authenticate/LoginRedirector.java
@@ -176,20 +176,16 @@ public class LoginRedirector {
 	}
 
 	/**
-	 * The application home page can be overridden by an attribute in the
-	 * ServletContext. Further, it can either be an absolute URL, or it can be
+	 * The application home page can either be an absolute URL, or it can be
 	 * relative to the application. Weird.
 	 */
 	private String getApplicationHomePageUrl() {
-		String contextRedirect = (String) session.getServletContext()
-				.getAttribute("postLoginRequest");
-		if (contextRedirect != null) {
-			if (contextRedirect.indexOf(":") == -1) {
-				return request.getContextPath() + contextRedirect;
-			} else {
-				return contextRedirect;
-			}
+		String contextPath = request.getContextPath();
+		if (contextPath.equals("")) {
+			return "/";
 		}
-		return request.getContextPath();
+		else {
+			return contextPath;
+		}
 	}
 }


### PR DESCRIPTION
**[JIRA Issue](https://jira.lyrasis.org/browse/VIVO-1736)**: VIVO-1736

# What does this pull request do?
Fixes an issue with external login redirects where they lead to an empty page in some situations.

# What's new?
Alters a method for determining the home page that didn't work, such that a trailing slash is added if the context resolves to a blank string. Removes unused functionality for determining the redirect based on a servlet attribute. Also added a single line to the debug log that reports back the URL path that is being used for the redirect.

# How should this be tested?
1. Setup an external authentication scheme, such as Shibboleth or CAS. That's the hard part.
2. Login to VIVO using this external mechanism as a user that is not attached to a profile and that does not have elevated privileges (i.e. is a self-editor)
3. If the user has not logged in before, complete the information VIVO asks for, log out and log back in
4. Confirm upon login that a blank page is shown and the browser url shows /loginExternalAuthReturn.

To confirm fix, repeat above but user should be redirected to homepage as intended.

# Additional Notes:
Pure speculation, but this bug may be limited to VIVO installations where VIVO is served at Tomcat's root, and may be a result of how that was set up. 
Previously merged, then un-merged (see https://github.com/vivo-project/Vitro/pull/221 and https://github.com/vivo-project/Vitro/pull/226). 

# Interested parties
@VIVO-project/vivo-committers
