### PR TITLE
Abort TDB write transaction before ending if not successfully committed

### DIFF
--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/rdfservice/impl/jena/tdb/RDFServiceTDB.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/rdfservice/impl/jena/tdb/RDFServiceTDB.java
@@ -76,11 +76,19 @@ public class RDFServiceTDB extends RDFServiceJena {
 			}
 			notifyListenersOfPreChangeEvents(changeSet);
 
-			dataset.begin(ReadWrite.WRITE);
-			try {
-				applyChangeSetToModel(changeSet, dataset);
-				dataset.commit();
-			} finally {
+			dataset.begin(ReadWrite.WRITE);          
+            try {
+                boolean committed = false;
+                try {                   
+                    applyChangeSetToModel(changeSet, dataset);
+                    dataset.commit();
+                    committed = true;
+                } finally {
+                    if(!committed) {
+                        dataset.abort();
+                    }
+                }
+            } finally {                
 				dataset.end();
 			}
 


### PR DESCRIPTION
**[https://jira.lyrasis.org/browse/VIVO-1986](https://jira.lyrasis.org/browse/VIVO-1986)**: 

# What does this pull request do?
Calls transaction.abort() before transaction.end() if exception thrown while writing a change set in RDFServiceTDB.java.

# How should this be tested?
Before applying fix, go to add/remove RDF and try to upload an N3 file containing invalid N3 (e.g. some gibberish text).  Error that appears will be the one shown in the JIRA issue, which is not related to the content of the file you uploaded.

After applying the pull request, the error that is show/logged will be a RIOT error related to the failed parsing of the N3 file and the row/column at which parsing failed.

# Interested parties
@VIVO-project/vivo-committers
