### PR TITLE
[VIVO-1989] URL-encode vCard-related resource URIs appended to edit links

### DIFF
--- a/webapp/src/main/webapp/templates/freemarker/lib/lib-properties.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/lib/lib-properties.ftl
@@ -183,16 +183,16 @@ name will be used as the label. -->
 	<#local url = statement.editUrl>
 	<#if url?has_content>
 		<#if propertyLocalName?contains("ARG_2000028")>
-		    <#if rangeUri?contains("Address")>
-		        <#local url = url + "&addressUri=" + "${statement.address!}">
-		    <#elseif rangeUri?contains("Telephone") || rangeUri?contains("Fax")>
-		        <#local url = url + "&phoneUri=" + "${statement.phone!}">
-		    <#elseif rangeUri?contains("Work") || rangeUri?contains("Email")>
-		        <#local url = url + "&emailUri=" + "${statement.email!}">
-		    <#elseif rangeUri?contains("Name")>
-		        <#local url = url + "&fullNameUri=" + "${statement.fullName!}">
-		    <#elseif rangeUri?contains("Title")>
-		        <#local url = url + "&titleUri=" + "${statement.title!}">
+		    <#if rangeUri?contains("Address") && statement.address??>
+		        <#local url = url + "&addressUri=" + "${statement.address?url}">
+		    <#elseif (rangeUri?contains("Telephone") || rangeUri?contains("Fax")) && statement.phone??>
+		        <#local url = url + "&phoneUri=" + "${statement.phone?url}">
+		    <#elseif (rangeUri?contains("Work") || rangeUri?contains("Email")) && statement.email??>
+		        <#local url = url + "&emailUri=" + "${statement.email?url}">
+		    <#elseif rangeUri?contains("Name") && statement.fullName??>
+		        <#local url = url + "&fullNameUri=" + "${statement.fullName?url}">
+		    <#elseif rangeUri?contains("Title") && statement.title??>
+		        <#local url = url + "&titleUri=" + "${statement.title?url}">
 		    </#if>
 		</#if>
         <@showEditLink propertyLocalName rangeUri url />


### PR DESCRIPTION
**[https://jira.lyrasis.org/browse/VIVO-1989](https://jira.lyrasis.org/browse/VIVO-1989)**: 

See Vitro-languages companion PR (https://github.com/vivo-project/Vitro-languages/pull/48)

# How should this be tested?
To reproduce bug:
1. Install vivo to a context other than root, e.g. localhost:8080/vivo/
2. Enter a person's preferred title / email / phone number / address or find an existing person with one or more of these.
3. Edit the existing value. Erase the existing value and submit an empty field.
4. You will be redirected out of the context: /editRequestDispatch?

To test fix, repeat the above steps.  You should remain in the context and see a validation error prompting you to enter a value.

# Interested parties
@VIVO-project/vivo-committers
