### PR TITLE
Fix hash validation in account email links

### DIFF
--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/beans/UserAccount.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/beans/UserAccount.java
@@ -145,6 +145,13 @@ public class UserAccount {
 	public boolean isPasswordChangeRequired() {
 		return passwordChangeRequired;
 	}
+	
+	public boolean isHashValid(String hashKey) {
+		if (Authenticator.verifyArgon2iHash(hashKey, String.valueOf(passwordLinkExpires))) {
+			return true;
+		}
+		return false;
+	}
 
 	public void setPasswordChangeRequired(Boolean passwordChangeRequired) {
 		this.passwordChangeRequired = nonNull(passwordChangeRequired,

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/beans/UserAccount.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/beans/UserAccount.java
@@ -134,8 +134,8 @@ public class UserAccount {
 	}
 
 	public String getPasswordLinkExpiresHash() {
-		return limitStringLength(8, Authenticator.applyArgon2iEncoding(String
-				.valueOf(passwordLinkExpires)));
+		return Authenticator.applyArgon2iEncoding(String.valueOf(
+		        passwordLinkExpires));
 	}
 
 	public void setPasswordLinkExpires(long passwordLinkExpires) {
@@ -227,16 +227,6 @@ public class UserAccount {
 
 	private <T> T nonNull(T value, T defaultValue) {
 		return (value == null) ? defaultValue : value;
-	}
-
-	private String limitStringLength(int limit, String s) {
-		if (s == null) {
-			return "";
-		} else if (s.length() <= limit) {
-			return s;
-		} else {
-			return s.substring(0, limit);
-		}
 	}
 
 	@Override

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/accounts/user/UserAccountsPasswordBasePage.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/accounts/user/UserAccountsPasswordBasePage.java
@@ -103,11 +103,9 @@ public abstract class UserAccountsPasswordBasePage extends UserAccountsPage {
 			return;
 		}
 
-		String expectedKey = userAccount.getPasswordLinkExpiresHash();
-		if (!key.equals(expectedKey)) {
-			log.warn("Password request for '" + userEmail + "' is bogus: key ("
-					+ key + ") doesn't match expected key (" + expectedKey
-					+ ")");
+		if (!userAccount.isHashValid(key)) {
+			log.warn("Password request for '" + userEmail + "' is bogus: hash ("
+					+ key + ") doesn't match key.");
 			bogusMessage = passwordChangeNotPendingMessage();
 			return;
 		}


### PR DESCRIPTION
# What does this pull request do?
Fix hash validation and removes limit of 8 characters on validation hash key.
# How should this be tested?
With properly configured smtp server in runtime.properties, create a new user with a valid email address. 
Check activation link in the recieved email. It should contain hash key longer than 8 characters.
Clicking the link successfully leads to the password setting page.
Try the same by resetting password in user account settings.
Try using empty keys or modified argon keys to verify they are not working.
# Interested parties
@VIVO-project/vivo-committers
