### PR TITLE
GitHub CI deploy workflow to publish snapshot

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,38 @@
+name: Deploy
+
+on:
+  push:
+    branches:
+      - rel-1.12.0-RC-workflow
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    env:
+      MAVEN_OPTS: -Xmx1024M
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Maven Cache
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-cache-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-cache-m2-
+
+      - name: Setup Java
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+          server-id: ossrh
+          server-username: MAVEN_USERNAME
+          server-password: MAVEN_PASSWORD
+
+      - name: Maven Deploy
+        run: mvn --batch-mode deploy
+        env:
+          MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+          MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}


### PR DESCRIPTION
Add deploy GitHub workflow to publish snapshots on push to main or by workflow dispatch.

This is currently failing as I did not have admin access to add the ossrh username and token secrets. As soon as I can, I will add them and re-run the workflows. Temporarily I modified branch on VIVO to publish 1.12.0-SNAPSHOT of Vitro.

@VIVO-project/vivo-committers
