### PR TITLE
Issue vivo 3738 show localized public descriptions in verbose property display mode

### DIFF
--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/web/templatemodels/individual/GroupedPropertyList.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/web/templatemodels/individual/GroupedPropertyList.java
@@ -2,9 +2,6 @@
 
 package edu.cornell.mannlib.vitro.webapp.web.templatemodels.individual;
 
-import static edu.cornell.mannlib.vitro.webapp.modelaccess.ModelAccess.LanguageOption.LANGUAGE_NEUTRAL;
-import static edu.cornell.mannlib.vitro.webapp.modelaccess.ModelAccess.PolicyOption.POLICY_NEUTRAL;
-
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -280,8 +277,7 @@ public class GroupedPropertyList extends BaseTemplateModel {
     }
 
 	private ObjectProperty assembleObjectProperty(PropertyInstance pi) {
-		WebappDaoFactory rawWadf = ModelAccess.on(vreq).getWebappDaoFactory(
-				LANGUAGE_NEUTRAL, POLICY_NEUTRAL);
+		WebappDaoFactory rawWadf = ModelAccess.on(vreq).getWebappDaoFactory();
 		ObjectPropertyDao opDao = rawWadf.getObjectPropertyDao();
 		FauxPropertyDao fpDao = rawWadf.getFauxPropertyDao();
 


### PR DESCRIPTION
**[VIVO GitHub issue](https://github.com/vivo-project/VIVO/issues/3738)**

# What does this pull request do?
Use language specific webapp dao factory to get properties information

# How should this be tested?
* Reproduce the problem in the issue

1. Fill public descriptions for vivo:geographicFocus in en_US, de_DE and es locales
2. Open individual page, turn on verbose property display mode
3. Hover over property to display public description
4. Switch to other locales to do the same
5. Displayed public descriptions should be in current locale if there are defined public description in that locale
6. Repeat the same for data property and faux property.

# Interested parties
@VIVO-project/vivo-committers
