### PR TITLE
Workaround for creating integer literals 

### DIFF
--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/VTwo/RdfLiteralHash.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/VTwo/RdfLiteralHash.java
@@ -55,6 +55,10 @@ public class RdfLiteralHash {
         }else{
             if( stmt.getDatatypeURI() != null && stmt.getDatatypeURI().trim().length() > 0){
                 langOrDatatype = stmt.getDatatypeURI();
+                //Treat integer data type the same as int 
+                //With Jena 3.16.0 all integer literals are stored as int
+                //TODO: remove workaround when bug is resolved
+                langOrDatatype = replaceIntegerWithInt(langOrDatatype);
             }
         }
 
@@ -63,7 +67,13 @@ public class RdfLiteralHash {
             log.debug("got hash " + hashMe.hashCode() + " for String '" + hashMe + "'");
         return hashMe.hashCode();
     }
-
+    
+    private static String replaceIntegerWithInt(String predicate) {
+        if( predicate.equals("http://www.w3.org/2001/XMLSchema#integer")) {
+            predicate = "http://www.w3.org/2001/XMLSchema#int";
+        }
+        return predicate;
+    }
 
     /**
      * @param stmt Data statement


### PR DESCRIPTION
**[VIVO GitHub issue](https://github.com/vivo-project/VIVO/issues/3728)**

# What does this pull request do?
Fixes issue related to creating integer literals in web interface by substituting integer data type with int for purpose of creating hash. It is required as for now integer literals are stored as int.

# How should this be tested?
1. Create Room individual
2. Set seating capacity
3. Verify that there is no error


# Interested parties
@VIVO-project/vivo-committers
