### PR TITLE
Replace hardcoded en locale with current locale in lang and xml:lang …

### DIFF
--- a/webapp/src/main/webapp/templates/freemarker/page/partials/doctype.html
+++ b/webapp/src/main/webapp/templates/freemarker/page/partials/doctype.html
@@ -1,3 +1,3 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
     "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="${country}" lang="${country}">

--- a/webapp/src/main/webapp/themes/vitro/templates/page-home.ftl
+++ b/webapp/src/main/webapp/themes/vitro/templates/page-home.ftl
@@ -4,7 +4,7 @@
 <#import "lib-home-page.ftl" as lh>
 
 <!DOCTYPE html>
-<html lang="en">
+<html lang="${country}">
     <head>
         <#include "head.ftl">
     </head>

--- a/webapp/src/main/webapp/themes/vitro/templates/page.ftl
+++ b/webapp/src/main/webapp/themes/vitro/templates/page.ftl
@@ -3,7 +3,7 @@
 <#import "lib-list.ftl" as l>
 
 <!DOCTYPE html>
-<html lang="en">
+<html lang="${country}">
     <head>
         <#include "head.ftl">
     </head>


### PR DESCRIPTION
…attributes

**[JIRA Issue](https://jira.lyrasis.org/browse/VIVO-1343)**

Companion VIVO pull request: https://github.com/vivo-project/VIVO/pull/237

# What's new?
Uses the existing (if oddly-named) "country" value supplied by FreemarkerHttpServlet to populate HTML lang and xml:lang values.  Replaces hardcoded "en" value.

# How should this be tested?
Test that value (visible at top of page source) changes properly with language selection on both the home page and other pages.  Test also with no language filtering enabled or a forced locale.

# Additional Notes:
Some pages that are not generated via the standard Freemarker stack (e.g. smoke tests, goToIndividual.jsp and other JSPs) have not been modified.  As these are not crawled by search engines and are used only by admins, the consequences of incorrect tags are probably minimal.

# Interested parties
@VIVO-project/vivo-committers
