### PR TITLE
fix: revert vitro installer packaging to war

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,15 @@ jobs:
       MAVEN_OPTS: -Xmx1024M
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+        with:
+          path: Vitro
+
+      - name: Checkout vitro languages
+        uses: actions/checkout@v3
+        with:
+          repository: vivo-project/Vitro-languages
+          path: Vitro-languages
 
       - name: Maven Cache
         uses: actions/cache@v2
@@ -25,4 +33,8 @@ jobs:
           java-version: 11
 
       - name: Maven Build
-        run: mvn clean install
+        run: |
+          cd ./Vitro-languages
+          mvn clean install
+          cd ../Vitro
+          mvn clean install

--- a/installer/webapp/pom.xml
+++ b/installer/webapp/pom.xml
@@ -8,7 +8,7 @@
     <groupId>org.vivoweb</groupId>
     <artifactId>vitro-installer-webapp</artifactId>
     <version>1.12.3-SNAPSHOT</version>
-    <packaging>pom</packaging>
+    <packaging>war</packaging>
 
     <parent>
         <groupId>org.vivoweb</groupId>


### PR DESCRIPTION
**[VIVO GitHub issue](https://github.com/vivo-project/VIVO/issues/3646)**
* Other Relevant Links (Mailing list discussion, related pull requests, etc.)

# What does this pull request do?
It should restore correct functioning of Vitro installer 

# How should this be tested?

* Test Vitro installer on it's own mvn clean install -s installer/settings.xml
* Test VIVO installation with modified Vitro.
* Try to create a release

# Interested parties
Tag (@ mention) interested parties or, if unsure, @VIVO-project/vivo-committers @roflinn @chenejac @brianjlowe 
