### PR TITLE
[VIVO-1985] Compare locales of equal rank alphabetically to provide consistent fallback

### DIFF
--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/BaseEditConfigurationGenerator.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/BaseEditConfigurationGenerator.java
@@ -16,6 +16,7 @@ import edu.cornell.mannlib.vitro.webapp.edit.n3editing.VTwo.EditConfigurationVTw
 import edu.cornell.mannlib.vitro.webapp.edit.n3editing.configuration.IdModelSelector;
 import edu.cornell.mannlib.vitro.webapp.edit.n3editing.configuration.StandardModelSelector;
 import edu.cornell.mannlib.vitro.webapp.modelaccess.ModelAccess;
+import edu.cornell.mannlib.vitro.webapp.modelaccess.ModelAccess.LanguageOption;
 
 public abstract class BaseEditConfigurationGenerator implements EditConfigurationGenerator {
 
@@ -63,6 +64,7 @@ public abstract class BaseEditConfigurationGenerator implements EditConfiguratio
         setupModelSelectorsFromVitroRequest(vreq, editConfig);
 
         OntModel queryModel = ModelAccess.on(vreq).getOntModel();
+        OntModel languageNeutralModel = vreq.getLanguageNeutralUnionFullModel();
 
         if( editConfig.getSubjectUri() == null)
             editConfig.setSubjectUri( EditConfigurationUtils.getSubjectUri(vreq));
@@ -78,7 +80,10 @@ public abstract class BaseEditConfigurationGenerator implements EditConfiguratio
             editConfig.prepareForObjPropUpdate(queryModel);
         } else if( dataKey != null ) { // edit of a data prop statement
             //do nothing since the data prop form generator must take care of it
-            editConfig.prepareForDataPropUpdate(queryModel, vreq.getWebappDaoFactory().getDataPropertyDao());
+            // Use language-neutral model to ensure that a data property statement
+            // is found for any literal hash, even if the UI locale is changed.
+            editConfig.prepareForDataPropUpdate(languageNeutralModel,
+                    vreq.getWebappDaoFactory().getDataPropertyDao());
         } else{
             //this might be a create new or a form
             editConfig.prepareForNonUpdate(queryModel);

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/modelaccess/impl/RequestModelAccessImpl.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/modelaccess/impl/RequestModelAccessImpl.java
@@ -202,7 +202,7 @@ public class RequestModelAccessImpl implements RequestModelAccess {
 
 	@Override
 	public OntModel getOntModel(String name, LanguageOption... options) {
-		return addLanguageAwareness(getOntModel(new OntModelKey(name, options)));
+		return getOntModel(new OntModelKey(name, options));
 	}
 
 	private OntModel getOntModel(OntModelKey key) {

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/rdfservice/filter/LangSort.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/rdfservice/filter/LangSort.java
@@ -36,7 +36,13 @@ public class LangSort {
     }
     
     protected int compareLangs(String t1lang, String t2lang) {
-        return languageIndex(t1lang) - languageIndex(t2lang);
+        int index1 = languageIndex(t1lang);
+        int index2 = languageIndex(t2lang);
+        if(index1 == index2) {
+            return t1lang.compareTo(t2lang);
+        } else {
+            return languageIndex(t1lang) - languageIndex(t2lang);
+        }
     }
 
     /**


### PR DESCRIPTION
**[https://jira.lyrasis.org/browse/VIVO-1985](https://jira.lyrasis.org/browse/VIVO-1985)**:

Updates the language sorting in LangSort so that languages of the same rank are consistently sorted with respect to one another.  This makes for a consistent selection of fallback language if no values appropriate to the current locale setting are available.

To reproduce, enter a research overview in two different languages.  Switch to a third language and edit reseach overview.  Should (likely) get a 'no match to existing literal' exception.

After applying fix, should be able to edit under the third language without error.

# Interested parties
@VIVO-project/vivo-committers
