### PR TITLE
Issue/vivo 3606 : add language-specific sorting and label fields to search index

### DIFF
--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/freemarker/IndividualListController.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/freemarker/IndividualListController.java
@@ -6,9 +6,11 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
-import edu.cornell.mannlib.vitro.webapp.web.templatemodels.individuallist.ListedIndividualBuilder;
+import javax.servlet.annotation.WebServlet;
+
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -16,6 +18,7 @@ import org.apache.commons.logging.LogFactory;
 import edu.cornell.mannlib.vitro.webapp.beans.Individual;
 import edu.cornell.mannlib.vitro.webapp.beans.VClass;
 import edu.cornell.mannlib.vitro.webapp.beans.VClassGroup;
+import edu.cornell.mannlib.vitro.webapp.config.ConfigurationProperties;
 import edu.cornell.mannlib.vitro.webapp.controller.VitroRequest;
 import edu.cornell.mannlib.vitro.webapp.controller.freemarker.responsevalues.ExceptionResponseValues;
 import edu.cornell.mannlib.vitro.webapp.controller.freemarker.responsevalues.ResponseValues;
@@ -27,8 +30,7 @@ import edu.cornell.mannlib.vitro.webapp.modules.searchEngine.SearchEngineExcepti
 import edu.cornell.mannlib.vitro.webapp.modules.searchEngine.SearchQuery;
 import edu.cornell.mannlib.vitro.webapp.utils.searchengine.SearchQueryUtils;
 import edu.cornell.mannlib.vitro.webapp.web.templatemodels.individuallist.ListedIndividual;
