### PR TITLE
Added action and resourceAPI to data property version

### DIFF
--- a/home/src/main/resources/rdf/tbox/filegraph/vitro-dynamic-api.owl
+++ b/home/src/main/resources/rdf/tbox/filegraph/vitro-dynamic-api.owl
@@ -131,8 +131,8 @@
         <rdfs:domain>
             <owl:Class>
                 <owl:unionOf rdf:parseType="Collection">
-                    <rdfs:domain rdf:resource="https://vivoweb.org/ontology/vitro-dynamic-api#sparqlQuery"/>
-                    <rdfs:domain rdf:resource="https://vivoweb.org/ontology/vitro-dynamic-api#template"/>
+                    <owl:Class rdf:about=="https://vivoweb.org/ontology/vitro-dynamic-api#sparqlQuery"/>
+                    <owl:Class rdf:about=="https://vivoweb.org/ontology/vitro-dynamic-api#template"/>
                 </owl:unionOf>
             </owl:Class>
         </rdfs:domain>
@@ -262,8 +262,8 @@
         <rdfs:domain>
             <owl:Class>
                 <owl:unionOf rdf:parseType="Collection">
-                    <rdfs:domain rdf:resource="https://vivoweb.org/ontology/vitro-dynamic-api#rpc"/>
-                    <rdfs:domain rdf:resource="https://vivoweb.org/ontology/vitro-dynamic-api#customRESTAction"/>
+                    <owl:Class rdf:about=="https://vivoweb.org/ontology/vitro-dynamic-api#rpc"/>
+                    <owl:Class rdf:about=="https://vivoweb.org/ontology/vitro-dynamic-api#customRESTAction"/>
                 </owl:unionOf>
             </owl:Class>
         </rdfs:domain>
@@ -406,13 +406,13 @@
         <rdfs:domain>
             <owl:Class>
                 <owl:unionOf rdf:parseType="Collection">
-                    <rdfs:domain rdf:resource="https://vivoweb.org/ontology/vitro-dynamic-api#rpc"/>
-                    <rdfs:domain rdf:resource="https://vivoweb.org/ontology/vitro-dynamic-api#model"/>
-                    <rdfs:domain rdf:resource="https://vivoweb.org/ontology/vitro-dynamic-api#parameter"/>
-                    <rdfs:domain rdf:resource="https://vivoweb.org/ontology/vitro-dynamic-api#parameterType"/>
-                    <rdfs:domain rdf:resource="https://vivoweb.org/ontology/vitro-dynamic-api#resourceAPI"/>
-                    <rdfs:domain rdf:resource="https://vivoweb.org/ontology/vitro-dynamic-api#httpMethod"/>
-                    <rdfs:domain rdf:resource="https://vivoweb.org/ontology/vitro-dynamic-api#customRESTAction"/>
+                    <owl:Class rdf:about=="https://vivoweb.org/ontology/vitro-dynamic-api#rpc"/>
+                    <owl:Class rdf:about=="https://vivoweb.org/ontology/vitro-dynamic-api#model"/>
+                    <owl:Class rdf:about=="https://vivoweb.org/ontology/vitro-dynamic-api#parameter"/>
+                    <owl:Class rdf:about=="https://vivoweb.org/ontology/vitro-dynamic-api#parameterType"/>
+                    <owl:Class rdf:about=="https://vivoweb.org/ontology/vitro-dynamic-api#resourceAPI"/>
+                    <owl:Class rdf:about=="https://vivoweb.org/ontology/vitro-dynamic-api#httpMethod"/>
+                    <owl:Class rdf:about=="https://vivoweb.org/ontology/vitro-dynamic-api#customRESTAction"/>
                 </owl:unionOf>
             </owl:Class>
         </rdfs:domain>
@@ -460,8 +460,8 @@
         <rdfs:domain>
             <owl:Class>
                 <owl:unionOf rdf:parseType="Collection">
-                    <rdfs:domain rdf:resource="https://vivoweb.org/ontology/vitro-dynamic-api#resourceAPI"/>
-                    <rdfs:domain rdf:resource="https://vivoweb.org/ontology/vitro-dynamic-api#rpc"/>
+                    <owl:Class rdf:about=="https://vivoweb.org/ontology/vitro-dynamic-api#resourceAPI"/>
+                    <owl:Class rdf:about=="https://vivoweb.org/ontology/vitro-dynamic-api#rpc"/>
                 </owl:unionOf>
             </owl:Class>
         </rdfs:domain>
@@ -474,8 +474,8 @@
         <rdfs:domain>
             <owl:Class>
                 <owl:unionOf rdf:parseType="Collection">
