### PR TITLE
[3654] Add parameter types to individuals.

### DIFF
--- a/home/src/main/resources/rdf/abox/filegraph/dynamic-api-individuals.n3
+++ b/home/src/main/resources/rdf/abox/filegraph/dynamic-api-individuals.n3
@@ -24,34 +24,6 @@
         rdfs:label              "Is integer"@en-US ;
         vitro:mostSpecificType  dynapi:validator .
 
-<https://vivoweb.org/ontology/vitro-dynamic-api/parameter/validator/IsMaxLength>
-        a                       dynapi:validator ,
-                                dynapi_java:validators.Validator ,
-                                dynapi_java:validators.IsMaxLength ;
-        rdfs:label              "Is max length"@en-US ;
-        vitro:mostSpecificType  dynapi:validator .
-
-<https://vivoweb.org/ontology/vitro-dynamic-api/parameter/validator/IsMaxValue>
-        a                       dynapi:validator ,
-                                dynapi_java:validators.Validator ,
-                                dynapi_java:validators.IsMaxValue ;
-        rdfs:label              "Is max value"@en-US ;
-        vitro:mostSpecificType  dynapi:validator .
-
-<https://vivoweb.org/ontology/vitro-dynamic-api/parameter/validator/IsMinValue>
-        a                       dynapi:validator ,
-                                dynapi_java:validators.Validator ,
-                                dynapi_java:validators.IsMinValue ;
-        rdfs:label              "Is min value"@en-US ;
-        vitro:mostSpecificType  dynapi:validator .
-
-<https://vivoweb.org/ontology/vitro-dynamic-api/parameter/validator/IsRegex>
-        a                       dynapi:validator ,
-                                dynapi_java:validators.Validator ,
-                                dynapi_java:validators.IsRegex ;
-        rdfs:label              "Is regular expression"@en-US ;
-        vitro:mostSpecificType  dynapi:validator .
-
 #-------------------------------------------------------------------------------
 #
 # Parameter types

--- a/home/src/main/resources/rdf/abox/filegraph/dynamic-api-individuals.n3
+++ b/home/src/main/resources/rdf/abox/filegraph/dynamic-api-individuals.n3
@@ -20,8 +20,36 @@
 <https://vivoweb.org/ontology/vitro-dynamic-api/parameter/validator/IsInteger>
         a                       dynapi:validator ,
                                 dynapi_java:validators.Validator ,
-                                dynapi_java:validators.IsInteger;
+                                dynapi_java:validators.IsInteger ;
         rdfs:label              "Is integer"@en-US ;
+        vitro:mostSpecificType  dynapi:validator .
+
+<https://vivoweb.org/ontology/vitro-dynamic-api/parameter/validator/IsMaxLength>
+        a                       dynapi:validator ,
+                                dynapi_java:validators.Validator ,
+                                dynapi_java:validators.IsMaxLength ;
+        rdfs:label              "Is max length"@en-US ;
+        vitro:mostSpecificType  dynapi:validator .
+
+<https://vivoweb.org/ontology/vitro-dynamic-api/parameter/validator/IsMaxValue>
+        a                       dynapi:validator ,
+                                dynapi_java:validators.Validator ,
+                                dynapi_java:validators.IsMaxValue ;
+        rdfs:label              "Is max value"@en-US ;
+        vitro:mostSpecificType  dynapi:validator .
+
+<https://vivoweb.org/ontology/vitro-dynamic-api/parameter/validator/IsMinValue>
+        a                       dynapi:validator ,
+                                dynapi_java:validators.Validator ,
+                                dynapi_java:validators.IsMinValue ;
+        rdfs:label              "Is min value"@en-US ;
+        vitro:mostSpecificType  dynapi:validator .
+
+<https://vivoweb.org/ontology/vitro-dynamic-api/parameter/validator/IsRegex>
+        a                       dynapi:validator ,
+                                dynapi_java:validators.Validator ,
+                                dynapi_java:validators.IsRegex ;
+        rdfs:label              "Is regular expression"@en-US ;
         vitro:mostSpecificType  dynapi:validator .
 
 #-------------------------------------------------------------------------------
