### PR TITLE
[3760 - i18n sprint] Adopting i18n bean to read translations from triple store instead from property files

### DIFF
--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/config/ConfigurationPropertiesSmokeTests.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/config/ConfigurationPropertiesSmokeTests.java
@@ -18,7 +18,6 @@ import javax.servlet.ServletContextEvent;
 import javax.servlet.ServletContextListener;
 
 import edu.cornell.mannlib.vitro.webapp.utils.LocaleUtility;
-import org.apache.commons.lang3.LocaleUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/config/ConfigurationPropertiesSmokeTests.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/config/ConfigurationPropertiesSmokeTests.java
@@ -10,12 +10,15 @@ import java.util.Arrays;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.nio.file.Path;
+import java.util.Locale;
 import java.util.stream.Collectors;
 
 import javax.servlet.ServletContext;
 import javax.servlet.ServletContextEvent;
 import javax.servlet.ServletContextListener;
 
+import edu.cornell.mannlib.vitro.webapp.utils.LocaleUtility;
+import org.apache.commons.lang3.LocaleUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -157,8 +160,9 @@ public class ConfigurationPropertiesSmokeTests implements
 		if (selectableLanguages) {
 			List<String> selectableLanguagesList = Arrays.asList(selectString.split("\\s*,\\s*"));
 			for (String language : selectableLanguagesList) {
-				String vivoBundle = VIVO_BUNDLE_PREFIX + language + ".properties";
-				String vitroBundle = VITRO_BUNDLE_PREFIX + language + ".properties";
+				Locale locale = LocaleUtility.languageStringToLocale(language);
+				String vivoBundle = VIVO_BUNDLE_PREFIX + locale.stripExtensions().toString() + ".properties";
+				String vitroBundle = VITRO_BUNDLE_PREFIX + locale.stripExtensions().toString() + ".properties";
 				if (!i18nNames.contains(vivoBundle) && !i18nNames.contains(vitroBundle)) {
 					ss.warning(this, language + " was found in the value for "
 						+ PROPERTY_LANGUAGE_SELECTABLE + " but no corresponding "

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/i18n/I18n.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/i18n/I18n.java
@@ -381,9 +381,14 @@ public class I18n {
 		public int compare(Locale o1, Locale o2) {
 			int c = o1.getLanguage().compareTo(o2.getLanguage());
 			if (c == 0) {
-				c = o1.getCountry().compareTo(o2.getCountry());
+				c = o1.getScript().compareTo(o2.getScript());
 				if (c == 0) {
-					c = o1.getVariant().compareTo(o2.getVariant());
+					c = o1.getCountry().compareTo(o2.getCountry());
+					if (c == 0) {
+						c = o1.getVariant().compareTo(o2.getVariant());
+					} if (c == 0) {
+						c = (o1.getExtensionKeys().size() >= o2.getExtensionKeys().size())?1:-1;
+					}
 				}
 			}
 			return c;

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/i18n/I18n.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/i18n/I18n.java
@@ -263,6 +263,7 @@ public class I18n {
 
 		private final ServletContext ctx;
 		private final String themeDirectory;
+		private Locale localeForLoading;
 
 
 		public ThemeBasedControl(ServletContext ctx, String themeDirectory) {
@@ -325,6 +326,7 @@ public class I18n {
 				approximateMatches.remove(locale);
 			}
 			if (approximateMatches.isEmpty()) {
+				localeForLoading = (usualList!=null)?usualList.get(0):null;
 				return usualList;
 			}
 
@@ -338,7 +340,20 @@ public class I18n {
 				mergedList.addAll(rootLocaleHere, approximateMatches);
 			}
 
+			localeForLoading = (mergedList!=null)?mergedList.get(0):null;
 			return mergedList;
+		}
+
+		@Override
+		public long getTimeToLive(String baseName, Locale locale) {
+			if (baseName == null) {
+				throw new NullPointerException();
+			} else if (locale == null) {
+				throw new NullPointerException();
+			} else if ((localeForLoading) != null && (!localeForLoading.equals(locale))){
+				return ResourceBundle.Control.TTL_DONT_CACHE;
+			}
+			return ResourceBundle.Control.TTL_NO_EXPIRATION_CONTROL;
 		}
 
 		private SortedSet<Locale> findApproximateMatches(Locale locale) {

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/i18n/I18n.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/i18n/I18n.java
@@ -3,20 +3,13 @@
 package edu.cornell.mannlib.vitro.webapp.i18n;
 
 import java.io.IOException;
-import java.util.Comparator;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Locale;
-import java.util.MissingResourceException;
-import java.util.Objects;
-import java.util.ResourceBundle;
-import java.util.SortedSet;
-import java.util.TreeSet;
+import java.util.*;
 import java.util.concurrent.atomic.AtomicReference;
 
 import javax.servlet.ServletContext;
 import javax.servlet.http.HttpServletRequest;
 
+import edu.cornell.mannlib.vitro.webapp.config.ConfigurationProperties;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
@@ -55,6 +48,8 @@ public class I18n {
 	private static I18n instance;
 
 	private final ServletContext ctx;
+
+
 
 	protected I18n(ServletContext ctx) {
 		this.ctx = ctx;
@@ -180,11 +175,11 @@ public class I18n {
 		} catch (MissingResourceException e) {
 			log.warn("Didn't find text bundle '" + bundleName + "'");
 
-			return I18nBundle.emptyBundle(bundleName, i18nLogger);
+			return NullI18nBundle.getInstance(bundleName, i18nLogger);
 		} catch (Exception e) {
 			log.error("Failed to create text bundle '" + bundleName + "'", e);
 
-			return I18nBundle.emptyBundle(bundleName, i18nLogger);
+			return NullI18nBundle.getInstance(bundleName, i18nLogger);
 		}
 	}
 
@@ -266,14 +261,16 @@ public class I18n {
 	 * the application i18n directory.
 	 */
 	static class ThemeBasedControl extends ResourceBundle.Control {
-		private static final String BUNDLE_DIRECTORY = "i18n/";
+
 		private final ServletContext ctx;
 		private final String themeDirectory;
+
 
 		public ThemeBasedControl(ServletContext ctx, String themeDirectory) {
 			this.ctx = ctx;
 			this.themeDirectory = themeDirectory;
 		}
+
 
 		/**
 		 * Don't look for classes to satisfy the request, just property files.
@@ -303,14 +300,7 @@ public class I18n {
 				throw new NullPointerException("bundleName may not be null.");
 			}
 
-			String themeI18nPath = "/" + themeDirectory + BUNDLE_DIRECTORY;
-			String appI18nPath = "/" + BUNDLE_DIRECTORY;
-
-			log.debug("Paths are '" + themeI18nPath + "' and '" + appI18nPath
-					+ "'");
-
-			return VitroResourceBundle.getBundle(bundleName, ctx, appI18nPath,
-					themeI18nPath, this);
+			return VitroResourceBundle.getBundle(bundleName, ctx, locale, themeDirectory, this);
 		}
 
 		/**

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/i18n/I18n.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/i18n/I18n.java
@@ -9,7 +9,6 @@ import java.util.concurrent.atomic.AtomicReference;
 import javax.servlet.ServletContext;
 import javax.servlet.http.HttpServletRequest;
 
-import edu.cornell.mannlib.vitro.webapp.config.ConfigurationProperties;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
@@ -321,6 +320,10 @@ public class I18n {
 			// are not already in the list, we're done.
 			SortedSet<Locale> approximateMatches = findApproximateMatches(locale);
 			approximateMatches.removeAll(usualList);
+			if ((! usualList.contains(locale)) && (approximateMatches.contains(locale))){
+				usualList.add(0, locale);
+				approximateMatches.remove(locale);
+			}
 			if (approximateMatches.isEmpty()) {
 				return usualList;
 			}
@@ -334,6 +337,7 @@ public class I18n {
 			} else {
 				mergedList.addAll(rootLocaleHere, approximateMatches);
 			}
+
 			return mergedList;
 		}
 

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/i18n/I18n.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/i18n/I18n.java
@@ -379,18 +379,7 @@ public class I18n {
 	private static class LocaleComparator implements Comparator<Locale> {
 		@Override
 		public int compare(Locale o1, Locale o2) {
-			int c = o1.getLanguage().compareTo(o2.getLanguage());
-			if (c == 0) {
-				c = o1.getScript().compareTo(o2.getScript());
-				if (c == 0) {
-					c = o1.getCountry().compareTo(o2.getCountry());
-					if (c == 0) {
-						c = o1.getVariant().compareTo(o2.getVariant());
-					} if (c == 0) {
-						c = (o1.getExtensionKeys().size() >= o2.getExtensionKeys().size())?1:-1;
-					}
-				}
-			}
+			int c = o1.toLanguageTag().compareTo(o2.toLanguageTag());
 			return c;
 		}
 	}

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/i18n/I18nBundle.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/i18n/I18nBundle.java
@@ -26,30 +26,20 @@ public class I18nBundle {
 	private static final String START_SEP = "\u25a4";
 	private static final String END_SEP = "\u25a5";
 	public static final String INT_SEP = "\u25a6";
-	private static final String MESSAGE_BUNDLE_NOT_FOUND = "Text bundle ''{0}'' not found.";
 	private static final String MESSAGE_KEY_NOT_FOUND = "Text bundle ''{0}'' has no text for ''{1}''";
 
-	public static I18nBundle emptyBundle(String bundleName,
-			I18nLogger i18nLogger) {
-		return new I18nBundle(bundleName, i18nLogger);
-	}
 
 	private final String bundleName;
 	private final ResourceBundle resources;
 	private final String notFoundMessage;
 	private final I18nLogger i18nLogger;
 
-	private I18nBundle(String bundleName, I18nLogger i18nLogger) {
-		this(bundleName, new EmptyResourceBundle(), MESSAGE_BUNDLE_NOT_FOUND,
-				i18nLogger);
-	}
-
 	public I18nBundle(String bundleName, ResourceBundle resources,
 			I18nLogger i18nLogger) {
 		this(bundleName, resources, MESSAGE_KEY_NOT_FOUND, i18nLogger);
 	}
 
-	private I18nBundle(String bundleName, ResourceBundle resources,
+	protected I18nBundle(String bundleName, ResourceBundle resources,
 			String notFoundMessage, I18nLogger i18nLogger) {
 		if (bundleName == null) {
 			throw new IllegalArgumentException("bundleName may not be null");

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/i18n/NullI18nBundle.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/i18n/NullI18nBundle.java
@@ -1,0 +1,53 @@
+/* $This file is distributed under the terms of the license in LICENSE$ */
+
+package edu.cornell.mannlib.vitro.webapp.i18n;
+
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.ResourceBundle;
+
+/**
+ * A wrapper for a ResourceBundle that will not throw an exception, no matter
+ * what string you request.
+ *
+ * If the ResourceBundle was not found, or if it doesn't contain the requested
+ * key, an error message string is returned, to help the developer diagnose the
+ * problem.
+ */
+public class NullI18nBundle extends I18nBundle{
+
+	private static final String MESSAGE_BUNDLE_NOT_FOUND = "Text bundle ''{0}'' not found.";
+
+	private static NullI18nBundle instance = null;
+
+	public static NullI18nBundle getInstance(String bundleName, I18nLogger i18nLogger){
+		if (instance == null)
+			instance = new NullI18nBundle(bundleName, i18nLogger);
+		return instance;
+	}
+
+	private NullI18nBundle(String bundleName, I18nLogger i18nLogger) {
+		super(bundleName, new EmptyResourceBundle(), MESSAGE_BUNDLE_NOT_FOUND,
+				i18nLogger);
+	}
+
+	/**
+	 * A resource bundle that contains no strings.
+	 */
+	public static class EmptyResourceBundle extends ResourceBundle {
+		@Override
+		public Enumeration<String> getKeys() {
+			return Collections.enumeration(Collections.<String> emptySet());
+		}
+
+		@Override
+		protected Object handleGetObject(String key) {
+			if (key == null) {
+				throw new NullPointerException("key may not be null.");
+			}
+			return null;
+		}
+
+	}
+
+}

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/i18n/VitroResourceBundle.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/i18n/VitroResourceBundle.java
@@ -60,6 +60,8 @@ public class VitroResourceBundle extends ResourceBundle {
 
 	private static final List<String> appPrefixes = new ArrayList<>();
 
+	private static String applicationName = null;
+
 	static {
 		addAppPrefix("vitro");
 	}
@@ -79,14 +81,12 @@ public class VitroResourceBundle extends ResourceBundle {
 														"  }\n" +
 														"  BIND(COALESCE(?found_theme, \"none\") as ?theme ) .\n" +
 														"  BIND(COALESCE(?found_application, \"none\") as ?application ) .\n" +
-														"  BIND(IF(?current_theme = ?theme, 100, 0) AS ?priority1 ) .\n" +
-														"  BIND(IF(\"local\" = ?application, xsd:integer(?priority1)+50, xsd:integer(?priority1)) AS ?priority2 ) .\n" +
-														"  BIND(IF(\"VIVO\" = ?application, xsd:integer(?priority2)+10, xsd:integer(?priority2)) AS ?priority3 ) .\n" +
-														"  BIND(IF(\"Vitro\" = ?application, xsd:integer(?priority3)+5, xsd:integer(?priority3)) AS ?priority4 ) .\n" +
-														"  BIND (STR(?translationWithLocale)  AS ?translation) .\n" +
+														"  BIND(IF(?current_theme = lcase(str(?theme)), 100, 0) AS ?priority1 ) .\n" +
+														"  BIND(IF(?current_application = lcase(str(?application)), xsd:integer(?priority1)+10, xsd:integer(?priority1)) AS ?priority2 ) .\n" +
+														"  BIND (STR(?translationWithLocale) AS ?translation) .\n" +
 														"  FILTER ( lang(?translationWithLocale) = ?locale ) .\n" +
 														"} \n" +
-														"ORDER by ASC(?priority4) " ;
+														"ORDER by ASC(?priority2) " ;
 
 	public static void addAppPrefix(String prefix) {
 		if (!prefix.endsWith("-") && !prefix.endsWith("_")) {
@@ -95,6 +95,7 @@ public class VitroResourceBundle extends ResourceBundle {
 
 		if (!appPrefixes.contains(prefix)) {
 			appPrefixes.add(prefix);
+			applicationName = prefix.substring(0, prefix.length()-1);
 		}
 	}
 
@@ -179,7 +180,7 @@ public class VitroResourceBundle extends ResourceBundle {
 		pss.setCommandText(SPARQL_LANGUAGE_QUERY);
 		pss.setLiteral("locale", locale);
 		pss.setLiteral("current_theme", theme);
-//		pss.setLiteral("current_application", "");
+		pss.setLiteral("current_application", applicationName);
 		ContextModelAccess modelAccess = ModelAccess.on(ctx);
 		Model queryModel = modelAccess.getOntModel(DISPLAY);
 		if (queryModel != null){

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/i18n/VitroResourceBundle.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/i18n/VitroResourceBundle.java
@@ -16,15 +16,15 @@ import javax.servlet.ServletContext;
 import edu.cornell.mannlib.vitro.webapp.beans.ApplicationBean;
 import edu.cornell.mannlib.vitro.webapp.modelaccess.ContextModelAccess;
 import edu.cornell.mannlib.vitro.webapp.modelaccess.ModelAccess;
+import edu.cornell.mannlib.vitro.webapp.rdfservice.filter.LanguageFilteringUtils;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.apache.jena.ontology.OntModel;
 import org.apache.jena.query.*;
 import org.apache.jena.rdf.model.Model;
-import org.apache.jena.shared.Lock;
 
 import static edu.cornell.mannlib.vitro.webapp.modelaccess.ModelNames.DISPLAY;
-import static edu.cornell.mannlib.vitro.webapp.modelaccess.ModelNames.FULL_UNION;
 
 /**
  * Works like a PropertyResourceBundle with two exceptions:
@@ -84,7 +84,6 @@ public class VitroResourceBundle extends ResourceBundle {
 														"  BIND(IF(?current_theme = lcase(str(?theme)), 100, 0) AS ?priority1 ) .\n" +
 														"  BIND(IF(?current_application = lcase(str(?application)), xsd:integer(?priority1)+10, xsd:integer(?priority1)) AS ?priority2 ) .\n" +
 														"  BIND (STR(?translationWithLocale) AS ?translation) .\n" +
-														"  FILTER ( lang(?translationWithLocale) = ?locale ) .\n" +
 														"} \n" +
 														"ORDER by ASC(?priority2) " ;
 
@@ -146,6 +145,7 @@ public class VitroResourceBundle extends ResourceBundle {
 	private final Properties properties;
 	private final String locale;
 	private final String theme;
+	private final OntModel displayModel;
 
 	private VitroResourceBundle(String bundleName, ServletContext ctx,
 			Locale locale, String themeDirectory, Control control)
@@ -158,8 +158,9 @@ public class VitroResourceBundle extends ResourceBundle {
 				+ "'");
 		this.bundleName = bundleName;
 		this.ctx = ctx;
-		//TODO ask Veljko do we have some issue with the line below regarding Serbian two scripts
 		this.locale = locale.toLanguageTag();
+		ContextModelAccess modelAccess = ModelAccess.on(ctx);
+		this.displayModel = modelAccess.getOntModel(DISPLAY);
 		this.theme = ApplicationBean.ThemeInfo.themeNameFromDir(themeDirectory);
 		this.appI18nPath = appI18nPath;
 		this.themeI18nPath = themeI18nPath;
@@ -178,13 +179,10 @@ public class VitroResourceBundle extends ResourceBundle {
 	private Properties loadTranslationsFromTriplestore(Properties props) throws IOException {
 		ParameterizedSparqlString pss = new ParameterizedSparqlString();
 		pss.setCommandText(SPARQL_LANGUAGE_QUERY);
-		pss.setLiteral("locale", locale);
 		pss.setLiteral("current_theme", theme);
 		pss.setLiteral("current_application", applicationName);
-		ContextModelAccess modelAccess = ModelAccess.on(ctx);
-		Model queryModel = modelAccess.getOntModel(DISPLAY);
-		if (queryModel != null){
-			queryModel.enterCriticalSection(Lock.READ);
+		if (displayModel != null){
+			Model queryModel = LanguageFilteringUtils.wrapOntModelInALanguageFilter(displayModel, locale);
 			try {
 				QueryExecution qexec = QueryExecutionFactory.create(pss.toString(), queryModel);
 				try {
@@ -204,8 +202,6 @@ public class VitroResourceBundle extends ResourceBundle {
 			} catch (Exception e) {
 				log.error(e.getLocalizedMessage());
 				e.printStackTrace();
-			} finally {
-				queryModel.leaveCriticalSection();
 			}
 		}
 		return props;

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/i18n/VitroResourceBundle.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/i18n/VitroResourceBundle.java
@@ -66,26 +66,27 @@ public class VitroResourceBundle extends ResourceBundle {
 		addAppPrefix("vitro");
 	}
 
-	private static final String SPARQL_LANGUAGE_QUERY = " PREFIX : <http://vivoweb.org/ontology/core/properties#>\n" +
+	private static final String SPARQL_LANGUAGE_QUERY = " PREFIX : <http://vivoweb.org/ontology/core/properties/vocabulary#>\n" +
 														"PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>\n" +
 														"PREFIX xsd: <http://www.w3.org/2001/XMLSchema#> \n" +
 														"SELECT ?key ?translation\n" +
 														"WHERE {\n" +
-														"  ?uri :key ?key .\n" +
+														"  ?uri :hasKey ?key .\n" +
 														"  ?uri rdfs:label ?translationWithLocale .\t\n" +
 														"  OPTIONAL { \n" +
-														"    ?uri :theme ?found_theme .\n" +
+														"    ?uri :hasTheme ?found_theme .\n" +
 														"  }\n" +
 														"  OPTIONAL { \n" +
-														"    ?uri :application ?found_application .\n" +
+														"    ?uri :hasApp ?found_application .\n" +
 														"  }\n" +
 														"  BIND(COALESCE(?found_theme, \"none\") as ?theme ) .\n" +
 														"  BIND(COALESCE(?found_application, \"none\") as ?application ) .\n" +
-														"  BIND(IF(?current_theme = lcase(str(?theme)), 100, 0) AS ?priority1 ) .\n" +
-														"  BIND(IF(?current_application = lcase(str(?application)), xsd:integer(?priority1)+10, xsd:integer(?priority1)) AS ?priority2 ) .\n" +
+														"  BIND(IF(?current_theme = lcase(str(?theme)), 50, 0) AS ?priority1 ) .\n" +
+														"  BIND(IF(?current_theme = \"none\", xsd:integer(?priority1)+10, xsd:integer(?priority1)) AS ?priority2 ) .\n" +
+														"  BIND(IF(?current_application = lcase(str(?application)), xsd:integer(?priority2)+5, xsd:integer(?priority2)) AS ?priority3 ) .\n" +
 														"  BIND (STR(?translationWithLocale) AS ?translation) .\n" +
 														"} \n" +
-														"ORDER by ASC(?priority2) " ;
+														"ORDER by ASC(?priority3) " ;
 
 	public static void addAppPrefix(String prefix) {
 		if (!prefix.endsWith("-") && !prefix.endsWith("_")) {

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/i18n/selection/LocaleSelectionSetup.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/i18n/selection/LocaleSelectionSetup.java
@@ -154,7 +154,7 @@ public class LocaleSelectionSetup implements ServletContextListener {
 		Locale locale = LocaleUtility.languageStringToLocale(localeString);
 
 		if (!"es_GO".equals(localeString) && // No complaint about bogus locale
-				!LocaleUtils.isAvailableLocale(locale)) {
+				!LocaleUtils.isAvailableLocale(locale.stripExtensions())) {
 			ssWarning("'" + locale + "' is not a recognized locale.");
 		}
 

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/rdfservice/filter/LanguageFilterModel.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/rdfservice/filter/LanguageFilterModel.java
@@ -18,14 +18,26 @@ import org.apache.jena.rdf.model.StmtIterator;
 public class LanguageFilterModel {
 
     private static final Log log = LogFactory.getLog(LanguageFilterModel.class);
-    
+
+    /**
+     *
+     * @param m the model to filter. May not be null.
+     * @param langs list of strings of type 'en-US'. May not be null.
+     * @return model with language-inappropriate literal statements filtered out. fr_FR is acceptable if fr_CA is requested
+     */
+    public Model filterModel(Model m, List<String> langs) {
+        return filterModel(m, langs, true);
+    }
+
+
     /**
      * 
      * @param m the model to filter. May not be null.
      * @param langs list of strings of type 'en-US'. May not be null.
+     * @param includeInexact if this parameter is true, fr_FR is acceptable if fr_CA is requested
      * @return model with language-inappropriate literal statements filtered out.
      */
-    public Model filterModel(Model m, List<String> langs) {
+    public Model filterModel(Model m, List<String> langs, boolean includeInexact) {
         log.debug("filterModel");
         List<Statement> retractions = new ArrayList<Statement>();
         StmtIterator stmtIt = m.listStatements();
@@ -52,6 +64,10 @@ public class LanguageFilterModel {
                     String lang = s.getObject().asLiteral().getLanguage();
                     if (langRegister == null) {
                         langRegister = lang;
+                        if (!includeInexact) {
+                            if (!langs.contains(langRegister))
+                                retractions.add(s);
+                        }
                     } else if (!langRegister.equals(lang)) {
                         chuckRemaining = true;
                         retractions.add(s);

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/rdfservice/filter/LanguageFilteringGraph.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/rdfservice/filter/LanguageFilteringGraph.java
@@ -21,17 +21,32 @@ public class LanguageFilteringGraph extends AbstractGraphDecorator
 
     private List<String> langs;
     private LanguageFilterModel filterModel = new LanguageFilterModel();
+    private boolean includeInexact = true;
     
     /**
      * Return a graph wrapped in a decorator that will filter find() results
-     * according to the supplied list of acceptable languages  
+     * according to the supplied list of acceptable languages, including inexact responses,
+     * meaning fr_FR is acceptable if fr_CA is requested
      * @param g the graph to wrap with language awareness. May not be null.
      * @param preferredLanguages a list of preferred language strings. May not 
      * be null.
      */
     protected LanguageFilteringGraph(Graph g, List<String> preferredLanguages) {
+        this(g, preferredLanguages, true);
+    }
+
+    /**
+     * Return a graph wrapped in a decorator that will filter find() results
+     * according to the supplied list of acceptable languages
+     * @param g the graph to wrap with language awareness. May not be null.
+     * @param preferredLanguages a list of preferred language strings. May not
+     * be null.
+     * @param includeInexact if this parameter is true, fr_FR is acceptable if fr_CA is requested
+     */
+    protected LanguageFilteringGraph(Graph g, List<String> preferredLanguages, Boolean includeInexact) {
         super(g);
         this.langs = preferredLanguages;
+        this.includeInexact = includeInexact;
     }
 
     @Override
@@ -52,7 +67,7 @@ public class LanguageFilteringGraph extends AbstractGraphDecorator
             tmp.add(t);
         }
         Model filteredModel = filterModel.filterModel(
-                ModelFactory.createModelForGraph(tmp), langs);
+                ModelFactory.createModelForGraph(tmp), langs, includeInexact);
         return filteredModel.getGraph().find();
     }
 

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/rdfservice/filter/LanguageFilteringUtils.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/rdfservice/filter/LanguageFilteringUtils.java
@@ -33,7 +33,7 @@ public class LanguageFilteringUtils {
      * (as in RDF language specifiers).
      */
     public static String localeToLanguage(Locale locale) {
-        return locale.toString().replace(UNDERSCORE, HYPHEN);
+        return locale.toLanguageTag().toString().replace(UNDERSCORE, HYPHEN);
     }
 	
     /**
@@ -69,7 +69,7 @@ public class LanguageFilteringUtils {
 		List<String> langs = new ArrayList<>();
 		while (locales.hasMoreElements()) {
 			Locale locale = (Locale) locales.nextElement();
-			langs.add(locale.toString().replace(UNDERSCORE, HYPHEN));
+			langs.add(locale.toLanguageTag().toString().replace(UNDERSCORE, HYPHEN));
 		}
 		if (langs.isEmpty()) {
 			langs.add(DEFAULT_LANG_STRING);
@@ -106,6 +106,19 @@ public class LanguageFilteringUtils {
 		return ModelFactory.createOntologyModel(OntModelSpec.OWL_MEM,
 		        ModelFactory.createModelForGraph(new LanguageFilteringGraph(
 		                rawModel.getGraph(), languages)));
+	}
+
+	/**
+	 * Add a Language Filtering layer to an OntModel for a certain locale
+	 */
+	public static OntModel wrapOntModelInALanguageFilter(OntModel rawModel,
+			String locale) {
+		List<String> locales = new ArrayList<>();
+		if(locale != null)
+			locales.add(locale);
+		return ModelFactory.createOntologyModel(OntModelSpec.OWL_MEM,
+				ModelFactory.createModelForGraph(new LanguageFilteringGraph(
+						rawModel.getGraph(), new AcceptableLanguages(locales))));
 	}
 
 	private LanguageFilteringUtils() {

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/rdfservice/filter/LanguageFilteringUtils.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/rdfservice/filter/LanguageFilteringUtils.java
@@ -109,7 +109,7 @@ public class LanguageFilteringUtils {
 	}
 
 	/**
-	 * Add a Language Filtering layer to an OntModel for a certain locale
+	 * Add a Language Filtering layer to an OntModel for a certain locale (not include inexact)
 	 */
 	public static OntModel wrapOntModelInALanguageFilter(OntModel rawModel,
 			String locale) {
@@ -118,7 +118,7 @@ public class LanguageFilteringUtils {
 			locales.add(locale);
 		return ModelFactory.createOntologyModel(OntModelSpec.OWL_MEM,
 				ModelFactory.createModelForGraph(new LanguageFilteringGraph(
-						rawModel.getGraph(), new AcceptableLanguages(locales))));
+						rawModel.getGraph(), locales, false)));
 	}
 
 	private LanguageFilteringUtils() {

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/servlet/setup/RDFFilesLoader.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/servlet/setup/RDFFilesLoader.java
@@ -32,6 +32,7 @@ import org.apache.jena.rdf.model.Statement;
 import org.apache.jena.rdf.model.StmtIterator;
 
 import edu.cornell.mannlib.vitro.webapp.application.ApplicationUtils;
+import sun.util.locale.LanguageTag;
 
 import javax.servlet.ServletContext;
 
@@ -136,7 +137,7 @@ public class RDFFilesLoader {
 		// Which locales are enabled in runtime.properties?
 		List<Locale> locales = SelectedLocale.getSelectableLocales(ctx);
 		for (Locale locale : locales) {
-			enabledLocales.add(locale.toLanguageTag().replace('-', '_'));
+			enabledLocales.add(locale.stripExtensions().toLanguageTag().replace('-', '_'));
 		}
 
 		// If no languages were enabled in runtime.properties, add a fallback as the default

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/utils/LocaleUtility.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/utils/LocaleUtility.java
@@ -10,10 +10,14 @@ public final class LocaleUtility {
 
     public static Locale languageStringToLocale(String localeString){
         String[] parsedLoc = localeString.trim().split("_", -1);
-        //regex pattern for locale tag with script specified
-        Locale locale = localeString.matches("^[a-z]{1,3}_[A-Z][a-z]{3}_[A-Z]{2}") ?
-            new Locale.Builder().setLanguage(parsedLoc[0]).setRegion(parsedLoc[2]).setScript(parsedLoc[1]).build() :
-            LocaleUtils.toLocale(localeString);
+        Locale locale =
+                //regex pattern for locale tag with private-use subtag
+                localeString.matches("^[a-z]{1,3}_[A-Za-z]{2}_x_[a-z]{1,}") ?
+                new Locale.Builder().setLanguage(parsedLoc[0]).setRegion(parsedLoc[1]).setExtension('x', parsedLoc[3]).build() :
+                //regex pattern for locale tag with script specified
+                localeString.matches("^[a-z]{1,3}_[A-Z][a-z]{3}_[A-Z]{2}") ?
+                        new Locale.Builder().setLanguage(parsedLoc[0]).setRegion(parsedLoc[2]).setScript(parsedLoc[1]).build() :
+                        LocaleUtils.toLocale(localeString);
         return locale;
     }
 }


### PR DESCRIPTION
**[VIVO GitHub issue 3760](https://github.com/vivo-project/VIVO/issues/3760)**

# What does this pull request do?
i18n object used in ftl files is filled from triple store.

# What's new?
Previously UI messages were loaded from property files

# How should this be tested?
At the moment, the ttl file from those branches might be used 
Vitro-languages - https://github.com/chenejac/Vitro-languages/tree/3760_translations_loading
VIVO-languages - https://github.com/chenejac/VIVO-languages/tree/3760_translations_loading 

1. Build VIVO (including VIVO-languages and Vitro-languages from the above mentioned branches)
2. Configure runtime.properties in the VIVO-HOME to include languages.selectableLocales = en_US, de_DE, sr_Latn_RS, ru_RU, fr_CA, en_CA, es, pt_BR
4. Run VIVO
5. Change language to English Canadian
6. Check label at the home page in the blue box - Research, it should be Research ttl
7. You can play around with commenting/uncommenting lines from ttl files (restart of tomcat is needed).
    5.1. Priority order (from the highest priority): 
            language specificity (for instance change in the runtime properties en_CA to en_CA_x_uqam, label from 6 should be Research ttl uqam) 
            property file (uncomment this [line](https://github.com/chenejac/VIVO-languages/blob/635bdbd97f1fe476fa473f2820149e86debe902b/en_CA/webapp/src/main/webapp/i18n/vivo_all_en_CA.properties#L200))
             an individual with data properties theme = "wilma" 
             an individual with data property application = "VIVO" 
             an individual with data property application = "Vitro" 


# Additional Notes:
* Does this change require documentation to be updated?  **this PR not, but after completion of i18n redesign, documentation about adding new language should be updated**
* Does this change add any new dependencies? **NO**
* Does this change require any other modifications to be made to the repository? **Yes, ttl (or n3) files representing messages from the property files should be added in VIVO-languages ($lang$/home/../resources) directory (at the moment, later it might be moved to VIVO repository)**
* Could this change impact execution of existing code? **Hopefully not, but it would be nice to have a test**
* Large pull requests should be avoided. If this PR is large (more than 1,000 lines of codes), please provide short explanation why your contribution can't be decoupled in smaller PRs.  **This is not a large PR**

# Interested parties
Tag (@ mention) interested parties or, if unsure, @VIVO-project/vivo-committers
