### PR TITLE
Renamed customAction to customRestAction

### DIFF
--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/dynapi/components/CustomRESTAction.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/dynapi/components/CustomRESTAction.java
@@ -2,7 +2,7 @@ package edu.cornell.mannlib.vitro.webapp.dynapi.components;
 
 import edu.cornell.mannlib.vitro.webapp.utils.configuration.Property;
 
-public class CustomAction implements Removable {
+public class CustomRESTAction implements Removable {
 
 	private String name;
 	private RPC targetRPC;
@@ -17,7 +17,7 @@ public class CustomAction implements Removable {
 		return name;
 	}
 
-	@Property(uri = "https://vivoweb.org/ontology/vitro-dynamic-api#customActionName", minOccurs = 1, maxOccurs = 1)
+	@Property(uri = "https://vivoweb.org/ontology/vitro-dynamic-api#customRESTActionName", minOccurs = 1, maxOccurs = 1)
 	public void setName(String name) {
 		this.name = name;
 	}

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/dynapi/components/Resource.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/dynapi/components/Resource.java
@@ -24,7 +24,7 @@ public class Resource implements Poolable {
 	private RPC rpcOnDelete;
 	private RPC rpcOnPut;
 	private RPC rpcOnPatch;
-	private List<CustomAction> customActions = new LinkedList<CustomAction>();
+	private List<CustomRESTAction> customRESTActions = new LinkedList<CustomRESTAction>();
 
 	private Set<Long> clients = ConcurrentHashMap.newKeySet();
 
@@ -105,10 +105,10 @@ public class Resource implements Poolable {
 	public void setRpcOnPatch(RPC rpcOnPatch) {
 		this.rpcOnPatch = rpcOnPatch;
 	}
-
-	@Property(uri = "https://vivoweb.org/ontology/vitro-dynamic-api#hasCustomAction")
-	public void addCustomAction(CustomAction customAction) {
-		customActions.add(customAction);
+	
+	@Property(uri = "https://vivoweb.org/ontology/vitro-dynamic-api#hasCustomRESTAction")
+	public void addCustomRESTAction(CustomRESTAction customRESTAction) {
+		customRESTActions.add(customRESTAction);
 	}
 
 	@Override

--- a/api/src/test/resources/rdf/abox/filegraph/dynamic-api-individuals-reloading.n3
+++ b/api/src/test/resources/rdf/abox/filegraph/dynamic-api-individuals-reloading.n3
@@ -25,9 +25,9 @@
         dynapi:rpcAPIVersionMin  "0.1.0" .
 
 <https://vivoweb.org/ontology/vitro-dynamic-api/custom_actions/test_reload_custom_action1>
-        a                        dynapi:customAction ;
+        a                        dynapi:customRESTAction ;
         dynapi:resourceName      "Test reload custom action" ;
-        dynapi:customActionName  "test_reload_custom_action_name" ;
+        dynapi:customRESTActionName  "test_reload_custom_action_name" ;
         dynapi:forwardTo         <https://vivoweb.org/ontology/vitro-dynamic-api/rpc/testReloadRPC1> ;
         dynapi:defaultMethod     <https://vivoweb.org/ontology/vitro-dynamic-api/http_method/post> ;
         dynapi:rpcAPIVersionMin  "0.1.0" .
@@ -41,7 +41,7 @@
         dynapi:onDelete          <https://vivoweb.org/ontology/vitro-dynamic-api/rpc/testReloadRPC1> ;
         dynapi:onPut             <https://vivoweb.org/ontology/vitro-dynamic-api/rpc/testReloadRPC1> ;
         dynapi:onPatch           <https://vivoweb.org/ontology/vitro-dynamic-api/rpc/testReloadRPC1> ;
-        dynapi:hasCustomAction   <https://vivoweb.org/ontology/vitro-dynamic-api/custom_actions/test_reload_custom_action1> ;
+        dynapi:hasCustomRESTAction   <https://vivoweb.org/ontology/vitro-dynamic-api/custom_actions/test_reload_custom_action1> ;
         dynapi:restAPIVersionMin "0.1.0" .
 
 

--- a/home/src/main/resources/rdf/abox/filegraph/dynamic-api-individuals-testing.n3
+++ b/home/src/main/resources/rdf/abox/filegraph/dynamic-api-individuals-testing.n3
@@ -39,9 +39,9 @@
         dynapi:rpcAPIVersionMin  "0.1.0" .
 
 <https://vivoweb.org/ontology/vitro-dynamic-api/custom_actions/test_custom_action1>
-        a                        dynapi:customAction ;
+        a                        dynapi:customRESTAction ;
         dynapi:resourceName      "Test custom action" ;
-        dynapi:customActionName  "test_custom_action_name" ;
+        dynapi:customRESTActionName  "test_custom_action_name" ;
         dynapi:forwardTo         <https://vivoweb.org/ontology/vitro-dynamic-api/rpc/testRPC1> ;
         dynapi:defaultMethod     <https://vivoweb.org/ontology/vitro-dynamic-api/http_method/post> ;
         dynapi:rpcAPIVersionMin  "0.1.0" .
@@ -55,7 +55,7 @@
         dynapi:onDelete          <https://vivoweb.org/ontology/vitro-dynamic-api/rpc/testRPC1> ;
         dynapi:onPut             <https://vivoweb.org/ontology/vitro-dynamic-api/rpc/testRPC1> ;
         dynapi:onPatch           <https://vivoweb.org/ontology/vitro-dynamic-api/rpc/testRPC1> ;
-        dynapi:hasCustomAction   <https://vivoweb.org/ontology/vitro-dynamic-api/custom_actions/test_custom_action1> ;
+        dynapi:hasCustomRESTAction   <https://vivoweb.org/ontology/vitro-dynamic-api/custom_actions/test_custom_action1> ;
         dynapi:restAPIVersionMin "0.1.0" .
 
 

--- a/home/src/main/resources/rdf/tbox/filegraph/dynamic-api-implementation.n3
+++ b/home/src/main/resources/rdf/tbox/filegraph/dynamic-api-implementation.n3
@@ -27,5 +27,5 @@ dynapi:rpc rdfs:subClassOf dynapi_java:RPC .
 
 dynapi:httpMethod rdfs:subClassOf dynapi_java:HTTPMethod .
 
-dynapi:customAction rdfs:subClassOf dynapi_java:CustomAction .
+dynapi:customRESTAction rdfs:subClassOf dynapi_java:CustomRESTAction .
 

--- a/home/src/main/resources/rdf/tbox/filegraph/vitro-dynamic-api.owl
+++ b/home/src/main/resources/rdf/tbox/filegraph/vitro-dynamic-api.owl
@@ -199,12 +199,12 @@
     </owl:ObjectProperty>
 
 
-    <!-- https://vivoweb.org/ontology/vitro-dynamic-api#hasCustomAction -->
+    <!-- https://vivoweb.org/ontology/vitro-dynamic-api#hasCustomRESTAction -->
 
-    <owl:ObjectProperty rdf:about="https://vivoweb.org/ontology/vitro-dynamic-api#hasCustomAction">
+    <owl:ObjectProperty rdf:about="https://vivoweb.org/ontology/vitro-dynamic-api#hasCustomRESTAction">
         <rdfs:subPropertyOf rdf:resource="http://www.w3.org/2002/07/owl#topObjectProperty"/>
         <rdfs:domain rdf:resource="https://vivoweb.org/ontology/vitro-dynamic-api#resource"/>
-        <rdfs:range rdf:resource="https://vivoweb.org/ontology/vitro-dynamic-api#customAction"/>
+        <rdfs:range rdf:resource="https://vivoweb.org/ontology/vitro-dynamic-api#customRESTAction"/>
         <rdfs:label xml:lang="en-US">has custom action</rdfs:label>
     </owl:ObjectProperty>
 
@@ -214,7 +214,7 @@
     <owl:ObjectProperty rdf:about="https://vivoweb.org/ontology/vitro-dynamic-api#forwardTo">
         <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#FunctionalProperty"/>
         <rdfs:subPropertyOf rdf:resource="http://www.w3.org/2002/07/owl#topObjectProperty"/>
-        <rdfs:domain rdf:resource="https://vivoweb.org/ontology/vitro-dynamic-api#customAction"/>
+        <rdfs:domain rdf:resource="https://vivoweb.org/ontology/vitro-dynamic-api#customRESTAction"/>
         <rdfs:range rdf:resource="https://vivoweb.org/ontology/vitro-dynamic-api#rpc"/>
         <rdfs:label xml:lang="en-US">forward to RPC</rdfs:label>
     </owl:ObjectProperty>
@@ -378,9 +378,9 @@
         <rdfs:label xml:lang="en-US">http method name</rdfs:label>
       </owl:DatatypeProperty>
 
-     <owl:DatatypeProperty rdf:about="https://vivoweb.org/ontology/vitro-dynamic-api#customActionName">
+     <owl:DatatypeProperty rdf:about="https://vivoweb.org/ontology/vitro-dynamic-api#customRESTActionName">
         <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#FunctionalProperty"/>
-        <rdfs:domain rdf:resource="https://vivoweb.org/ontology/vitro-dynamic-api#customAction"/>
+        <rdfs:domain rdf:resource="https://vivoweb.org/ontology/vitro-dynamic-api#customRESTAction"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
         <rdfs:label xml:lang="en-US">custom action name</rdfs:label>
       </owl:DatatypeProperty>
@@ -524,9 +524,9 @@
         <rdfs:label xml:lang="en-US">HTTP method</rdfs:label>
     </owl:Class>
 
-    <!-- https://vivoweb.org/ontology/vitro-dynamic-api#customAction -->
+    <!-- https://vivoweb.org/ontology/vitro-dynamic-api#customRESTAction -->
 
-    <owl:Class rdf:about="https://vivoweb.org/ontology/vitro-dynamic-api#customAction">
+    <owl:Class rdf:about="https://vivoweb.org/ontology/vitro-dynamic-api#customRESTAction">
         <rdfs:label xml:lang="en-US">Custom action</rdfs:label>
     </owl:Class>
 


### PR DESCRIPTION
Renamed customAction to customRestAction, used by Resources to avoid ambiguity.
# Interested parties
Tag (@ mention) interested parties or, if unsure, @VIVO-project/vivo-committers