@@ -29,11 +57,46 @@
 # Parameter types
 #
 
+<https://vivoweb.org/ontology/vitro-dynamic-api/parameter/type/XSDboolean>
+        a                       dynapi:parameterType ,
+                                dynapi_java:ParameterType ;
+        dynapi:typeName         "boolean" ;
+        rdfs:label              "Boolean type"@en-US ;
+        vitro:mostSpecificType  dynapi:parameterType .
+
+<https://vivoweb.org/ontology/vitro-dynamic-api/parameter/type/XSDdecimal>
+        a                       dynapi:parameterType ,
+                                dynapi_java:ParameterType ;
+        dynapi:typeName         "decimal" ;
+        rdfs:label              "Decimal type"@en-US ;
+        vitro:mostSpecificType  dynapi:parameterType .
+
 <https://vivoweb.org/ontology/vitro-dynamic-api/parameter/type/XSDinteger>
         a                       dynapi:parameterType ,
-                                dynapi_java:ParameterType;
-        dynapi:typeName         "integer" ;        
+                                dynapi_java:ParameterType ;
+        dynapi:typeName         "integer" ;
         rdfs:label              "Integer type"@en-US ;
+        vitro:mostSpecificType  dynapi:parameterType .
+
+<https://vivoweb.org/ontology/vitro-dynamic-api/parameter/type/XSDindividual>
+        a                       dynapi:parameterType ,
+                                dynapi_java:ParameterType ;
+        dynapi:typeName         "individual" ;
+        rdfs:label              "Individual type"@en-US ;
+        vitro:mostSpecificType  dynapi:parameterType .
+
+<https://vivoweb.org/ontology/vitro-dynamic-api/parameter/type/XSDlist>
+        a                       dynapi:parameterType ,
+                                dynapi_java:ParameterType ;
+        dynapi:typeName         "list" ;
+        rdfs:label              "List type"@en-US ;
+        vitro:mostSpecificType  dynapi:parameterType .
+
+<https://vivoweb.org/ontology/vitro-dynamic-api/parameter/type/XSDstring>
+        a                       dynapi:parameterType ,
+                                dynapi_java:ParameterType ;
+        dynapi:typeName         "string" ;
+        rdfs:label              "String type"@en-US ;
         vitro:mostSpecificType  dynapi:parameterType .
 
 #-------------------------------------------------------------------------------
@@ -43,43 +106,43 @@
 
 <https://vivoweb.org/ontology/vitro-dynamic-api/model/tbox_assertions>
         a                       dynapi:model ;
-        dynapi:modelName        "TBOX_ASSERTIONS" ;        
+        dynapi:modelName        "TBOX_ASSERTIONS" ;
         rdfs:label              "tbox assertions model"@en-US ;
         vitro:mostSpecificType  dynapi:model .
 
 <https://vivoweb.org/ontology/vitro-dynamic-api/model/abox_assertions>
         a                       dynapi:model ;
-        dynapi:modelName        "ABOX_ASSERTIONS";        
+        dynapi:modelName        "ABOX_ASSERTIONS" ;
         rdfs:label              "abox assertions model"@en-US ;
         vitro:mostSpecificType  dynapi:model .
 
 <https://vivoweb.org/ontology/vitro-dynamic-api/model/abox_union>
         a                       dynapi:model ;
-        dynapi:modelName        "ABOX_UNION" ;        
+        dynapi:modelName        "ABOX_UNION" ;
         rdfs:label              "abox union model"@en-US ;
         vitro:mostSpecificType  dynapi:model .
 
 <https://vivoweb.org/ontology/vitro-dynamic-api/model/tbox_union>
         a                       dynapi:model ;
-        dynapi:modelName        "TBOX_UNION" ;        
+        dynapi:modelName        "TBOX_UNION" ;
         rdfs:label              "tbox union model"@en-US ;
         vitro:mostSpecificType  dynapi:model .
 
 <https://vivoweb.org/ontology/vitro-dynamic-api/model/full_union>
         a                       dynapi:model ;
