### PR TITLE
[3667] REST endpoint implementation

### DIFF
--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/dynapi/OperationData.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/dynapi/OperationData.java
@@ -7,8 +7,8 @@ import javax.servlet.http.HttpServletRequest;
 
 public class OperationData {
 
-	private Map<String, String[]> params;
-	private ServletContext context;
+	private final Map<String, String[]> params;
+	private final ServletContext context;
 
 	public OperationData(HttpServletRequest request) {
 		params = request.getParameterMap();
@@ -20,10 +20,7 @@ public class OperationData {
 	}
 
 	public boolean has(String paramName) {
-		if (params.containsKey(paramName)) {
-			return true;
-		}
-		return false;
+		return params.containsKey(paramName);
 	}
 
 	public String[] get(String paramName) {

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/dynapi/RESTEndpoint.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/dynapi/RESTEndpoint.java
@@ -1,5 +1,8 @@
 package edu.cornell.mannlib.vitro.webapp.dynapi;
 
+import static edu.cornell.mannlib.vitro.webapp.dynapi.request.RequestPath.REST_BASE_PATH;
+import static java.lang.String.format;
+
 import java.io.IOException;
 
 import javax.servlet.ServletException;
@@ -11,15 +14,19 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
 import edu.cornell.mannlib.vitro.webapp.controller.VitroHttpServlet;
+import edu.cornell.mannlib.vitro.webapp.dynapi.components.Action;
+import edu.cornell.mannlib.vitro.webapp.dynapi.components.OperationResult;
+import edu.cornell.mannlib.vitro.webapp.dynapi.components.Resource;
+import edu.cornell.mannlib.vitro.webapp.dynapi.components.ResourceKey;
+import edu.cornell.mannlib.vitro.webapp.dynapi.request.RequestPath;
 
-@WebServlet(name = "RESTEndpoint", urlPatterns = { "/api/rest/*" })
+@WebServlet(name = "RESTEndpoint", urlPatterns = { REST_BASE_PATH + "/*" })
 public class RESTEndpoint extends VitroHttpServlet {
-
-	private static final long serialVersionUID = 1L;
 
 	private static final Log log = LogFactory.getLog(RESTEndpoint.class);
 
 	private ResourcePool resourcePool = ResourcePool.getInstance();
+	private ActionPool actionPool = ActionPool.getInstance();
 
 	@Override
 	public void service(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
@@ -55,10 +62,64 @@ public class RESTEndpoint extends VitroHttpServlet {
 	}
 
 	private void process(HttpServletRequest request, HttpServletResponse response) {
-		String requestURL = request.getRequestURI();
-		// String resourceName = requestURL.substring(requestURL.lastIndexOf("/") + 1 );
-		// Resource resource = resourcePool.getByName(resourceName);
-		log.debug(request.getMethod());
+		RequestPath requestPath = RequestPath.from(request);
+
+		if (requestPath.isValid()) {
+			ResourceKey resourceKey = ResourceKey.of(requestPath.getResourceName(), requestPath.getResourceVersion());
+
+			if (log.isDebugEnabled()) {
+				resourcePool.printKeys();
+			}
+			Resource resource = resourcePool.get(resourceKey);
+			String method = request.getMethod();
+
+			String actionName = null;
+
+			if (requestPath.isCustomRestAction()) {
+				if (method.toUpperCase().equals("POST")) {
+					String customRestActionName = requestPath.getActionName();
+
+					try {
+						actionName = resource.getCustomRestActionByName(customRestActionName);
+					} catch (UnsupportedOperationException e) {
+						log.error(format("Custom REST action %s not implemented for resource %s", customRestActionName,
+								resource.getKey()), e);
+						OperationResult.notImplemented().prepareResponse(response);
+						return;
+					} finally {
+						resource.removeClient();
+					}
+				} else {
+					OperationResult.notImplemented().prepareResponse(response);
+					resource.removeClient();
+					return;
+				}
+			} else {
+				try {
+					actionName = resource.getActionNameByMethod(method);
+				} catch (UnsupportedOperationException e) {
+					log.error(format("Method %s not implemented for resource %s", method, resource.getKey()), e);
+					OperationResult.notImplemented().prepareResponse(response);
+					return;
+				} finally {
+					resource.removeClient();
+				}
+			}
+
+			if (log.isDebugEnabled()) {
+				actionPool.printKeys();
+			}
+			Action action = actionPool.get(actionName);
+			OperationData input = new OperationData(request);
+			try {
+				OperationResult result = action.run(input);
+				result.prepareResponse(response);
+			} finally {
+				action.removeClient();
+			}
+		} else {
+			OperationResult.notFound().prepareResponse(response);
+		}
 	}
 
 }

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/dynapi/RPCEndpoint.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/dynapi/RPCEndpoint.java
@@ -1,5 +1,7 @@
 package edu.cornell.mannlib.vitro.webapp.dynapi;
 
+import static edu.cornell.mannlib.vitro.webapp.dynapi.request.RequestPath.RPC_BASE_PATH;
+
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -10,13 +12,12 @@ import org.apache.commons.logging.LogFactory;
 import edu.cornell.mannlib.vitro.webapp.controller.VitroHttpServlet;
 import edu.cornell.mannlib.vitro.webapp.dynapi.components.Action;
 import edu.cornell.mannlib.vitro.webapp.dynapi.components.OperationResult;
+import edu.cornell.mannlib.vitro.webapp.dynapi.request.RequestPath;
 
-@WebServlet(name = "RPCEndpoint", urlPatterns = { "/api/rpc/*" })
+@WebServlet(name = "RPCEndpoint", urlPatterns = { RPC_BASE_PATH + "/*" })
 public class RPCEndpoint extends VitroHttpServlet {
 
-	private static final long serialVersionUID = 1L;
-
-	private static final Log log = LogFactory.getLog(RPCEndpoint.class);
+	private static final Log log = LogFactory.getLog(RESTEndpoint.class);
 
 	private ActionPool actionPool = ActionPool.getInstance();
 
@@ -27,29 +28,21 @@ public class RPCEndpoint extends VitroHttpServlet {
 
 	@Override
 	public void doPost(HttpServletRequest request, HttpServletResponse response) {
-		if (request.getPathInfo() == null) {
+		RequestPath requestPath = RequestPath.from(request);
+		if (requestPath.isValid()) {
+			if (log.isDebugEnabled()) {
+				actionPool.printKeys(); 
+			}
+			Action action = actionPool.get(requestPath.getActionName());
+			OperationData input = new OperationData(request);
+			try {
+				OperationResult result = action.run(input);
+				result.prepareResponse(response);
+			} finally {
+				action.removeClient();
+			}
+		} else {
 			OperationResult.notFound().prepareResponse(response);
-			return;
-		}
-
-		String[] paths = request.getPathInfo().split("/");
-
-		if (paths.length < 2) {
-			OperationResult.notFound().prepareResponse(response);
-			return;
-		}
-
-		String actionName = paths[1];
-
-		actionPool.printKeys();
-		Action action = actionPool.get(actionName);
-		OperationData input = new OperationData(request);
-
-		try {
-			OperationResult result = action.run(input);
-			result.prepareResponse(response);
-		} finally {
-			action.removeClient();
 		}
 	}
 
@@ -62,4 +55,5 @@ public class RPCEndpoint extends VitroHttpServlet {
 	public void doPut(HttpServletRequest request, HttpServletResponse response) {
 		OperationResult.notImplemented().prepareResponse(response);
 	}
+
 }

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/dynapi/components/Resource.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/dynapi/components/Resource.java
@@ -43,6 +43,10 @@ public class Resource implements Versionable<ResourceKey> {
 		this.versionMax = versionMax;
 	}
 
+	public String getName() {
+		return name;
+	}
+
 	@Property(uri = "https://vivoweb.org/ontology/vitro-dynamic-api#resourceName", minOccurs = 1, maxOccurs = 1)
 	public void setName(String name) {
 		this.name = name;
@@ -141,6 +145,41 @@ public class Resource implements Versionable<ResourceKey> {
 	@Override
 	public boolean hasClients() {
 		return !clients.isEmpty();
+	}
+
+	public String getCustomRestActionByName(String name) {
+		for (CustomRESTAction customRestAction : customRESTActions) {
+			if (customRestAction.getName().equals(name)) {
+				return customRestAction.getTargetRPC().getName();
+			}
+		}
+		throw new UnsupportedOperationException("Unsupported custom action");
+	}
+
+	public String getActionNameByMethod(String method) {
+		System.out.println("\nget action name: " + method + "\n");
+		switch (method.toUpperCase()) {
+			case "POST":
+				return getNameOfRpc(rpcOnPost);
+			case "GET":
+				return getNameOfRpc(rpcOnGet);
+			case "DELETE":
+				return getNameOfRpc(rpcOnDelete);
+			case "PUT":
+				return getNameOfRpc(rpcOnPut);
+			case "PATCH":
+				return getNameOfRpc(rpcOnPatch);
+			default:
+				throw new UnsupportedOperationException("Unsupported method");
+		}
+	}
+
+	private String getNameOfRpc(RPC rpc) {
+		System.out.println("\nget name of rpc: " + rpc + "\n");
+		if (rpc != null) {
+			return rpc.getName();
+		}
+		throw new UnsupportedOperationException("Unable to determine action");
 	}
 
 }

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/dynapi/request/RequestPath.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/dynapi/request/RequestPath.java
@@ -1,0 +1,139 @@
+package edu.cornell.mannlib.vitro.webapp.dynapi.request;
+
+import static org.apache.commons.lang3.StringUtils.EMPTY;
+import static org.apache.commons.lang3.StringUtils.isNotEmpty;
+
+import java.util.Base64;
+
+import javax.servlet.http.HttpServletRequest;
+
+public class RequestPath {
+
+    public static final String RESOURCE_ID_PARAM = "RESOURCE_ID";
+
+    public static final String API_BASE_PATH = "/api";
+    public static final String RPC_BASE_PATH = API_BASE_PATH + "/rpc";
+    public static final String REST_BASE_PATH = API_BASE_PATH + "/rest";
+
+    private final RequestType type;
+
+    private final String[] pathParts;
+
+    private final String resourceVersion;
+
+    private final String resourceName;
+
+    private final String resourceId;
+
+    private final String actionName;
+
+    private RequestPath(HttpServletRequest request) {
+        String contextPath = request != null && request.getContextPath() != null
+                ? request.getContextPath()
+                : EMPTY;
+        String pathInfo = request != null && request.getPathInfo() != null
+                ? request.getPathInfo()
+                : EMPTY;
+
+        pathParts = pathInfo.split("/");
+
+        if (contextPath.toLowerCase().contains(RPC_BASE_PATH)) {
+            type = RequestType.RPC;
+            actionName = pathParts.length > 1 ? pathParts[1] : null;
+            resourceVersion = null;
+            resourceName = null;
+            resourceId = null;
+        } else if (contextPath.toLowerCase().contains(REST_BASE_PATH)) {
+            type = RequestType.REST;
+            resourceVersion = pathParts.length > 1 ? pathParts[1] : null;
+            resourceName = pathParts.length > 2 ? pathParts[2] : null;
+
+            if (pathParts.length > 3) {
+                if (pathParts[3].toLowerCase().startsWith("resource:")) {
+                    resourceId = decode(pathParts[3]);
+                    actionName = pathParts.length > 4 ? pathParts[4] : null;
+                    request.getParameterMap().put(RESOURCE_ID_PARAM, new String[] { resourceId });
+                } else {
+                    resourceId = null;
+                    actionName = pathParts[3];
+                }
+            } else {
+                resourceId = null;
+                actionName = null;
+            }
+        } else {
+            type = RequestType.UNKNOWN;
+            resourceVersion = null;
+            resourceName = null;
+            resourceId = null;
+            actionName = null;
+        }
+    }
+
+    private String decode(String pathParameter) {
+        return new String(Base64.getDecoder().decode(pathParameter.split(":")[1]));
+    }
+
+    public RequestType getType() {
+        return type;
+    }
+
+    public String getResourceVersion() {
+        return resourceVersion;
+    }
+
+    public String getResourceName() {
+        return resourceName;
+    }
+
+    public String getResourceId() {
+        return resourceId;
+    }
+
+    public String getActionName() {
+        return actionName;
+    }
+
+    public boolean isValid() {
+        boolean isValid = false;
+        switch (type) {
+            case REST:
+                boolean hasVersionAndName = isNotEmpty(resourceVersion) && isNotEmpty(resourceName);
+                if (pathParts.length == 3) {
+                    isValid = hasVersionAndName;
+                } else if (pathParts.length > 3) {
+                    boolean hasActionName = isNotEmpty(actionName);
+                    boolean hasResourceId = isNotEmpty(resourceId);
+
+                    if (pathParts.length == 4) {
+                        isValid = hasVersionAndName && (hasActionName || hasResourceId);
+                    } else if (pathParts.length == 5) {
+                        isValid = hasVersionAndName && hasResourceId && hasActionName;
+                    }
+                }
+                break;
+            case RPC:
+                boolean hasActionName = isNotEmpty(actionName);
+
+                isValid = hasActionName;
+                break;
+            case UNKNOWN:
+            default:
+        }
+
+        return isValid;
+    }
+
+    public boolean isCustomRestAction() {
+        return isNotEmpty(resourceVersion) && isNotEmpty(resourceName) && isNotEmpty(actionName);
+    }
+
+    public static RequestPath from(HttpServletRequest request) {
+        return new RequestPath(request);
+    }
+
+    public enum RequestType {
+        RPC, REST, UNKNOWN
+    }
+
+}

--- a/api/src/test/java/edu/cornell/mannlib/vitro/webapp/dynapi/RESTEndpointTest.java
+++ b/api/src/test/java/edu/cornell/mannlib/vitro/webapp/dynapi/RESTEndpointTest.java
@@ -1,0 +1,204 @@
+package edu.cornell.mannlib.vitro.webapp.dynapi;
+
+import static edu.cornell.mannlib.vitro.webapp.dynapi.request.RequestPath.REST_BASE_PATH;
+import static org.apache.commons.lang3.StringUtils.EMPTY;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Map;
+
+import javax.servlet.ServletContext;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.Spy;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import edu.cornell.mannlib.vitro.webapp.dynapi.components.Action;
+import edu.cornell.mannlib.vitro.webapp.dynapi.components.OperationResult;
+import edu.cornell.mannlib.vitro.webapp.dynapi.components.Resource;
+import edu.cornell.mannlib.vitro.webapp.dynapi.components.ResourceKey;
+
+@RunWith(MockitoJUnitRunner.class)
+public class RESTEndpointTest {
+
+	private final static String PATH_INFO = "/1/test";
+	private final static String CONTEXT_PATH = REST_BASE_PATH + PATH_INFO;
+
+	private Map<String, String[]> params;
+
+	private ServletContext context;
+
+	private MockedStatic<ResourcePool> resourcePoolStatic;
+
+	private MockedStatic<ActionPool> actionPoolStatic;
+
+	private RESTEndpoint restEndpoint;
+
+	@Mock
+	private ResourcePool resourcePool;
+
+	@Mock
+	private ActionPool actionPool;
+
+	@Mock
+	private Resource resource;
+
+	@Spy
+	private Action action;
+
+	@Mock
+	private HttpServletRequest request;
+
+	@Mock
+	private HttpServletResponse response;
+
+	@Before
+	public void beforeEach() {
+		resourcePoolStatic = mockStatic(ResourcePool.class);
+		actionPoolStatic = mockStatic(ActionPool.class);
+
+		when(ResourcePool.getInstance()).thenReturn(resourcePool);
+		when(resourcePool.get(any(ResourceKey.class))).thenReturn(resource);
+
+		when(ActionPool.getInstance()).thenReturn(actionPool);
+		when(actionPool.get(any(String.class))).thenReturn(action);
+
+		when(request.getParameterMap()).thenReturn(params);
+		when(request.getServletContext()).thenReturn(context);
+
+		restEndpoint = new RESTEndpoint();
+	}
+
+	@After
+	public void afterEach() {
+		resourcePoolStatic.close();
+		actionPoolStatic.close();
+	}
+
+	@Test
+	public void doPostTest() {
+		prepareMocks("POST", "test");
+		restEndpoint.doPost(request, response);
+		verifyMocks(1, HttpServletResponse.SC_OK);
+	}
+
+	@Test
+	public void doPostCustomRestActionTest() {
+		OperationResult result = new OperationResult(HttpServletResponse.SC_OK);
+
+		when(request.getMethod()).thenReturn("POST");
+		when(request.getContextPath()).thenReturn(CONTEXT_PATH + "/dedupe");
+		when(request.getPathInfo()).thenReturn(PATH_INFO + "/dedupe");
+
+		when(action.run(any(OperationData.class))).thenReturn(result);
+
+		when(resource.getCustomRestActionByName("dedupe")).thenReturn("dedupe");
+		doNothing().when(resource).removeClient();
+
+		restEndpoint.doPost(request, response);
+
+		verify(resource, times(0)).getActionNameByMethod(any());
+		verify(resource, times(1)).getCustomRestActionByName(any());
+		verify(resource, times(1)).removeClient();
+		verify(action, times(1)).run(any());
+		verify(action, times(1)).removeClient();
+		verify(response, times(1)).setStatus(HttpServletResponse.SC_OK);
+	}
+
+	@Test
+	public void doPostTestNotFound() {
+		when(request.getPathInfo()).thenReturn(EMPTY);
+		restEndpoint.doPost(request, response);
+		verifyMocks(0, HttpServletResponse.SC_NOT_FOUND);
+	}
+
+	@Test
+	public void doGetTest() {
+		prepareMocks("GET", "test");
+		restEndpoint.doGet(request, response);
+		verifyMocks(1, HttpServletResponse.SC_OK);
+	}
+
+	@Test
+	public void doGetTestNotFound() {
+		when(request.getPathInfo()).thenReturn(EMPTY);
+		restEndpoint.doGet(request, response);
+		verifyMocks(0, HttpServletResponse.SC_NOT_FOUND);
+	}
+
+	@Test
+	public void doPutTest() {
+		prepareMocks("PUT", "test");
+		restEndpoint.doPut(request, response);
+		verifyMocks(1, HttpServletResponse.SC_OK);
+	}
+
+	@Test
+	public void doPutTestNotFound() {
+		when(request.getPathInfo()).thenReturn(EMPTY);
+		restEndpoint.doPut(request, response);
+		verifyMocks(0, HttpServletResponse.SC_NOT_FOUND);
+	}
+
+	@Test
+	public void doPatchTest() {
+		prepareMocks("PATCH", "test");
+		restEndpoint.doPatch(request, response);
+		verifyMocks(1, HttpServletResponse.SC_OK);
+	}
+
+	@Test
+	public void doPatchTestNotFound() {
+		when(request.getPathInfo()).thenReturn(EMPTY);
+		restEndpoint.doPatch(request, response);
+		verifyMocks(0, HttpServletResponse.SC_NOT_FOUND);
+	}
+
+	@Test
+	public void doDeleteTest() {
+		prepareMocks("DELETE", "test");
+		restEndpoint.doDelete(request, response);
+		verifyMocks(1, HttpServletResponse.SC_OK);
+	}
+
+	@Test
+	public void doDeleteTestNotFound() {
+		when(request.getPathInfo()).thenReturn(EMPTY);
+		restEndpoint.doDelete(request, response);
+		verifyMocks(0, HttpServletResponse.SC_NOT_FOUND);
+	}
+
+	private void prepareMocks(String method, String actionName) {
+		OperationResult result = new OperationResult(HttpServletResponse.SC_OK);
+
+		when(request.getMethod()).thenReturn(method);
+		when(request.getContextPath()).thenReturn(CONTEXT_PATH);
+		when(request.getPathInfo()).thenReturn(PATH_INFO);
+
+		when(action.run(any(OperationData.class))).thenReturn(result);
+
+		when(resource.getActionNameByMethod(method)).thenReturn(actionName);
+		doNothing().when(resource).removeClient();
+	}
+
+	private void verifyMocks(int count, int status) {
+		verify(resource, times(count)).getActionNameByMethod(any());
+		verify(resource, times(0)).getCustomRestActionByName(any());
+		verify(resource, times(count)).removeClient();
+		verify(action, times(count)).run(any());
+		verify(action, times(count)).removeClient();
+		verify(response, times(1)).setStatus(status);
+	}
+
+}

--- a/api/src/test/java/edu/cornell/mannlib/vitro/webapp/dynapi/RPCEndpointTest.java
+++ b/api/src/test/java/edu/cornell/mannlib/vitro/webapp/dynapi/RPCEndpointTest.java
@@ -1,5 +1,7 @@
 package edu.cornell.mannlib.vitro.webapp.dynapi;
 
+import static edu.cornell.mannlib.vitro.webapp.dynapi.request.RequestPath.RPC_BASE_PATH;
+import static org.apache.commons.lang3.StringUtils.EMPTY;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.times;
@@ -27,7 +29,8 @@ import edu.cornell.mannlib.vitro.webapp.dynapi.components.OperationResult;
 @RunWith(MockitoJUnitRunner.class)
 public class RPCEndpointTest {
 
-	private final static String URI_TEST = "/test";
+	private final static String PATH_INFO = "/test";
+	private final static String CONTEXT_PATH = RPC_BASE_PATH + PATH_INFO;
 
 	private Map<String, String[]> params;
 
@@ -77,7 +80,8 @@ public class RPCEndpointTest {
 	public void doPostTest() {
 		OperationResult result = new OperationResult(HttpServletResponse.SC_OK);
 
-		when(request.getPathInfo()).thenReturn(URI_TEST);
+		when(request.getContextPath()).thenReturn(CONTEXT_PATH);
+		when(request.getPathInfo()).thenReturn(PATH_INFO);
 		when(action.run(any(OperationData.class))).thenReturn(result);
 
 		rpcEndpoint.doPost(request, response);
@@ -87,7 +91,7 @@ public class RPCEndpointTest {
 
 	@Test
 	public void doPostTestOnMissing() {
-		when(request.getPathInfo()).thenReturn("");
+		when(request.getPathInfo()).thenReturn(EMPTY);
 
 		rpcEndpoint.doPost(request, response);
 		verify(action, times(0)).run(any());

--- a/api/src/test/java/edu/cornell/mannlib/vitro/webapp/dynapi/request/RequestPathTest.java
+++ b/api/src/test/java/edu/cornell/mannlib/vitro/webapp/dynapi/request/RequestPathTest.java
@@ -1,0 +1,174 @@
+package edu.cornell.mannlib.vitro.webapp.dynapi.request;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.when;
+
+import java.util.Base64;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import edu.cornell.mannlib.vitro.webapp.dynapi.request.RequestPath.RequestType;
+
+@RunWith(MockitoJUnitRunner.class)
+public class RequestPathTest {
+
+    private String resourceId = "https://scholars.institution.edu/individual/n1f9d4ddc";
+    private String encodedResourceId = Base64.getEncoder().encodeToString(resourceId.getBytes());
+
+    @Mock
+    private HttpServletRequest request;
+
+    @Test
+    public void testRpc() {
+        when(request.getContextPath()).thenReturn("/api/rpc/create");
+        when(request.getPathInfo()).thenReturn("/create");
+
+        RequestPath requestPath = RequestPath.from(request);
+
+        assertTrue(requestPath.isValid());
+        assertFalse(requestPath.isCustomRestAction());
+        assertEquals(RequestType.RPC, requestPath.getType());
+        assertEquals("create", requestPath.getActionName());
+        assertEquals(null, requestPath.getResourceVersion());
+        assertEquals(null, requestPath.getResourceName());
+        assertEquals(null, requestPath.getResourceId());
+
+
+        when(request.getContextPath()).thenReturn("/api/rpc/");
+        when(request.getPathInfo()).thenReturn("/");
+
+        assertFalse(RequestPath.from(request).isValid());
+
+
+        when(request.getContextPath()).thenReturn(null);
+        when(request.getPathInfo()).thenReturn("/create");
+
+        assertFalse(RequestPath.from(request).isValid());
+
+
+        when(request.getContextPath()).thenReturn("/api/rpc");
+        when(request.getPathInfo()).thenReturn(null);
+
+        assertFalse(RequestPath.from(request).isValid());
+
+
+        when(request.getContextPath()).thenReturn(null);
+        when(request.getPathInfo()).thenReturn(null);
+
+        assertFalse(RequestPath.from(request).isValid());
+    }
+
+    @Test
+    public void testRestCollection() {
+        when(request.getContextPath()).thenReturn("/api/rest/1/persons");
+        when(request.getPathInfo()).thenReturn("/1/persons");
+
+        RequestPath requestPath = RequestPath.from(request);
+
+        assertTrue(requestPath.isValid());
+        assertFalse(requestPath.isCustomRestAction());
+        assertEquals(RequestType.REST, requestPath.getType());
+        assertEquals("1", requestPath.getResourceVersion());
+        assertEquals("persons", requestPath.getResourceName());
+        assertEquals(null, requestPath.getResourceId());
+        assertEquals(null, requestPath.getActionName());
+
+
+        when(request.getContextPath()).thenReturn("/api/rest/");
+        when(request.getPathInfo()).thenReturn("/");
+
+        assertFalse(RequestPath.from(request).isValid());
+
+
+        when(request.getContextPath()).thenReturn(null);
+        when(request.getPathInfo()).thenReturn("/1/persons");
+
+        assertFalse(RequestPath.from(request).isValid());
+
+
+        when(request.getContextPath()).thenReturn("/api/rest");
+        when(request.getPathInfo()).thenReturn(null);
+
+        assertFalse(RequestPath.from(request).isValid());
+
+
+        when(request.getContextPath()).thenReturn(null);
+        when(request.getPathInfo()).thenReturn(null);
+
+        assertFalse(RequestPath.from(request).isValid());
+    }
+
+    @Test
+    public void testRestCustomAction() {
+        when(request.getContextPath()).thenReturn("/api/rest/1/persons/dedupe");
+        when(request.getPathInfo()).thenReturn("/1/persons/dedupe");
+
+        RequestPath requestPath = RequestPath.from(request);
+
+        assertTrue(requestPath.isValid());
+        assertTrue(requestPath.isCustomRestAction());
+        assertEquals(RequestType.REST, requestPath.getType());
+        assertEquals("1", requestPath.getResourceVersion());
+        assertEquals("persons", requestPath.getResourceName());
+        assertEquals(null, requestPath.getResourceId());
+        assertEquals("dedupe", requestPath.getActionName());
+    }
+
+    @Test
+    public void testRestIndividual() {
+        when(request.getContextPath()).thenReturn("/api/rest/1/persons/resource:" + encodedResourceId);
+        when(request.getPathInfo()).thenReturn("/1/persons/resource:" + encodedResourceId);
+
+        RequestPath requestPath = RequestPath.from(request);
+
+        assertTrue(requestPath.isValid());
+        assertFalse(requestPath.isCustomRestAction());
+        assertEquals(RequestType.REST, requestPath.getType());
+        assertEquals("1", requestPath.getResourceVersion());
+        assertEquals("persons", requestPath.getResourceName());
+        assertEquals(resourceId, requestPath.getResourceId());
+        assertEquals(null, requestPath.getActionName());
+    }
+
+    @Test
+    public void testRestIndividualCustomAction() {
+        when(request.getContextPath()).thenReturn("/api/rest/1/persons/resource:" + encodedResourceId + "/patch");
+        when(request.getPathInfo()).thenReturn("/1/persons/resource:" + encodedResourceId + "/patch");
+
+        RequestPath requestPath = RequestPath.from(request);
+
+        assertTrue(requestPath.isValid());
+        assertTrue(requestPath.isCustomRestAction());
+        assertEquals(RequestType.REST, requestPath.getType());
+        assertEquals("1", requestPath.getResourceVersion());
+        assertEquals("persons", requestPath.getResourceName());
+        assertEquals(resourceId, requestPath.getResourceId());
+        assertEquals("patch", requestPath.getActionName());
+    }
+
+    @Test
+    public void testNotFound() {
+        when(request.getContextPath()).thenReturn("/api/rest/1/persons/resource:" + encodedResourceId + "/patch/foo");
+        when(request.getPathInfo()).thenReturn("/1/persons/resource:" + encodedResourceId + "/patch/foo");
+
+        assertFalse(RequestPath.from(request).isValid());
+
+        when(request.getContextPath()).thenReturn("/api/bar/1/persons");
+        when(request.getPathInfo()).thenReturn("/1/persons");
+
+        assertFalse(RequestPath.from(request).isValid());
+
+        when(request.getContextPath()).thenReturn("/some/random/path");
+        when(request.getPathInfo()).thenReturn("/3/2/1");
+
+        assertFalse(RequestPath.from(request).isValid());
+    }
+
+}


### PR DESCRIPTION
**[VIVO GitHub issue](https://github.com/vivo-project/VIVO/issues)**: https://github.com/vivo-project/VIVO/issues/3667

# What does this pull request do?
Add RequestPath object to parse request path. Implement REST endpoint. Added unit tests for both.

https://editor.swagger.io/?url=https://gist.githubusercontent.com/wwelling/fa140a474cce0f0540dce7491baec6eb/raw/1eb45168636993fb2361b1c0c3478e2b5e925624/vivo-dynamic-api.yaml

# What's new?
During parsing the request path, if a resource id is provided it is added to the `HTTPServletRequest` parameter map using param key `RESOURCE_ID`.

# Interested parties
Tag (@ mention) interested parties or, if unsure, @VIVO-project/vivo-committers
