### PR TITLE
Issue/vivo 3606 : add language-specific sorting and label fields to search index

### DIFF
--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/freemarker/IndividualListController.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/freemarker/IndividualListController.java
@@ -6,9 +6,11 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
-import edu.cornell.mannlib.vitro.webapp.web.templatemodels.individuallist.ListedIndividualBuilder;
+import javax.servlet.annotation.WebServlet;
+
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -16,6 +18,7 @@ import org.apache.commons.logging.LogFactory;
 import edu.cornell.mannlib.vitro.webapp.beans.Individual;
 import edu.cornell.mannlib.vitro.webapp.beans.VClass;
 import edu.cornell.mannlib.vitro.webapp.beans.VClassGroup;
+import edu.cornell.mannlib.vitro.webapp.config.ConfigurationProperties;
 import edu.cornell.mannlib.vitro.webapp.controller.VitroRequest;
 import edu.cornell.mannlib.vitro.webapp.controller.freemarker.responsevalues.ExceptionResponseValues;
 import edu.cornell.mannlib.vitro.webapp.controller.freemarker.responsevalues.ResponseValues;
@@ -27,8 +30,7 @@ import edu.cornell.mannlib.vitro.webapp.modules.searchEngine.SearchEngineExcepti
 import edu.cornell.mannlib.vitro.webapp.modules.searchEngine.SearchQuery;
 import edu.cornell.mannlib.vitro.webapp.utils.searchengine.SearchQueryUtils;
 import edu.cornell.mannlib.vitro.webapp.web.templatemodels.individuallist.ListedIndividual;
-
-import javax.servlet.annotation.WebServlet;
+import edu.cornell.mannlib.vitro.webapp.web.templatemodels.individuallist.ListedIndividualBuilder;
 
 /**
  * Generates a list of individuals for display in a template
@@ -43,6 +45,7 @@ public class IndividualListController extends FreemarkerHttpServlet {
     private static final int MAX_PAGES = 40;  // must be even
 
     private static final String TEMPLATE_DEFAULT = "individualList.ftl";
+    private static final String LANGUAGE_FILTER_PROPERTY = "RDFService.languageFilter";
 
     @Override
     protected ResponseValues processRequest(VitroRequest vreq) {
@@ -152,11 +155,17 @@ public class IndividualListController extends FreemarkerHttpServlet {
         return SearchQueryUtils.getPageParameter(request);
     }
 
-    public static IndividualListResults getResultsForVClass(String vclassURI, int page, String alpha, VitroRequest vreq)
+    public static IndividualListResults getResultsForVClass(String vclassURI,
+            int page, String alpha, VitroRequest vreq)
     throws SearchException{
    	 	try{
+            ConfigurationProperties props = ConfigurationProperties.getBean(vreq);
+            boolean languageFilter = Boolean.valueOf(props.getProperty(
+                    LANGUAGE_FILTER_PROPERTY, "false"));
             List<String> classUris = Collections.singletonList(vclassURI);
-			IndividualListQueryResults results = buildAndExecuteVClassQuery(classUris, alpha, page, INDIVIDUALS_PER_PAGE, vreq.getWebappDaoFactory().getIndividualDao());
+			IndividualListQueryResults results = buildAndExecuteVClassQuery(
+			        classUris, alpha, ((languageFilter) ? vreq.getLocale() : null),
+			        page, INDIVIDUALS_PER_PAGE, vreq.getWebappDaoFactory().getIndividualDao());
 	        return getResultsForVClassQuery(results, page, INDIVIDUALS_PER_PAGE, alpha, vreq);
    	 	} catch (SearchEngineException e) {
    	 	    String msg = "An error occurred retrieving results for vclass query";
@@ -169,9 +178,15 @@ public class IndividualListController extends FreemarkerHttpServlet {
 	    }
     }
 
-    public static IndividualListResults getResultsForVClassIntersections(List<String> vclassURIs, int page, int pageSize, String alpha, VitroRequest vreq) {
+    public static IndividualListResults getResultsForVClassIntersections(
+            List<String> vclassURIs, int page, int pageSize, String alpha, VitroRequest vreq) {
         try{
-            IndividualListQueryResults results = buildAndExecuteVClassQuery(vclassURIs, alpha, page, pageSize, vreq.getWebappDaoFactory().getIndividualDao());
+            ConfigurationProperties props = ConfigurationProperties.getBean(vreq);
+            boolean languageFilter = Boolean.valueOf(props.getProperty(
+                    LANGUAGE_FILTER_PROPERTY, "false"));
+            IndividualListQueryResults results = buildAndExecuteVClassQuery(
+                    vclassURIs, alpha, ((languageFilter) ? vreq.getLocale() : null),
+                    page, pageSize, vreq.getWebappDaoFactory().getIndividualDao());
 	        return getResultsForVClassQuery(results, page, pageSize, alpha, vreq);
         } catch(Throwable th) {
        	    log.error("Error retrieving individuals corresponding to intersection multiple classes." + vclassURIs.toString(), th);
@@ -201,9 +216,10 @@ public class IndividualListController extends FreemarkerHttpServlet {
 
 
     private static IndividualListQueryResults buildAndExecuteVClassQuery(
-			List<String> vclassURIs, String alpha, int page, int pageSize, IndividualDao indDao)
+			List<String> vclassURIs, String alpha, Locale locale, int page,
+			int pageSize, IndividualDao indDao)
 			throws SearchEngineException {
-		 SearchQuery query = SearchQueryUtils.getQuery(vclassURIs, alpha, page, pageSize);
+		 SearchQuery query = SearchQueryUtils.getQuery(vclassURIs, alpha, locale, page, pageSize);
 		 IndividualListQueryResults results = IndividualListQueryResults.runQuery(query, indDao);
 		 log.debug("Executed search query for " + vclassURIs);
 		 if (results.getIndividuals().isEmpty()) {

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/freemarker/IndividualListController.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/freemarker/IndividualListController.java
@@ -159,14 +159,8 @@ public class IndividualListController extends FreemarkerHttpServlet {
             int page, String alpha, VitroRequest vreq)
     throws SearchException{
    	 	try{
-            ConfigurationProperties props = ConfigurationProperties.getBean(vreq);
-            boolean languageFilter = Boolean.valueOf(props.getProperty(
-                    LANGUAGE_FILTER_PROPERTY, "false"));
-            List<String> classUris = Collections.singletonList(vclassURI);
-			IndividualListQueryResults results = buildAndExecuteVClassQuery(
-			        classUris, alpha, ((languageFilter) ? vreq.getLocale() : null),
-			        page, INDIVIDUALS_PER_PAGE, vreq.getWebappDaoFactory().getIndividualDao());
-	        return getResultsForVClassQuery(results, page, INDIVIDUALS_PER_PAGE, alpha, vreq);
+   	        List<String> classUris = Collections.singletonList(vclassURI);
+            return buildAndExecuteVClassQuery(classUris, page, INDIVIDUALS_PER_PAGE, alpha, vreq);
    	 	} catch (SearchEngineException e) {
    	 	    String msg = "An error occurred retrieving results for vclass query";
    	 	    log.error(msg, e);
@@ -179,20 +173,25 @@ public class IndividualListController extends FreemarkerHttpServlet {
     }
 
     public static IndividualListResults getResultsForVClassIntersections(
-            List<String> vclassURIs, int page, int pageSize, String alpha, VitroRequest vreq) {
+            List<String> classUris, int page, int pageSize, String alpha, VitroRequest vreq) {
         try{
-            ConfigurationProperties props = ConfigurationProperties.getBean(vreq);
-            boolean languageFilter = Boolean.valueOf(props.getProperty(
-                    LANGUAGE_FILTER_PROPERTY, "false"));
-            IndividualListQueryResults results = buildAndExecuteVClassQuery(
-                    vclassURIs, alpha, ((languageFilter) ? vreq.getLocale() : null),
-                    page, pageSize, vreq.getWebappDaoFactory().getIndividualDao());
-	        return getResultsForVClassQuery(results, page, pageSize, alpha, vreq);
+            return buildAndExecuteVClassQuery(classUris, page, pageSize, alpha, vreq);
         } catch(Throwable th) {
-       	    log.error("Error retrieving individuals corresponding to intersection multiple classes." + vclassURIs.toString(), th);
+       	    log.error("Error retrieving individuals corresponding to intersection multiple classes." + classUris.toString(), th);
        	    return IndividualListResults.EMPTY;
         }
     }
+
+	private static IndividualListResults buildAndExecuteVClassQuery(List<String> classUris, int page, int pageSize,
+			String alpha, VitroRequest vreq) throws SearchEngineException {
+		ConfigurationProperties props = ConfigurationProperties.getBean(vreq);
+		boolean languageFilter = Boolean.valueOf(props.getProperty(LANGUAGE_FILTER_PROPERTY, "false"));
+		IndividualListQueryResults results = buildAndExecuteVClassQuery(classUris, alpha,
+				((languageFilter) ? vreq.getLocale() : null), page, pageSize,
+				vreq.getWebappDaoFactory().getIndividualDao());
+		IndividualListResults indListResults = getResultsForVClassQuery(results, page, pageSize, alpha, vreq);
+		return indListResults;
+	}
 
     public static IndividualListResults getRandomResultsForVClass(String vclassURI, int page, int pageSize, VitroRequest vreq) {
    	 	try{

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/search/VitroSearchTermNames.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/search/VitroSearchTermNames.java
@@ -72,7 +72,7 @@ public class VitroSearchTermNames {
 	public static final String SITE_NAME = "siteName";
 	
 	/** Multilingual sort field suffix */
