### PR TITLE
Creating Locale with specified Language script

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,4 @@ research and scholarship portal, [VIVO](https://duraspace.org/vivo/).
 
 For more information, contact the [VIVO community](https://duraspace.org/vivo/resources/contact/).
 
+

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/i18n/selection/LocaleSelectionController.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/i18n/selection/LocaleSelectionController.java
@@ -12,6 +12,7 @@ import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import edu.cornell.mannlib.vitro.webapp.utils.LocaleUtility;
 import org.apache.commons.lang3.LocaleUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
@@ -74,7 +75,7 @@ public class LocaleSelectionController extends HttpServlet {
 		Locale locale = null;
 
 		try {
-			locale = LocaleUtils.toLocale(selectedLocale.trim());
+			locale = LocaleUtility.languageStringToLocale(selectedLocale);
 			log.debug("Locale selection is " + locale);
 		} catch (IllegalArgumentException e) {
 			log.error("Failed to convert the selection to a Locale", e);

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/i18n/selection/LocaleSelectionDataGetter.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/i18n/selection/LocaleSelectionDataGetter.java
@@ -88,7 +88,8 @@ public class LocaleSelectionDataGetter implements DataGetter {
 	private Map<String, Object> buildLocaleMap(Locale locale,
 			Locale currentLocale) throws FileNotFoundException {
 		Map<String, Object> map = new HashMap<>();
-		map.put("code", locale.toString());
+        
+		map.put("code", locale.toLanguageTag().replace('-','_'));
 		map.put("label", locale.getDisplayLanguage(locale));
 		map.put("country", locale.getDisplayCountry(locale));
 		map.put("selected", currentLocale.equals(locale));

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/i18n/selection/LocaleSelectionSetup.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/i18n/selection/LocaleSelectionSetup.java
@@ -10,12 +10,16 @@ import javax.servlet.ServletContext;
 import javax.servlet.ServletContextEvent;
 import javax.servlet.ServletContextListener;
 
+import edu.cornell.mannlib.vitro.webapp.utils.LocaleUtility;
 import org.apache.commons.lang3.LocaleUtils;
 import org.apache.commons.lang3.StringUtils;
 
 import edu.cornell.mannlib.vitro.webapp.config.ConfigurationProperties;
 import edu.cornell.mannlib.vitro.webapp.i18n.I18n;
 import edu.cornell.mannlib.vitro.webapp.startup.StartupStatus;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
 
 /**
  * Check the ConfigurationProperties for a forced locale, or for a
@@ -24,6 +28,10 @@ import edu.cornell.mannlib.vitro.webapp.startup.StartupStatus;
  * Create the appropriate Locale objects and store them in the ServletContext.
  */
 public class LocaleSelectionSetup implements ServletContextListener {
+
+	private static final Log log = LogFactory
+			.getLog(LocaleSelectionSetup.class);
+
 	/**
 	 * If this is set, the locale is forced. No selection will be offered to the
 	 * user, and browser locales will be ignored.
@@ -143,12 +151,13 @@ public class LocaleSelectionSetup implements ServletContextListener {
 			throw new IllegalArgumentException("Invalid locale format");
 		}
 
-		Locale locale = LocaleUtils.toLocale(localeString);
+		Locale locale = LocaleUtility.languageStringToLocale(localeString);
 
 		if (!"es_GO".equals(localeString) && // No complaint about bogus locale
 				!LocaleUtils.isAvailableLocale(locale)) {
 			ssWarning("'" + locale + "' is not a recognized locale.");
 		}
+
 		return locale;
 	}
 

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/utils/LocaleUtility.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/utils/LocaleUtility.java
@@ -1,0 +1,19 @@
+package edu.cornell.mannlib.vitro.webapp.utils;
+
+import org.apache.commons.lang3.LocaleUtils;
+
+import java.util.Locale;
+
+public final class LocaleUtility {
+
+    private LocaleUtility(){}
+
+    public static Locale languageStringToLocale(String localeString){
+        String[] parsedLoc = localeString.trim().split("_", -1);
+        //regex pattern for locale tag with script specified
+        Locale locale = localeString.matches("^[a-z]{1,3}_[A-Z][a-z]{3}_[A-Z]{2}") ?
+            new Locale.Builder().setLanguage(parsedLoc[0]).setRegion(parsedLoc[2]).setScript(parsedLoc[1]).build() :
+            LocaleUtils.toLocale(localeString);
+        return locale;
+    }
+}


### PR DESCRIPTION
# What does this pull request do?
Adds a LocaleUtility class which expands LocaleUtil from lang3 package. LocaleUtil does not support creation of Locales with script specified (Latin, Cyrillic, etc.). LocaleUtility checks if the string that represents locale contains script. If so, it creates Locale using Locale.Builder class, otherwise calls the LocaleUtil.toLocale() as it was done before.

# What's new?
Now we can specify locales like sr_Latn_RS or sr_Cyrl_RS, which was not the case before.

# How should this be tested?
 Only way to see the difference is to have Locales of same languages but in different scripts.


* Does this change require documentation to be updated? 
    - Yes. Localization documentation should contain example of Locale string representation which specifies the script.
 * Does this change add any new dependencies? 
    - Not external

# Interested parties
@VIVO-project/vivo-committers
