### PR TITLE
Add password authentification on external smtp servers

### DIFF
--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/email/FreemarkerEmailFactory.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/email/FreemarkerEmailFactory.java
@@ -124,7 +124,7 @@ public class FreemarkerEmailFactory {
 		return replyToAddress;
 	}
 
-	Session getEmailSession() {
+	private Session getEmailSession() {
 		return emailSession;
 	}
 	

--- a/home/src/main/resources/config/example.runtime.properties
+++ b/home/src/main/resources/config/example.runtime.properties
@@ -40,6 +40,9 @@ vitro.local.solr.url = http://localhost:8983/solr/vitrocore
   #   Example:
   #     email.smtpHost = smtp.mydomain.edu
   #     email.replyTo = vitroAdmin@mydomain.edu
+  #     email.username = vivtroAdmin@mydomain.edu
+  #     email.password = secret
+  #     email.port = 25 or 465 or 587
   #
 email.smtpHost =
 email.replyTo =


### PR DESCRIPTION
JIRA Issue [VIVO-2001](https://jira.lyrasis.org/browse/VIVO-2001)
# What does this pull request do?
Adds authentification on external smtp servers

# How should this be tested?
Set email username and password
email.username = email_user_name
email.password = email_password
By default email port 25 will be used.
Try using email.port = 25 or 465 or 587

# Interested parties
@VIVO-project/vivo-committers
