### PR TITLE
fix: use public description in data property template model

### DIFF
--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/web/templatemodels/individual/DataPropertyTemplateModel.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/web/templatemodels/individual/DataPropertyTemplateModel.java
@@ -64,6 +64,7 @@ public class DataPropertyTemplateModel extends PropertyTemplateModel {
     private DataPropertyListConfig config;
     private String objectKey;
     private String queryString;
+    private String publicDescription;
     private String rangeDatatypeURI;
     private Set<String> constructQueries;
     private int displayLimit;
@@ -82,6 +83,7 @@ public class DataPropertyTemplateModel extends PropertyTemplateModel {
 
         queryString = getSelectQuery();
         constructQueries = getConstructQueries();
+        publicDescription = dp.getPublicDescription();
 
         statements = new ArrayList<DataPropertyStatementTemplateModel>();
 		displayLimit = dp.getDisplayLimit();
@@ -158,6 +160,10 @@ public class DataPropertyTemplateModel extends PropertyTemplateModel {
         return Route.DATA_PROPERTY_EDIT;
     }
 
+	public String getPublicDescription() {
+		return publicDescription;
+	}
+    
 	@Override
 	public int getDisplayLimit() {
 			return displayLimit;


### PR DESCRIPTION
[Issue](https://github.com/vivo-project/VIVO/issues/3736)
# What does this pull request do?
Uses public description for data properties when verbose property display is on
Before the fix public description show up only for object properties and faux properties

# How should this be tested?
A description of what steps someone could take to:

1. Log in
2. Turn on verbose property display
3. Hover over data property  ( over **data** word ) that has public description (A hint with public description should appear)

# Interested parties
@VIVO-project/vivo-committers