-                    <rdfs:domain rdf:resource="https://vivoweb.org/ontology/vitro-dynamic-api#resourceAPI"/>
-                    <rdfs:domain rdf:resource="https://vivoweb.org/ontology/vitro-dynamic-api#rpc"/>
+                    <owl:Class rdf:about=="https://vivoweb.org/ontology/vitro-dynamic-api#resourceAPI"/>
+                    <owl:Class rdf:about=="https://vivoweb.org/ontology/vitro-dynamic-api#rpc"/>
                 </owl:unionOf>
             </owl:Class>
         </rdfs:domain>
@@ -495,9 +495,9 @@
         <rdfs:domain>
             <owl:Class>
                 <owl:unionOf rdf:parseType="Collection">
-                    <rdfs:domain rdf:resource="https://vivoweb.org/ontology/vitro-dynamic-api#api"/>
-                    <rdfs:domain rdf:resource="https://vivoweb.org/ontology/vitro-dynamic-api#rpc"/>
-                    <rdfs:domain rdf:resource="https://vivoweb.org/ontology/vitro-dynamic-api#parameter"/>
+                    <owl:Class rdf:about=="https://vivoweb.org/ontology/vitro-dynamic-api#api"/>
+                    <owl:Class rdf:about=="https://vivoweb.org/ontology/vitro-dynamic-api#rpc"/>
+                    <owl:Class rdf:about=="https://vivoweb.org/ontology/vitro-dynamic-api#parameter"/>
                 </owl:unionOf>
             </owl:Class>
         </rdfs:domain>

--- a/home/src/main/resources/rdf/tbox/filegraph/vitro-dynamic-api.owl
+++ b/home/src/main/resources/rdf/tbox/filegraph/vitro-dynamic-api.owl
@@ -128,8 +128,14 @@
 
     <owl:ObjectProperty rdf:about="https://vivoweb.org/ontology/vitro-dynamic-api#hasModel">
         <rdfs:subPropertyOf rdf:resource="http://www.w3.org/2002/07/owl#topObjectProperty"/>
-        <rdfs:domain rdf:resource="https://vivoweb.org/ontology/vitro-dynamic-api#sparqlQuery"/>
-        <rdfs:domain rdf:resource="https://vivoweb.org/ontology/vitro-dynamic-api#template"/>
+        <rdfs:domain>
+            <owl:Class>
+                <owl:unionOf rdf:parseType="Collection">
+                    <rdfs:domain rdf:resource="https://vivoweb.org/ontology/vitro-dynamic-api#sparqlQuery"/>
+                    <rdfs:domain rdf:resource="https://vivoweb.org/ontology/vitro-dynamic-api#template"/>
+                </owl:unionOf>
+            </owl:Class>
+        </rdfs:domain>
         <rdfs:range rdf:resource="https://vivoweb.org/ontology/vitro-dynamic-api#model"/>
         <rdfs:label xml:lang="en-US">has query model</rdfs:label>
     </owl:ObjectProperty>
@@ -253,8 +259,14 @@
 
     <owl:ObjectProperty rdf:about="https://vivoweb.org/ontology/vitro-dynamic-api#hasDefaultMethod">
         <rdfs:subPropertyOf rdf:resource="http://www.w3.org/2002/07/owl#topObjectProperty"/>
-        <rdfs:domain rdf:resource="https://vivoweb.org/ontology/vitro-dynamic-api#rpc"/>
-        <rdfs:domain rdf:resource="https://vivoweb.org/ontology/vitro-dynamic-api#customRESTAction"/>
+        <rdfs:domain>
+            <owl:Class>
+                <owl:unionOf rdf:parseType="Collection">
+                    <rdfs:domain rdf:resource="https://vivoweb.org/ontology/vitro-dynamic-api#rpc"/>
+                    <rdfs:domain rdf:resource="https://vivoweb.org/ontology/vitro-dynamic-api#customRESTAction"/>
+                </owl:unionOf>
+            </owl:Class>
+        </rdfs:domain>
         <rdfs:range rdf:resource="https://vivoweb.org/ontology/vitro-dynamic-api#httpMethod"/>
         <rdfs:label xml:lang="en-US">default http method</rdfs:label>
     </owl:ObjectProperty>
@@ -391,13 +403,19 @@
 
     <owl:DatatypeProperty rdf:about="https://vivoweb.org/ontology/vitro-dynamic-api#name">
         <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#FunctionalProperty"/>
