### PR TITLE
[VIVO-1997] Log blank node deletion messages at DEBUG instead of WARN

### DIFF
--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/rdfservice/impl/jena/RDFServiceJena.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/rdfservice/impl/jena/RDFServiceJena.java
@@ -202,7 +202,7 @@ public abstract class RDFServiceJena extends RDFServiceImpl implements RDFServic
 
         if (blankNodeModel.size() == 1) {
             log.debug("Deleting single triple with blank node: " + blankNodeModel);
-            log.debug("This likely indicates a problem; excessive data may be deleted.");
+            log.debug("This could result in the deletion of multiple triples if multiple blank nodes match the same triple pattern.");
         }
 
         Query rootFinderQuery = QueryFactory.create(BNODE_ROOT_QUERY);

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/rdfservice/impl/jena/RDFServiceJena.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/rdfservice/impl/jena/RDFServiceJena.java
@@ -201,8 +201,8 @@ public abstract class RDFServiceJena extends RDFServiceImpl implements RDFServic
         log.debug("blank node model size " + blankNodeModel.size());
 
         if (blankNodeModel.size() == 1) {
-            log.warn("Deleting single triple with blank node: " + blankNodeModel);
-            log.warn("This likely indicates a problem; excessive data may be deleted.");
+            log.debug("Deleting single triple with blank node: " + blankNodeModel);
+            log.debug("This likely indicates a problem; excessive data may be deleted.");
         }
 
         Query rootFinderQuery = QueryFactory.create(BNODE_ROOT_QUERY);


### PR DESCRIPTION
**[https://jira.lyrasis.org/browse/VIVO-1997](https://jira.lyrasis.org/browse/VIVO-1997)**:

As part of the new "every-time" update of "first time" content, single-triple deletions with blank nodes occur and are innocuous.  This pull request logs warnings related to this type of deletion at DEBUG so as not to litter the log with ominous-looking warnings during each startup with default settings.

# How should this be tested?
Start Tomcat.  Log should not show warnings related to blank node deletion.

# Interested parties
@VIVO-project/vivo-committers