-	public static final String SORT_SUFFIX = "_label_sort";
+	public static final String LABEL_SORT_SUFFIX = "_label_sort";
 	
 	/** Multilingual label field suffix */
 	public static final String LABEL_DISPLAY_SUFFIX = "_label_display";

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/search/VitroSearchTermNames.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/search/VitroSearchTermNames.java
@@ -70,5 +70,11 @@ public class VitroSearchTermNames {
 
 	/** Source institution name */
 	public static final String SITE_NAME = "siteName";
+	
+	/** Multilingual sort field suffix */
+	public static final String SORT_SUFFIX = "_label_sort";
+	
+	/** Multilingual label field suffix */
+	public static final String LABEL_DISPLAY_SUFFIX = "_label_display";
 
 }

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/search/controller/AutocompleteController.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/search/controller/AutocompleteController.java
@@ -36,6 +36,7 @@ import edu.cornell.mannlib.vitro.webapp.modules.searchEngine.SearchResultDocumen
 import edu.cornell.mannlib.vitro.webapp.rdfservice.RDFService;
 import edu.cornell.mannlib.vitro.webapp.rdfservice.impl.RDFServiceUtils;
 import edu.cornell.mannlib.vitro.webapp.search.VitroSearchTermNames;
+import edu.cornell.mannlib.vitro.webapp.utils.searchengine.SearchQueryUtils;
 
 /**
  * AutocompleteController generates autocomplete content
@@ -127,7 +128,10 @@ public class AutocompleteController extends VitroAjaxController {
             for (SearchResultDocument doc : docs) {
                 try {
                     String uri = doc.getStringValue(VitroSearchTermNames.URI);
-                    String name = doc.getStringValue(VitroSearchTermNames.NAME_RAW);
+                    String name = doc.getStringValue(SearchQueryUtils.getLabelFieldNameForLocale(vreq.getLocale()));
+                    if (name == null) {
+                        name = doc.getStringValue(VitroSearchTermNames.NAME_RAW);
+                    }
                     //There may be multiple most specific types, sending them all back
                     String mst = doc.getStringValue(VitroSearchTermNames.MOST_SPECIFIC_TYPE_URIS);
                     //Assuming these will get me string values
@@ -184,7 +188,9 @@ public class AutocompleteController extends VitroAjaxController {
         	addFilterQuery(query, typeParam,  multipleTypesParam);
         }
 
-        query.addFields(VitroSearchTermNames.NAME_RAW, VitroSearchTermNames.URI, VitroSearchTermNames.MOST_SPECIFIC_TYPE_URIS); // fields to retrieve
+        query.addFields(SearchQueryUtils.getLabelFieldNameForLocale(vreq.getLocale()),
+                VitroSearchTermNames.NAME_RAW, VitroSearchTermNames.URI,
+                VitroSearchTermNames.MOST_SPECIFIC_TYPE_URIS); // fields to retrieve
 
         // Can't sort on multivalued field, so we sort the results in Java when we get them.
         // query.addSortField(VitroSearchTermNames.NAME_LOWERCASE, Order.ASC);

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/searchengine/base/BaseSearchQuery.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/searchengine/base/BaseSearchQuery.java
@@ -7,6 +7,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 
@@ -21,7 +22,7 @@ public class BaseSearchQuery implements SearchQuery {
 	private int rows = -1;
 
 	private final Set<String> fieldsToReturn = new HashSet<>();
-	private final Map<String, SearchQuery.Order> sortFields = new HashMap<>();
+	private final Map<String, SearchQuery.Order> sortFields = new LinkedHashMap <>();
 	private final Set<String> filters = new HashSet<>();
 
 	private final Set<String> facetFields = new HashSet<>();

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/searchengine/base/BaseSearchQuery.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/searchengine/base/BaseSearchQuery.java
@@ -5,7 +5,6 @@ package edu.cornell.mannlib.vitro.webapp.searchengine.base;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.Map;

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/searchengine/solr/SolrFieldInitializer.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/searchengine/solr/SolrFieldInitializer.java
@@ -1,0 +1,72 @@
+package edu.cornell.mannlib.vitro.webapp.searchengine.solr;
+
+import static edu.cornell.mannlib.vitro.webapp.search.VitroSearchTermNames.LABEL_DISPLAY_SUFFIX;
+import static edu.cornell.mannlib.vitro.webapp.search.VitroSearchTermNames.SORT_SUFFIX;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.solr.client.solrj.SolrClient;
+import org.apache.solr.client.solrj.SolrQuery;
+import org.apache.solr.client.solrj.impl.ConcurrentUpdateSolrClient;
+import org.apache.solr.client.solrj.request.schema.SchemaRequest;
+import org.apache.solr.client.solrj.response.QueryResponse;
+import org.apache.solr.client.solrj.response.schema.SchemaResponse;
+import org.apache.solr.common.params.CommonParams;
+import org.apache.solr.common.util.SimpleOrderedMap;
+
+public class SolrFieldInitializer {
+
+	static void initializeFields(SolrClient queryEngine, ConcurrentUpdateSolrClient updateEngine) throws Exception {
+		Set<String> fieldSuffixes = new HashSet<>(Arrays.asList(SORT_SUFFIX, LABEL_DISPLAY_SUFFIX));
+		excludeMatchedFields(fieldSuffixes, queryEngine, "dynamicFields");
+		excludeMatchedFields(fieldSuffixes, queryEngine, "fields");
+		createMissingFields(fieldSuffixes, updateEngine);
+	}
+
+	private static void createMissingFields(Set<String> fieldSuffixes, ConcurrentUpdateSolrClient updateEngine)
+			throws Exception {
+		for (String suffix : fieldSuffixes) {
+			Map<String, Object> fieldAttributes = getFieldAttributes(suffix);
+			SchemaRequest.AddDynamicField request = new SchemaRequest.AddDynamicField(fieldAttributes);
+			SchemaResponse.UpdateResponse response = request.process(updateEngine);
+			if (response.getStatus() != 0) {
+				throw new Exception("Creation of missing solr field '*" + suffix + "' failed");
+			}
+		}
+	}
+
+	private static Map<String, Object> getFieldAttributes(String suffix) {
+		Map<String, Object> fieldAttributes = new HashMap<String, Object>();
+		fieldAttributes.put("type", "string");
+		fieldAttributes.put("stored", "true");
+		fieldAttributes.put("indexed", "true");
+		fieldAttributes.put("name", "*" + suffix);
+		return fieldAttributes;
+	}
+
+	private static void excludeMatchedFields(Set<String> fieldSuffixes, SolrClient queryEngine, String fieldType)
+			throws Exception {
+		SolrQuery query = new SolrQuery();
+		query.add(CommonParams.QT, "/schema/" + fieldType.toLowerCase());
+		QueryResponse response = queryEngine.query(query);
+		ArrayList<SimpleOrderedMap> fieldList = (ArrayList<SimpleOrderedMap>) response.getResponse().get(fieldType);
+		if (fieldList == null) {
+			return;
+		}
+		Set<String> it = new HashSet<>(fieldSuffixes);
+		for (String target : it) {
+			for (SimpleOrderedMap field : fieldList) {
+				String fieldName = (String) field.get("name");
+				if (fieldName.endsWith(target)) {
+					fieldSuffixes.remove(target);
+				}
+			}
+		}
+	}
+
+}

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/searchengine/solr/SolrFieldInitializer.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/searchengine/solr/SolrFieldInitializer.java
@@ -1,7 +1,7 @@
 package edu.cornell.mannlib.vitro.webapp.searchengine.solr;
 
 import static edu.cornell.mannlib.vitro.webapp.search.VitroSearchTermNames.LABEL_DISPLAY_SUFFIX;
-import static edu.cornell.mannlib.vitro.webapp.search.VitroSearchTermNames.SORT_SUFFIX;
+import static edu.cornell.mannlib.vitro.webapp.search.VitroSearchTermNames.LABEL_SORT_SUFFIX;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -22,7 +22,7 @@ import org.apache.solr.common.util.SimpleOrderedMap;
 public class SolrFieldInitializer {
 
 	static void initializeFields(SolrClient queryEngine, ConcurrentUpdateSolrClient updateEngine) throws Exception {
-		Set<String> fieldSuffixes = new HashSet<>(Arrays.asList(SORT_SUFFIX, LABEL_DISPLAY_SUFFIX));
+		Set<String> fieldSuffixes = new HashSet<>(Arrays.asList(LABEL_SORT_SUFFIX, LABEL_DISPLAY_SUFFIX));
 		excludeMatchedFields(fieldSuffixes, queryEngine, "dynamicFields");
 		excludeMatchedFields(fieldSuffixes, queryEngine, "fields");
 		createMissingFields(fieldSuffixes, updateEngine);

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/searchengine/solr/SolrSearchEngine.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/searchengine/solr/SolrSearchEngine.java
@@ -76,7 +76,9 @@ public class SolrSearchEngine implements SearchEngine {
 			// no apparent 7.4.0 analogy to `setPollQueueTime(25)`
 
 			updateEngine = updateBuilder.build();
-
+			
+			SolrFieldInitializer.initializeFields(queryEngine, updateEngine);
+			
 			css.info("Set up the Solr search engine; URL = '" + solrServerUrlString + "'.");
 		} catch (Exception e) {
 			css.fatal("Could not set up the Solr search engine", e);

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/searchindex/documentBuilding/SelectQueryDocumentModifier.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/searchindex/documentBuilding/SelectQueryDocumentModifier.java
@@ -141,7 +141,7 @@ public class SelectQueryDocumentModifier implements DocumentModifier,
 		return false;
 	}
 
-	protected List<String> getTextForQueries(Individual ind) {
+	private List<String> getTextForQueries(Individual ind) {
 		List<String> list = new ArrayList<>();
 		for (String query : queries) {
 			list.addAll(getTextForQuery(query, ind));
@@ -149,7 +149,7 @@ public class SelectQueryDocumentModifier implements DocumentModifier,
 		return list;
 	}
 
-	protected List<String> getTextForQuery(String query, Individual ind) {
+	private List<String> getTextForQuery(String query, Individual ind) {
 		try {
 			QueryHolder queryHolder = new QueryHolder(query).bindToUri("uri",
 					ind.getURI());

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/searchindex/documentBuilding/SelectQueryDocumentModifier.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/searchindex/documentBuilding/SelectQueryDocumentModifier.java
@@ -52,25 +52,25 @@ public class SelectQueryDocumentModifier implements DocumentModifier,
 	private static final Log log = LogFactory
 			.getLog(SelectQueryDocumentModifier.class);
 
-	private RDFService rdfService;
+	protected RDFService rdfService;
 
 	/** A name to be used in logging, to identify this instance. */