-        <rdfs:domain rdf:resource="https://vivoweb.org/ontology/vitro-dynamic-api#rpc"/>
-        <rdfs:domain rdf:resource="https://vivoweb.org/ontology/vitro-dynamic-api#model"/>
-        <rdfs:domain rdf:resource="https://vivoweb.org/ontology/vitro-dynamic-api#parameter"/>
-        <rdfs:domain rdf:resource="https://vivoweb.org/ontology/vitro-dynamic-api#parameterType"/>
-        <rdfs:domain rdf:resource="https://vivoweb.org/ontology/vitro-dynamic-api#resourceAPI"/>
-        <rdfs:domain rdf:resource="https://vivoweb.org/ontology/vitro-dynamic-api#httpMethod"/>
-        <rdfs:domain rdf:resource="https://vivoweb.org/ontology/vitro-dynamic-api#customRESTAction"/>
+        <rdfs:domain>
+            <owl:Class>
+                <owl:unionOf rdf:parseType="Collection">
+                    <rdfs:domain rdf:resource="https://vivoweb.org/ontology/vitro-dynamic-api#rpc"/>
+                    <rdfs:domain rdf:resource="https://vivoweb.org/ontology/vitro-dynamic-api#model"/>
+                    <rdfs:domain rdf:resource="https://vivoweb.org/ontology/vitro-dynamic-api#parameter"/>
+                    <rdfs:domain rdf:resource="https://vivoweb.org/ontology/vitro-dynamic-api#parameterType"/>
+                    <rdfs:domain rdf:resource="https://vivoweb.org/ontology/vitro-dynamic-api#resourceAPI"/>
+                    <rdfs:domain rdf:resource="https://vivoweb.org/ontology/vitro-dynamic-api#httpMethod"/>
+                    <rdfs:domain rdf:resource="https://vivoweb.org/ontology/vitro-dynamic-api#customRESTAction"/>
+                </owl:unionOf>
+            </owl:Class>
+        </rdfs:domain>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
         <rdfs:label xml:lang="en-US">name</rdfs:label>
     </owl:DatatypeProperty>
@@ -439,16 +457,28 @@
 
     <owl:DatatypeProperty rdf:about="https://vivoweb.org/ontology/vitro-dynamic-api#minAPIVersion">
         <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#FunctionalProperty"/>
-        <rdfs:domain rdf:resource="https://vivoweb.org/ontology/vitro-dynamic-api#resourceAPI"/>
-        <rdfs:domain rdf:resource="https://vivoweb.org/ontology/vitro-dynamic-api#rpc"/>
+        <rdfs:domain>
+            <owl:Class>
+                <owl:unionOf rdf:parseType="Collection">
+                    <rdfs:domain rdf:resource="https://vivoweb.org/ontology/vitro-dynamic-api#resourceAPI"/>
+                    <rdfs:domain rdf:resource="https://vivoweb.org/ontology/vitro-dynamic-api#rpc"/>
+                </owl:unionOf>
+            </owl:Class>
+        </rdfs:domain>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
         <rdfs:label xml:lang="en-US">API minimum version</rdfs:label>
     </owl:DatatypeProperty>
 
     <owl:DatatypeProperty rdf:about="https://vivoweb.org/ontology/vitro-dynamic-api#maxAPIVersion">
         <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#FunctionalProperty"/>
-        <rdfs:domain rdf:resource="https://vivoweb.org/ontology/vitro-dynamic-api#resourceAPI"/>
-        <rdfs:domain rdf:resource="https://vivoweb.org/ontology/vitro-dynamic-api#rpc"/>
+        <rdfs:domain>
+            <owl:Class>
+                <owl:unionOf rdf:parseType="Collection">
+                    <rdfs:domain rdf:resource="https://vivoweb.org/ontology/vitro-dynamic-api#resourceAPI"/>
+                    <rdfs:domain rdf:resource="https://vivoweb.org/ontology/vitro-dynamic-api#rpc"/>
+                </owl:unionOf>
+            </owl:Class>
+        </rdfs:domain>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
         <rdfs:label xml:lang="en-US">API maximum version</rdfs:label>
     </owl:DatatypeProperty>
@@ -462,9 +492,15 @@
 
     <owl:DatatypeProperty rdf:about="https://vivoweb.org/ontology/vitro-dynamic-api#description">
         <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#FunctionalProperty"/>