-
-import javax.servlet.annotation.WebServlet;
+import edu.cornell.mannlib.vitro.webapp.web.templatemodels.individuallist.ListedIndividualBuilder;
 
 /**
  * Generates a list of individuals for display in a template
@@ -43,6 +45,7 @@ public class IndividualListController extends FreemarkerHttpServlet {
     private static final int MAX_PAGES = 40;  // must be even
 
     private static final String TEMPLATE_DEFAULT = "individualList.ftl";
+    private static final String LANGUAGE_FILTER_PROPERTY = "RDFService.languageFilter";
 
     @Override
     protected ResponseValues processRequest(VitroRequest vreq) {
@@ -152,11 +155,17 @@ public class IndividualListController extends FreemarkerHttpServlet {
         return SearchQueryUtils.getPageParameter(request);
     }
 
-    public static IndividualListResults getResultsForVClass(String vclassURI, int page, String alpha, VitroRequest vreq)
+    public static IndividualListResults getResultsForVClass(String vclassURI,
+            int page, String alpha, VitroRequest vreq)
     throws SearchException{
    	 	try{
+            ConfigurationProperties props = ConfigurationProperties.getBean(vreq);
+            boolean languageFilter = Boolean.valueOf(props.getProperty(
+                    LANGUAGE_FILTER_PROPERTY, "false"));
             List<String> classUris = Collections.singletonList(vclassURI);
-			IndividualListQueryResults results = buildAndExecuteVClassQuery(classUris, alpha, page, INDIVIDUALS_PER_PAGE, vreq.getWebappDaoFactory().getIndividualDao());
+			IndividualListQueryResults results = buildAndExecuteVClassQuery(
+			        classUris, alpha, ((languageFilter) ? vreq.getLocale() : null),
+			        page, INDIVIDUALS_PER_PAGE, vreq.getWebappDaoFactory().getIndividualDao());
 	        return getResultsForVClassQuery(results, page, INDIVIDUALS_PER_PAGE, alpha, vreq);
    	 	} catch (SearchEngineException e) {
    	 	    String msg = "An error occurred retrieving results for vclass query";
@@ -169,9 +178,15 @@ public class IndividualListController extends FreemarkerHttpServlet {
 	    }
     }
 
-    public static IndividualListResults getResultsForVClassIntersections(List<String> vclassURIs, int page, int pageSize, String alpha, VitroRequest vreq) {
+    public static IndividualListResults getResultsForVClassIntersections(
+            List<String> vclassURIs, int page, int pageSize, String alpha, VitroRequest vreq) {
         try{
-            IndividualListQueryResults results = buildAndExecuteVClassQuery(vclassURIs, alpha, page, pageSize, vreq.getWebappDaoFactory().getIndividualDao());
+            ConfigurationProperties props = ConfigurationProperties.getBean(vreq);
+            boolean languageFilter = Boolean.valueOf(props.getProperty(
+                    LANGUAGE_FILTER_PROPERTY, "false"));
+            IndividualListQueryResults results = buildAndExecuteVClassQuery(
+                    vclassURIs, alpha, ((languageFilter) ? vreq.getLocale() : null),
+                    page, pageSize, vreq.getWebappDaoFactory().getIndividualDao());
 	        return getResultsForVClassQuery(results, page, pageSize, alpha, vreq);
         } catch(Throwable th) {
        	    log.error("Error retrieving individuals corresponding to intersection multiple classes." + vclassURIs.toString(), th);
@@ -201,9 +216,10 @@ public class IndividualListController extends FreemarkerHttpServlet {
 
 
     private static IndividualListQueryResults buildAndExecuteVClassQuery(
-			List<String> vclassURIs, String alpha, int page, int pageSize, IndividualDao indDao)
+			List<String> vclassURIs, String alpha, Locale locale, int page,
+			int pageSize, IndividualDao indDao)
 			throws SearchEngineException {
-		 SearchQuery query = SearchQueryUtils.getQuery(vclassURIs, alpha, page, pageSize);
+		 SearchQuery query = SearchQueryUtils.getQuery(vclassURIs, alpha, locale, page, pageSize);
 		 IndividualListQueryResults results = IndividualListQueryResults.runQuery(query, indDao);
 		 log.debug("Executed search query for " + vclassURIs);
 		 if (results.getIndividuals().isEmpty()) {

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/search/controller/AutocompleteController.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/search/controller/AutocompleteController.java
@@ -36,6 +36,7 @@ import edu.cornell.mannlib.vitro.webapp.modules.searchEngine.SearchResultDocumen
 import edu.cornell.mannlib.vitro.webapp.rdfservice.RDFService;
 import edu.cornell.mannlib.vitro.webapp.rdfservice.impl.RDFServiceUtils;
 import edu.cornell.mannlib.vitro.webapp.search.VitroSearchTermNames;
+import edu.cornell.mannlib.vitro.webapp.utils.searchengine.SearchQueryUtils;
 
 /**
  * AutocompleteController generates autocomplete content
@@ -127,7 +128,10 @@ public class AutocompleteController extends VitroAjaxController {
             for (SearchResultDocument doc : docs) {
                 try {
                     String uri = doc.getStringValue(VitroSearchTermNames.URI);
-                    String name = doc.getStringValue(VitroSearchTermNames.NAME_RAW);
+                    String name = doc.getStringValue(SearchQueryUtils.getLabelFieldNameForLocale(vreq.getLocale()));
+                    if (name == null) {
+                        name = doc.getStringValue(VitroSearchTermNames.NAME_RAW);
+                    }
                     //There may be multiple most specific types, sending them all back
                     String mst = doc.getStringValue(VitroSearchTermNames.MOST_SPECIFIC_TYPE_URIS);
                     //Assuming these will get me string values
@@ -184,7 +188,9 @@ public class AutocompleteController extends VitroAjaxController {
         	addFilterQuery(query, typeParam,  multipleTypesParam);
         }
 
-        query.addFields(VitroSearchTermNames.NAME_RAW, VitroSearchTermNames.URI, VitroSearchTermNames.MOST_SPECIFIC_TYPE_URIS); // fields to retrieve
+        query.addFields(SearchQueryUtils.getLabelFieldNameForLocale(vreq.getLocale()),
+                VitroSearchTermNames.NAME_RAW, VitroSearchTermNames.URI,
+                VitroSearchTermNames.MOST_SPECIFIC_TYPE_URIS); // fields to retrieve
 
         // Can't sort on multivalued field, so we sort the results in Java when we get them.
         // query.addSortField(VitroSearchTermNames.NAME_LOWERCASE, Order.ASC);

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/searchindex/documentBuilding/SelectQueryDocumentModifier.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/searchindex/documentBuilding/SelectQueryDocumentModifier.java
@@ -52,25 +52,25 @@ public class SelectQueryDocumentModifier implements DocumentModifier,
 	private static final Log log = LogFactory
 			.getLog(SelectQueryDocumentModifier.class);
 
-	private RDFService rdfService;
+	protected RDFService rdfService;
 
 	/** A name to be used in logging, to identify this instance. */
