### PR TITLE
[3622] Add getMethod() and rpcMethodUnsupported(), also updating tests accordingly.

### DIFF
--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/dynapi/OperationData.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/dynapi/OperationData.java
@@ -7,12 +7,14 @@ import javax.servlet.http.HttpServletRequest;
 
 public class OperationData {
 
-	private Map<String, String[]> params;
-	private ServletContext context;
+	private final Map<String, String[]> params;
+	private final ServletContext context;
+	private final String method;
 
 	public OperationData(HttpServletRequest request) {
 		params = request.getParameterMap();
 		context = request.getServletContext();
+		method = request.getMethod();
 	}
 
 	public ServletContext getContext() {
@@ -28,6 +30,10 @@ public class OperationData {
 
 	public String[] get(String paramName) {
 		return params.get(paramName);
+	}
+
+	public String getMethod() {
+		return method;
 	}
 
 }

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/dynapi/components/Action.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/dynapi/components/Action.java
@@ -1,5 +1,11 @@
 package edu.cornell.mannlib.vitro.webapp.dynapi.components;
 
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+
 import javax.servlet.http.HttpServletResponse;
 
 import org.apache.commons.logging.Log;
@@ -7,12 +13,6 @@ import org.apache.commons.logging.LogFactory;
 
 import edu.cornell.mannlib.vitro.webapp.dynapi.OperationData;
 import edu.cornell.mannlib.vitro.webapp.utils.configuration.Property;
-
-import java.util.Collections;
-import java.util.Map;
-import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.stream.Collectors;
 
 public class Action implements RunnableComponent, Poolable, Operation, Link {
 
@@ -38,7 +38,7 @@ public class Action implements RunnableComponent, Poolable, Operation, Link {
 	}
 
 	public OperationResult run(OperationData input) {
-		if (firstStep == null) {
+		if (firstStep == null || rpcMethodUnsupported(input.getMethod())) {
 			return new OperationResult(HttpServletResponse.SC_NOT_IMPLEMENTED);
 		}
 		return firstStep.run(input);
@@ -121,5 +121,13 @@ public class Action implements RunnableComponent, Poolable, Operation, Link {
   public boolean isRoot() {
     return true;
   }
+
+	private boolean rpcMethodUnsupported(String method) {
+		if (rpc == null || rpc.getHttpMethod() == null || rpc.getHttpMethod().getName() == null) {
+			return false;
+		}
+
+		return rpc.getHttpMethod().getName().equalsIgnoreCase(method);
+	}
 
 }

--- a/api/src/test/java/edu/cornell/mannlib/vitro/webapp/dynapi/RPCEndpointTest.java
+++ b/api/src/test/java/edu/cornell/mannlib/vitro/webapp/dynapi/RPCEndpointTest.java
@@ -3,8 +3,7 @@ package edu.cornell.mannlib.vitro.webapp.dynapi;
 import static org.easymock.EasyMock.anyObject;
 import static org.easymock.EasyMock.anyString;
 import static org.easymock.EasyMock.expect;
-import static org.easymock.EasyMock.expectLastCall;
-import static org.powermock.api.easymock.PowerMock.createMock;
+import static org.powermock.api.easymock.PowerMock.expectLastCall;
 import static org.powermock.api.easymock.PowerMock.mockStatic;
 import static org.powermock.api.easymock.PowerMock.replay;
 import static org.powermock.api.easymock.PowerMock.verify;
@@ -29,38 +28,31 @@ import edu.cornell.mannlib.vitro.webapp.dynapi.components.OperationResult;
 @PrepareForTest(ActionPool.class)
 public class RPCEndpointTest {
 
-	final private static String URI_TEST = "/api/rpc/test";
+	private final static String URI_TEST = "/api/rpc/test";
 
-	private static RPCEndpoint rpcEndpoint;
+	private RPCEndpoint rpcEndpoint;
 
-	@Mock
-	private static ActionPool actionPool;
+	private Map<String, String[]> params;
 
-	@Mock
-	private static Action action;
+	private ServletContext context;
 
 	@Mock
-	private static OperationResult operationResult;
+	private ActionPool actionPool;
 
 	@Mock
-	private static HttpServletRequest request;
+	private Action action;
 
 	@Mock
-	private static HttpServletResponse response;
+	private OperationResult operationResult;
 
 	@Mock
-	private static Map<String, String[]> params;
+	private HttpServletRequest request;
 
 	@Mock
-	private static ServletContext context;
+	private HttpServletResponse response;
 
 	@Before
 	public void beforeEach() {
-		operationResult = createMock(OperationResult.class);
-		action = createMock(Action.class);
-		actionPool = createMock(ActionPool.class);
-		request = createMock(HttpServletRequest.class);
-		response = createMock(HttpServletResponse.class);
 
 		// The order of where mockStatic (and possibly all mocks herein) matters and should only be changed cautiously.
 		mockStatic(ActionPool.class);
@@ -81,6 +73,7 @@ public class RPCEndpointTest {
 		expect(request.getParameterMap()).andReturn(params).anyTimes();
 		expect(request.getServletContext()).andReturn(context).anyTimes();
 		expect(request.getRequestURI()).andReturn(URI_TEST).anyTimes();
+		expect(request.getMethod()).andReturn("POST").anyTimes();
 		replay(request);
 
 		action.removeClient();


### PR DESCRIPTION
**[VIVO GitHub issue 3622](https://github.com/vivo-project/VIVO/issues/3622)**:

# What does this pull request do?
The RPC Endpoint needs to be aware of the correctness of the HTTP Method received.
If the Method is not Implemented, then properly return this.
The facility for doing this is missing and so this PR introduces this needed behavior for returning "501 Not Implemented" as appropriate.

# What's new?
Add `getMethod()` to `OperationData` to facilitate this.
Add `rpcMethodUnsupported()` to `Action` and utilize `rpcMethodUnsupported()` to validate the HTTP Method.

Some `RPCEndpointTest` tests are updated to accomodate this.
Remove some unecessary steps from `RPCEndpointTest`, as the `@Mock` already handles mock instantiation.

# How should this be tested?
* This mostly adds new methods, so the existing RPC Endpoints should be tested to continue to work in the same way they did before this PR.

# Additional Notes:
* This does not solve the aforementioned issue, this PR instead improves the RPC Endpoint implementation.
* There appears to be more work needed to properly verify the Methods than simply adding these methods.

# Interested parties
Tag (@ mention) interested parties or, if unsure, @VIVO-project/vivo-committers
