### PR TITLE
Individual list calculation fix

### DIFF
--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/freemarker/IndividualListController.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/freemarker/IndividualListController.java
@@ -250,8 +250,7 @@ public class IndividualListController extends FreemarkerHttpServlet {
         }else if ( requiredPages > MAX_PAGES && selectedPage > requiredPages - MAX_PAGES ){
             //the selected page is in the end of the list
             int startPage = requiredPages - MAX_PAGES;
-            double max = Math.ceil(size/pageSize);
-            for(int page = startPage; page <= max; page++ ){
+            for(int page = startPage; page <= requiredPages; page++ ){
                 records.add( new PageRecord( "page=" + page, Integer.toString(page), Integer.toString(page), selectedPage == page ) );
             }
         }else{


### PR DESCRIPTION
If individual list is big enough (4584 for example), last page (153) would be missing on all pages other than 113, because of rounding toward negative infinity 4584/30 = 152.8 , after rounding it would be 152. 

The problem starts to appear from 1231 individuals 40 pages (30 individuals on each ) + more button represents 41 page( 30 more )

### How to test:
Create 4584 individuals, open individuals list, go to page greater than 113, observe that page 153 is visible.
# Interested parties
Tag (@ mention) interested parties or, if unsure, @VIVO-project/vivo-committers
