### PR TITLE
 Move stream reset inside loop so that every listener gets the same state

### DIFF
--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/rdfservice/impl/RDFServiceImpl.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/rdfservice/impl/RDFServiceImpl.java
@@ -142,8 +142,8 @@ public abstract class RDFServiceImpl implements RDFService {
     }
 
     protected void notifyListeners(ModelChange modelChange) throws IOException {
-        modelChange.getSerializedModel().reset();
         for (ChangeListener listener : registeredListeners) {
+            modelChange.getSerializedModel().reset();
             listener.notifyModelChange(modelChange);
         }
         log.debug(registeredJenaListeners.size() + " registered Jena listeners");


### PR DESCRIPTION
https://github.com/vivo-project/VIVO/issues/3647
What does this pull request do?

Re-apply commit that was accidentally reverted during i18n [sprint](https://github.com/vivo-project/Vitro/commit/eb949919b50c58288ee8936915a8136122fa46fe#)
How should this be tested?

A description of what steps someone could take to:

Reproduce the problem you are fixing
Create two change listeners, second doesn't get data from InputStream as it was already used
Test that the pull request does what is intended.
Create two change listeners, second InputStream should get the same data without using multi threading

Interested parties

https://github.com/orgs/vivo-project/teams/vivo-committers @roflinn @brianjlowe @chenejac