### PR TITLE
fix: allow self editors to create individuals in faux property forms

### DIFF
--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/controller/EditRequestDispatchController.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/controller/EditRequestDispatchController.java
@@ -72,12 +72,7 @@ public class EditRequestDispatchController extends FreemarkerHttpServlet {
     
 	@Override
 	protected AuthorizationRequest requiredActions(VitroRequest vreq) {
-		// If request is for new individual, return simple do back end editing action permission
-		if (StringUtils.isNotEmpty(EditConfigurationUtils.getTypeOfNew(vreq))) {
-			return SimplePermission.DO_BACK_END_EDITING.ACTION;
-		} else if(MANAGE_MENUS_FORM.equals(vreq.getParameter("editForm"))) {
-		    return SimplePermission.MANAGE_MENUS.ACTION;
-		}
+
 		if (isIndividualDeletion(vreq)) {
 			return SimplePermission.DO_BACK_END_EDITING.ACTION;
 		}
@@ -93,7 +88,7 @@ public class EditRequestDispatchController extends FreemarkerHttpServlet {
 		predicateProp.setRangeVClassURI(rangeUri);
 		OntModel ontModel = ModelAccess.on(vreq).getOntModel();
 		AbstractObjectPropertyStatementAction objectPropertyAction;
-		if (objectUri == null) {
+		if (StringUtils.isBlank(objectUri)) {
 			objectPropertyAction = new AddObjectPropertyStatement(ontModel, subjectUri, predicateProp, RequestedAction.SOME_URI);
 		} else {
 			if (isDeleteForm(vreq)) {
@@ -105,7 +100,14 @@ public class EditRequestDispatchController extends FreemarkerHttpServlet {
 		boolean isAuthorized = PolicyHelper.isAuthorizedForActions(vreq, 
 				new EditDataPropertyStatement(ontModel, subjectUri, predicateUri, objectUri).
 				or(objectPropertyAction));
-
+		if (!isAuthorized) {
+			// If request is for new individual, return simple do back end editing action permission
+			if (StringUtils.isNotEmpty(EditConfigurationUtils.getTypeOfNew(vreq))) {
+				return SimplePermission.DO_BACK_END_EDITING.ACTION;
+			} else if (MANAGE_MENUS_FORM.equals(vreq.getParameter("editForm"))) {
+				return SimplePermission.MANAGE_MENUS.ACTION;
+			}
+		}
 		return isAuthorized? SimplePermission.DO_FRONT_END_EDITING.ACTION: AuthorizationRequest.UNAUTHORIZED;
 	}
 


### PR DESCRIPTION
# What does this pull request do?
Allow self editors to create individuals in faux property forms 

# How should this be tested?
* Reproduce the problem without fix:
As a self editor add geographic location and create new instance in the form, see error
* Apply PR, try to add geographic location.
Verify that admins still able to [create individuals](https://vivo-project.atlassian.net/browse/VIVO-1929)
Verify that admins still able to [edit pages ](https://vivo-project.atlassian.net/browse/VIVO-1973)

[Latest release candidate + this fix](https://vivo.tib.eu/vivo113rc)
# Interested parties
@hudajkhan @gneissone  @chenejac @wwelling @bkampe 
