### PR TITLE
Run unit tests in alphabetical order

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -23,6 +23,13 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <runOrder>alphabetical</runOrder>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
                 <executions>
                     <execution>


### PR DESCRIPTION
**[https://jira.lyrasis.org/browse/VIVO-2005](https://jira.lyrasis.org/browse/VIVO-2005)**: 

Adds runOrder to unit tests to ensure that they are run in an order that allows all tests to have properly set-up dependencies.  This is a temporary workaround for the general problem to be addressed in https://jira.lyrasis.org/browse/VIVO-2003

# How should this be tested?
Should be tested with the companion VIVO pull request.
Test that VIVO builds normally and that all the unit tests are run in alphabetical order.

**Before merging, change the base branch dropdown to rel-1.12.1-RC (once it becomes available).**

# Interested parties
@VIVO-project/vivo-committers