### PR TITLE
Add RPC Endpoint tests using PowerMock

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -102,6 +102,18 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-module-junit4</artifactId>
+            <version>2.0.9</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-api-easymock</artifactId>
+            <version>2.0.9</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-all</artifactId>
             <version>1.3</version>

--- a/api/src/test/java/edu/cornell/mannlib/vitro/webapp/dynapi/RPCEndpointTest.java
+++ b/api/src/test/java/edu/cornell/mannlib/vitro/webapp/dynapi/RPCEndpointTest.java
@@ -1,0 +1,114 @@
+package edu.cornell.mannlib.vitro.webapp.dynapi;
+
+import static org.easymock.EasyMock.anyObject;
+import static org.easymock.EasyMock.anyString;
+import static org.easymock.EasyMock.expect;
+import static org.powermock.api.easymock.PowerMock.createMock;
+import static org.powermock.api.easymock.PowerMock.mockStatic;
+import static org.powermock.api.easymock.PowerMock.replay;
+import static org.powermock.api.easymock.PowerMock.verify;
+
+import java.io.IOException;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.api.easymock.annotation.Mock;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import edu.cornell.mannlib.vitro.webapp.dynapi.components.Action;
+import edu.cornell.mannlib.vitro.webapp.dynapi.components.OperationResult;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(ActionPool.class)
+public class RPCEndpointTest {
+
+	final static String URI_TEST = "/api/rpc/test";
+
+	private static RESTEndpoint restEndpoint;
+
+	@Mock
+	private static ActionPool actionPool;
+
+	@Mock
+	private Action action;
+
+	@Mock
+	private OperationResult operationResult;
+
+	@Mock
+	private HttpServletRequest request;
+
+	@Mock
+	private HttpServletResponse response;
+
+	@BeforeClass
+	public static void beforeAll()  throws IOException, ServletException {
+		mockStatic(ActionPool.class);
+		expect(ActionPool.getInstance()).andReturn(actionPool).anyTimes();
+		replay(ActionPool.class);
+
+		restEndpoint = new RESTEndpoint();
+	}
+
+	@Before
+	public void beforeEach() {
+		actionPool = createMock(ActionPool.class);
+		action = createMock(Action.class);
+
+		operationResult = createMock(OperationResult.class);
+
+		request = createMock(HttpServletRequest.class);
+		response = createMock(HttpServletResponse.class);
+
+		expect(action.run(anyObject())).andReturn(operationResult);
+		replay(action);
+
+		expect(actionPool.getByName(anyString())).andReturn(action);
+		replay(actionPool);
+
+		expect(request.getRequestURI()).andReturn(URI_TEST);
+	}
+
+	@Test
+	public void doGetTest() {
+		expect(request.getMethod()).andReturn("GET").atLeastOnce();
+		replay(request);
+
+		restEndpoint.doGet(request, response);
+		verify(request);
+	}
+
+	@Test
+	public void doPostTest() {
+		expect(request.getMethod()).andReturn("POST").atLeastOnce();
+		replay(request);
+
+		restEndpoint.doPost(request, response);
+		verify(request);
+	}
+
+	@Test
+	public void doDeleteTest() {
+		expect(request.getMethod()).andReturn("DELETE").atLeastOnce();
+		replay(request);
+
+		restEndpoint.doDelete(request, response);
+		verify(request);
+	}
+
+	@Test
+	public void doPutTest() {
+		expect(request.getMethod()).andReturn("PUT").atLeastOnce();
+		replay(request);
+
+		restEndpoint.doPut(request, response);
+		verify(request);
+	}
+}


### PR DESCRIPTION
# What does this pull request do?
Add unit tests for the RPC Endpoint using PowerMock.

This demostrates a simple approach to unit testing endpoints.

This test works by confirming that the `action.run()` is called.

# What's new?
* Add PowerMock 2.0.9 test dependencies.