### PR TITLE
 Prevent copying pom file to home directory

### DIFF
--- a/installer/home/pom.xml
+++ b/installer/home/pom.xml
@@ -111,7 +111,7 @@
             <groupId>org.vivoweb</groupId>
             <artifactId>vitro-languages-home-core</artifactId>
             <version>${project.version}</version>
-            <type>pom</type>
+            <type>tar.gz</type>
         </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
Changes artifact type from pom to tar.gz to prevent copying pom files ( vitro-languages-home-core-1.12.3-SNAPSHOT.pom) to home directory.

**How to test**
Install Vitro from sources before applying, notice that file is added to home directory.
Clean home directory
Apply this PR
Install Vitro from sources, verify that file is not added to home directory