### PR TITLE
fix: reuse instances in configurationBeanLoader to prevent stack over…

### DIFF
--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/utils/configuration/ConfigurationBeanLoader.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/utils/configuration/ConfigurationBeanLoader.java
@@ -140,13 +140,13 @@ public class ConfigurationBeanLoader {
 	/**
 	 * Load the instance with this URI, if it is assignable to this class.
 	 */
-  public <T> T loadInstance(String uri, Class<T> resultClass) throws ConfigurationBeanLoaderException {
-    instancesMap.clear();
-    T result = loadSubordinateInstance(uri, resultClass);
-    instancesMap.clear();
-    return result;
-  }
-	
+	public <T> T loadInstance(String uri, Class<T> resultClass) throws ConfigurationBeanLoaderException {
+		instancesMap.clear();
+		T result = loadSubordinateInstance(uri, resultClass);
+		instancesMap.clear();
+		return result;
+	}
+
 	protected <T> T loadSubordinateInstance(String uri, Class<T> resultClass)
 			throws ConfigurationBeanLoaderException {
 		if (uri == null) {
@@ -156,9 +156,9 @@ public class ConfigurationBeanLoader {
 			throw new NullPointerException("resultClass may not be null.");
 		}
 		if (instancesMap.containsKey(uri)) {
-		  try {
-		    T t = (T) instancesMap.get(uri);
-        return t;
+			try {
+				T t = (T) instancesMap.get(uri);
+				return t;
 		  } catch (ClassCastException e) {
 		    throw new ConfigurationBeanLoaderException(uri, e);
 		  }

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/utils/configuration/ConfigurationBeanLoader.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/utils/configuration/ConfigurationBeanLoader.java
@@ -4,8 +4,10 @@ package edu.cornell.mannlib.vitro.webapp.utils.configuration;
 
 import static org.apache.jena.rdf.model.ResourceFactory.createResource;
 
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.TreeSet;
@@ -32,6 +34,9 @@ public class ConfigurationBeanLoader {
 
 	private static final String JAVA_URI_PREFIX = "java:";
 
+  Map<String, Object> instancesMap = new HashMap<String,Object>();
+
+	
 	// ----------------------------------------------------------------------
 	// utility methods
 	// ----------------------------------------------------------------------
@@ -135,7 +140,14 @@ public class ConfigurationBeanLoader {
 	/**
 	 * Load the instance with this URI, if it is assignable to this class.
 	 */
-	public <T> T loadInstance(String uri, Class<T> resultClass)
+  public <T> T loadInstance(String uri, Class<T> resultClass) throws ConfigurationBeanLoaderException {
+    instancesMap.clear();
+    T result = loadSubordinateInstance(uri, resultClass);
+    instancesMap.clear();
+    return result;
+  }
+	
+	protected <T> T loadSubordinateInstance(String uri, Class<T> resultClass)
 			throws ConfigurationBeanLoaderException {
 		if (uri == null) {
 			throw new NullPointerException("uri may not be null.");
@@ -143,7 +155,15 @@ public class ConfigurationBeanLoader {
 		if (resultClass == null) {
 			throw new NullPointerException("resultClass may not be null.");
 		}
-
+		if (instancesMap.containsKey(uri)) {
+		  try {
+		    T t = (T) instancesMap.get(uri);
+        return t;
+		  } catch (ClassCastException e) {
+		    throw new ConfigurationBeanLoaderException(uri, e);
+		  }
+		}
+		
 		try {
 			ConfigurationRdf<T> parsedRdf = ConfigurationRdfParser
 					.parse(locking, uri, resultClass);
@@ -151,6 +171,7 @@ public class ConfigurationBeanLoader {
 					.wrap(parsedRdf.getConcreteClass());
 			wrapper.satisfyInterfaces(ctx, req);
 			wrapper.checkCardinality(parsedRdf.getPropertyStatements());
+			instancesMap.put(uri, wrapper.getInstance());
 			wrapper.setProperties(this, parsedRdf.getPropertyStatements());
 			wrapper.validate();
 			return wrapper.getInstance();

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/utils/configuration/WrappedInstance.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/utils/configuration/WrappedInstance.java
@@ -120,8 +120,7 @@ public class WrappedInstance<T> {
 
 			if (ps instanceof ResourcePropertyStatement) {
 				ResourcePropertyStatement rps = (ResourcePropertyStatement) ps;
-				Object subordinate = loader.loadInstance(rps.getValue(),
-						pm.getParameterType());
+				Object subordinate = loader.loadSubordinateInstance(rps.getValue(), pm.getParameterType());
 				pm.invoke(instance, subordinate);
 			} else {
 				pm.invoke(instance, ps.getValue());

--- a/api/src/test/java/edu/cornell/mannlib/vitro/webapp/utils/configuration/ConfigurationBeanLoaderTest.java
+++ b/api/src/test/java/edu/cornell/mannlib/vitro/webapp/utils/configuration/ConfigurationBeanLoaderTest.java
@@ -9,6 +9,7 @@ import static edu.cornell.mannlib.vitro.webapp.utils.configuration.Configuration
 import static org.apache.jena.datatypes.xsd.XSDDatatype.XSDfloat;
 import static org.apache.jena.datatypes.xsd.XSDDatatype.XSDstring;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -24,6 +25,7 @@ import org.apache.jena.rdf.model.Statement;
 import org.junit.Ignore;
 import org.junit.Test;
 
+import edu.cornell.mannlib.vitro.webapp.dynapi.components.OperationalStep;
 import edu.cornell.mannlib.vitro.webapp.modelaccess.ContextModelAccess;
 import edu.cornell.mannlib.vitro.webapp.modelaccess.RequestModelAccess;
 import edu.cornell.mannlib.vitro.webapp.utils.configuration.ConfigurationRdfParser.InvalidConfigurationRdfException;
@@ -31,13 +33,6 @@ import edu.cornell.mannlib.vitro.webapp.utils.configuration.InstanceWrapper.Inst
 import edu.cornell.mannlib.vitro.webapp.utils.configuration.PropertyType.PropertyTypeException;
 import edu.cornell.mannlib.vitro.webapp.utils.configuration.WrappedInstance.ResourceUnavailableException;
 
-/**
- * TODO
- *
- * Circularity prevention. Before setting properties, create a WeakMap of
- * instances by URIs, so if a property refers to a created instance, we just
- * pass it in.
- */
 public class ConfigurationBeanLoaderTest extends
 		ConfigurationBeanLoaderTestBase {
 
@@ -394,6 +389,19 @@ public class ConfigurationBeanLoaderTest extends
 	public static class SimpleSuccess {
 		// Nothing of interest.
 	}
+	
+  public static class Friend {
+
+    public Friend() {
+      
+    }
+    Friend friend;
+
+    @Property(uri = "http://set.friend/property")
+    public void setFriend(Friend friend) {
+      this.friend = friend;
+    }
+  }
 
 	// --------------------------------------------
 
@@ -673,6 +681,21 @@ public class ConfigurationBeanLoaderTest extends
 		Set<SimpleSuccess> instances = loader.loadAll(SimpleSuccess.class);
 		assertEquals(1, instances.size());
 	}
+	
+	// --------------------------------------------
+	
+	 @Test
+	  public void loop_test() throws ConfigurationBeanLoaderException {
+	    model.add(new Statement[] {
+	        typeStatement("http://friend.instance/one", toJavaUri(Friend.class)),
+	        typeStatement("http://friend.instance/two", toJavaUri(Friend.class)),
+	        objectProperty("http://friend.instance/one", "http://set.friend/property", "http://friend.instance/two"),
+	        objectProperty("http://friend.instance/two", "http://set.friend/property", "http://friend.instance/one") });
+
+	    Friend friend = loader.loadInstance("http://friend.instance/one", Friend.class);
+	    assertNotEquals(friend, friend.friend);
+	    assertEquals(friend, friend.friend.friend);
+	  }
 
 	// --------------------------------------------
 

--- a/api/src/test/java/edu/cornell/mannlib/vitro/webapp/utils/configuration/ConfigurationBeanLoaderTest.java
+++ b/api/src/test/java/edu/cornell/mannlib/vitro/webapp/utils/configuration/ConfigurationBeanLoaderTest.java
@@ -390,18 +390,18 @@ public class ConfigurationBeanLoaderTest extends
 		// Nothing of interest.
 	}
 	
-  public static class Friend {
+	public static class Friend {
 
-    public Friend() {
-      
-    }
-    Friend friend;
+		public Friend() {
 
-    @Property(uri = "http://set.friend/property")
-    public void setFriend(Friend friend) {
-      this.friend = friend;
-    }
-  }
+		}
+		Friend friend;
+
+		@Property(uri = "http://set.friend/property")
+		public void setFriend(Friend friend) {
+			this.friend = friend;
+		}
+	}
 
 	// --------------------------------------------
 


### PR DESCRIPTION
**[VIVO GitHub issue](https://github.com/vivo-project/VIVO/issues/3675)**: (please link to issue)

- Added map of created objects to prevent creation of duplicates for each requested instance.
- Adds loop test for configuration bean loader


# Interested parties
Tag (@ mention) interested parties or, if unsure, @VIVO-project/vivo-committers