-        <rdfs:domain rdf:resource="https://vivoweb.org/ontology/vitro-dynamic-api#api"/>
-        <rdfs:domain rdf:resource="https://vivoweb.org/ontology/vitro-dynamic-api#rpc"/>
-        <rdfs:domain rdf:resource="https://vivoweb.org/ontology/vitro-dynamic-api#parameter"/>
+        <rdfs:domain>
+            <owl:Class>
+                <owl:unionOf rdf:parseType="Collection">
+                    <rdfs:domain rdf:resource="https://vivoweb.org/ontology/vitro-dynamic-api#api"/>
+                    <rdfs:domain rdf:resource="https://vivoweb.org/ontology/vitro-dynamic-api#rpc"/>
+                    <rdfs:domain rdf:resource="https://vivoweb.org/ontology/vitro-dynamic-api#parameter"/>
+                </owl:unionOf>
+            </owl:Class>
+        </rdfs:domain>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
         <rdfs:label xml:lang="en-US">description</rdfs:label>
     </owl:DatatypeProperty>

--- a/home/src/main/resources/rdf/tbox/filegraph/vitro-dynamic-api.owl
+++ b/home/src/main/resources/rdf/tbox/filegraph/vitro-dynamic-api.owl
@@ -131,8 +131,8 @@
         <rdfs:domain>
             <owl:Class>
                 <owl:unionOf rdf:parseType="Collection">
-                    <owl:Class rdf:about=="https://vivoweb.org/ontology/vitro-dynamic-api#sparqlQuery"/>
-                    <owl:Class rdf:about=="https://vivoweb.org/ontology/vitro-dynamic-api#template"/>
+                    <owl:Class rdf:about="https://vivoweb.org/ontology/vitro-dynamic-api#sparqlQuery"/>
+                    <owl:Class rdf:about="https://vivoweb.org/ontology/vitro-dynamic-api#template"/>
                 </owl:unionOf>
             </owl:Class>
         </rdfs:domain>
@@ -262,8 +262,8 @@
         <rdfs:domain>
             <owl:Class>
                 <owl:unionOf rdf:parseType="Collection">
-                    <owl:Class rdf:about=="https://vivoweb.org/ontology/vitro-dynamic-api#rpc"/>
-                    <owl:Class rdf:about=="https://vivoweb.org/ontology/vitro-dynamic-api#customRESTAction"/>
+                    <owl:Class rdf:about="https://vivoweb.org/ontology/vitro-dynamic-api#rpc"/>
+                    <owl:Class rdf:about="https://vivoweb.org/ontology/vitro-dynamic-api#customRESTAction"/>
                 </owl:unionOf>
             </owl:Class>
         </rdfs:domain>
@@ -406,13 +406,13 @@
         <rdfs:domain>
             <owl:Class>
                 <owl:unionOf rdf:parseType="Collection">
-                    <owl:Class rdf:about=="https://vivoweb.org/ontology/vitro-dynamic-api#rpc"/>
-                    <owl:Class rdf:about=="https://vivoweb.org/ontology/vitro-dynamic-api#model"/>
-                    <owl:Class rdf:about=="https://vivoweb.org/ontology/vitro-dynamic-api#parameter"/>
-                    <owl:Class rdf:about=="https://vivoweb.org/ontology/vitro-dynamic-api#parameterType"/>
-                    <owl:Class rdf:about=="https://vivoweb.org/ontology/vitro-dynamic-api#resourceAPI"/>
-                    <owl:Class rdf:about=="https://vivoweb.org/ontology/vitro-dynamic-api#httpMethod"/>
-                    <owl:Class rdf:about=="https://vivoweb.org/ontology/vitro-dynamic-api#customRESTAction"/>
+                    <owl:Class rdf:about="https://vivoweb.org/ontology/vitro-dynamic-api#rpc"/>
+                    <owl:Class rdf:about="https://vivoweb.org/ontology/vitro-dynamic-api#model"/>
+                    <owl:Class rdf:about="https://vivoweb.org/ontology/vitro-dynamic-api#parameter"/>
+                    <owl:Class rdf:about="https://vivoweb.org/ontology/vitro-dynamic-api#parameterType"/>
+                    <owl:Class rdf:about="https://vivoweb.org/ontology/vitro-dynamic-api#resourceAPI"/>
+                    <owl:Class rdf:about="https://vivoweb.org/ontology/vitro-dynamic-api#httpMethod"/>
+                    <owl:Class rdf:about="https://vivoweb.org/ontology/vitro-dynamic-api#customRESTAction"/>
                 </owl:unionOf>
             </owl:Class>
         </rdfs:domain>
@@ -460,8 +460,8 @@
         <rdfs:domain>
             <owl:Class>
                 <owl:unionOf rdf:parseType="Collection">
