### PR TITLE
Float data properties regex

### DIFF
--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/validators/DefaultDataPropertyFormValidator.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/validators/DefaultDataPropertyFormValidator.java
@@ -42,7 +42,7 @@ public class DefaultDataPropertyFormValidator implements N3ValidatorVTwo{
     private final Pattern ymPattern = Pattern.compile(ymRegex);
     private final String monthRegex = "^--(0[1-9]|1[012])";
     private final Pattern monthPattern = Pattern.compile(monthRegex);
-    private final String floatRegex = "^[-+]?[0-9]*\\.?[0-9]+([eE][-+]?[0-9]+)?.";
+    private final String floatRegex = "^[-+]?[0-9]*\\.?[0-9]+([eE][-+]?[0-9]+)?";
     private final Pattern floatPattern = Pattern.compile(floatRegex);
     private final String intRegex = "^-?\\d+$";
     private final Pattern intPattern = Pattern.compile(intRegex);

--- a/webapp/src/main/webapp/templates/freemarker/body/partials/individual/propStatement-dataDefault.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/body/partials/individual/propStatement-dataDefault.ftl
@@ -81,7 +81,7 @@
 		     	<span class="invalidFormatText">invalid format</span>
 				<#break>
 		  	<#case "float">
-				<#if !value?matches("^[-+]?[0-9]*\\.?[0-9]+([eE][-+]?[0-9]+)?.") >
+				<#if !value?matches("^[-+]?[0-9]*\\.?[0-9]+([eE][-+]?[0-9]+)?") >
 		     		<img class="invalidFormatImg" src="${urls.base}/images/iconAlert.png" width="18" alt=" ${i18n().invalid_format}" title=" ${i18n().invalid_format}">
 			     	<span class="invalidFormatText">invalid format</span>
 				</#if>


### PR DESCRIPTION
Current float validation regex doesn't match values 1, 1.1, 10.1 which prevents web interface from creating data properties.

# What does this pull request do?
Fixes float validation regex

# How should this be tested?
* Create data property with range float
* Try adding float values: 1 , 1.1 10.1

# Interested parties
@bkampe @chenejac  @brianjlowe  @hudajkhan @gneissone @wwelling 
