### PR TITLE
[Issue 3651] Apply action pool strategy to resource pool

### DIFF
--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/dynapi/ResourcePool.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/dynapi/ResourcePool.java
@@ -2,8 +2,10 @@ package edu.cornell.mannlib.vitro.webapp.dynapi;
 
 import static edu.cornell.mannlib.vitro.webapp.modelaccess.ModelNames.FULL_UNION;
 
-import java.util.HashMap;
+import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedQueue;
 
 import javax.servlet.ServletContext;
 
@@ -11,6 +13,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.jena.ontology.OntModel;
 
+import edu.cornell.mannlib.vitro.webapp.dynapi.components.DefaultResource;
 import edu.cornell.mannlib.vitro.webapp.dynapi.components.Resource;
 import edu.cornell.mannlib.vitro.webapp.modelaccess.ContextModelAccess;
 import edu.cornell.mannlib.vitro.webapp.modelaccess.ModelAccess;
@@ -18,43 +21,124 @@ import edu.cornell.mannlib.vitro.webapp.utils.configuration.ConfigurationBeanLoa
 
 public class ResourcePool {
 
- 	private static final Log log = LogFactory.getLog(ResourcePool.class);
-	private static ResourcePool INSTANCE;
+	private static final Log log = LogFactory.getLog(ResourcePool.class);
+
+	private static ResourcePool INSTANCE = null;
+
+	private static Object mutex = new Object();
+
+	private ConcurrentHashMap<String, Resource> resources;
+	private ServletContext ctx;
+	private ConfigurationBeanLoader loader;
 	private ContextModelAccess modelAccess;
 	private OntModel dynamicAPIModel;
-	private ConfigurationBeanLoader loader;
-	private HashMap<String, Resource> resources;
-	private ServletContext ctx;
+	private ConcurrentLinkedQueue<Resource> obsoleteResources;
 
 	private ResourcePool() {
-		this.resources = new HashMap<String,Resource>();
+		resources = new ConcurrentHashMap<>();
+		obsoleteResources = new ConcurrentLinkedQueue<>();
 		INSTANCE = this;
 	}
+
 	public static ResourcePool getInstance() {
-		if (INSTANCE == null) {
-			INSTANCE = new ResourcePool();
+		ResourcePool result = INSTANCE;
+		if (result == null) {
+			synchronized (mutex) {
+				result = INSTANCE;
+				if (result == null) {
+					INSTANCE = new ResourcePool();
+					result = INSTANCE;
+				}
+			}
 		}
-		return INSTANCE;
+		return result;
+	}
+
+	/**
+	 * Returns a resource and registers current thread as resource client.
+	 *
+	 * @param name
+	 * @return resource
+	 */
+	public Resource getByName(String name) {
+		Resource resource = resources.get(name);
+		if (resource == null) {
+			resource = new DefaultResource();
+		} else {
+			resource.addClient();
+		}
+		return resource;
+	}
+
+	public void printResourceNames() {
+		for (Map.Entry<String, Resource> entry : resources.entrySet()) {
+			log.debug("Resource in pool: '" + entry.getKey() + "'");
+		}
+	}
+
+	public synchronized void reload() {
+		if (ctx == null ) {
+			log.error("Context is null. Can't reload resource pool.");
+			return;
+		}
+		if (loader == null ) {
+			log.error("Loader is null. Can't reload resource pool.");
+			return;
+		}
+		ConcurrentHashMap<String, Resource> newResources = new ConcurrentHashMap<>();
+		loadResources(newResources);
+		ConcurrentHashMap<String, Resource> oldResources = this.resources;
+		this.resources = newResources;
+		for (Map.Entry<String, Resource> resource : oldResources.entrySet()) {
+			obsoleteResources.add(resource.getValue());
+			oldResources.remove(resource.getKey());
+		}
+		unloadObsoleteResources();
 	}
 
 	public void init(ServletContext ctx) {
 			this.ctx = ctx;
 			modelAccess = ModelAccess.on(ctx);
 			dynamicAPIModel = modelAccess.getOntModel(FULL_UNION);
-			loader = new ConfigurationBeanLoader(	dynamicAPIModel, ctx);
-			loadResources();
+			loader = new ConfigurationBeanLoader(dynamicAPIModel, ctx);
+			loadResources(resources);
+	}
+
+	public long obsoleteResourcesCount() {
+		return obsoleteResources.size();
 	}
 	
-	private void loadResources() {
-		Set<Resource> resources = loader.loadEach(Resource.class);
+	public long resourcesCount() {
+		return resources.size();
+	}
+	
+	private void loadResources(ConcurrentHashMap<String, Resource> resources) {
+		Set<Resource> newResources = loader.loadEach(Resource.class);
 		log.debug("Context Initialization. resources created: " + resources.size());
-		for (Resource resource : resources) {
-			add(resource);
+		for (Resource resource : newResources) {
+			resources.put(resource.getName(), resource);
 		}
 		log.debug("Context Initialization finished. " + resources.size() + " resources loaded.");
 	}
 
-	private void add(Resource resource) {
-		resources.put(resource.getName(), resource);
+	private void unloadObsoleteResources() {
+		for (Resource resource : obsoleteResources) {
+			if (!isResourceInUse(resource)) {
+				resource.dereference();
+				obsoleteResources.remove(resource);
+			} 
+		}
 	}
+	
+	private boolean isResourceInUse(Resource resource) {
+		if (!resource.hasClients()) {
+			return false;
+		}
+		resource.removeDeadClients();
+		if (!resource.hasClients()) {
+			return false;
+		}
+		return true;
+	}
+
 }

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/dynapi/components/Action.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/dynapi/components/Action.java
@@ -79,6 +79,6 @@ public class Action implements RunnableComponent {
 	}
 
 	public boolean hasClients() {
-		return clients.size() != 0;
+		return !clients.isEmpty();
 	}
 }

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/dynapi/components/DefaultResource.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/dynapi/components/DefaultResource.java
@@ -1,0 +1,10 @@
+package edu.cornell.mannlib.vitro.webapp.dynapi.components;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+public class DefaultResource extends Resource {
+
+	private static final Log log = LogFactory.getLog(DefaultResource.class);
+
+}

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/dynapi/components/Resource.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/dynapi/components/Resource.java
@@ -2,6 +2,10 @@ package edu.cornell.mannlib.vitro.webapp.dynapi.components;
 
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -20,6 +24,8 @@ public class Resource implements Removable {
 	private RPC rpcOnPut;
 	private RPC rpcOnPatch;
 	private List<CustomAction> customActions = new LinkedList<CustomAction>();
+
+	private Set<Long> clients = ConcurrentHashMap.newKeySet();
 
 	public String getVersionMin() {
 		return versionMin;
@@ -103,5 +109,30 @@ public class Resource implements Removable {
 		// TODO Auto-generated method stub
 		
 	}
-	
+
+	public void addClient() {
+		clients.add(Thread.currentThread().getId());
+	}
+
+	public void removeClient() {
+		clients.remove(Thread.currentThread().getId());
+	}
+
+	public void removeDeadClients() {
+		Map<Long, Boolean> currentThreadIds = Thread
+				.getAllStackTraces()
+				.keySet()
+				.stream()
+				.collect(Collectors.toMap(Thread::getId, Thread::isAlive));
+		for (Long client : clients) {
+			if (!currentThreadIds.containsKey(client) || currentThreadIds.get(client) == false) {
+				clients.remove(client);
+			}
+		}
+	}
+
+	public boolean hasClients() {
+		return !clients.isEmpty();
+	}
+
 }

--- a/api/src/test/java/edu/cornell/mannlib/vitro/webapp/dynapi/ResourcePoolTest.java
+++ b/api/src/test/java/edu/cornell/mannlib/vitro/webapp/dynapi/ResourcePoolTest.java
@@ -1,0 +1,200 @@
+package edu.cornell.mannlib.vitro.webapp.dynapi;
+
+import static java.lang.String.format;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.util.concurrent.CompletableFuture;
+
+import org.junit.After;
+import org.junit.Test;
+
+import edu.cornell.mannlib.vitro.webapp.dynapi.components.DefaultResource;
+import edu.cornell.mannlib.vitro.webapp.dynapi.components.Resource;
+
+public class ResourcePoolTest extends ServletContextTest {
+
+    @After
+    public void reset() {
+        setup();
+
+        ActionPool actionPool = ActionPool.getInstance();
+        actionPool.init(servletContext);
+        actionPool.reload();
+
+        ResourcePool resourcePool = ResourcePool.getInstance();
+        resourcePool.init(servletContext);
+        resourcePool.reload();
+    }
+
+    @Test
+    public void testGetInstance() {
+        ResourcePool resourcePool = ResourcePool.getInstance();
+        assertNotNull(resourcePool);
+        assertEquals(resourcePool, ResourcePool.getInstance());
+    }
+
+    @Test
+    public void testGetByNameBeforeInit() {
+        ResourcePool resourcePool = ResourcePool.getInstance();
+        Resource resource = resourcePool.getByName(TEST_RESOURCE_NAME);
+        assertNotNull(resource);
+        assertTrue(resource instanceof DefaultResource);
+    }
+
+    @Test
+    public void testPrintActionNamesBeforeInit() {
+        ResourcePool resourcePool = ResourcePool.getInstance();
+        resourcePool.printResourceNames();
+        // nothing to assert
+    }
+
+    @Test
+    public void testReloadBeforeInit() throws IOException {
+        ResourcePool resourcePool = ResourcePool.getInstance();
+        resourcePool.reload();
+        // not sure what to assert
+    }
+
+    @Test
+    public void testInit() throws IOException {
+        ResourcePool resourcePool = initWithDefaultModel();
+
+        assertResourceByName(resourcePool.getByName(TEST_RESOURCE_NAME), TEST_RESOURCE_NAME, TEST_ACTION_NAME);
+    }
+
+    @Test
+    public void testPrintActionNames() throws IOException {
+        ResourcePool resourcePool = initWithDefaultModel();
+
+        resourcePool.printResourceNames();
+        // nothing to assert
+    }
+
+    @Test
+    public void testReload() throws IOException {
+        ResourcePool resourcePool = initWithDefaultModel();
+
+        assertResourceByName(resourcePool.getByName(TEST_RESOURCE_NAME), TEST_RESOURCE_NAME, TEST_ACTION_NAME);
+
+        loadReloadModel();
+
+        resourcePool.reload();
+
+        assertResourceByName(resourcePool.getByName(TEST_RELOAD_RESOURCE_NAME), TEST_RELOAD_RESOURCE_NAME, TEST_RELOAD_ACTION_NAME);
+    }
+
+    @Test
+    public void testReloadThreadSafety() throws IOException {
+        ResourcePool resourcePool = initWithDefaultModel();
+
+        assertResourceByName(resourcePool.getByName(TEST_RESOURCE_NAME), TEST_RESOURCE_NAME, TEST_ACTION_NAME);
+
+        loadReloadModel();
+
+        CompletableFuture<Void> reloadFuture = CompletableFuture.runAsync(() -> resourcePool.reload());
+
+        while (!reloadFuture.isDone()) {
+            assertResourceByName(resourcePool.getByName(TEST_RESOURCE_NAME), TEST_RESOURCE_NAME, TEST_ACTION_NAME);
+        }
+
+        assertResourceByName(resourcePool.getByName(TEST_RESOURCE_NAME), TEST_RESOURCE_NAME, TEST_ACTION_NAME);
+
+        assertResourceByName(resourcePool.getByName(TEST_RELOAD_RESOURCE_NAME), TEST_RELOAD_RESOURCE_NAME, TEST_RELOAD_ACTION_NAME);
+    }
+
+    @Test
+    public void testRealodOfActionInUse() throws IOException {
+        ResourcePool resourcePool = initWithDefaultModel();
+
+        loadReloadModel();
+
+        Resource resource = resourcePool.getByName(TEST_RESOURCE_NAME);
+
+        CompletableFuture<Void> reloadFuture = CompletableFuture.runAsync(() -> resourcePool.reload());
+
+        while (!reloadFuture.isDone()) {
+            assertEquals(TEST_RESOURCE_NAME, resource.getName());
+        }
+
+        resource.removeClient();
+    }
+
+    @Test
+    public void testClientsManagement() throws IOException, InterruptedException {
+        ResourcePool resourcePool = initWithDefaultModel();
+
+        resourcePool.reload();
+
+        long initalCount = resourcePool.obsoleteResourcesCount();
+        Resource resource = resourcePool.getByName(TEST_RESOURCE_NAME);
+
+        resource.removeClient();
+
+        assertFalse(resource.hasClients());
+
+        Thread t1 = getResourceInThread(resourcePool, TEST_RESOURCE_NAME, TEST_ACTION_NAME);
+
+        t1.join();
+
+        assertTrue(resource.hasClients());
+
+        resourcePool.reload();
+
+        assertEquals(initalCount, resourcePool.obsoleteResourcesCount());
+    }
+
+    private Thread getResourceInThread(ResourcePool resourcePool, String name, String actionName) {
+        Runnable client = new Runnable() {
+            @Override
+            public void run() {
+                Resource resource = resourcePool.getByName(name);
+                assertResourceByName(resource, name, actionName);
+            }
+        };
+        Thread thread = new Thread(client);
+        thread.start();
+        return thread;
+    }
+
+    private ResourcePool initWithDefaultModel() throws IOException {
+        loadDefaultModel();
+
+        ActionPool actionPool = ActionPool.getInstance();
+        actionPool.init(servletContext);
+
+        ResourcePool resourcePool = ResourcePool.getInstance();
+        resourcePool.init(servletContext);
+
+        return resourcePool;
+    }
+
+    private void assertResourceByName(Resource resource, String name, String actionName) {
+        assertNotNull(resource);
+        assertFalse(format("%s not loaded!", name), resource instanceof DefaultResource);
+        assertEquals(name, resource.getName());
+        assertTrue(resource.hasClients());
+
+        String minVer = "0.1.0";
+
+        assertEquals(actionName, resource.getRpcOnGet().getName());
+        // assertEquals("GET", resource.getRpcOnGet().getHttpMethod().getName());
+        assertEquals(minVer, resource.getRpcOnGet().getMinVersion());
+        assertEquals(actionName, resource.getRpcOnPost().getName());
+        assertEquals("POST", resource.getRpcOnPost().getHttpMethod().getName());
+        assertEquals(minVer, resource.getRpcOnPost().getMinVersion());
+        assertEquals(actionName, resource.getRpcOnDelete().getName());
+        // assertEquals("DELETE", resource.getRpcOnDelete().getHttpMethod().getName());
+        assertEquals(minVer, resource.getRpcOnDelete().getMinVersion());
+        assertEquals(actionName, resource.getRpcOnPut().getName());
+        // assertEquals("PUT", resource.getRpcOnPut().getHttpMethod().getName());
+        assertEquals(minVer, resource.getRpcOnPut().getMinVersion());
+        assertEquals(actionName, resource.getRpcOnPatch().getName());
+        // assertEquals("PATCH", resource.getRpcOnPatch().getHttpMethod().getName());
+        assertEquals(minVer, resource.getRpcOnPatch().getMinVersion());
+    }
+
+}

--- a/api/src/test/java/edu/cornell/mannlib/vitro/webapp/dynapi/ServletContextTest.java
+++ b/api/src/test/java/edu/cornell/mannlib/vitro/webapp/dynapi/ServletContextTest.java
@@ -1,0 +1,82 @@
+package edu.cornell.mannlib.vitro.webapp.dynapi;
+
+import static edu.cornell.mannlib.vitro.webapp.modelaccess.ModelNames.FULL_UNION;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.StringReader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.apache.jena.ontology.OntModel;
+import org.apache.jena.rdf.model.ModelFactory;
+import org.junit.Before;
+
+import stubs.edu.cornell.mannlib.vitro.webapp.modelaccess.ContextModelAccessStub;
+import stubs.edu.cornell.mannlib.vitro.webapp.modelaccess.ModelAccessFactoryStub;
+import stubs.javax.servlet.ServletContextStub;
+
+public abstract class ServletContextTest {
+
+    protected final static String TEST_ACTION_NAME = "test_action";
+    protected final static String TEST_RELOAD_ACTION_NAME = "test_reload";
+
+    protected final static String TEST_RESOURCE_NAME = "test_resource";
+    protected final static String TEST_RELOAD_RESOURCE_NAME = "test_reload_resource";
+
+    protected ServletContextStub servletContext;
+    protected ModelAccessFactoryStub modelAccessFactory;
+    protected ContextModelAccessStub contentModelAccess;
+    protected OntModel ontModel;
+
+    @Before
+    public void setup() {
+        servletContext = new ServletContextStub();
+        modelAccessFactory = new ModelAccessFactoryStub();
+
+        contentModelAccess = modelAccessFactory.get(servletContext);
+
+        ontModel = ModelFactory.createOntologyModel();
+
+        contentModelAccess.setOntModel(FULL_UNION, ontModel);
+    }
+
+    protected void loadReloadModel() throws IOException {
+        // reloading action reuses testSparqlQuery1 from testing action
+        loadModel(
+            new RDFFile("N3", "src/test/resources/rdf/abox/filegraph/dynamic-api-individuals-reloading.n3")
+        );
+    }
+
+    protected void loadDefaultModel() throws IOException {
+        loadModel(
+            new RDFFile("N3", "../home/src/main/resources/rdf/tbox/filegraph/dynamic-api-implementation.n3"),
+            new RDFFile("N3", "../home/src/main/resources/rdf/abox/filegraph/dynamic-api-individuals.n3"),
+            new RDFFile("N3", "../home/src/main/resources/rdf/abox/filegraph/dynamic-api-individuals-testing.n3")
+        );
+    }
+
+    protected void loadModel(RDFFile... rdfFiles) throws IOException {
+        for (RDFFile rdfFile : rdfFiles) {
+            String rdf = readRdf(rdfFile.path);
+            ontModel.read(new StringReader(rdf), null, rdfFile.format);
+        }
+    }
+
+    protected String readRdf(String rdfPath) throws IOException {
+        Path path = new File(rdfPath).toPath();
+
+        return new String(Files.readAllBytes(path));
+    }
+
+    protected class RDFFile {
+        private final String format;
+        private final String path;
+
+        private RDFFile(String format, String path) {
+            this.format = format;
+            this.path = path;
+        }
+    }
+
+}


### PR DESCRIPTION
Superseded by #260 

**[VIVO GitHub issue](https://github.com/vivo-project/VIVO/issues)**: https://github.com/vivo-project/VIVO/issues/3651

# What does this pull request do?
Applies same pool strategy from ActionPool to ResourcePool with test coverage. Minor cleanup.

# What's new?
Resource pool load, reload, and thread safety.

# Interested parties
Tag (@ mention) interested parties or, if unsure, @VIVO-project/vivo-committers