-                    <owl:Class rdf:about=="https://vivoweb.org/ontology/vitro-dynamic-api#resourceAPI"/>
-                    <owl:Class rdf:about=="https://vivoweb.org/ontology/vitro-dynamic-api#rpc"/>
+                    <owl:Class rdf:about="https://vivoweb.org/ontology/vitro-dynamic-api#resourceAPI"/>
+                    <owl:Class rdf:about="https://vivoweb.org/ontology/vitro-dynamic-api#rpc"/>
                 </owl:unionOf>
             </owl:Class>
         </rdfs:domain>
@@ -474,8 +474,8 @@
         <rdfs:domain>
             <owl:Class>
                 <owl:unionOf rdf:parseType="Collection">
-                    <owl:Class rdf:about=="https://vivoweb.org/ontology/vitro-dynamic-api#resourceAPI"/>
-                    <owl:Class rdf:about=="https://vivoweb.org/ontology/vitro-dynamic-api#rpc"/>
+                    <owl:Class rdf:about="https://vivoweb.org/ontology/vitro-dynamic-api#resourceAPI"/>
+                    <owl:Class rdf:about="https://vivoweb.org/ontology/vitro-dynamic-api#rpc"/>
                 </owl:unionOf>
             </owl:Class>
         </rdfs:domain>
@@ -495,9 +495,9 @@
         <rdfs:domain>
             <owl:Class>
                 <owl:unionOf rdf:parseType="Collection">
-                    <owl:Class rdf:about=="https://vivoweb.org/ontology/vitro-dynamic-api#api"/>
-                    <owl:Class rdf:about=="https://vivoweb.org/ontology/vitro-dynamic-api#rpc"/>
-                    <owl:Class rdf:about=="https://vivoweb.org/ontology/vitro-dynamic-api#parameter"/>
+                    <owl:Class rdf:about="https://vivoweb.org/ontology/vitro-dynamic-api#api"/>
+                    <owl:Class rdf:about="https://vivoweb.org/ontology/vitro-dynamic-api#rpc"/>
+                    <owl:Class rdf:about="https://vivoweb.org/ontology/vitro-dynamic-api#parameter"/>
                 </owl:unionOf>
             </owl:Class>
         </rdfs:domain>

--- a/home/src/main/resources/rdf/tbox/filegraph/vitro-dynamic-api.owl
+++ b/home/src/main/resources/rdf/tbox/filegraph/vitro-dynamic-api.owl
@@ -471,6 +471,15 @@
 
     <owl:DatatypeProperty rdf:about="https://vivoweb.org/ontology/vitro-dynamic-api#version">
         <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#FunctionalProperty"/>
+        <rdfs:domain>
+            <owl:Class>
+                <owl:unionOf rdf:parseType="Collection">
+                    <owl:Class rdf:about="https://vivoweb.org/ontology/vitro-dynamic-api#api"/>
+                    <owl:Class rdf:about="https://vivoweb.org/ontology/vitro-dynamic-api#action"/>
+                    <owl:Class rdf:about="https://vivoweb.org/ontology/vitro-dynamic-api#resourceAPI"/>
+                </owl:unionOf>
+            </owl:Class>
+        </rdfs:domain>
         <rdfs:domain rdf:resource="https://vivoweb.org/ontology/vitro-dynamic-api#api"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
         <rdfs:label xml:lang="en-US">version</rdfs:label>


### PR DESCRIPTION
**Added action and resourceAPI to data property "version" to store version number**
* * *

# What does this pull request do?
To store a version number with action and resourceAPI I extended vitro-dynamic-api#version with both domains

# What's new?
Additionally some other properties with multible domains were corrected from intersection of the classes to a union of the classes

Example:
    <owl:DatatypeProperty rdf:about="https://vivoweb.org/ontology/vitro-dynamic-api#version">
        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#FunctionalProperty"/>
        <rdfs:domain>
            <owl:Class>
                <owl:unionOf rdf:parseType="Collection">
                    <owl:Class rdf:about="https://vivoweb.org/ontology/vitro-dynamic-api#api"/>
                    <owl:Class rdf:about="https://vivoweb.org/ontology/vitro-dynamic-api#action"/>
                    <owl:Class rdf:about="https://vivoweb.org/ontology/vitro-dynamic-api#resourceAPI"/>
                </owl:unionOf>
            </owl:Class>
        </rdfs:domain>
        <rdfs:domain rdf:resource="https://vivoweb.org/ontology/vitro-dynamic-api#api"/>
        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
        <rdfs:label xml:lang="en-US">version</rdfs:label>
    </owl:DatatypeProperty>



# Interested parties
@litvinovg @chenejac 
