### PR TITLE
Properly handle unimplemented Methods in RPC and replace testing framework.

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -96,21 +96,15 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.easymock</groupId>
-            <artifactId>easymock</artifactId>
-            <version>3.5</version>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>4.3.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-module-junit4</artifactId>
-            <version>2.0.9</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-api-easymock</artifactId>
-            <version>2.0.9</version>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-inline</artifactId>
+            <version>4.3.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/dynapi/RPCEndpoint.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/dynapi/RPCEndpoint.java
@@ -12,47 +12,41 @@ import edu.cornell.mannlib.vitro.webapp.dynapi.components.Action;
 import edu.cornell.mannlib.vitro.webapp.dynapi.components.OperationResult;
 
 @WebServlet(name = "RPCEndpoint", urlPatterns = { "/api/rpc/*" })
-public class RPCEndpoint extends VitroHttpServlet  {
+public class RPCEndpoint extends VitroHttpServlet {
 
 	private static final long serialVersionUID = 1L;
- 	private static final Log log = LogFactory.getLog(RPCEndpoint.class);
+	private static final Log log = LogFactory.getLog(RPCEndpoint.class);
 	private ActionPool actionPool = ActionPool.getInstance();
-	
+
 	@Override
-	public void doGet( HttpServletRequest request, HttpServletResponse response ) {
-		process(request, response);
+	public void doGet(HttpServletRequest request, HttpServletResponse response) {
+		response.setStatus(HttpServletResponse.SC_NOT_IMPLEMENTED);
 	}
-	
+
 	@Override
-	public void doPost( HttpServletRequest request, HttpServletResponse response ) {
-		process(request, response);
-	}
-	
-	@Override
-	public void doDelete( HttpServletRequest request, HttpServletResponse response ) {
-		process(request, response);
-	}
-	
-	@Override
-	public void doPut( HttpServletRequest request, HttpServletResponse response ) {
-		process(request, response);
-	}
-	
-	private void process(HttpServletRequest request, HttpServletResponse response) {
+	public void doPost(HttpServletRequest request, HttpServletResponse response) {
 		String requestURL = request.getRequestURI();
-		String actionName = requestURL.substring(requestURL.lastIndexOf("/") + 1 );
-		Action action = null;
-		log.debug(actionName);
+		String actionName = requestURL.substring(requestURL.lastIndexOf("/") + 1);
+
+		actionPool.printNames();
+		Action action = actionPool.getByName(actionName);
+
 		try {
-  		actionPool.printNames();
-  		action = actionPool.getByName(actionName);
-  		OperationData input = new OperationData(request);
-  		OperationResult result = action.run(input);
-  		result.prepareResponse(response);
+			OperationData input = new OperationData(request);
+			OperationResult result = action.run(input);
+			result.prepareResponse(response);
 		} finally {
-			if (action != null) {
-				action.removeClient();
-			}
+			action.removeClient();
 		}
+	}
+
+	@Override
+	public void doDelete(HttpServletRequest request, HttpServletResponse response) {
+		response.setStatus(HttpServletResponse.SC_NOT_IMPLEMENTED);
+	}
+	
+	@Override
+	public void doPut(HttpServletRequest request, HttpServletResponse response) {
+		response.setStatus(HttpServletResponse.SC_NOT_IMPLEMENTED);
 	}
 }

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/dynapi/RPCEndpoint.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/dynapi/RPCEndpoint.java
@@ -20,7 +20,7 @@ public class RPCEndpoint extends VitroHttpServlet {
 
 	@Override
 	public void doGet(HttpServletRequest request, HttpServletResponse response) {
-		response.setStatus(HttpServletResponse.SC_NOT_IMPLEMENTED);
+		OperationResult.notImplemented().prepareResponse(response);
 	}
 
 	@Override
@@ -42,11 +42,11 @@ public class RPCEndpoint extends VitroHttpServlet {
 
 	@Override
 	public void doDelete(HttpServletRequest request, HttpServletResponse response) {
-		response.setStatus(HttpServletResponse.SC_NOT_IMPLEMENTED);
+		OperationResult.notImplemented().prepareResponse(response);
 	}
 	
 	@Override
 	public void doPut(HttpServletRequest request, HttpServletResponse response) {
-		response.setStatus(HttpServletResponse.SC_NOT_IMPLEMENTED);
+		OperationResult.notImplemented().prepareResponse(response);
 	}
 }

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/dynapi/RPCEndpoint.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/dynapi/RPCEndpoint.java
@@ -25,14 +25,25 @@ public class RPCEndpoint extends VitroHttpServlet {
 
 	@Override
 	public void doPost(HttpServletRequest request, HttpServletResponse response) {
-		String requestURL = request.getRequestURI();
-		String actionName = requestURL.substring(requestURL.lastIndexOf("/") + 1);
+		if (request.getPathInfo() == null) {
+			OperationResult.notFound().prepareResponse(response);
+			return;
+		}
+
+		String[] paths = request.getPathInfo().split("/");
+
+		if (paths.length < 2) {
+			OperationResult.notFound().prepareResponse(response);
+			return;
+		}
+
+		String actionName = paths[1];
 
 		actionPool.printNames();
 		Action action = actionPool.getByName(actionName);
+		OperationData input = new OperationData(request);
 
 		try {
-			OperationData input = new OperationData(request);
 			OperationResult result = action.run(input);
 			result.prepareResponse(response);
 		} finally {

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/dynapi/components/OperationResult.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/dynapi/components/OperationResult.java
@@ -27,5 +27,9 @@ public class OperationResult {
 	public static OperationResult notImplemented() {
 		return new OperationResult(HttpServletResponse.SC_NOT_IMPLEMENTED);
 	}
+
+	public static OperationResult notFound() {
+		return new OperationResult(HttpServletResponse.SC_NOT_FOUND);
+	}
 	
 }

--- a/api/src/test/java/edu/cornell/mannlib/vitro/webapp/controller/freemarker/UrlBuilderTest.java
+++ b/api/src/test/java/edu/cornell/mannlib/vitro/webapp/controller/freemarker/UrlBuilderTest.java
@@ -3,21 +3,17 @@
 
 package edu.cornell.mannlib.vitro.webapp.controller.freemarker;
 
-import static org.mockito.Mockito.mock;
-
-import javax.servlet.http.HttpServletRequest;
-
 import org.junit.Assert;
-
 import org.junit.Test;
 
-import stubs.edu.cornell.mannlib.vitro.webapp.dao.ApplicationDaoStub;
-import stubs.edu.cornell.mannlib.vitro.webapp.dao.WebappDaoFactoryStub;
 import edu.cornell.mannlib.vitro.testing.AbstractTestClass;
 import edu.cornell.mannlib.vitro.webapp.controller.VitroRequest;
 import edu.cornell.mannlib.vitro.webapp.controller.freemarker.UrlBuilder.ParamMap;
 import edu.cornell.mannlib.vitro.webapp.dao.WebappDaoFactory;
 import edu.cornell.mannlib.vitro.webapp.web.URLEncoder;
+import stubs.edu.cornell.mannlib.vitro.webapp.dao.ApplicationDaoStub;
+import stubs.edu.cornell.mannlib.vitro.webapp.dao.WebappDaoFactoryStub;
+import stubs.javax.servlet.http.HttpServletRequestStub;
 
 public class UrlBuilderTest extends AbstractTestClass {
 
@@ -114,7 +110,7 @@ public class UrlBuilderTest extends AbstractTestClass {
     }
 
     protected VitroRequest makeMockVitroRequest( final String defaultNS){
-        HttpServletRequest req = mock(HttpServletRequest.class);
+        HttpServletRequestStub req = new HttpServletRequestStub();
         return new VitroRequest(req){
 
             @Override

--- a/api/src/test/java/edu/cornell/mannlib/vitro/webapp/controller/freemarker/UrlBuilderTest.java
+++ b/api/src/test/java/edu/cornell/mannlib/vitro/webapp/controller/freemarker/UrlBuilderTest.java
@@ -3,7 +3,7 @@
 
 package edu.cornell.mannlib.vitro.webapp.controller.freemarker;
 
-import static org.easymock.EasyMock.*;
+import static org.mockito.Mockito.mock;
 
 import javax.servlet.http.HttpServletRequest;
 
@@ -114,7 +114,7 @@ public class UrlBuilderTest extends AbstractTestClass {
     }
 
     protected VitroRequest makeMockVitroRequest( final String defaultNS){
-        HttpServletRequest req = createMock( HttpServletRequest.class );
+        HttpServletRequest req = mock(HttpServletRequest.class);
         return new VitroRequest(req){
 
             @Override

--- a/api/src/test/java/edu/cornell/mannlib/vitro/webapp/dynapi/RPCEndpointTest.java
+++ b/api/src/test/java/edu/cornell/mannlib/vitro/webapp/dynapi/RPCEndpointTest.java
@@ -1,13 +1,10 @@
 package edu.cornell.mannlib.vitro.webapp.dynapi;
 
-import static org.easymock.EasyMock.anyObject;
-import static org.easymock.EasyMock.anyString;
-import static org.easymock.EasyMock.expect;
-import static org.easymock.EasyMock.expectLastCall;
-import static org.powermock.api.easymock.PowerMock.createMock;
-import static org.powermock.api.easymock.PowerMock.mockStatic;
-import static org.powermock.api.easymock.PowerMock.replay;
-import static org.powermock.api.easymock.PowerMock.verify;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.util.Map;
 
@@ -15,109 +12,81 @@ import javax.servlet.ServletContext;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.powermock.api.easymock.annotation.Mock;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.Spy;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import edu.cornell.mannlib.vitro.webapp.dynapi.components.Action;
-import edu.cornell.mannlib.vitro.webapp.dynapi.components.OperationResult;
 
-@RunWith(PowerMockRunner.class)
-@PrepareForTest(ActionPool.class)
+@RunWith(MockitoJUnitRunner.class)
 public class RPCEndpointTest {
 
-	final private static String URI_TEST = "/api/rpc/test";
+	private final static String URI_TEST = "/api/rpc/test";
 
-	private static RPCEndpoint rpcEndpoint;
+	private Map<String, String[]> params;
 
-	@Mock
-	private static ActionPool actionPool;
+	private ServletContext context;
 
-	@Mock
-	private static Action action;
+	private MockedStatic<ActionPool> actionPoolStatic;
 
-	@Mock
-	private static OperationResult operationResult;
+	private RPCEndpoint rpcEndpoint;
 
 	@Mock
-	private static HttpServletRequest request;
+	private ActionPool actionPool;
+
+	@Spy
+	private Action action;
 
 	@Mock
-	private static HttpServletResponse response;
+	private HttpServletRequest request;
 
 	@Mock
-	private static Map<String, String[]> params;
-
-	@Mock
-	private static ServletContext context;
+	private HttpServletResponse response;
 
 	@Before
 	public void beforeEach() {
-		operationResult = createMock(OperationResult.class);
-		action = createMock(Action.class);
-		actionPool = createMock(ActionPool.class);
-		request = createMock(HttpServletRequest.class);
-		response = createMock(HttpServletResponse.class);
+		actionPoolStatic = mockStatic(ActionPool.class);
+		when(ActionPool.getInstance()).thenReturn(actionPool);
+		when(actionPool.getByName(any())).thenReturn(action);
 
-		// The order of where mockStatic (and possibly all mocks herein) matters and should only be changed cautiously.
-		mockStatic(ActionPool.class);
-		expect(ActionPool.getInstance()).andReturn(actionPool).anyTimes();
-		replay(ActionPool.class);
+		when(request.getParameterMap()).thenReturn(params);
+		when(request.getServletContext()).thenReturn(context);
+		when(request.getRequestURI()).thenReturn(URI_TEST);
 
 		rpcEndpoint = new RPCEndpoint();
+	}
 
-		actionPool.printNames();
-		expectLastCall().anyTimes();
-		expect(actionPool.getByName(anyString())).andReturn(action).anyTimes();
-		replay(actionPool);
-
-		operationResult.prepareResponse(response);
-		expectLastCall().anyTimes();
-		replay(operationResult);
-
-		expect(request.getParameterMap()).andReturn(params).anyTimes();
-		expect(request.getServletContext()).andReturn(context).anyTimes();
-		expect(request.getRequestURI()).andReturn(URI_TEST).anyTimes();
-		replay(request);
-
-		action.removeClient();
-		expectLastCall().anyTimes();
-		expect(action.run(anyObject())).andReturn(operationResult).once();
-		replay(action);
+	@After
+	public void afterEach() {
+		actionPoolStatic.close();
 	}
 
 	@Test
 	public void doGetTest() {
 		rpcEndpoint.doGet(request, response);
-		verify(request);
-		verify(action);
-		verify(actionPool);
+		verify(action, times(0)).run(any());
 	}
 
 	@Test
 	public void doPostTest() {
 		rpcEndpoint.doPost(request, response);
-		verify(request);
-		verify(action);
-		verify(actionPool);
+		verify(action, times(1)).run(any());
 	}
 
 	@Test
 	public void doDeleteTest() {
 		rpcEndpoint.doDelete(request, response);
-		verify(request);
-		verify(action);
-		verify(actionPool);
+		verify(action, times(0)).run(any());
 	}
 
 	@Test
 	public void doPutTest() {
 		rpcEndpoint.doPut(request, response);
-		verify(request);
-		verify(action);
-		verify(actionPool);
+		verify(action, times(0)).run(any());
 	}
 }

--- a/api/src/test/java/edu/cornell/mannlib/vitro/webapp/dynapi/RPCEndpointTest.java
+++ b/api/src/test/java/edu/cornell/mannlib/vitro/webapp/dynapi/RPCEndpointTest.java
@@ -22,11 +22,12 @@ import org.mockito.Spy;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import edu.cornell.mannlib.vitro.webapp.dynapi.components.Action;
+import edu.cornell.mannlib.vitro.webapp.dynapi.components.OperationResult;
 
 @RunWith(MockitoJUnitRunner.class)
 public class RPCEndpointTest {
 
-	private final static String URI_TEST = "/api/rpc/test";
+	private final static String URI_TEST = "/test";
 
 	private Map<String, String[]> params;
 
@@ -52,11 +53,10 @@ public class RPCEndpointTest {
 	public void beforeEach() {
 		actionPoolStatic = mockStatic(ActionPool.class);
 		when(ActionPool.getInstance()).thenReturn(actionPool);
-		when(actionPool.getByName(any())).thenReturn(action);
+		when(actionPool.getByName(any(String.class))).thenReturn(action);
 
 		when(request.getParameterMap()).thenReturn(params);
 		when(request.getServletContext()).thenReturn(context);
-		when(request.getRequestURI()).thenReturn(URI_TEST);
 
 		rpcEndpoint = new RPCEndpoint();
 	}
@@ -70,23 +70,41 @@ public class RPCEndpointTest {
 	public void doGetTest() {
 		rpcEndpoint.doGet(request, response);
 		verify(action, times(0)).run(any());
+		verify(response, times(1)).setStatus(HttpServletResponse.SC_NOT_IMPLEMENTED);
 	}
 
 	@Test
 	public void doPostTest() {
+		OperationResult result = new OperationResult(HttpServletResponse.SC_OK);
+
+		when(request.getPathInfo()).thenReturn(URI_TEST);
+		when(action.run(any(OperationData.class))).thenReturn(result);
+
 		rpcEndpoint.doPost(request, response);
 		verify(action, times(1)).run(any());
+		verify(response, times(1)).setStatus(HttpServletResponse.SC_OK);
+	}
+
+	@Test
+	public void doPostTestOnMissing() {
+		when(request.getPathInfo()).thenReturn("");
+
+		rpcEndpoint.doPost(request, response);
+		verify(action, times(0)).run(any());
+		verify(response, times(1)).setStatus(HttpServletResponse.SC_NOT_FOUND);
 	}
 
 	@Test
 	public void doDeleteTest() {
 		rpcEndpoint.doDelete(request, response);
 		verify(action, times(0)).run(any());
+		verify(response, times(1)).setStatus(HttpServletResponse.SC_NOT_IMPLEMENTED);
 	}
 
 	@Test
 	public void doPutTest() {
 		rpcEndpoint.doPut(request, response);
 		verify(action, times(0)).run(any());
+		verify(response, times(1)).setStatus(HttpServletResponse.SC_NOT_IMPLEMENTED);
 	}
 }

--- a/api/src/test/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/preprocessors/LimitRemovalsToLanguageTest.java
+++ b/api/src/test/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/preprocessors/LimitRemovalsToLanguageTest.java
@@ -1,12 +1,14 @@
 package edu.cornell.mannlib.vitro.webapp.edit.n3editing.configuration.preprocessors;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
 import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.rdf.model.ResourceFactory;
 import org.apache.jena.vocabulary.RDFS;
 import org.junit.Test;
-import org.testng.Assert;
 
 import edu.cornell.mannlib.vitro.testing.AbstractTestClass;
 
@@ -26,10 +28,10 @@ public class LimitRemovalsToLanguageTest extends AbstractTestClass {
         retractions.add(res, RDFS.label, ResourceFactory.createLangLiteral("es1", "es"));
         additions.add(res, RDFS.label, ResourceFactory.createLangLiteral("en-US2", "en-US"));
         preproc.preprocess(retractions, additions, null);
-        Assert.assertEquals(retractions.size(), 1);
-        Assert.assertTrue(retractions.contains(res, RDFS.label, ResourceFactory.createLangLiteral("en-US1", "en-US")));
-        Assert.assertEquals(additions.size(), 1);
-        Assert.assertTrue(additions.contains(res, RDFS.label, ResourceFactory.createLangLiteral("en-US2", "en-US")));
+        assertEquals(retractions.size(), 1);
+        assertTrue(retractions.contains(res, RDFS.label, ResourceFactory.createLangLiteral("en-US1", "en-US")));
+        assertEquals(additions.size(), 1);
+        assertTrue(additions.contains(res, RDFS.label, ResourceFactory.createLangLiteral("en-US2", "en-US")));
         additions.removeAll();
         retractions.removeAll();
         // Keep all retractions unmolested if no labels at all are being re-added.
@@ -37,10 +39,10 @@ public class LimitRemovalsToLanguageTest extends AbstractTestClass {
         retractions.add(res, RDFS.label, ResourceFactory.createLangLiteral("en-US1", "en-US"));
         retractions.add(res, RDFS.label, ResourceFactory.createLangLiteral("es1", "es"));
         preproc.preprocess(retractions, additions, null);
-        Assert.assertEquals(retractions.size(), 2);
-        Assert.assertTrue(retractions.contains(res, RDFS.label, ResourceFactory.createLangLiteral("en-US1", "en-US")));
-        Assert.assertTrue(retractions.contains(res, RDFS.label, ResourceFactory.createLangLiteral("es1", "es")));
-        Assert.assertEquals(additions.size(), 0);
+        assertEquals(retractions.size(), 2);
+        assertTrue(retractions.contains(res, RDFS.label, ResourceFactory.createLangLiteral("en-US1", "en-US")));
+        assertTrue(retractions.contains(res, RDFS.label, ResourceFactory.createLangLiteral("es1", "es")));
+        assertEquals(additions.size(), 0);
         additions.removeAll();
         retractions.removeAll();
         // Keep both retractions if the form supplies new values for both languages
@@ -49,12 +51,12 @@ public class LimitRemovalsToLanguageTest extends AbstractTestClass {
         additions.add(res, RDFS.label, ResourceFactory.createLangLiteral("en-US2", "en-US"));
         additions.add(res, RDFS.label, ResourceFactory.createLangLiteral("es2", "es"));
         preproc.preprocess(retractions, additions, null);        
-        Assert.assertEquals(retractions.size(), 2);
-        Assert.assertTrue(retractions.contains(res, RDFS.label, ResourceFactory.createLangLiteral("en-US1", "en-US")));
-        Assert.assertTrue(retractions.contains(res, RDFS.label, ResourceFactory.createLangLiteral("es1", "es")));
-        Assert.assertEquals(additions.size(), 2);
-        Assert.assertTrue(additions.contains(res, RDFS.label, ResourceFactory.createLangLiteral("en-US2", "en-US")));
-        Assert.assertTrue(additions.contains(res, RDFS.label, ResourceFactory.createLangLiteral("es2", "es")));
+        assertEquals(retractions.size(), 2);
+        assertTrue(retractions.contains(res, RDFS.label, ResourceFactory.createLangLiteral("en-US1", "en-US")));
+        assertTrue(retractions.contains(res, RDFS.label, ResourceFactory.createLangLiteral("es1", "es")));
+        assertEquals(additions.size(), 2);
+        assertTrue(additions.contains(res, RDFS.label, ResourceFactory.createLangLiteral("en-US2", "en-US")));
+        assertTrue(additions.contains(res, RDFS.label, ResourceFactory.createLangLiteral("es2", "es")));
         additions.removeAll();
         retractions.removeAll();
     }


### PR DESCRIPTION
**[VIVO GitHub issue 3622](https://github.com/vivo-project/VIVO/issues/3622)**:

* Other Relevant Links (Mailing list discussion, related pull requests, etc.)

# What does this pull request do?
* Change RPC Endpoint to return 501 for some REST methods that are not supported.
* Fully replaces EasyMock (and PowerMock) with Mockito.

# What's new?
Uses `request.getPathInfo()` to parse the action name from the URI.

The RPC endpoints should return 501 for the GET, PUT, and DELETE methods.

The tests are updated to handle this.
Using EasyMock continued to be enough problems that I feel that it is necessary to replace EasyMock (and the recently added PowerMock) with Mockito.

Mockito allows for much cleaner test writing and provides a more stable API.

The other projects depending on EasyMock either use it in very few ways or are using it when they should instead be using JUnit (specifically the JUnit assertions).

# Interested parties
Tag (@ mention) interested parties or, if unsure, @VIVO-project/vivo-committers
