### PR TITLE
Improved thread safety in action pool

### DIFF
--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/dynapi/RPCEndpoint.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/dynapi/RPCEndpoint.java
@@ -41,11 +41,18 @@ public class RPCEndpoint extends VitroHttpServlet  {
 	private void process(HttpServletRequest request, HttpServletResponse response) {
 		String requestURL = request.getRequestURI();
 		String actionName = requestURL.substring(requestURL.lastIndexOf("/") + 1 );
+		Action action = null;
 		log.debug(actionName);
-		actionPool.printActionNames();
-		Action action = actionPool.getByName(actionName);
-		OperationData input = new OperationData(request);
-		OperationResult result = action.run(input);
-		result.prepareResponse(response);
+		try {
+  		actionPool.printActionNames();
+  		action = actionPool.getByName(actionName);
+  		OperationData input = new OperationData(request);
+  		OperationResult result = action.run(input);
+  		result.prepareResponse(response);
+		} finally {
+			if (action != null) {
+				action.removeClient();
+			}
+		}
 	}
 }


### PR DESCRIPTION
Improved thread safety in Action pool:
- Thread safe singleton initialization 
- Store thread ids of clients in action instance
- Safe reload: initialize new actions then swap with old ones
- Prevent dereferencing of action that is currently in use
- Try to remove dead thread ids if client is gone while unloading obsolete actions
Added a few tests to test thread safety

# Interested parties
Tag (@ mention) interested parties or, if unsure, @VIVO-project/vivo-committers
