### PR TITLE
Use full hash string for account email links

### DIFF
--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/beans/UserAccount.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/beans/UserAccount.java
@@ -134,8 +134,8 @@ public class UserAccount {
 	}
 
 	public String getPasswordLinkExpiresHash() {
-		return limitStringLength(8, Authenticator.applyArgon2iEncoding(String
-				.valueOf(passwordLinkExpires)));
+		return Authenticator.applyArgon2iEncoding(String.valueOf(
+		        passwordLinkExpires));
 	}
 
 	public void setPasswordLinkExpires(long passwordLinkExpires) {
@@ -227,16 +227,6 @@ public class UserAccount {
 
 	private <T> T nonNull(T value, T defaultValue) {
 		return (value == null) ? defaultValue : value;
-	}
-
-	private String limitStringLength(int limit, String s) {
-		if (s == null) {
-			return "";
-		} else if (s.length() <= limit) {
-			return s;
-		} else {
-			return s.substring(0, limit);
-		}
 	}
 
 	@Override


### PR DESCRIPTION
# What does this pull request do?
Removes limit of 8 characters on passwordLinkExpiresHash and stores the full string.

# How should this be tested?
With  #SMTP server configured in runtime.properties, create a new user with a valid email address.  Confirm that the link sent in the email contains an activation code longer than 8 characters, and that the clicking the link successfully leads to the password setting page.

# Interested parties
@VIVO-project/vivo-committers