-	private String label;
+	protected String label;
 
 	/** The queries to be executed. There must be at least one. */
-	private List<String> queries = new ArrayList<>();
+	protected List<String> queries = new ArrayList<>();
 
 	/**
 	 * The names of the fields where the results of the queries will be stored.
 	 * If empty, it is assumed to be ALLTEXT and ALLTEXTUNSTEMMED.
 	 */
-	private List<String> fieldNames = new ArrayList<>();
+	protected List<String> fieldNames = new ArrayList<>();
 
 	/**
 	 * URIs of the types of individuals to whom these queries apply. If empty,
 	 * then the queries apply to all individuals.
 	 */
-	private Set<String> typeRestrictions = new HashSet<>();
+	protected Set<String> typeRestrictions = new HashSet<>();
 
 	@Override
 	public void setContextModels(ContextModelAccess models) {
@@ -128,7 +128,7 @@ public class SelectQueryDocumentModifier implements DocumentModifier,
 		}
 	}
 
-	private boolean passesTypeRestrictions(Individual ind) {
+	protected boolean passesTypeRestrictions(Individual ind) {
 		if (typeRestrictions.isEmpty()) {
 			return true;
 		} else {
@@ -141,7 +141,7 @@ public class SelectQueryDocumentModifier implements DocumentModifier,
 		return false;
 	}
 
-	private List<String> getTextForQueries(Individual ind) {
+	protected List<String> getTextForQueries(Individual ind) {
 		List<String> list = new ArrayList<>();
 		for (String query : queries) {
 			list.addAll(getTextForQuery(query, ind));
@@ -149,7 +149,7 @@ public class SelectQueryDocumentModifier implements DocumentModifier,
 		return list;
 	}
 
-	private List<String> getTextForQuery(String query, Individual ind) {
+	protected List<String> getTextForQuery(String query, Individual ind) {
 		try {
 			QueryHolder queryHolder = new QueryHolder(query).bindToUri("uri",
 					ind.getURI());

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/searchindex/documentBuilding/SelectQueryDocumentModifierDynamicTargetField.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/searchindex/documentBuilding/SelectQueryDocumentModifierDynamicTargetField.java
@@ -1,0 +1,98 @@
+/* $This file is distributed under the terms of the license in LICENSE$ */
+
+package edu.cornell.mannlib.vitro.webapp.searchindex.documentBuilding;
+
+import static edu.cornell.mannlib.vitro.webapp.utils.sparqlrunner.SparqlQueryRunner.createSelectQueryContext;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import edu.cornell.mannlib.vitro.webapp.beans.Individual;
+import edu.cornell.mannlib.vitro.webapp.modules.searchEngine.SearchInputDocument;
+import edu.cornell.mannlib.vitro.webapp.utils.configuration.ContextModelsUser;
+import edu.cornell.mannlib.vitro.webapp.utils.configuration.Property;
+import edu.cornell.mannlib.vitro.webapp.utils.sparqlrunner.QueryHolder;
+import edu.cornell.mannlib.vitro.webapp.utils.sparqlrunner.StringResultsMapping;
+
+/**
+ * A variation on SelectQueryDocument where the target field of the search
+ * index document is specified in the query results.
+ *
+ * Each query should contain a ?uri variable, which will be replaced by the URI
+ * of the individual.
+ * 
+ * Each query must return a ?targetField variable specifying the name of the 
+ * search document field to be populated. 
+ *
+ * All of the other result fields in each row of each query will
+ * be converted to strings and added to the field specified in ?targetField.
+ *
+ */
+public class SelectQueryDocumentModifierDynamicTargetField
+        extends SelectQueryDocumentModifier 
+        implements DocumentModifier, ContextModelsUser {
+    private static final Log log = LogFactory
+            .getLog(SelectQueryDocumentModifierDynamicTargetField.class);
+    
+    private static final String TARGET_FIELD_VAR = "targetField";
+
+    @Override
+    /**
+     * Grab the un-flattened query solution mappings and use the field name
+     * specified in the TARGET_FIELD_VAR variable as the location to store the 
+     * rest of the values.
+     */
+    public void modifyDocument(Individual ind, SearchInputDocument doc) {
+        if (passesTypeRestrictions(ind)) {
+            List<StringResultsMapping> values = getMappingsForQueries(ind);
+            for(StringResultsMapping value : values) {
+                for(Map<String, String> map : value.getListOfMaps()) {
+                    String targetFieldName = map.get(TARGET_FIELD_VAR);
+                    if(targetFieldName == null) {
+                        log.error(label + " select query must return variable "
+                            + TARGET_FIELD_VAR + " to specify document field"
+                                    + " in which to store remaining values");
+                    } else {
+                        for(String key : map.keySet()) {
+                            if(!TARGET_FIELD_VAR.equals(key)) {
+                                doc.addField(targetFieldName, map.get(key));
+                                if(log.isDebugEnabled()) {
+                                    log.debug("Added field " + targetFieldName
+                                            + " value " + map.get(key) + " to "
+                                            + ind.getURI());
+                                }
+                            }                                                       
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    protected List<StringResultsMapping> getMappingsForQueries(Individual ind) {
+        List<StringResultsMapping> list = new ArrayList<>();
+        for (String query : queries) {
+            list.add(getQueryResults(query, ind));
+        }
+        return list;
+    }
+
+    protected StringResultsMapping getQueryResults(String query, Individual ind) {
+        try {
+            QueryHolder queryHolder = new QueryHolder(query).bindToUri("uri",
+                    ind.getURI());
+            StringResultsMapping mapping = createSelectQueryContext(rdfService,
+                    queryHolder).execute().toStringFields();
+            log.debug(label + " query: '" + query + "' returns " + mapping);
+            return mapping;
+        } catch (Throwable t) {
+            log.error("problem while running query '" + query + "'", t);
+            return StringResultsMapping.EMPTY;
+        }
+    }
+
+}

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/utils/searchengine/SearchQueryUtils.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/utils/searchengine/SearchQueryUtils.java
@@ -212,6 +212,11 @@ public class SearchQueryUtils {
         return VitroSearchTermNames.NAME_LOWERCASE_SINGLE_VALUED + "_"
             + locale.toString().replace('_', '-') + "_s";
     }
+    
+    public static String getLabelFieldNameForLocale(Locale locale) {
+        return VitroSearchTermNames.NAME_RAW + "SingleValued_"
+            + locale.toString().replace('_', '-') + "_s";
+    }
 
     public static SearchQuery getRandomQuery(List<String> vclassUris, int page, int pageSize){
         String queryText = "";

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/utils/searchengine/SearchQueryUtils.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/utils/searchengine/SearchQueryUtils.java
@@ -5,6 +5,7 @@ package edu.cornell.mannlib.vitro.webapp.utils.searchengine;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 import org.apache.commons.lang3.StringUtils;
@@ -150,19 +151,38 @@ public class SearchQueryUtils {
     }
 
 	/**
-     * builds a query with a type clause for each type in vclassUris, NAME_LOWERCASE filetred by
-     * alpha, and just the hits for the page for pageSize.
+     * builds a query with a type clause for each type in vclassUris,
+     * NAME_LOWERCASE filtered by alpha, and just the hits for the page for pageSize.
+     * @param locale may be null.  If null, default sort field will be used.
+     *            Otherwise, query will be sorted by locale-specific sort field. 
      */
-    public static SearchQuery getQuery(List<String> vclassUris, String alpha, int page, int pageSize){
+    public static SearchQuery getQuery(List<String> vclassUris, String alpha,
+            Locale locale, int page, int pageSize){
         String queryText = "";
         SearchEngine searchEngine = ApplicationUtils.instance().getSearchEngine();
 
         try {
             queryText = makeMultiClassQuery(vclassUris);
-
+                        
+            String localeSpecificField = null;
+            
+            if (locale != null) {
+                localeSpecificField = getSortFieldNameForLocale(locale); 
+            }
+            
         	 // Add alpha filter if applicable
             if ( alpha != null && !"".equals(alpha) && alpha.length() == 1) {
-                queryText += VitroSearchTermNames.NAME_LOWERCASE + ":" + alpha.toLowerCase() + "*";
+                if (locale == null) {
+                    queryText += VitroSearchTermNames.NAME_LOWERCASE + ":" + alpha.toLowerCase() + "*";
+                } else {
+                    // Retrieve items matching the appropriate alpha char
+                    // on the i18ned field if that field exists.  For records
+                    // where the field does not exist, fall back to NAME_LOWERCASE
+                    queryText += "(" + localeSpecificField + ":" + alpha.toLowerCase()
+                           + "* OR (-" + localeSpecificField + ":[* TO *] AND "
+                           + VitroSearchTermNames.NAME_LOWERCASE + ":" + alpha.toLowerCase() + "*))";
+                    log.debug("Multiclass query text: " + queryText);
+                }
             }
 
             SearchQuery query = searchEngine.createQuery(queryText);
@@ -172,6 +192,11 @@ public class SearchQueryUtils {
             query.setStart( startRow ).setRows( pageSize );
 
             // Need a single-valued field for sorting
+            // Sort first by sort field for locale; fall back to
+            // NAME_LOWERCASE_SINGLE_VALUED if not available.
+            if(locale != null) {
+                query.addSortField(localeSpecificField, Order.ASC);
+            }
             query.addSortField(VitroSearchTermNames.NAME_LOWERCASE_SINGLE_VALUED, Order.ASC);
 
             log.debug("Query is " + query.toString());
@@ -181,6 +206,11 @@ public class SearchQueryUtils {
             log.error("Could not make the search query",ex);
             return searchEngine.createQuery();
         }
+    }
+    
+    public static String getSortFieldNameForLocale(Locale locale) {
+        return VitroSearchTermNames.NAME_LOWERCASE_SINGLE_VALUED + "_"
+            + locale.toString().replace('_', '-') + "_s";
     }
 
     public static SearchQuery getRandomQuery(List<String> vclassUris, int page, int pageSize){

--- a/home/src/main/resources/rdf/display/everytime/documentModifierI18nLabel.n3
+++ b/home/src/main/resources/rdf/display/everytime/documentModifierI18nLabel.n3
@@ -8,7 +8,7 @@
     rdfs:label "multilingual label document modifier" ;
     :hasSelectQuery """
         PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
-        SELECT ?targetField (LCASE(STR(MIN(?labelRaw))) AS ?label) WHERE {
+        SELECT ?targetField (STR(MIN(?labelRaw)) AS ?label) WHERE {
             ?uri rdfs:label ?labelRaw
             FILTER("" != LANG(?labelRaw))
             BIND(CONCAT("nameRawSingleValued_", LANG(?labelRaw), "_s") AS ?targetField)

--- a/home/src/main/resources/rdf/display/everytime/documentModifierI18nLabel.n3
+++ b/home/src/main/resources/rdf/display/everytime/documentModifierI18nLabel.n3
@@ -2,15 +2,15 @@
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-:documentModifier_multilingual_sort
+:documentModifier_multilingual_label
     a   <java:edu.cornell.mannlib.vitro.webapp.searchindex.documentBuilding.SelectQueryDocumentModifierDynamicTargetField> ,
             <java:edu.cornell.mannlib.vitro.webapp.searchindex.documentBuilding.DocumentModifier> ;
-    rdfs:label "multilingual sort document modifier" ;
+    rdfs:label "multilingual label document modifier" ;
     :hasSelectQuery """
         PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
         SELECT ?targetField (LCASE(STR(MIN(?labelRaw))) AS ?label) WHERE {
             ?uri rdfs:label ?labelRaw
             FILTER("" != LANG(?labelRaw))
-            BIND(CONCAT("nameLowercaseSingleValued_", LANG(?labelRaw), "_s") AS ?targetField)
+            BIND(CONCAT("nameRawSingleValued_", LANG(?labelRaw), "_s") AS ?targetField)
         } GROUP BY ?targetField
     """ .

--- a/home/src/main/resources/rdf/display/everytime/documentModifierI18nSort.n3
+++ b/home/src/main/resources/rdf/display/everytime/documentModifierI18nSort.n3
@@ -1,0 +1,15 @@
+@prefix : <http://vitro.mannlib.cornell.edu/ns/vitro/ApplicationSetup#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+:documentModifier_multilingual_sort
+    a   <java:edu.cornell.mannlib.vitro.webapp.searchindex.documentBuilding.SelectQueryDocumentModifierDynamicTargetField> ,
+            <java:edu.cornell.mannlib.vitro.webapp.searchindex.documentBuilding.DocumentModifier> ;
+    rdfs:label "multilingual sort document modifier" ;
+    :hasSelectQuery """
+        PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+        SELECT ?targetField (LCASE(STR(MIN(?labelRaw))) AS ?label) WHERE {
+            ?uri rdfs:label ?labelRaw
+            BIND(CONCAT("nameLowercaseSingleValued_", IF(LANG(?labelRaw) = "", "plain", LANG(?labelRaw)), "_s") AS ?targetField)
+        } GROUP BY ?targetField
+    """ .


### PR DESCRIPTION
**[Issue VIVO-3606](https://github.com/vivo-project/VIVO/issues/3606)**: 

# What does this pull request do?
- Populates a sort field and label field in the search index for each language tag found in the list of labels for an individual.  
- If RDFService.languageFilter = true in runtime.properties, the sort field that corresponds to the current locale is used to sort the individual lists in the VClassGroup-based browse pages (People, Organizations, Events, etc.).  The original nameLowercasedSingleValue field is used as a secondary sort in case this field is not populated.
- alpha (A*) browse lookups search either for documents where the locale-specific sort field starts with the selected letter OR documents where the locale-specific sort field does not exist at all but the default nameLowerCaseSingleValued starts with the selected letter.  This should prevent content from disappearing entirely if the locale-specific sort field is not available, though it may mean that individuals appear under the wrong letter (unchanged from current behavior).
- When displaying the results of an autocomplete request, the label corresponding to the current locale is displayed if available.  If not, the original field nameRaw is used instead.

Note that this approach is intended only to enable the minimum sorting / autocomplete functionality needed by production i18nized sites.  It has (inter alia) the following key limitations:
- There is only one level of fallback (e.g. from nameLowercasedSingleValue_de-DE_s to nameLowercasedSingleValue).  There is no attempt to try de or de-AT if de-DE is not available, which means that improperly sorted values may appear if the appropriate label is not available.  Similarly, content may continue to appear under the wrong alpha heading.
- Because all sort fields use the dynamic string type _s, there is no language-specific collation enabled.  All languages will sort based on (lowercased) unicode values and not by more complex rules.  It would be nice to add this in the future, but will require the ability to modify the Solr schema according to the languages in use. 

# What's new?
- SelectQueryDocumentModifierDynamicTargetField extends SelectQueryDocumentModifier for queries that return the na e of the search index field to modify in the ?targetField variable.
- Two new document modifiers are added to home/rdf/display/everytime to populate the i18nized sort and label fields.
- AutocompleteController/IndividualListController/SearchQueryUtils are modified to take advantage of the new fields.

# How should this be tested?
- In runtime.properties, enable RDFService.languageFilter = true and add en_US, es, fr_CA, and de_DE as the selectable locales.
- Load sorttest.n3.txt (attached).
- Switch between the four locales and observe that the items in the People tab sort and alpha-filter properly, displaying the language-appropriate label in parentheses except in the case of 'Yanny' when de_DE is selected.  In the latter case, Yanny (en-US) will be displayed instead.
- Observe that Yanny is still browsable on the People tab when the locale is set to de_DE, even though there is no de-DE label for the individual.
- Add a publication to the DB.  Add an author.  Autocomplete on the author names 'Alpha', 'Bravo', 'Charlie' or 'Delta'.  Note that all 4 individuals are returned when you type one of these names.  This is because the autocomplete edgengram is not language-specific, and is out of scope for this PR.  The improvement with this PR is that the labels in the autocomplete dropdown will change according to your currently-selected locale.

# Interested parties
@VIVO-project/vivo-committers

[sorttest.n3.txt](https://github.com/vivo-project/Vitro/files/9241040/sorttest.n3.txt)