-        dynapi:modelName        "FULL_UNION" ;        
+        dynapi:modelName        "FULL_UNION" ;
         rdfs:label              "full union model"@en-US ;
         vitro:mostSpecificType  dynapi:model .
 
 <https://vivoweb.org/ontology/vitro-dynamic-api/model/application_metadata>
         a                       dynapi:model ;
-        dynapi:modelName        "APPLICATION_METADATA" ;        
+        dynapi:modelName        "APPLICATION_METADATA" ;
         rdfs:label              "application metadata model"@en-US ;
         vitro:mostSpecificType  dynapi:model .
 
 <https://vivoweb.org/ontology/vitro-dynamic-api/model/user_accounts>
         a                       dynapi:model ;
-        dynapi:modelName        "USER_ACCOUNTS" ;        
+        dynapi:modelName        "USER_ACCOUNTS" ;
         rdfs:label              "user accounts model"@en-US ;
         vitro:mostSpecificType  dynapi:model .
 
@@ -90,42 +153,36 @@
 
 <https://vivoweb.org/ontology/vitro-dynamic-api/http_method/get>
         a                       dynapi:httpMethod ;
-        dynapi:methodName       "GET" ;        
+        dynapi:methodName       "GET" ;
         rdfs:label              "HTTP GET method"@en-US ;
         vitro:mostSpecificType  dynapi:httpMethod .
 
 <https://vivoweb.org/ontology/vitro-dynamic-api/http_method/post>
         a                       dynapi:httpMethod ;
-        dynapi:methodName       "POST" ;        
+        dynapi:methodName       "POST" ;
         rdfs:label              "HTTP POST method"@en-US ;
         vitro:mostSpecificType  dynapi:httpMethod .
 
 <https://vivoweb.org/ontology/vitro-dynamic-api/http_method/put>
         a                       dynapi:httpMethod ;
-        dynapi:methodName       "PUT" ;        
+        dynapi:methodName       "PUT" ;
         rdfs:label              "HTTP PUT method"@en-US ;
         vitro:mostSpecificType  dynapi:httpMethod .
 
 <https://vivoweb.org/ontology/vitro-dynamic-api/http_method/patch>
         a                       dynapi:httpMethod ;
-        dynapi:methodName       "PATCH" ;        
+        dynapi:methodName       "PATCH" ;
         rdfs:label              "HTTP PATCH method"@en-US ;
         vitro:mostSpecificType  dynapi:httpMethod .
 
 <https://vivoweb.org/ontology/vitro-dynamic-api/http_method/delete>
         a                       dynapi:httpMethod ;
-        dynapi:methodName       "DELETE" ;        
+        dynapi:methodName       "DELETE" ;
         rdfs:label              "HTTP DELETE method"@en-US ;
         vitro:mostSpecificType  dynapi:httpMethod .
 
 <https://vivoweb.org/ontology/vitro-dynamic-api/http_method/options>
         a                       dynapi:httpMethod ;
-        dynapi:methodName       "OPTIONS" ;        
+        dynapi:methodName       "OPTIONS" ;
         rdfs:label              "HTTP OPTIONS method"@en-US ;
         vitro:mostSpecificType  dynapi:httpMethod .
-
-
-
-
-
-


### PR DESCRIPTION
**[VIVO GitHub issue 3654](https://github.com/vivo-project/VIVO/issues/3654)**:

# What does this pull request do?
Add additional Parameter Types and Validators to the dynamic-api-individuals.n3 file.

# What's new?

* Cleaned up syntax.
* Added XSDboolean parameter type.
* Added XSDdecimal parameter type.
* Added XSDindividual parameter type.
* Added XSDlist parameter type.
* Added XSDstring parameter type.

# How should this be tested?
A description of what steps someone could take to:
* Reproduce the problem you are fixing (if applicable)
* Test that the pull request does what is intended.

# Additional Notes:
Should specific Individual types be created, such as: XSDResearcher, XSDOrganization, XSDProject, XSDPublication?

# Interested parties
Tag (@ mention) interested parties or, if unsure, @VIVO-project/vivo-committers
