### PR TITLE
fixing the issue with type of match property (changed from string to …

### DIFF
--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/grefine/JSONReconcileServlet.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/grefine/JSONReconcileServlet.java
@@ -338,7 +338,7 @@ public class JSONReconcileServlet extends VitroHttpServlet {
 							}
 
 							resultJson.put("type", typesJsonArr);
-							resultJson.put("match", "false");
+							resultJson.put("match", false);
 							resultJsonArr.add(resultJson);
 
 						} catch (Exception e) {


### PR DESCRIPTION
…boolean)


**[VIVO GitHub 3741 issue](https://github.com/vivo-project/VIVO/issues/3741)**

# What does this pull request do?
Fixing a bug with wrong type of the match property in reconcile API. 

# How should this be tested?
- Go to https://reconciliation-api.github.io/testbench/#/client/
- Enter the Endpoint of a VIVO reconciliation API, for example http://localhost:8080/reconcile
- Enter "Spain" in the name box, click on the Reconcile button.
- there shouldn't be any error (you can see the error if you enter in the Endpoint box https://vivo.tib.eu/fis/reconcile)

# Interested parties
Tag (@ mention) interested parties or, if unsure, @VIVO-project/vivo-committers
