### PR TITLE
[3654] adding validators for parameters

### DIFF
--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/dynapi/components/validators/AbstractValidator.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/dynapi/components/validators/AbstractValidator.java
@@ -1,8 +1,10 @@
 package edu.cornell.mannlib.vitro.webapp.dynapi.components.validators;
 
+import edu.cornell.mannlib.vitro.webapp.utils.configuration.Property;
+
 public abstract class AbstractValidator implements Validator {
 
-	
+
 	private String name;
 	
 	@Override
@@ -14,7 +16,7 @@ public abstract class AbstractValidator implements Validator {
 		return name;
 	}
 
-	@Override
+	@Property(uri = "https://vivoweb.org/ontology/vitro-dynamic-api#validatorName", minOccurs = 0, maxOccurs = 1)
 	public void setName(String name) {
 		this.name = name;
 	}

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/dynapi/components/validators/AbstractValidator.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/dynapi/components/validators/AbstractValidator.java
@@ -4,21 +4,8 @@ import edu.cornell.mannlib.vitro.webapp.utils.configuration.Property;
 
 public abstract class AbstractValidator implements Validator {
 
-
-	private String name;
-	
 	@Override
 	public void dereference() {
-	}
-
-	@Override
-	public String getName() {
-		return name;
-	}
-
-	@Property(uri = "https://vivoweb.org/ontology/vitro-dynamic-api#validatorName", minOccurs = 0, maxOccurs = 1)
-	public void setName(String name) {
-		this.name = name;
 	}
 
 }

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/dynapi/components/validators/IsInteger.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/dynapi/components/validators/IsInteger.java
@@ -13,18 +13,20 @@ public class IsInteger extends IsNotBlank {
 		if (!super.isValid(name, values)) {
 			return false;
 		}
-		
-		if (!isInteger(values[0])) {
-			return false;
+
+		for (String value : values) {
+			if (!isInteger(values[0])) {
+				return false;
+			}
 		}
 		return true;
 	}
 
 	private boolean isInteger(String string) {
-		//TODO: Do the real check 
-		if (NumberUtils.isParsable(string)) {
+		if (NumberUtils.isDigits(string)) {
 			 return true;	
 		}
+		log.debug("Value is not a number. Validation failed.");
 		return false;
 	}
 }

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/dynapi/components/validators/NumericRangeValidator.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/dynapi/components/validators/NumericRangeValidator.java
@@ -1,0 +1,61 @@
+package edu.cornell.mannlib.vitro.webapp.dynapi.components.validators;
+
+import edu.cornell.mannlib.vitro.webapp.utils.configuration.Property;
+import org.apache.commons.lang3.math.NumberUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+public class NumericRangeValidator extends IsNotBlank {
+	
+	private static final Log log = LogFactory.getLog(NumericRangeValidator.class);
+
+	private Float minValue;
+
+	private Float maxValue;
+
+	public Float getMinValue() {
+		return minValue;
+	}
+
+	@Property(uri = "https://vivoweb.org/ontology/vitro-dynamic-api#validatorMinNumericValue", minOccurs = 1, maxOccurs = 1)
+	public void setMinValue(float minValue) {
+		this.minValue = minValue;
+	}
+
+	public Float getMaxValue() {
+		return maxValue;
+	}
+
+	@Property(uri = "https://vivoweb.org/ontology/vitro-dynamic-api#validatorMaxNumericValue", minOccurs = 1, maxOccurs = 1)
+	public void setMaxValue(float maxValue) {
+		this.maxValue = maxValue;
+	}
+
+	@Override
+	public boolean isValid(String name, String[] values) {
+		if (!super.isValid(name, values)) {
+			return false;
+		}
+		for (String value : values) {
+			if (!isInRange(value)) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	private boolean isInRange(String string) {
+		if (NumberUtils.isParsable(string)) {
+			double value = NumberUtils.toDouble(string);
+
+			if ((minValue != null) && (value < minValue))
+				return false;
+
+			if ((maxValue != null) && (value > maxValue))
+				return false;
+
+			return true;
+		}
+		return false;
+	}
+}

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/dynapi/components/validators/NumericRangeValidator.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/dynapi/components/validators/NumericRangeValidator.java
@@ -17,7 +17,7 @@ public class NumericRangeValidator extends IsNotBlank {
 		return minValue;
 	}
 
-	@Property(uri = "https://vivoweb.org/ontology/vitro-dynamic-api#validatorMinNumericValue", minOccurs = 1, maxOccurs = 1)
+	@Property(uri = "https://vivoweb.org/ontology/vitro-dynamic-api#validatorMinNumericValue", maxOccurs = 1)
 	public void setMinValue(float minValue) {
 		this.minValue = minValue;
 	}
@@ -26,7 +26,7 @@ public class NumericRangeValidator extends IsNotBlank {
 		return maxValue;
 	}
 
-	@Property(uri = "https://vivoweb.org/ontology/vitro-dynamic-api#validatorMaxNumericValue", minOccurs = 1, maxOccurs = 1)
+	@Property(uri = "https://vivoweb.org/ontology/vitro-dynamic-api#validatorMaxNumericValue", maxOccurs = 1)
 	public void setMaxValue(float maxValue) {
 		this.maxValue = maxValue;
 	}
@@ -38,6 +38,7 @@ public class NumericRangeValidator extends IsNotBlank {
 		}
 		for (String value : values) {
 			if (!isInRange(value)) {
+				log.debug("Value of " + name + " is not in range [" + ((minValue != null)?minValue:" ") + "-" + ((maxValue != null)?maxValue:" ")+"].");
 				return false;
 			}
 		}

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/dynapi/components/validators/RegularExpressionValidator.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/dynapi/components/validators/RegularExpressionValidator.java
@@ -23,11 +23,18 @@ public class RegularExpressionValidator extends AbstractValidator {
 
 	@Override
 	public boolean isValid(String name, String[] values) {
+		if (values.length == 0) {
+			log.debug("No values of " + name + " found. Validation failed.");
+			return false;
+		}
+
 		for (String value : values) {
 			if (!isLengthInRange(value)) {
+				log.debug("Value of " + name + " is not in accordance with the pattern \"" + regularExpression + "\"");
 				return false;
 			}
 		}
+
 		return true;
 	}
 

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/dynapi/components/validators/RegularExpressionValidator.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/dynapi/components/validators/RegularExpressionValidator.java
@@ -1,0 +1,37 @@
+package edu.cornell.mannlib.vitro.webapp.dynapi.components.validators;
+
+import edu.cornell.mannlib.vitro.webapp.utils.configuration.Property;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import java.util.regex.Pattern;
+
+public class RegularExpressionValidator extends AbstractValidator {
+	
+	private static final Log log = LogFactory.getLog(RegularExpressionValidator.class);
+
+	private String regularExpression;
+
+	public String getRegularExpression() {
+		return regularExpression;
+	}
+
+	@Property(uri = "https://vivoweb.org/ontology/vitro-dynamic-api#validatorRegularExpressionValue", minOccurs = 1, maxOccurs = 1)
+	public void setRegularExpression (String regularExpression) {
+		this.regularExpression = regularExpression;
+	}
+
+	@Override
+	public boolean isValid(String name, String[] values) {
+		for (String value : values) {
+			if (!isLengthInRange(value)) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	private boolean isLengthInRange(String string) {
+		return Pattern.matches(regularExpression, string);
+	}
+}

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/dynapi/components/validators/StringLengthRangeValidator.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/dynapi/components/validators/StringLengthRangeValidator.java
@@ -8,26 +8,26 @@ public class StringLengthRangeValidator extends IsNotBlank {
 	
 	private static final Log log = LogFactory.getLog(StringLengthRangeValidator.class);
 
-	private Integer minValue;
+	private Integer minLength;
 
-	private Integer maxValue;
+	private Integer maxLength;
 
-	public Integer getMinValue() {
-		return minValue;
+	public Integer getMinLength() {
+		return minLength;
 	}
 
-	@Property(uri = "https://vivoweb.org/ontology/vitro-dynamic-api#validatorMinNumericValue", minOccurs = 1, maxOccurs = 1)
-	public void setMinValue(int minValue) {
-		this.minValue = minValue;
+	@Property(uri = "https://vivoweb.org/ontology/vitro-dynamic-api#validatorMinLengthValue", maxOccurs = 1)
+	public void setMinLength(int minLength) {
+		this.minLength = minLength;
 	}
 
-	public Integer getMaxValue() {
-		return maxValue;
+	public Integer getMaxLength() {
+		return maxLength;
 	}
 
-	@Property(uri = "https://vivoweb.org/ontology/vitro-dynamic-api#validatorMaxNumericValue", minOccurs = 1, maxOccurs = 1)
-	public void setMaxValue(int maxValue) {
-		this.maxValue = maxValue;
+	@Property(uri = "https://vivoweb.org/ontology/vitro-dynamic-api#validatorMaxLengthValue", maxOccurs = 1)
+	public void setMaxLength(int maxValue) {
+		this.maxLength = maxValue;
 	}
 
 	@Override
@@ -38,6 +38,7 @@ public class StringLengthRangeValidator extends IsNotBlank {
 
 		for (String value : values) {
 			if (!isLengthInRange(value)) {
+				log.debug("Length of " + name + " is not in range [" + ((minLength != null)?minLength:" ") + "-" + ((maxLength != null)?maxLength:" ")+"].");
 				return false;
 			}
 		}
@@ -47,10 +48,10 @@ public class StringLengthRangeValidator extends IsNotBlank {
 	private boolean isLengthInRange(String string) {
 		int length = string.length();
 
-		if ((minValue != null) && (length < minValue))
+		if ((minLength != null) && (length < minLength))
 			return false;
 
-		if ((maxValue != null) && (length > maxValue))
+		if ((maxLength != null) && (length > maxLength))
 			return false;
 
 		return true;

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/dynapi/components/validators/StringLengthRangeValidator.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/dynapi/components/validators/StringLengthRangeValidator.java
@@ -1,0 +1,58 @@
+package edu.cornell.mannlib.vitro.webapp.dynapi.components.validators;
+
+import edu.cornell.mannlib.vitro.webapp.utils.configuration.Property;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+public class StringLengthRangeValidator extends IsNotBlank {
+	
+	private static final Log log = LogFactory.getLog(StringLengthRangeValidator.class);
+
+	private Integer minValue;
+
+	private Integer maxValue;
+
+	public Integer getMinValue() {
+		return minValue;
+	}
+
+	@Property(uri = "https://vivoweb.org/ontology/vitro-dynamic-api#validatorMinNumericValue", minOccurs = 1, maxOccurs = 1)
+	public void setMinValue(int minValue) {
+		this.minValue = minValue;
+	}
+
+	public Integer getMaxValue() {
+		return maxValue;
+	}
+
+	@Property(uri = "https://vivoweb.org/ontology/vitro-dynamic-api#validatorMaxNumericValue", minOccurs = 1, maxOccurs = 1)
+	public void setMaxValue(int maxValue) {
+		this.maxValue = maxValue;
+	}
+
+	@Override
+	public boolean isValid(String name, String[] values) {
+		if (!super.isValid(name, values)) {
+			return false;
+		}
+
+		for (String value : values) {
+			if (!isLengthInRange(value)) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	private boolean isLengthInRange(String string) {
+		int length = string.length();
+
+		if ((minValue != null) && (length < minValue))
+			return false;
+
+		if ((maxValue != null) && (length > maxValue))
+			return false;
+
+		return true;
+	}
+}

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/dynapi/components/validators/Validator.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/dynapi/components/validators/Validator.java
@@ -4,10 +4,6 @@ import edu.cornell.mannlib.vitro.webapp.dynapi.components.Removable;
 
 public interface Validator extends Removable {
 
-	public boolean isValid(String name, String[] values);
-
-	public String getName();
-
-	public void setName(String getName);
+	boolean isValid(String name, String[] values);
 
 }

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/utils/configuration/PropertyType.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/utils/configuration/PropertyType.java
@@ -2,11 +2,6 @@
 
 package edu.cornell.mannlib.vitro.webapp.utils.configuration;
 
-import static org.apache.jena.datatypes.xsd.XSDDatatype.XSDfloat;
-import static org.apache.jena.datatypes.xsd.XSDDatatype.XSDstring;
-import static org.apache.jena.datatypes.xsd.XSDDatatype.XSDdateTime;
-import static org.apache.jena.datatypes.xsd.XSDDatatype.XSDboolean;
-
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 
@@ -15,6 +10,8 @@ import org.apache.jena.datatypes.xsd.impl.RDFLangString;
 import org.apache.jena.rdf.model.Literal;
 import org.apache.jena.rdf.model.RDFNode;
 import org.apache.jena.rdf.model.Statement;
+
+import static org.apache.jena.datatypes.xsd.XSDDatatype.*;
 
 /**
  * An enumeration of the types of properties that the ConfigurationBeanLoader
@@ -60,10 +57,23 @@ public enum PropertyType {
 
 		@Override
 		protected PropertyMethod buildPropertyMethod(Method method,
-				Property annotation) {
+													 Property annotation) {
 			return new FloatPropertyMethod(method, annotation);
 		}
-	}, 
+	},
+	INTEGER {
+		@Override
+		public PropertyStatement buildPropertyStatement(Statement s) {
+			return new IntegerPropertyStatement(s.getPredicate().getURI(), s
+					.getObject().asLiteral().getInt());
+		}
+
+		@Override
+		protected PropertyMethod buildPropertyMethod(Method method,
+													 Property annotation) {
+			return new IntegerPropertyMethod(method, annotation);
+		}
+	},
 	BOOLEAN{
 		@Override
 		public PropertyStatement buildPropertyStatement(Statement s) {
@@ -93,8 +103,13 @@ public enum PropertyType {
 					datatype.equals(XSDdateTime)) {
 				return STRING;
 			}
-			if (datatype.equals(XSDfloat)) {
+			if (datatype.equals(XSDfloat) ||
+					datatype.equals(XSDdecimal)){
 				return FLOAT;
+			}
+			if (datatype.equals(XSDint) ||
+					datatype.equals(XSDinteger)) {
+				return INTEGER;
 			}
 			if (datatype.equals(XSDboolean)) {
 				return BOOLEAN;
@@ -108,6 +123,9 @@ public enum PropertyType {
 			throws PropertyTypeException {
 		if (Float.TYPE.equals(parameterType)) {
 			return FLOAT;
+		}
+		if (Integer.class.equals(parameterType)) {
+			return INTEGER;
 		}
 		if (Boolean.TYPE.equals(parameterType)) {
 			return BOOLEAN;
@@ -201,6 +219,20 @@ public enum PropertyType {
 			return f;
 		}
 	}
+
+	public static class IntegerPropertyStatement extends PropertyStatement {
+		private final int i;
+
+		public IntegerPropertyStatement(String predicateUri, int i) {
+			super(INTEGER, predicateUri);
+			this.i = i;
+		}
+
+		@Override
+		public Integer getValue() {
+			return i;
+		}
+	}
 	
 	public static class BooleanPropertyStatement extends PropertyStatement {
 		private final Boolean bool;
@@ -260,11 +292,18 @@ public enum PropertyType {
 
 		public void confirmCompatible(PropertyStatement ps)
 				throws PropertyTypeException {
-			if (type != ps.getType()) {
+			if (type != ps.getType() &&
+					! (isSubtype(ps.getType(), type))){
 				throw new PropertyTypeException(
 						"Can't apply statement of type " + ps.getType()
 								+ " to a method of type " + type);
 			}
+		}
+
+		private boolean isSubtype(PropertyType subType, PropertyType superType){
+			if (subType.equals(INTEGER) && superType.equals(FLOAT))
+				return true;
+			return false;
 		}
 
 		public void invoke(Object instance, Object value)
@@ -294,6 +333,12 @@ public enum PropertyType {
 	public static class FloatPropertyMethod extends PropertyMethod {
 		public FloatPropertyMethod(Method method, Property annotation) {
 			super(FLOAT, method, annotation);
+		}
+	}
+
+	public static class IntegerPropertyMethod extends PropertyMethod {
+		public IntegerPropertyMethod(Method method, Property annotation) {
+			super(INTEGER, method, annotation);
 		}
 	}
 	

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/utils/configuration/PropertyType.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/utils/configuration/PropertyType.java
@@ -124,7 +124,7 @@ public enum PropertyType {
 		if (Float.TYPE.equals(parameterType)) {
 			return FLOAT;
 		}
-		if (Integer.class.equals(parameterType)) {
+		if (Integer.TYPE.equals(parameterType)) {
 			return INTEGER;
 		}
 		if (Boolean.TYPE.equals(parameterType)) {

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/utils/configuration/PropertyType.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/utils/configuration/PropertyType.java
@@ -29,8 +29,7 @@ public enum PropertyType {
 		}
 
 		@Override
-		protected PropertyMethod buildPropertyMethod(Method method,
-				Property annotation) {
+		protected PropertyMethod buildPropertyMethod(Method method, Property annotation) {
 			return new ResourcePropertyMethod(method, annotation);
 		}
 
@@ -43,8 +42,7 @@ public enum PropertyType {
 		}
 
 		@Override
-		protected PropertyMethod buildPropertyMethod(Method method,
-				Property annotation) {
+		protected PropertyMethod buildPropertyMethod(Method method, Property annotation) {
 			return new StringPropertyMethod(method, annotation);
 		}
 	},
@@ -56,8 +54,7 @@ public enum PropertyType {
 		}
 
 		@Override
-		protected PropertyMethod buildPropertyMethod(Method method,
-													 Property annotation) {
+		protected PropertyMethod buildPropertyMethod(Method method, Property annotation) {
 			return new FloatPropertyMethod(method, annotation);
 		}
 	},
@@ -69,8 +66,7 @@ public enum PropertyType {
 		}
 
 		@Override
-		protected PropertyMethod buildPropertyMethod(Method method,
-													 Property annotation) {
+		protected PropertyMethod buildPropertyMethod(Method method, Property annotation) {
 			return new IntegerPropertyMethod(method, annotation);
 		}
 	},
@@ -82,8 +78,7 @@ public enum PropertyType {
 		}
 
 		@Override
-		protected PropertyMethod buildPropertyMethod(Method method,
-				Property annotation) {
+		protected PropertyMethod buildPropertyMethod(Method method, Property annotation) {
 			return new BooleanPropertyMethod(method, annotation);
 		}
 	};
@@ -146,8 +141,7 @@ public enum PropertyType {
 		return type.buildPropertyStatement(s);
 	}
 
-	public static PropertyMethod createPropertyMethod(Method method,
-			Property annotation) throws PropertyTypeException {
+	public static PropertyMethod createPropertyMethod(Method method, Property annotation) throws PropertyTypeException {
 		Class<?> parameterType = method.getParameterTypes()[0];
 		PropertyType type = PropertyType.typeForParameterType(parameterType);
 		return type.buildPropertyMethod(method, annotation);

--- a/api/src/test/java/edu/cornell/mannlib/vitro/webapp/dynapi/ValidatorsTest.java
+++ b/api/src/test/java/edu/cornell/mannlib/vitro/webapp/dynapi/ValidatorsTest.java
@@ -1,0 +1,125 @@
+package edu.cornell.mannlib.vitro.webapp.dynapi;
+
+import edu.cornell.mannlib.vitro.webapp.dynapi.components.Action;
+import edu.cornell.mannlib.vitro.webapp.dynapi.components.DefaultAction;
+import edu.cornell.mannlib.vitro.webapp.dynapi.components.validators.*;
+import edu.cornell.mannlib.vitro.webapp.utils.configuration.ConfigurationBeanLoaderException;
+import org.junit.After;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.concurrent.CompletableFuture;
+
+import static java.lang.String.format;
+import static org.junit.Assert.*;
+
+public class ValidatorsTest {
+
+    @Test
+    public void testIsIntegerValidator() {
+
+        Validator validator = new IsInteger();
+
+        String fieldName = "field";
+
+        String[] values1 = {"1245","-123"};
+        assertTrue(validator.isValid(fieldName, values1));
+
+        String[] values2 = {"1245.2"};
+        assertFalse(validator.isValid(fieldName, values2));
+    }
+
+    @Test
+    public void testIsNotBlankValidator() {
+
+        Validator validator = new IsNotBlank();
+
+        String fieldName = "field";
+
+        String[] values1 = {};
+        assertFalse(validator.isValid(fieldName, values1));
+
+        String[] values2 = {""};
+        assertFalse(validator.isValid(fieldName, values2));
+
+        String[] values3 = {"a string"};
+        assertTrue(validator.isValid(fieldName, values3));
+    }
+
+    @Test
+    public void testNumericRangeValidator() {
+
+        NumericRangeValidator validator1 = new NumericRangeValidator();
+        validator1.setMaxValue(40.3f);
+        NumericRangeValidator validator2 = new NumericRangeValidator();
+        validator2.setMinValue(36);
+        NumericRangeValidator validator3 = new NumericRangeValidator();
+        validator3.setMinValue(36);
+        validator3.setMaxValue(40.3f);
+
+        String fieldName = "field";
+
+        String[] values1 = {"35"};
+        assertTrue(validator1.isValid(fieldName, values1));
+        assertFalse(validator2.isValid(fieldName, values1));
+        assertFalse(validator3.isValid(fieldName, values1));
+
+        String[] values2 = {"36.3"};
+        assertTrue(validator1.isValid(fieldName, values2));
+        assertTrue(validator2.isValid(fieldName, values2));
+        assertTrue(validator3.isValid(fieldName, values2));
+
+        String[] values3 = {"42"};
+        assertFalse(validator1.isValid(fieldName, values3));
+        assertTrue(validator2.isValid(fieldName, values3));
+        assertFalse(validator3.isValid(fieldName, values3));
+    }
+
+    @Test
+    public void testStringLengthRangeValidator() {
+
+        StringLengthRangeValidator validator1 = new StringLengthRangeValidator();
+        validator1.setMaxLength(7);
+        StringLengthRangeValidator validator2 = new StringLengthRangeValidator();
+        validator2.setMinLength(5);
+        StringLengthRangeValidator validator3 = new StringLengthRangeValidator();
+        validator3.setMinLength(5);
+        validator3.setMaxLength(7);
+
+        String fieldName = "field";
+
+        String[] values1 = {"test"};
+        assertTrue(validator1.isValid(fieldName, values1));
+        assertFalse(validator2.isValid(fieldName, values1));
+        assertFalse(validator3.isValid(fieldName, values1));
+
+        String[] values2 = {"testte"};
+        assertTrue(validator1.isValid(fieldName, values2));
+        assertTrue(validator2.isValid(fieldName, values2));
+        assertTrue(validator3.isValid(fieldName, values2));
+
+        String[] values3 = {"testtest"};
+        assertFalse(validator1.isValid(fieldName, values3));
+        assertTrue(validator2.isValid(fieldName, values3));
+        assertFalse(validator3.isValid(fieldName, values3));
+    }
+
+    @Test
+    public void testRegularExpressionValidator() {
+
+        RegularExpressionValidator validator1 = new RegularExpressionValidator();
+        validator1.setRegularExpression("^(.+)@(\\S+)$");
+
+        String fieldName = "email";
+
+        String[] values1 = {"dragan@uns.ac.rs"};
+        assertTrue(validator1.isValid(fieldName, values1));
+
+        String[] values2 = {"dragan@"};
+        assertFalse(validator1.isValid(fieldName, values2));
+
+        String[] values3 = {"uns.ac.rs"};
+        assertFalse(validator1.isValid(fieldName, values3));
+    }
+
+}

--- a/home/src/main/resources/rdf/abox/filegraph/dynamic-api-individuals-testing.n3
+++ b/home/src/main/resources/rdf/abox/filegraph/dynamic-api-individuals-testing.n3
@@ -8,65 +8,80 @@
 
 
 <https://vivoweb.org/ontology/vitro-dynamic-api/action/testAction1>
-        a                        dynapi:action ;
-        rdfs:label               "Test action"@en-US ;
-        dynapi:assignedRPC       <https://vivoweb.org/ontology/vitro-dynamic-api/rpc/testRPC1> ;
-        dynapi:firstStep         <https://vivoweb.org/ontology/vitro-dynamic-api/step/testStep1> .
+        a                               dynapi:action ;
+        rdfs:label                      "Test action"@en-US ;
+        dynapi:assignedRPC              <https://vivoweb.org/ontology/vitro-dynamic-api/rpc/testRPC1> ;
+        dynapi:firstStep                <https://vivoweb.org/ontology/vitro-dynamic-api/step/testStep1> .
 
 <https://vivoweb.org/ontology/vitro-dynamic-api/step/testStep1>
-        a                        dynapi:step, dynapi:operationalStep ;
-        rdfs:label               "Test operational step 1"@en-US ;
-        dynapi:hasOperation      <https://vivoweb.org/ontology/vitro-dynamic-api/sparqlQuery/testSparqlQuery1> .
+        a                                   dynapi:step, dynapi:operationalStep ;
+        rdfs:label                          "Test operational step 1"@en-US ;
+        dynapi:hasOperation                 <https://vivoweb.org/ontology/vitro-dynamic-api/sparqlQuery/testSparqlQuery1> .
 
 <https://vivoweb.org/ontology/vitro-dynamic-api/sparqlQuery/testSparqlQuery1>
-        a                        dynapi:operation, dynapi:sparqlQuery ;
-        rdfs:label               "Test sparql query 1"@en-US ;
-        dynapi:hasQueryModel     <https://vivoweb.org/ontology/vitro-dynamic-api/model/full_union> ;
-        dynapi:requiresParameter <https://vivoweb.org/ontology/vitro-dynamic-api/parameter/testParam1> ;
-        dynapi:sparqlQueryText   "SELECT ?geoLocation ?label\nWHERE\n{\n      ?geoLocation <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://vivoweb.org/ontology/core#GeographicLocation>\n       OPTIONAL { ?geoLocation <http://www.w3.org/2000/01/rdf-schema#label> ?label } \n}\nLIMIT ?limit" .
+        a                                   dynapi:operation, dynapi:sparqlQuery ;
+        rdfs:label                          "Test sparql query 1"@en-US ;
+        dynapi:hasQueryModel                <https://vivoweb.org/ontology/vitro-dynamic-api/model/full_union> ;
+        dynapi:requiresParameter            <https://vivoweb.org/ontology/vitro-dynamic-api/parameter/testParam1>,
+                                            <https://vivoweb.org/ontology/vitro-dynamic-api/parameter/testParam2> ;
+        dynapi:sparqlQueryText              "SELECT ?geoLocation ?label\nWHERE\n{\n      ?geoLocation <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://vivoweb.org/ontology/core#GeographicLocation>\n       OPTIONAL { ?geoLocation <http://www.w3.org/2000/01/rdf-schema#label> ?label } \n}\nLIMIT ?limit" .
 
 <https://vivoweb.org/ontology/vitro-dynamic-api/parameter/testParam1>
-        a                        dynapi:parameter;
-        dynapi:paramName         "limit";
-        dynapi:hasParameterType  <https://vivoweb.org/ontology/vitro-dynamic-api/parameter/type/XSDinteger> ;
-        dynapi:hasValidator      <https://vivoweb.org/ontology/vitro-dynamic-api/parameter/validator/IsInteger>,
-                                    <https://vivoweb.org/ontology/vitro-dynamic-api/parameter/validator/TestNumericRangeValidator> ;
-        rdfs:label               "Test parameter 1 for query 1"@en-US .
+        a                                   dynapi:parameter ;
+        dynapi:paramName                    "limit" ;
+        dynapi:hasParameterType             <https://vivoweb.org/ontology/vitro-dynamic-api/parameter/type/XSDinteger> ;
+        dynapi:hasValidator                 <https://vivoweb.org/ontology/vitro-dynamic-api/parameter/validator/IsInteger> ,
+                                            <https://vivoweb.org/ontology/vitro-dynamic-api/parameter/validator/TestNumericRangeValidator> ;
+        rdfs:label                          "Test parameter 1 for query 1"@en-US .
+
+<https://vivoweb.org/ontology/vitro-dynamic-api/parameter/testParam2>
+        a                                   dynapi:parameter ;
+        dynapi:paramName                    "limit" ;
+        dynapi:hasParameterType             <https://vivoweb.org/ontology/vitro-dynamic-api/parameter/type/XSDstring> ;
+        dynapi:hasValidator                 <https://vivoweb.org/ontology/vitro-dynamic-api/parameter/validator/IsEmail>,
+                                            <https://vivoweb.org/ontology/vitro-dynamic-api/parameter/validator/TestStringLengthRangeValidator> ;
+        rdfs:label                          "Test parameter 1 for query 1"@en-US .
 
 <https://vivoweb.org/ontology/vitro-dynamic-api/parameter/validator/TestNumericRangeValidator>
         a                                   dynapi:validator ,
                                             dynapi_java:validators.Validator ,
-                                            dynapi_java:validators.NumericRangeValidator;
-        dynapi:validatorName                "Test numeric [10-30.5] range validator";
-        dynapi:validatorMinNumericValue     10;
-        dynapi:validatorMaxNumericValue     30.5;
-        rdfs:label                           "Test range validator for parameter 1"@en-US .
+                                            dynapi_java:validators.NumericRangeValidator ;
+        dynapi:validatorMinNumericValue     10 ;
+        dynapi:validatorMaxNumericValue     30.5 ;
+        rdfs:label                          "Test range validator for parameter 1"@en-US .
+
+<https://vivoweb.org/ontology/vitro-dynamic-api/parameter/validator/TestStringLengthRangeValidator>
+        a                                   dynapi:validator ,
+                                            dynapi_java:validators.Validator ,
+                                            dynapi_java:validators.StringLengthRangeValidator ;
+        dynapi:validatorMinLengthValue      5 ;
+        rdfs:label                          "Test string length range validator for parameter 2"@en-US .
 
 <https://vivoweb.org/ontology/vitro-dynamic-api/rpc/testRPC1>
-        a                        dynapi:rpc ;
-        dynapi:resourceName      "Test rpc individual" ;
-        dynapi:rpcName           "test_action"@en-US ;
-        dynapi:defaultMethod     <https://vivoweb.org/ontology/vitro-dynamic-api/http_method/post> ;
-        dynapi:rpcAPIVersionMin  "0.1.0" .
+        a                                   dynapi:rpc ;
+        dynapi:resourceName                 "Test rpc individual" ;
+        dynapi:rpcName                      "test_action"@en-US ;
+        dynapi:defaultMethod                <https://vivoweb.org/ontology/vitro-dynamic-api/http_method/post> ;
+        dynapi:rpcAPIVersionMin             "0.1.0" .
 
 <https://vivoweb.org/ontology/vitro-dynamic-api/custom_actions/test_custom_action1>
-        a                        dynapi:customRESTAction ;
-        dynapi:resourceName      "Test custom action" ;
-        dynapi:customRESTActionName  "test_custom_action_name" ;
-        dynapi:forwardTo         <https://vivoweb.org/ontology/vitro-dynamic-api/rpc/testRPC1> ;
-        dynapi:defaultMethod     <https://vivoweb.org/ontology/vitro-dynamic-api/http_method/post> ;
-        dynapi:rpcAPIVersionMin  "0.1.0" .
+        a                                   dynapi:customRESTAction ;
+        dynapi:resourceName                 "Test custom action" ;
+        dynapi:customRESTActionName         "test_custom_action_name" ;
+        dynapi:forwardTo                    <https://vivoweb.org/ontology/vitro-dynamic-api/rpc/testRPC1> ;
+        dynapi:defaultMethod                <https://vivoweb.org/ontology/vitro-dynamic-api/http_method/post> ;
+        dynapi:rpcAPIVersionMin             "0.1.0" .
 
 <https://vivoweb.org/ontology/vitro-dynamic-api/resource/testResource1>
-        a                        dynapi:resource ;
-        dynapi:resourceName      "test_resource" ;
-        rdfs:label               "Test resource 1"@en-US ;
-        dynapi:onGet             <https://vivoweb.org/ontology/vitro-dynamic-api/rpc/testRPC1> ;
-        dynapi:onPost            <https://vivoweb.org/ontology/vitro-dynamic-api/rpc/testRPC1> ;
-        dynapi:onDelete          <https://vivoweb.org/ontology/vitro-dynamic-api/rpc/testRPC1> ;
-        dynapi:onPut             <https://vivoweb.org/ontology/vitro-dynamic-api/rpc/testRPC1> ;
-        dynapi:onPatch           <https://vivoweb.org/ontology/vitro-dynamic-api/rpc/testRPC1> ;
-        dynapi:hasCustomRESTAction   <https://vivoweb.org/ontology/vitro-dynamic-api/custom_actions/test_custom_action1> ;
-        dynapi:restAPIVersionMin "0.1.0" .
+        a                                   dynapi:resource ;
+        dynapi:resourceName                 "test_resource" ;
+        rdfs:label                          "Test resource 1"@en-US ;
+        dynapi:onGet                        <https://vivoweb.org/ontology/vitro-dynamic-api/rpc/testRPC1> ;
+        dynapi:onPost                       <https://vivoweb.org/ontology/vitro-dynamic-api/rpc/testRPC1> ;
+        dynapi:onDelete                     <https://vivoweb.org/ontology/vitro-dynamic-api/rpc/testRPC1> ;
+        dynapi:onPut                        <https://vivoweb.org/ontology/vitro-dynamic-api/rpc/testRPC1> ;
+        dynapi:onPatch                      <https://vivoweb.org/ontology/vitro-dynamic-api/rpc/testRPC1> ;
+        dynapi:hasCustomRESTAction          <https://vivoweb.org/ontology/vitro-dynamic-api/custom_actions/test_custom_action1> ;
+        dynapi:restAPIVersionMin            "0.1.0" .
 
 

--- a/home/src/main/resources/rdf/abox/filegraph/dynamic-api-individuals-testing.n3
+++ b/home/src/main/resources/rdf/abox/filegraph/dynamic-api-individuals-testing.n3
@@ -2,6 +2,7 @@
 @prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix owl:   <http://www.w3.org/2002/07/owl#> .
 @prefix vitro: <http://vitro.mannlib.cornell.edu/ns/vitro/0.7#> .
+@prefix dynapi_java: <java:edu.cornell.mannlib.vitro.webapp.dynapi.components#> .
 @prefix dynapi: <https://vivoweb.org/ontology/vitro-dynamic-api#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
@@ -28,8 +29,18 @@
         a                        dynapi:parameter;
         dynapi:paramName         "limit";
         dynapi:hasParameterType  <https://vivoweb.org/ontology/vitro-dynamic-api/parameter/type/XSDinteger> ;
-        dynapi:hasValidator      <https://vivoweb.org/ontology/vitro-dynamic-api/parameter/validator/IsInteger> ;
+        dynapi:hasValidator      <https://vivoweb.org/ontology/vitro-dynamic-api/parameter/validator/IsInteger>,
+                                    <https://vivoweb.org/ontology/vitro-dynamic-api/parameter/validator/TestNumericRangeValidator> ;
         rdfs:label               "Test parameter 1 for query 1"@en-US .
+
+<https://vivoweb.org/ontology/vitro-dynamic-api/parameter/validator/TestNumericRangeValidator>
+        a                                   dynapi:validator ,
+                                            dynapi_java:validators.Validator ,
+                                            dynapi_java:validators.NumericRangeValidator;
+        dynapi:validatorName                "Test numeric [10-30.5] range validator";
+        dynapi:validatorMinNumericValue     10;
+        dynapi:validatorMaxNumericValue     30.5;
+        rdfs:label                           "Test range validator for parameter 1"@en-US .
 
 <https://vivoweb.org/ontology/vitro-dynamic-api/rpc/testRPC1>
         a                        dynapi:rpc ;

--- a/home/src/main/resources/rdf/abox/filegraph/dynamic-api-individuals.n3
+++ b/home/src/main/resources/rdf/abox/filegraph/dynamic-api-individuals.n3
@@ -24,6 +24,14 @@
         rdfs:label              "Is integer"@en-US ;
         vitro:mostSpecificType  dynapi:validator .
 
+<https://vivoweb.org/ontology/vitro-dynamic-api/parameter/validator/IsEmail>
+        a                                       dynapi:validator ,
+                                                dynapi_java:validators.Validator ,
+                                                dynapi_java:validators.RegularExpressionValidator ;
+        dynapi:validatorRegularExpressionValue  "^(.+)@(\\S+)$" ;
+        rdfs:label                              "Is email"@en-US ;
+        vitro:mostSpecificType                  dynapi:validator .
+
 #-------------------------------------------------------------------------------
 #
 # Parameter types

--- a/home/src/main/resources/rdf/tbox/filegraph/vitro-dynamic-api.owl
+++ b/home/src/main/resources/rdf/tbox/filegraph/vitro-dynamic-api.owl
@@ -306,34 +306,27 @@
     </owl:DatatypeProperty>
     
 
-     <owl:DatatypeProperty rdf:about="https://vivoweb.org/ontology/vitro-dynamic-api#rpcName">
+    <owl:DatatypeProperty rdf:about="https://vivoweb.org/ontology/vitro-dynamic-api#rpcName">
         <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#FunctionalProperty"/>
         <rdfs:domain rdf:resource="https://vivoweb.org/ontology/vitro-dynamic-api#rpc"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
         <rdfs:label xml:lang="en-US">rpc name</rdfs:label>
-      </owl:DatatypeProperty>
+    </owl:DatatypeProperty>
 
 
-     <owl:DatatypeProperty rdf:about="https://vivoweb.org/ontology/vitro-dynamic-api#modelName">
+    <owl:DatatypeProperty rdf:about="https://vivoweb.org/ontology/vitro-dynamic-api#modelName">
         <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#FunctionalProperty"/>
         <rdfs:domain rdf:resource="https://vivoweb.org/ontology/vitro-dynamic-api#model"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
         <rdfs:label xml:lang="en-US">model name</rdfs:label>
-      </owl:DatatypeProperty>
+    </owl:DatatypeProperty>
 
 
-     <owl:DatatypeProperty rdf:about="https://vivoweb.org/ontology/vitro-dynamic-api#paramName">
+    <owl:DatatypeProperty rdf:about="https://vivoweb.org/ontology/vitro-dynamic-api#paramName">
         <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#FunctionalProperty"/>
         <rdfs:domain rdf:resource="https://vivoweb.org/ontology/vitro-dynamic-api#parameter"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
         <rdfs:label xml:lang="en-US">parameter name</rdfs:label>
-      </owl:DatatypeProperty>
-
-    <owl:DatatypeProperty rdf:about="https://vivoweb.org/ontology/vitro-dynamic-api#validatorName">
-        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#FunctionalProperty"/>
-        <rdfs:domain rdf:resource="https://vivoweb.org/ontology/vitro-dynamic-api#validator"/>
-        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-        <rdfs:label xml:lang="en-US">validator name</rdfs:label>
     </owl:DatatypeProperty>
 
     <owl:DatatypeProperty rdf:about="https://vivoweb.org/ontology/vitro-dynamic-api#validatorMinNumericValue">

--- a/home/src/main/resources/rdf/tbox/filegraph/vitro-dynamic-api.owl
+++ b/home/src/main/resources/rdf/tbox/filegraph/vitro-dynamic-api.owl
@@ -329,6 +329,48 @@
         <rdfs:label xml:lang="en-US">parameter name</rdfs:label>
       </owl:DatatypeProperty>
 
+    <owl:DatatypeProperty rdf:about="https://vivoweb.org/ontology/vitro-dynamic-api#validatorName">
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#FunctionalProperty"/>
+        <rdfs:domain rdf:resource="https://vivoweb.org/ontology/vitro-dynamic-api#validator"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+        <rdfs:label xml:lang="en-US">validator name</rdfs:label>
+    </owl:DatatypeProperty>
+
+    <owl:DatatypeProperty rdf:about="https://vivoweb.org/ontology/vitro-dynamic-api#validatorMinNumericValue">
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#FunctionalProperty"/>
+        <rdfs:domain rdf:resource="https://vivoweb.org/ontology/vitro-dynamic-api#numericRangeValidator"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#float"/>
+        <rdfs:label xml:lang="en-US">validator min value</rdfs:label>
+    </owl:DatatypeProperty>
+
+    <owl:DatatypeProperty rdf:about="https://vivoweb.org/ontology/vitro-dynamic-api#validatorMaxNumericValue">
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#FunctionalProperty"/>
+        <rdfs:domain rdf:resource="https://vivoweb.org/ontology/vitro-dynamic-api#numericRangeValidator"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#float"/>
+        <rdfs:label xml:lang="en-US">validator max value</rdfs:label>
+    </owl:DatatypeProperty>
+
+    <owl:DatatypeProperty rdf:about="https://vivoweb.org/ontology/vitro-dynamic-api#validatorMinLengthValue">
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#FunctionalProperty"/>
+        <rdfs:domain rdf:resource="https://vivoweb.org/ontology/vitro-dynamic-api#stringLengthRangeValidator"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#int"/>
+        <rdfs:label xml:lang="en-US">validator min length value</rdfs:label>
+    </owl:DatatypeProperty>
+
+    <owl:DatatypeProperty rdf:about="https://vivoweb.org/ontology/vitro-dynamic-api#validatorMaxLengthValue">
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#FunctionalProperty"/>
+        <rdfs:domain rdf:resource="https://vivoweb.org/ontology/vitro-dynamic-api#stringLengthRangeValidator"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#int"/>
+        <rdfs:label xml:lang="en-US">validator max length value</rdfs:label>
+    </owl:DatatypeProperty>
+
+    <owl:DatatypeProperty rdf:about="https://vivoweb.org/ontology/vitro-dynamic-api#validatorRegularExpressionValue">
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#FunctionalProperty"/>
+        <rdfs:domain rdf:resource="https://vivoweb.org/ontology/vitro-dynamic-api#regularExpressionValidator"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+        <rdfs:label xml:lang="en-US">validator regular expression value</rdfs:label>
+    </owl:DatatypeProperty>
+
      <owl:DatatypeProperty rdf:about="https://vivoweb.org/ontology/vitro-dynamic-api#typeName">
         <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#FunctionalProperty"/>
         <rdfs:domain rdf:resource="https://vivoweb.org/ontology/vitro-dynamic-api#parameterType"/>
@@ -496,6 +538,27 @@
 
     <owl:Class rdf:about="https://vivoweb.org/ontology/vitro-dynamic-api#validator">
         <rdfs:label xml:lang="en-US">Validator</rdfs:label>
+    </owl:Class>
+
+    <!-- https://vivoweb.org/ontology/vitro-dynamic-api#numericRangeValidator -->
+
+    <owl:Class rdf:about="https://vivoweb.org/ontology/vitro-dynamic-api#numericRangeValidator">
+        <rdfs:subClassOf rdf:resource="https://vivoweb.org/ontology/vitro-dynamic-api#Validator"/>
+        <rdfs:label xml:lang="en-US">Numeric Range Validator</rdfs:label>
+    </owl:Class>
+
+    <!-- https://vivoweb.org/ontology/vitro-dynamic-api#stringLengthRangeValidator -->
+
+    <owl:Class rdf:about="https://vivoweb.org/ontology/vitro-dynamic-api#stringLengthRangeValidator">
+        <rdfs:subClassOf rdf:resource="https://vivoweb.org/ontology/vitro-dynamic-api#Validator"/>
+        <rdfs:label xml:lang="en-US">String Length Range Validator</rdfs:label>
+    </owl:Class>
+
+    <!-- https://vivoweb.org/ontology/vitro-dynamic-api#regularExpressionValidator -->
+
+    <owl:Class rdf:about="https://vivoweb.org/ontology/vitro-dynamic-api#regularExpressionValidator">
+        <rdfs:subClassOf rdf:resource="https://vivoweb.org/ontology/vitro-dynamic-api#Validator"/>
+        <rdfs:label xml:lang="en-US">Regular Expression Validator</rdfs:label>
     </owl:Class>
 
     <!-- https://vivoweb.org/ontology/vitro-dynamic-api#model -->


### PR DESCRIPTION
**[VIVO GitHub issue](https://github.com/vivo-project/VIVO/issues/3654)**

* Other Relevant Links (Mailing list discussion, related pull requests, etc.)
     - Also the [example](https://github.com/vivo-project/Vitro/blob/sprint-dynapi-2022-feb/home/src/main/resources/rdf/abox/filegraph/dynamic-api-individuals-testing.n3) has been extended to use NumericRangeValidator, StringLegthRangeValidator and IsEmail validator (RegularExpressionValidator) https://github.com/vivo-project/VIVO/issues/3655 

# What does this pull request do?
A brief description of what the intended result of the PR will be and/or what problem it solves.

# What's new?
Added validators:
NumericRangeValidator (min value and max value defined)
RegularExpressionValidator
StringLengthRangeValidator (min length and max length defined)


# How should this be tested?
The loading of new validators has been tested by using ActionPoolTest, while methods "isValid" are tested in the separated Unit test (ValidatorsTest). 

# Additional Notes:
* Does this change require documentation to be updated? Yes, it should be documented at the end how validators should be used


# Interested parties
Tag (@ mention) interested parties or, if unsure, @VIVO-project/vivo-committers
