### PR TITLE
[3678] Refactor Integration Tests to use the full word Test.

### DIFF
--- a/api/src/test/java/edu/cornell/mannlib/vitro/webapp/dynapi/RPCEndpointITest.java
+++ b/api/src/test/java/edu/cornell/mannlib/vitro/webapp/dynapi/RPCEndpointITest.java
@@ -34,7 +34,7 @@ import org.junit.runners.Parameterized.Parameter;
 import org.mockito.MockedStatic;
 
 @RunWith(Parameterized.class)
-public class RPCEndpointIT extends ServletContextIT {
+public class RPCEndpointITest extends ServletContextITest {
 
     private final static String URI_CONTEXT = "/api/rpc/";
     private final static String URI_BASE = "http://localhost" + URI_CONTEXT;
@@ -181,7 +181,7 @@ public class RPCEndpointIT extends ServletContextIT {
         String emailIsGood = "example@localhost";
 
         Method[] before = new Method[] {
-            RPCEndpointIT.class.getDeclaredMethod("mockSparqlResponseEmptySuccess")
+            RPCEndpointITest.class.getDeclaredMethod("mockSparqlResponseEmptySuccess")
         };
 
         return Arrays.asList(new Object[][] {

--- a/api/src/test/java/edu/cornell/mannlib/vitro/webapp/dynapi/ServletContextITest.java
+++ b/api/src/test/java/edu/cornell/mannlib/vitro/webapp/dynapi/ServletContextITest.java
@@ -12,7 +12,7 @@ import java.util.Map;
 
 import javax.servlet.http.HttpServletResponse;
 
-public abstract class ServletContextIT extends ServletContextTest {
+public abstract class ServletContextITest extends ServletContextTest {
 
     protected Map<String, String[]> parameterMap;
 


### PR DESCRIPTION
**[VIVO GitHub issue 3678](https://github.com/vivo-project/VIVO/issues/3678)**:

# What does this pull request do?
This allows for the tests to be properly picked up and executed.

# What's new?
Refactor the `IT` part of the integration test names into `ITest`.

# How should this be tested?
Run the tests at the top level **without** passing `-Dtest=RPCEndpointITest` for explicitly calling.
This can be confirmed to run by looking into the surefire reports at these paths:
```
api/target/surefire-reports/edu.cornell.mannlib.vitro.webapp.dynapi.RPCEndpointITest.txt
api/target/surefire-reports/TEST-edu.cornell.mannlib.vitro.webapp.dynapi.RPCEndpointITest.xml
```

# Interested parties
Tag (@ mention) interested parties or, if unsure, @VIVO-project/vivo-committers
- @wwelling
- @chenejac 
