### PR TITLE
fix: retain language tags on editing data properties with backend editor

### DIFF
--- a/api/src/main/java/edu/cornell/mannlib/vedit/beans/DynamicFieldRow.java
+++ b/api/src/main/java/edu/cornell/mannlib/vedit/beans/DynamicFieldRow.java
@@ -8,6 +8,7 @@ public class DynamicFieldRow {
 
     private int id = -1;
     private String value = null;
+    private String language = "";
     private Map parameterMap = null;
 
     public int getId() {
@@ -34,4 +35,13 @@ public class DynamicFieldRow {
         this.parameterMap = parameterMap;
     }
 
+    public String getLanguage() {
+        return language;
+    }
+
+    public void setLanguage(String language) {
+        if (language != null) {
+            this.language = language;    
+        }
+    }
 }

--- a/api/src/main/java/edu/cornell/mannlib/vedit/tags/DynamicFieldsTag.java
+++ b/api/src/main/java/edu/cornell/mannlib/vedit/tags/DynamicFieldsTag.java
@@ -23,9 +23,13 @@ import edu.cornell.mannlib.vedit.beans.FormObject;
 import edu.cornell.mannlib.vedit.beans.DynamicField;
 import edu.cornell.mannlib.vedit.beans.DynamicFieldRow;
 import org.apache.commons.codec.binary.Base64;
+import org.apache.commons.lang3.StringUtils;
+
 import edu.cornell.mannlib.vedit.tags.EditTag;
 
 public class DynamicFieldsTag extends EditTag {
+
+    private static final String LANGUAGE = "language";
 
     private char PATH_SEP = File.separatorChar;
 
@@ -175,7 +179,12 @@ public class DynamicFieldsTag extends EditTag {
                                 String key = (String) paramIt.next();
                                 String value = (String) row.getParameterMap().get(key);
                                 byte[] valueInBase64 = Base64.encodeBase64(value.getBytes());
-                                taName.append(key).append(":").append(new String(valueInBase64)).append(";");
+                                taName.append(key).append(":").append(new String(valueInBase64));
+                                if (StringUtils.isNotBlank(row.getLanguage())) {
+                                    byte[] encodedLang = Base64.encodeBase64(row.getLanguage().getBytes());
+                                    taName.append(":").append(LANGUAGE).append(":").append(new String(encodedLang));                                    
+                                }
+                                taName.append(";");
                             }
                             if (row.getValue().length() > 0) {
                                 String templateWithVars = templateMarkup;

--- a/api/src/main/java/edu/cornell/mannlib/vedit/util/FormUtils.java
+++ b/api/src/main/java/edu/cornell/mannlib/vedit/util/FormUtils.java
@@ -369,6 +369,9 @@ public class FormUtils {
         for (String aParam : param) {
             String[] p = aParam.split(":");
             beanParamMap.put(p[0], new String(Base64.decodeBase64(p[1].getBytes())));
+            if (p.length > 3) {
+                beanParamMap.put(p[2], new String(Base64.decodeBase64(p[3].getBytes())));
+            }
         }
         return beanParamMap;
     }

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/edit/EntityRetryController.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/edit/EntityRetryController.java
@@ -20,8 +20,11 @@ import javax.servlet.http.HttpServletResponse;
 
 import edu.cornell.mannlib.vitro.webapp.utils.JSPPageHandler;
 import org.apache.commons.collections4.map.ListOrderedMap;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+
+import com.ctc.wstx.util.StringUtil;
 
 import edu.cornell.mannlib.vedit.beans.DynamicField;
 import edu.cornell.mannlib.vedit.beans.DynamicFieldRow;
@@ -250,7 +253,12 @@ public class EntityRetryController extends BaseEditController {
                         //TODO: UGH
                         //row.setId(existingValue.getId());
                         row.setParameterMap(parameterMap);
-                        row.setValue(existingValue.getData());
+                        String value = existingValue.getData();
+                        row.setValue(value);
+                        String language = existingValue.getLanguage();
+                        if (!StringUtils.isBlank(language)) {
+                            row.setLanguage(language);
+                        }
                         if (dynamo.getRowList() == null)
                             dynamo.setRowList(new ArrayList());
                         dynamo.getRowList().add(row);

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/listener/impl/IndividualDataPropertyStatementProcessor.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/listener/impl/IndividualDataPropertyStatementProcessor.java
@@ -22,7 +22,8 @@ import edu.cornell.mannlib.vitro.webapp.edit.n3editing.VTwo.BasicValidationVTwo;
 
 public class IndividualDataPropertyStatementProcessor implements ChangeListener {
 
-	private static final Log log = LogFactory.getLog(IndividualDataPropertyStatementProcessor.class.getName());
+    private static final String LANGUAGE = "language";
+    private static final Log log = LogFactory.getLog(IndividualDataPropertyStatementProcessor.class.getName());
 
     public void doInserted(Object newObj, EditProcessObject epo) {
         processDataprops(epo);
@@ -53,6 +54,9 @@ public class IndividualDataPropertyStatementProcessor implements ChangeListener 
                 try {
                     Map beanParamMap = FormUtils.beanParamMapFromString(keyArg[3]);
                     String dataPropertyURI = (String) beanParamMap.get("DatatypePropertyURI");
+                    if (beanParamMap.containsKey(LANGUAGE)) {
+                        dataPropertyStmt.setLanguage((String) beanParamMap.get(LANGUAGE));
+                    }
                     if (!deletedDataPropertyURIs.contains(dataPropertyURI)) {
                         deletedDataPropertyURIs.add(dataPropertyURI);
                         dataPropertyStatementDao.deleteDataPropertyStatementsForIndividualByDataProperty(((Individual) epo.getNewBean()).getURI(), dataPropertyURI);


### PR DESCRIPTION
**[VIVO GitHub issue](https://github.com/vivo-project/VIVO/issues/3727)**: (please link to issue)
# What does this pull request do?
Added fixes to retain language tags while editing data properties

# How should this be tested?
1. Create individual with data properties with langString datatype.
2. Edit individual with "Edit this individual"
3. Verify that data properties didn't loose it's language tags.


# Interested parties
@gneissone 