-	private String label;
+	protected String label;
 
 	/** The queries to be executed. There must be at least one. */
-	private List<String> queries = new ArrayList<>();
+	protected List<String> queries = new ArrayList<>();
 
 	/**
 	 * The names of the fields where the results of the queries will be stored.
 	 * If empty, it is assumed to be ALLTEXT and ALLTEXTUNSTEMMED.
 	 */
-	private List<String> fieldNames = new ArrayList<>();
+	protected List<String> fieldNames = new ArrayList<>();
 
 	/**
 	 * URIs of the types of individuals to whom these queries apply. If empty,
 	 * then the queries apply to all individuals.
 	 */
-	private Set<String> typeRestrictions = new HashSet<>();
+	protected Set<String> typeRestrictions = new HashSet<>();
 
 	@Override
 	public void setContextModels(ContextModelAccess models) {
@@ -128,7 +128,7 @@ public class SelectQueryDocumentModifier implements DocumentModifier,
 		}
 	}
 
-	private boolean passesTypeRestrictions(Individual ind) {
+	protected boolean passesTypeRestrictions(Individual ind) {
 		if (typeRestrictions.isEmpty()) {
 			return true;
 		} else {
@@ -141,7 +141,7 @@ public class SelectQueryDocumentModifier implements DocumentModifier,
 		return false;
 	}
 
-	private List<String> getTextForQueries(Individual ind) {
+	protected List<String> getTextForQueries(Individual ind) {
 		List<String> list = new ArrayList<>();
 		for (String query : queries) {
 			list.addAll(getTextForQuery(query, ind));
@@ -149,7 +149,7 @@ public class SelectQueryDocumentModifier implements DocumentModifier,
 		return list;
 	}
 
-	private List<String> getTextForQuery(String query, Individual ind) {
+	protected List<String> getTextForQuery(String query, Individual ind) {
 		try {
 			QueryHolder queryHolder = new QueryHolder(query).bindToUri("uri",
 					ind.getURI());

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/searchindex/documentBuilding/SelectQueryDocumentModifier.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/searchindex/documentBuilding/SelectQueryDocumentModifier.java
@@ -64,13 +64,13 @@ public class SelectQueryDocumentModifier implements DocumentModifier,
 	 * The names of the fields where the results of the queries will be stored.
 	 * If empty, it is assumed to be ALLTEXT and ALLTEXTUNSTEMMED.
 	 */
-	protected List<String> fieldNames = new ArrayList<>();
+	private List<String> fieldNames = new ArrayList<>();
 
 	/**
 	 * URIs of the types of individuals to whom these queries apply. If empty,
 	 * then the queries apply to all individuals.
 	 */
-	protected Set<String> typeRestrictions = new HashSet<>();
+	private Set<String> typeRestrictions = new HashSet<>();
 
 	@Override
 	public void setContextModels(ContextModelAccess models) {

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/searchindex/documentBuilding/SelectQueryDocumentModifierDynamicTargetField.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/searchindex/documentBuilding/SelectQueryDocumentModifierDynamicTargetField.java
@@ -95,7 +95,8 @@ public class SelectQueryDocumentModifierDynamicTargetField extends SelectQueryDo
 		if (!StringUtils.isBlank(property)) {
 			String[] values = property.trim().split("\\s*,\\s*");
 			for (String value : values) {
-				addLocale(value);
+				String locale = value.replace("_", "-");
+				addLocale(locale);
 			}
 		}
 	}

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/searchindex/documentBuilding/SelectQueryDocumentModifierDynamicTargetField.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/searchindex/documentBuilding/SelectQueryDocumentModifierDynamicTargetField.java
@@ -1,0 +1,98 @@
+/* $This file is distributed under the terms of the license in LICENSE$ */
+
+package edu.cornell.mannlib.vitro.webapp.searchindex.documentBuilding;
+
+import static edu.cornell.mannlib.vitro.webapp.utils.sparqlrunner.SparqlQueryRunner.createSelectQueryContext;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import edu.cornell.mannlib.vitro.webapp.beans.Individual;
+import edu.cornell.mannlib.vitro.webapp.modules.searchEngine.SearchInputDocument;
+import edu.cornell.mannlib.vitro.webapp.utils.configuration.ContextModelsUser;
+import edu.cornell.mannlib.vitro.webapp.utils.configuration.Property;
+import edu.cornell.mannlib.vitro.webapp.utils.sparqlrunner.QueryHolder;
+import edu.cornell.mannlib.vitro.webapp.utils.sparqlrunner.StringResultsMapping;
+
+/**
+ * A variation on SelectQueryDocument where the target field of the search
+ * index document is specified in the query results.
+ *
+ * Each query should contain a ?uri variable, which will be replaced by the URI
+ * of the individual.
+ * 
+ * Each query must return a ?targetField variable specifying the name of the 
+ * search document field to be populated. 
+ *
+ * All of the other result fields in each row of each query will
+ * be converted to strings and added to the field specified in ?targetField.
+ *
+ */
+public class SelectQueryDocumentModifierDynamicTargetField
+        extends SelectQueryDocumentModifier 
+        implements DocumentModifier, ContextModelsUser {
+    private static final Log log = LogFactory
+            .getLog(SelectQueryDocumentModifierDynamicTargetField.class);
+    
+    private static final String TARGET_FIELD_VAR = "targetField";
+
+    @Override
+    /**
+     * Grab the un-flattened query solution mappings and use the field name
+     * specified in the TARGET_FIELD_VAR variable as the location to store the 
+     * rest of the values.
+     */
+    public void modifyDocument(Individual ind, SearchInputDocument doc) {
+        if (passesTypeRestrictions(ind)) {
+            List<StringResultsMapping> values = getMappingsForQueries(ind);
+            for(StringResultsMapping value : values) {
+                for(Map<String, String> map : value.getListOfMaps()) {
+                    String targetFieldName = map.get(TARGET_FIELD_VAR);
+                    if(targetFieldName == null) {
+                        log.error(label + " select query must return variable "
+                            + TARGET_FIELD_VAR + " to specify document field"
+                                    + " in which to store remaining values");
+                    } else {
+                        for(String key : map.keySet()) {
+                            if(!TARGET_FIELD_VAR.equals(key)) {
+                                doc.addField(targetFieldName, map.get(key));
+                                if(log.isDebugEnabled()) {
+                                    log.debug("Added field " + targetFieldName
+                                            + " value " + map.get(key) + " to "
+                                            + ind.getURI());
+                                }
+                            }                                                       
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    protected List<StringResultsMapping> getMappingsForQueries(Individual ind) {
+        List<StringResultsMapping> list = new ArrayList<>();
+        for (String query : queries) {
+            list.add(getQueryResults(query, ind));
+        }
+        return list;
+    }
+
+    protected StringResultsMapping getQueryResults(String query, Individual ind) {
+        try {
+            QueryHolder queryHolder = new QueryHolder(query).bindToUri("uri",
+                    ind.getURI());
+            StringResultsMapping mapping = createSelectQueryContext(rdfService,
+                    queryHolder).execute().toStringFields();
+            log.debug(label + " query: '" + query + "' returns " + mapping);
+            return mapping;
+        } catch (Throwable t) {
+            log.error("problem while running query '" + query + "'", t);
+            return StringResultsMapping.EMPTY;
+        }
+    }
+
+}

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/searchindex/documentBuilding/SelectQueryDocumentModifierDynamicTargetField.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/searchindex/documentBuilding/SelectQueryDocumentModifierDynamicTargetField.java
@@ -3,96 +3,108 @@
 package edu.cornell.mannlib.vitro.webapp.searchindex.documentBuilding;
 
 import static edu.cornell.mannlib.vitro.webapp.utils.sparqlrunner.SparqlQueryRunner.createSelectQueryContext;
-
+import static edu.cornell.mannlib.vitro.webapp.i18n.selection.LocaleSelectionSetup.PROPERTY_SELECTABLE_LOCALES;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
 import edu.cornell.mannlib.vitro.webapp.beans.Individual;
+import edu.cornell.mannlib.vitro.webapp.config.ConfigurationProperties;
 import edu.cornell.mannlib.vitro.webapp.modules.searchEngine.SearchInputDocument;
+import edu.cornell.mannlib.vitro.webapp.rdfservice.filter.LanguageFilteringRDFService;
+import edu.cornell.mannlib.vitro.webapp.utils.configuration.ConfigurationReader;
 import edu.cornell.mannlib.vitro.webapp.utils.configuration.ContextModelsUser;
 import edu.cornell.mannlib.vitro.webapp.utils.configuration.Property;
 import edu.cornell.mannlib.vitro.webapp.utils.sparqlrunner.QueryHolder;
-import edu.cornell.mannlib.vitro.webapp.utils.sparqlrunner.StringResultsMapping;
 
 /**
- * A variation on SelectQueryDocument where the target field of the search
- * index document is specified in the query results.
- *
+ * A variation on SelectQueryDocument where the suffix of target field is defined.
+ * Multiple queries are performed for each of locales configured in runtime.properties
+ * 
+ * Target field names are composed of locale + fieldSuffix.
+ * 
  * Each query should contain a ?uri variable, which will be replaced by the URI
  * of the individual.
  * 
- * Each query must return a ?targetField variable specifying the name of the 
- * search document field to be populated. 
- *
- * All of the other result fields in each row of each query will
- * be converted to strings and added to the field specified in ?targetField.
+ * All of the other result fields in each row of each query will be converted to
+ * strings and added to the field.
  *
  */
-public class SelectQueryDocumentModifierDynamicTargetField
-        extends SelectQueryDocumentModifier 
-        implements DocumentModifier, ContextModelsUser {
-    private static final Log log = LogFactory
-            .getLog(SelectQueryDocumentModifierDynamicTargetField.class);
-    
-    private static final String TARGET_FIELD_VAR = "targetField";
+public class SelectQueryDocumentModifierDynamicTargetField extends SelectQueryDocumentModifier
+		implements DocumentModifier, ContextModelsUser, ConfigurationReader {
+	private static final Log log = LogFactory.getLog(SelectQueryDocumentModifierDynamicTargetField.class);
 
-    @Override
-    /**
-     * Grab the un-flattened query solution mappings and use the field name
-     * specified in the TARGET_FIELD_VAR variable as the location to store the 
-     * rest of the values.
-     */
-    public void modifyDocument(Individual ind, SearchInputDocument doc) {
-        if (passesTypeRestrictions(ind)) {
-            List<StringResultsMapping> values = getMappingsForQueries(ind);
-            for(StringResultsMapping value : values) {
-                for(Map<String, String> map : value.getListOfMaps()) {
-                    String targetFieldName = map.get(TARGET_FIELD_VAR);
-                    if(targetFieldName == null) {
-                        log.error(label + " select query must return variable "
-                            + TARGET_FIELD_VAR + " to specify document field"
-                                    + " in which to store remaining values");
-                    } else {
-                        for(String key : map.keySet()) {
-                            if(!TARGET_FIELD_VAR.equals(key)) {
-                                doc.addField(targetFieldName, map.get(key));
-                                if(log.isDebugEnabled()) {
-                                    log.debug("Added field " + targetFieldName
-                                            + " value " + map.get(key) + " to "
-                                            + ind.getURI());
-                                }
-                            }                                                       
-                        }
-                    }
-                }
-            }
-        }
-    }
+	private String fieldSuffix = "";
 
-    protected List<StringResultsMapping> getMappingsForQueries(Individual ind) {
-        List<StringResultsMapping> list = new ArrayList<>();
-        for (String query : queries) {
-            list.add(getQueryResults(query, ind));
-        }
-        return list;
-    }
+	private ArrayList<String> locales = new ArrayList<>();
 
-    protected StringResultsMapping getQueryResults(String query, Individual ind) {
-        try {
-            QueryHolder queryHolder = new QueryHolder(query).bindToUri("uri",
-                    ind.getURI());
-            StringResultsMapping mapping = createSelectQueryContext(rdfService,
-                    queryHolder).execute().toStringFields();
-            log.debug(label + " query: '" + query + "' returns " + mapping);
-            return mapping;
-        } catch (Throwable t) {
-            log.error("problem while running query '" + query + "'", t);
-            return StringResultsMapping.EMPTY;
-        }
-    }
+	@Property(uri = "http://vitro.mannlib.cornell.edu/ns/vitro/ApplicationSetup#hasTargetSuffix")
+	public void setTargetSuffix(String fieldSuffix) {
+		this.fieldSuffix = fieldSuffix;
+	}
+
+	@Override
+	public void modifyDocument(Individual ind, SearchInputDocument doc) {
+		if (passesTypeRestrictions(ind) && StringUtils.isNotBlank(fieldSuffix)) {
+			List<Map<String, List<String>>> maps = getTextForQueries(ind);
+			for (Map<String, List<String>> map : maps) {
+				for (String locale : map.keySet()) {
+					List<String> values = map.get(locale);
+					String fieldName = locale + fieldSuffix; 
+					doc.addField(fieldName, values);
+				}
+			}
+		}
+	}
+
+	protected List<Map<String, List<String>>> getTextForQueries(Individual ind) {
+		List<Map<String, List<String>>> list = new ArrayList<>();
+		for (String query : queries) {
+			list.add(getTextForQuery(query, ind));
+		}
+		return list;
+	}
+
+	protected Map<String, List<String>> getTextForQuery(String query, Individual ind) {
+		try {
+			QueryHolder queryHolder = new QueryHolder(query).bindToUri("uri", ind.getURI());
+			Map<String, List<String>> mapLocaleToFields = new HashMap<>();
+			for (String locale : locales) {
+				LanguageFilteringRDFService lfrs = new LanguageFilteringRDFService(rdfService,
+						Collections.singletonList(locale));
+				List<String> list = createSelectQueryContext(lfrs, queryHolder).execute().toStringFields().flatten();
+				mapLocaleToFields.put(locale, list);
+				log.debug(label + " for locale " + locale + " - query: '" + query + "' returns " + list);
+			}
+			return mapLocaleToFields;
+		} catch (Throwable t) {
+			log.error("problem while running query '" + query + "'", t);
+			return Collections.emptyMap();
+		}
+	}
+
+	@Override
+	public void setConfigurationProperties(ConfigurationProperties config) {
+		String property = config.getProperty(PROPERTY_SELECTABLE_LOCALES);
+		if (!StringUtils.isBlank(property)) {
+			String[] values = property.trim().split("\\s*,\\s*");
+			for (String value : values) {
+				addLocale(value);
+			}
+		}
+	}
+
+	private void addLocale(String localeString) {
+		if (StringUtils.isBlank(localeString)) {
+			return;	
+		}
+		locales.add(localeString);
+	}
 
 }

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/searchindex/documentBuilding/SelectQueryI18nDocumentModifier.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/searchindex/documentBuilding/SelectQueryI18nDocumentModifier.java
@@ -24,7 +24,7 @@ import edu.cornell.mannlib.vitro.webapp.utils.configuration.Property;
 import edu.cornell.mannlib.vitro.webapp.utils.sparqlrunner.QueryHolder;
 
 /**
- * A variation on SelectQueryDocument where the suffix of target field is defined.
+ * A variation on SelectQueryDocumentModifier where the suffix of target field is defined.
  * Multiple queries are performed for each of locales configured in runtime.properties
  * 
  * Target field names are composed of locale + fieldSuffix.
@@ -36,9 +36,9 @@ import edu.cornell.mannlib.vitro.webapp.utils.sparqlrunner.QueryHolder;
  * strings and added to the field.
  *
  */
-public class SelectQueryDocumentModifierDynamicTargetField extends SelectQueryDocumentModifier
+public class SelectQueryI18nDocumentModifier extends SelectQueryDocumentModifier
 		implements DocumentModifier, ContextModelsUser, ConfigurationReader {
-	private static final Log log = LogFactory.getLog(SelectQueryDocumentModifierDynamicTargetField.class);
+	private static final Log log = LogFactory.getLog(SelectQueryI18nDocumentModifier.class);
 
 	private String fieldSuffix = "";
 

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/utils/configuration/ConfigurationReader.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/utils/configuration/ConfigurationReader.java
@@ -1,0 +1,13 @@
+/* $This file is distributed under the terms of the license in LICENSE$ */
+
+package edu.cornell.mannlib.vitro.webapp.utils.configuration;
+
+import edu.cornell.mannlib.vitro.webapp.config.ConfigurationProperties;
+
+/**
+ * When the ConfigurationBeanLoader creates an instance of this class, it will
+ * call this method, supplying ConfigurationProperties.
+ */
+public interface ConfigurationReader {
+	void setConfigurationProperties(ConfigurationProperties properties);
+}

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/utils/configuration/WrappedInstance.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/utils/configuration/WrappedInstance.java
@@ -12,6 +12,7 @@ import java.util.Set;
 import javax.servlet.ServletContext;
 import javax.servlet.http.HttpServletRequest;
 
+import edu.cornell.mannlib.vitro.webapp.config.ConfigurationProperties;
 import edu.cornell.mannlib.vitro.webapp.modelaccess.ModelAccess;
 import edu.cornell.mannlib.vitro.webapp.utils.configuration.PropertyType.PropertyMethod;
 import edu.cornell.mannlib.vitro.webapp.utils.configuration.PropertyType.PropertyStatement;
@@ -60,6 +61,15 @@ public class WrappedInstance<T> {
 			} else {
 				RequestModelsUser rmu = (RequestModelsUser) instance;
 				rmu.setRequestModels(ModelAccess.on(req));
+			}
+		}
+		if (instance instanceof ConfigurationReader) {
+			if (ctx == null) {
+				throw new ResourceUnavailableException("Cannot satisfy "
+						+ "ConfigurationReader interface: context not available.");
+			} else {
+				ConfigurationReader cr = (ConfigurationReader) instance;
+				cr.setConfigurationProperties(ConfigurationProperties.getBean(ctx));
 			}
 		}
 	}

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/utils/searchengine/SearchQueryUtils.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/utils/searchengine/SearchQueryUtils.java
@@ -209,7 +209,7 @@ public class SearchQueryUtils {
     }
     
     public static String getSortFieldNameForLocale(Locale locale) {
-        return locale.toString().replace('_', '-') + VitroSearchTermNames.SORT_SUFFIX;
+        return locale.toString().replace('_', '-') + VitroSearchTermNames.LABEL_SORT_SUFFIX;
     }
     
     public static String getLabelFieldNameForLocale(Locale locale) {

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/utils/searchengine/SearchQueryUtils.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/utils/searchengine/SearchQueryUtils.java
@@ -209,13 +209,11 @@ public class SearchQueryUtils {
     }
     
     public static String getSortFieldNameForLocale(Locale locale) {
-        return VitroSearchTermNames.NAME_LOWERCASE_SINGLE_VALUED + "_"
-            + locale.toString().replace('_', '-') + "_s";
+        return locale.toString() + VitroSearchTermNames.SORT_SUFFIX;
     }
     
     public static String getLabelFieldNameForLocale(Locale locale) {
-        return VitroSearchTermNames.NAME_RAW + "SingleValued_"
-            + locale.toString().replace('_', '-') + "_s";
+        return locale.toString() + VitroSearchTermNames.LABEL_DISPLAY_SUFFIX;
     }
 
     public static SearchQuery getRandomQuery(List<String> vclassUris, int page, int pageSize){

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/utils/searchengine/SearchQueryUtils.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/utils/searchengine/SearchQueryUtils.java
@@ -209,11 +209,11 @@ public class SearchQueryUtils {
     }
     
     public static String getSortFieldNameForLocale(Locale locale) {
-        return locale.toString() + VitroSearchTermNames.SORT_SUFFIX;
+        return locale.toString().replace('_', '-') + VitroSearchTermNames.SORT_SUFFIX;
     }
     
     public static String getLabelFieldNameForLocale(Locale locale) {
-        return locale.toString() + VitroSearchTermNames.LABEL_DISPLAY_SUFFIX;
+        return locale.toString().replace('_', '-') + VitroSearchTermNames.LABEL_DISPLAY_SUFFIX;
     }
 
     public static SearchQuery getRandomQuery(List<String> vclassUris, int page, int pageSize){

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/utils/searchengine/SearchQueryUtils.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/utils/searchengine/SearchQueryUtils.java
@@ -212,6 +212,11 @@ public class SearchQueryUtils {
         return VitroSearchTermNames.NAME_LOWERCASE_SINGLE_VALUED + "_"
             + locale.toString().replace('_', '-') + "_s";
     }
+    
+    public static String getLabelFieldNameForLocale(Locale locale) {
+        return VitroSearchTermNames.NAME_RAW + "SingleValued_"
+            + locale.toString().replace('_', '-') + "_s";
+    }
 
     public static SearchQuery getRandomQuery(List<String> vclassUris, int page, int pageSize){
         String queryText = "";

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/utils/searchengine/SearchQueryUtils.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/utils/searchengine/SearchQueryUtils.java
@@ -5,6 +5,7 @@ package edu.cornell.mannlib.vitro.webapp.utils.searchengine;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 import org.apache.commons.lang3.StringUtils;
@@ -150,19 +151,38 @@ public class SearchQueryUtils {
     }
 
 	/**
-     * builds a query with a type clause for each type in vclassUris, NAME_LOWERCASE filetred by
-     * alpha, and just the hits for the page for pageSize.
+     * builds a query with a type clause for each type in vclassUris,
+     * NAME_LOWERCASE filtered by alpha, and just the hits for the page for pageSize.
+     * @param locale may be null.  If null, default sort field will be used.
+     *            Otherwise, query will be sorted by locale-specific sort field. 
      */
-    public static SearchQuery getQuery(List<String> vclassUris, String alpha, int page, int pageSize){
+    public static SearchQuery getQuery(List<String> vclassUris, String alpha,
+            Locale locale, int page, int pageSize){
         String queryText = "";
         SearchEngine searchEngine = ApplicationUtils.instance().getSearchEngine();
 
         try {
             queryText = makeMultiClassQuery(vclassUris);
-
+                        
+            String localeSpecificField = null;
+            
+            if (locale != null) {
+                localeSpecificField = getSortFieldNameForLocale(locale); 
+            }
+            
         	 // Add alpha filter if applicable
             if ( alpha != null && !"".equals(alpha) && alpha.length() == 1) {
-                queryText += VitroSearchTermNames.NAME_LOWERCASE + ":" + alpha.toLowerCase() + "*";
+                if (locale == null) {
+                    queryText += VitroSearchTermNames.NAME_LOWERCASE + ":" + alpha.toLowerCase() + "*";
+                } else {
+                    // Retrieve items matching the appropriate alpha char
+                    // on the i18ned field if that field exists.  For records
+                    // where the field does not exist, fall back to NAME_LOWERCASE
+                    queryText += "(" + localeSpecificField + ":" + alpha.toLowerCase()
+                           + "* OR (-" + localeSpecificField + ":[* TO *] AND "
+                           + VitroSearchTermNames.NAME_LOWERCASE + ":" + alpha.toLowerCase() + "*))";
+                    log.debug("Multiclass query text: " + queryText);
+                }
             }
 
             SearchQuery query = searchEngine.createQuery(queryText);
@@ -172,6 +192,11 @@ public class SearchQueryUtils {
             query.setStart( startRow ).setRows( pageSize );
 
             // Need a single-valued field for sorting
+            // Sort first by sort field for locale; fall back to
+            // NAME_LOWERCASE_SINGLE_VALUED if not available.
+            if(locale != null) {
+                query.addSortField(localeSpecificField, Order.ASC);
+            }
             query.addSortField(VitroSearchTermNames.NAME_LOWERCASE_SINGLE_VALUED, Order.ASC);
 
             log.debug("Query is " + query.toString());
@@ -181,6 +206,11 @@ public class SearchQueryUtils {
             log.error("Could not make the search query",ex);
             return searchEngine.createQuery();
         }
+    }
+    
+    public static String getSortFieldNameForLocale(Locale locale) {
+        return VitroSearchTermNames.NAME_LOWERCASE_SINGLE_VALUED + "_"
+            + locale.toString().replace('_', '-') + "_s";
     }
 
     public static SearchQuery getRandomQuery(List<String> vclassUris, int page, int pageSize){

--- a/home/src/main/resources/rdf/display/everytime/documentModifierI18nLabel.n3
+++ b/home/src/main/resources/rdf/display/everytime/documentModifierI18nLabel.n3
@@ -8,7 +8,7 @@
     rdfs:label "multilingual label document modifier" ;
     :hasSelectQuery """
         PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
-        SELECT ?targetField (LCASE(STR(MIN(?labelRaw))) AS ?label) WHERE {
+        SELECT ?targetField (STR(MIN(?labelRaw)) AS ?label) WHERE {
             ?uri rdfs:label ?labelRaw
             FILTER("" != LANG(?labelRaw))
             BIND(CONCAT("nameRawSingleValued_", LANG(?labelRaw), "_s") AS ?targetField)

--- a/home/src/main/resources/rdf/display/everytime/documentModifierI18nLabel.n3
+++ b/home/src/main/resources/rdf/display/everytime/documentModifierI18nLabel.n3
@@ -2,15 +2,15 @@
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-:documentModifier_multilingual_sort
+:documentModifier_multilingual_label
     a   <java:edu.cornell.mannlib.vitro.webapp.searchindex.documentBuilding.SelectQueryDocumentModifierDynamicTargetField> ,
             <java:edu.cornell.mannlib.vitro.webapp.searchindex.documentBuilding.DocumentModifier> ;
-    rdfs:label "multilingual sort document modifier" ;
+    rdfs:label "multilingual label document modifier" ;
     :hasSelectQuery """
         PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
         SELECT ?targetField (LCASE(STR(MIN(?labelRaw))) AS ?label) WHERE {
             ?uri rdfs:label ?labelRaw
             FILTER("" != LANG(?labelRaw))
-            BIND(CONCAT("nameLowercaseSingleValued_", LANG(?labelRaw), "_s") AS ?targetField)
+            BIND(CONCAT("nameRawSingleValued_", LANG(?labelRaw), "_s") AS ?targetField)
         } GROUP BY ?targetField
     """ .

--- a/home/src/main/resources/rdf/display/everytime/documentModifierI18nLabel.n3
+++ b/home/src/main/resources/rdf/display/everytime/documentModifierI18nLabel.n3
@@ -6,11 +6,10 @@
     a   <java:edu.cornell.mannlib.vitro.webapp.searchindex.documentBuilding.SelectQueryDocumentModifierDynamicTargetField> ,
             <java:edu.cornell.mannlib.vitro.webapp.searchindex.documentBuilding.DocumentModifier> ;
     rdfs:label "multilingual label document modifier" ;
+    :hasTargetSuffix "_label_display" ;
     :hasSelectQuery """
         PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
-        SELECT ?targetField (STR(MIN(?labelRaw)) AS ?label) WHERE {
-            ?uri rdfs:label ?labelRaw
-            FILTER("" != LANG(?labelRaw))
-            BIND(CONCAT("nameRawSingleValued_", LANG(?labelRaw), "_s") AS ?targetField)
-        } GROUP BY ?targetField
+        SELECT ( MIN(?label) as ?singleLabel ) WHERE {
+            ?uri rdfs:label ?label .
+        }
     """ .

--- a/home/src/main/resources/rdf/display/everytime/documentModifierI18nLabel.n3
+++ b/home/src/main/resources/rdf/display/everytime/documentModifierI18nLabel.n3
@@ -9,7 +9,8 @@
     :hasTargetSuffix "_label_display" ;
     :hasSelectQuery """
         PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
-        SELECT ( MIN(?label) as ?singleLabel ) WHERE {
+        SELECT (MIN(?label) AS ?singleLabel ) WHERE {
             ?uri rdfs:label ?label .
-        }
+            BIND (LANG(?label) as ?lang )
+        } GROUP BY ?lang ORDER BY ?lang
     """ .

--- a/home/src/main/resources/rdf/display/everytime/documentModifierI18nLabel.n3
+++ b/home/src/main/resources/rdf/display/everytime/documentModifierI18nLabel.n3
@@ -3,7 +3,7 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 :documentModifier_multilingual_label
-    a   <java:edu.cornell.mannlib.vitro.webapp.searchindex.documentBuilding.SelectQueryDocumentModifierDynamicTargetField> ,
+    a   <java:edu.cornell.mannlib.vitro.webapp.searchindex.documentBuilding.SelectQueryI18nDocumentModifier> ,
             <java:edu.cornell.mannlib.vitro.webapp.searchindex.documentBuilding.DocumentModifier> ;
     rdfs:label "multilingual label document modifier" ;
     :hasTargetSuffix "_label_display" ;

--- a/home/src/main/resources/rdf/display/everytime/documentModifierI18nSort.n3
+++ b/home/src/main/resources/rdf/display/everytime/documentModifierI18nSort.n3
@@ -1,0 +1,15 @@
+@prefix : <http://vitro.mannlib.cornell.edu/ns/vitro/ApplicationSetup#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+:documentModifier_multilingual_sort
+    a   <java:edu.cornell.mannlib.vitro.webapp.searchindex.documentBuilding.SelectQueryDocumentModifierDynamicTargetField> ,
+            <java:edu.cornell.mannlib.vitro.webapp.searchindex.documentBuilding.DocumentModifier> ;
+    rdfs:label "multilingual sort document modifier" ;
+    :hasSelectQuery """
+        PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+        SELECT ?targetField (LCASE(STR(MIN(?labelRaw))) AS ?label) WHERE {
+            ?uri rdfs:label ?labelRaw
+            BIND(CONCAT("nameLowercaseSingleValued_", IF(LANG(?labelRaw) = "", "plain", LANG(?labelRaw)), "_s") AS ?targetField)
+        } GROUP BY ?targetField
+    """ .

--- a/home/src/main/resources/rdf/display/everytime/documentModifierI18nSort.n3
+++ b/home/src/main/resources/rdf/display/everytime/documentModifierI18nSort.n3
@@ -6,11 +6,10 @@
     a   <java:edu.cornell.mannlib.vitro.webapp.searchindex.documentBuilding.SelectQueryDocumentModifierDynamicTargetField> ,
             <java:edu.cornell.mannlib.vitro.webapp.searchindex.documentBuilding.DocumentModifier> ;
     rdfs:label "multilingual sort document modifier" ;
+    :hasTargetSuffix "_label_sort" ;
     :hasSelectQuery """
         PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
-        SELECT ?targetField (LCASE(STR(MIN(?labelRaw))) AS ?label) WHERE {
-            ?uri rdfs:label ?labelRaw
-            FILTER("" != LANG(?labelRaw))
-            BIND(CONCAT("nameLowercaseSingleValued_", LANG(?labelRaw), "_s") AS ?targetField)
-        } GROUP BY ?targetField
+        SELECT ( MIN(?label) as ?singleLabel ) WHERE {
+            ?uri rdfs:label ?label .
+        }
     """ .

--- a/home/src/main/resources/rdf/display/everytime/documentModifierI18nSort.n3
+++ b/home/src/main/resources/rdf/display/everytime/documentModifierI18nSort.n3
@@ -9,7 +9,7 @@
     :hasTargetSuffix "_label_sort" ;
     :hasSelectQuery """
         PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
-        SELECT ( MIN(?label) as ?singleLabel ) WHERE {
+        SELECT ( LCASE(STR(MIN(?label))) as ?singleLabel ) WHERE {
             ?uri rdfs:label ?label .
         }
     """ .

--- a/home/src/main/resources/rdf/display/everytime/documentModifierI18nSort.n3
+++ b/home/src/main/resources/rdf/display/everytime/documentModifierI18nSort.n3
@@ -9,7 +9,8 @@
     :hasTargetSuffix "_label_sort" ;
     :hasSelectQuery """
         PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
-        SELECT ( LCASE(STR(MIN(?label))) as ?singleLabel ) WHERE {
-            ?uri rdfs:label ?label .
-        }
+        SELECT ( LCASE(MIN(?label)) AS ?singleLabel ) WHERE {
+        	?uri rdfs:label ?label .
+            BIND (LANG(?label) as ?lang )
+        } GROUP BY ?lang ORDER BY ?lang
     """ .

--- a/home/src/main/resources/rdf/display/everytime/documentModifierI18nSort.n3
+++ b/home/src/main/resources/rdf/display/everytime/documentModifierI18nSort.n3
@@ -3,7 +3,7 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 :documentModifier_multilingual_sort
-    a   <java:edu.cornell.mannlib.vitro.webapp.searchindex.documentBuilding.SelectQueryDocumentModifierDynamicTargetField> ,
+    a   <java:edu.cornell.mannlib.vitro.webapp.searchindex.documentBuilding.SelectQueryI18nDocumentModifier> ,
             <java:edu.cornell.mannlib.vitro.webapp.searchindex.documentBuilding.DocumentModifier> ;
     rdfs:label "multilingual sort document modifier" ;
     :hasTargetSuffix "_label_sort" ;


### PR DESCRIPTION
**[Issue VIVO-3606](https://github.com/vivo-project/VIVO/issues/3606)**: 
This PR is a successor of this [PR](https://github.com/vivo-project/Vitro/pull/320)

[VIVO-Solr PR](https://github.com/vivo-project/vivo-solr/pull/6) (companion PR, but it still works without it )

# What does this pull request do?
- Populates a sort field and label field in the search index for each language tag found in the list of labels for an individual.  
- If RDFService.languageFilter = true in runtime.properties, the sort field that corresponds to the current locale is used to sort the individual lists in the VClassGroup-based browse pages (People, Organizations, Events, etc.).  The original nameLowercasedSingleValue field is used as a secondary sort in case this field is not populated.
- alpha (A*) browse lookups search either for documents where the locale-specific sort field starts with the selected letter OR documents where the locale-specific sort field does not exist at all but the default nameLowerCaseSingleValued starts with the selected letter.  This should prevent content from disappearing entirely if the locale-specific sort field is not available, though it may mean that individuals appear under the wrong letter (unchanged from current behavior).
- When displaying the results of an autocomplete request, the label corresponding to the current locale is displayed if available.  If not, the original field nameRaw is used instead.

Note that this approach is intended only to enable the minimum sorting / autocomplete functionality needed by production i18nized sites.  It has the following key limitations:
- There is only one level of fallback (e.g. from de-DE_label_sort to nameLowercasedSingleValue).  There is no attempt to try de or de-AT if de-DE is not available, which means that improperly sorted values may appear if the appropriate label is not available.  Similarly, content may continue to appear under the wrong alpha heading.
- Because all sort fields use the dynamic string type, there is no language-specific collation enabled.  All languages will sort based on (lowercased by solr schema configuration) unicode values and not by more complex rules.  It would be nice to add this in the future, but will require the ability to modify the Solr schema according to the languages in use. 

# What's new?
- SelectQueryDocumentModifierDynamicTargetField extends SelectQueryDocumentModifier for queries that performs queries for each of locales found in runtime properties and return search index fields with names composed of locale + targetSuffix.
- Two new document modifiers are added to home/rdf/display/everytime to populate the i18nized sort and label fields.
- AutocompleteController/IndividualListController/SearchQueryUtils are modified to take advantage of the new fields.
- If solr schema doesn't contain fields with "_label_sort" and "_label_display" suffixes then dynamic fields with standard string type will be created at SolrSearchEngine startup. It will fix label display and label sort on instances where old solr schema is used (still adviced to be updated ).

# How should this be tested?
- In runtime.properties, enable RDFService.languageFilter = true and add en_US, es, fr_CA, and de_DE as the selectable locales.
- Load sorttest.n3.txt and sorttest_2.n3.txt (attached).
- Switch between the four locales and observe that the items in the People tab sort and alpha-filter properly, displaying the language-appropriate label in parentheses except in the case of 'Yanny' when de_DE is selected.  In the latter case, Yanny (en-US) will be displayed instead.
- Observe that Yanny is still browsable on the People tab when the locale is set to de_DE, even though there is no de-DE label for the individual.
- Add a publication to the DB.  Add an author.  Autocomplete on the author names 'Alpha', 'Bravo', 'Charlie' or 'Delta'.  Note that all 4 individuals are returned when you type one of these names.  This is because the autocomplete is not language-specific, and is out of scope for this PR.  The improvement with this PR is that the labels in the autocomplete dropdown will change according to your currently-selected locale.
- Verify that individuals without labels for specified languages still sorted correctly.
- Try load VIVO with old and new solr schemas and run rebuild search index. With old solr schema default dynamic fields should be created. With updated solr schema dynamic fields provided by solr schema should be used.

# Interested parties
@VIVO-project/vivo-committers

[sorttest.n3.txt](https://github.com/vivo-project/Vitro/files/9241040/sorttest.n3.txt)
[sorttest_2.n3.txt](https://github.com/vivo-project/Vitro/files/9267085/sorttest_2.n3.txt)



