### PR TITLE
Log ConfigurationProperties bean at DEBUG level.

### DIFF
--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/config/ConfigurationProperties.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/config/ConfigurationProperties.java
@@ -109,7 +109,7 @@ public abstract class ConfigurationProperties {
 			throw new NullPointerException("bean may not be null.");
 		}
 		context.setAttribute(ATTRIBUTE_NAME, bean);
-		log.info(bean);
+		log.debug(bean);
 	}
 
 	/** Package access, so unit tests can call it. */


### PR DESCRIPTION
**[https://jira.lyrasis.org/browse/VIVO-1995](https://jira.lyrasis.org/browse/VIVO-1995)**:

Logs the ConfigurationProperties bean (contents of runtime.properties) at the DEBUG level, so it will not be logged under the default settings.

# How should this be tested?
Install PR. Start Tomcat. Note that ConfigurationProperties does not log the config settings.
Logging can be restored by adding log4j.logger.edu.cornell.mannlib.vitro.webapp.config.ConfigurationProperties=DEBUG to WEB-INF/classes/log4j.properties.

# Interested parties
@VIVO-project/vivo-committers
