### PR TITLE
[ i18n sprint ] VIVO-3748 Remove "Other" special case from ChildVClassesWithParent

### DIFF
--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/VTwo/fields/ChildVClassesWithParent.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/VTwo/fields/ChildVClassesWithParent.java
@@ -38,11 +38,6 @@ public class ChildVClassesWithParent implements FieldOptions {
         return this;
     }
 
-/*
- * UQAM-Linguistic-Management
- * This method is polymorphism of getOptions(EditConfigurationVTwo editConfig,String fieldName, WebappDaoFactory wDaoFact)
- * for the internationalization of word "other" in the scroling list of personHasAdvisorRelationship.ftl
- */
     public Map<String, String> getOptions(
             EditConfigurationVTwo editConfig,
             String fieldName,
@@ -53,16 +48,17 @@ public class ChildVClassesWithParent implements FieldOptions {
         if ( ! StringUtils.isEmpty( defaultOptionLabel ) ){
             optionsMap.put(LEFT_BLANK, defaultOptionLabel);
         }
-        String other_i18n = i18n.text("other");
-        // first character in capital
-        optionsMap.put(classUri, other_i18n.substring(0, 1).toUpperCase() + other_i18n.substring(1));
         VClassDao vclassDao = wDaoFact.getVClassDao();
+        VClass rdfClass = vclassDao.getVClassByURI(classUri);
+        if (rdfClass != null && !OWL.Nothing.getURI().equals(classUri)) {
+        	optionsMap.put(classUri, rdfClass.getName().trim());
+        }
         List<String> subClassList = vclassDao.getAllSubClassURIs(classUri);
         if (subClassList != null && subClassList.size() > 0) {
             for (String subClassUri : subClassList) {
-                VClass subClass = vclassDao.getVClassByURI(subClassUri);
-                if (subClass != null && !OWL.Nothing.getURI().equals(subClassUri)) {
-                    optionsMap.put(subClassUri, subClass.getName().trim());
+                rdfClass = vclassDao.getVClassByURI(subClassUri);
+                if (rdfClass != null && !OWL.Nothing.getURI().equals(subClassUri)) {
+                    optionsMap.put(subClassUri, rdfClass.getName().trim());
                 }
             }
         }
@@ -72,5 +68,5 @@ public class ChildVClassesWithParent implements FieldOptions {
     public Comparator<String[]> getCustomComparator() {
     	return null;
     }
-
+ 
 }


### PR DESCRIPTION
**[VIVO GitHub issue](https://github.com/vivo-project/VIVO/issues/3748)**
[Companion VIVO PR](https://github.com/vivo-project/VIVO/pull/3750)
[Companion VIVO-languages PR](https://github.com/vivo-project/VIVO-languages/pull/112)

# What does this pull request do?
Removed "Other" special case from ChildVClassesWithParent, instead provide names of parent and children.

# Interested parties
@VIVO-project/vivo-committers
