### PR TITLE
fixes for language filtering to support private-use subtags

### DIFF
--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/rdfservice/filter/AcceptableLanguages.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/rdfservice/filter/AcceptableLanguages.java
@@ -1,6 +1,7 @@
 package edu.cornell.mannlib.vitro.webapp.rdfservice.filter;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import org.apache.commons.logging.Log;
@@ -12,6 +13,8 @@ import org.apache.commons.logging.LogFactory;
  */
 public class AcceptableLanguages extends ArrayList<String>{
     
+    private static final String SEPARATOR = "-";
+    private static final String PRIVATE_USE_SUBTAG = "x";
     private static final long serialVersionUID = 1L;
     private static final Log log = LogFactory.getLog(AcceptableLanguages.class);
     
@@ -25,9 +28,17 @@ public class AcceptableLanguages extends ArrayList<String>{
         log.debug("Raw language strings:" + rawLanguageStrs);
         for (String lang : rawLanguageStrs) {
             this.add(lang);
-            String baseLang = lang.split("-")[0];
-            if (!lang.equals(baseLang) && !this.contains(baseLang)) {
-                this.add(baseLang);
+            String[] subtags = lang.split(SEPARATOR);
+            int length = subtags.length;
+            for (int i = 1; i < length; i++) {
+                int lastIndex = length - i;
+                if (PRIVATE_USE_SUBTAG.equals(subtags[lastIndex - 1])) {
+                    continue;
+                }
+                String baseLang = String.join(SEPARATOR, Arrays.copyOfRange(subtags, 0, lastIndex));
+                if (!lang.equals(baseLang) && !this.contains(baseLang)) {
+                    this.add(baseLang);
+                }
             }
         }
         log.debug("Normalized language strings:" + this);

--- a/api/src/test/java/edu/cornell/mannlib/vitro/webapp/rdfservice/filter/LanguageFilteringRDFServiceTest.java
+++ b/api/src/test/java/edu/cornell/mannlib/vitro/webapp/rdfservice/filter/LanguageFilteringRDFServiceTest.java
@@ -200,6 +200,80 @@ public class LanguageFilteringRDFServiceTest extends AbstractTestClass {
 		assertEquals(model.size(),1);
 		assertEquals(model.listStatements().next().getObject().toString(), "no tag label");
 	}
+	
+	@Test
+	public void sparqlConstructQueryTestPrivateFallback1() throws RDFServiceException {
+		preferredLanguages = list("fr-CA");
+		OntModel model;
+		createLanguageFilter("LangFilteringTestModelPrivateFallback.n3");
+		model = ModelFactory.createOntologyModel(OntModelSpec.OWL_MEM);
+		filteringRDFService.sparqlConstructQuery(TEST_CONSTRUCT_QUERY, model);
+		assertEquals(model.size(),1);
+		final String expected = "fr@fr";
+		assertEquals(expected, model.listStatements().next().getObject().toString());
+	}
+
+	@Test
+	public void sparqlConstructQueryTestPrivateFallback2() throws RDFServiceException {
+		preferredLanguages = list("fr");
+		OntModel model;
+		createLanguageFilter("LangFilteringTestModelPrivateFallback2.n3");
+		model = ModelFactory.createOntologyModel(OntModelSpec.OWL_MEM);
+		filteringRDFService.sparqlConstructQuery(TEST_CONSTRUCT_QUERY, model);
+		assertEquals(model.size(),1);
+		final String expected = "TIB FR ca@fr-CA-x-tib";
+		assertEquals(expected, model.listStatements().next().getObject().toString());
+	}
+
+	@Test
+	public void sparqlConstructQueryTestPrivateFallback3() throws RDFServiceException {
+		preferredLanguages = list("fr-CA-x-tib");
+		OntModel model;
+		createLanguageFilter("LangFilteringTestModelPrivateFallback3.n3");
+		model = ModelFactory.createOntologyModel(OntModelSpec.OWL_MEM);
+		filteringRDFService.sparqlConstructQuery(TEST_CONSTRUCT_QUERY, model);
+		assertEquals(model.size(),1);
+		final String expected = "fr@fr";
+		assertEquals(expected, model.listStatements().next().getObject().toString());
+	}
+	
+	@Test
+	public void sparqlConstructQueryTestPrivate() throws RDFServiceException {
+		preferredLanguages = list("fr-CA-x-tib");
+		OntModel model;
+		createLanguageFilter("LangFilteringTestModelPrivate.n3");
+		model = ModelFactory.createOntologyModel(OntModelSpec.OWL_MEM);
+		filteringRDFService.sparqlConstructQuery(TEST_CONSTRUCT_QUERY, model);
+		assertEquals(model.size(),1);
+		final String expected = "TIB FR ca@fr-CA-x-tib";
+		assertEquals(expected, model.listStatements().next().getObject().toString());
+	}
+	
+	@Test
+	public void sparqlConstructQueryTestFallback1() throws RDFServiceException {
+		preferredLanguages = list("fr-CA");
+		OntModel model;
+		createLanguageFilter("LangFilteringTestModelFallback.n3");
+		model = ModelFactory.createOntologyModel(OntModelSpec.OWL_MEM);
+		filteringRDFService.sparqlConstructQuery(TEST_CONSTRUCT_QUERY, model);
+		assertEquals(model.size(),1);
+		final String expected = "fr CH@fr-CH";
+		assertEquals(expected, model.listStatements().next().getObject().toString());
+	}
+	
+	@Test
+	public void sparqlConstructQueryTestFallback2() throws RDFServiceException {
+		preferredLanguages = list("fr");
+		OntModel model;
+		createLanguageFilter("LangFilteringTestModelFallback.n3");
+		model = ModelFactory.createOntologyModel(OntModelSpec.OWL_MEM);
+		filteringRDFService.sparqlConstructQuery(TEST_CONSTRUCT_QUERY, model);
+		assertEquals(model.size(),1);
+		final String expected = "fr CH@fr-CH";
+		assertEquals(expected, model.listStatements().next().getObject().toString());
+	}
+
+
 
 	// ----------------------------------------------------------------------
 	// Helper methods

--- a/api/src/test/resources/edu/cornell/mannlib/vitro/webapp/rdfservice/filter/LangFilteringTestModelFallback.n3
+++ b/api/src/test/resources/edu/cornell/mannlib/vitro/webapp/rdfservice/filter/LangFilteringTestModelFallback.n3
@@ -1,0 +1,2 @@
+@prefix rdfs:    <http://www.w3.org/2000/01/rdf-schema#> .
+<http://test.edu/u> rdfs:label "fr CH"@fr-CH, "de DE"@de-DE, "en US"@en-US, "no tag" .

--- a/api/src/test/resources/edu/cornell/mannlib/vitro/webapp/rdfservice/filter/LangFilteringTestModelPrivate.n3
+++ b/api/src/test/resources/edu/cornell/mannlib/vitro/webapp/rdfservice/filter/LangFilteringTestModelPrivate.n3
@@ -1,0 +1,2 @@
+@prefix rdfs:    <http://www.w3.org/2000/01/rdf-schema#> .
+<http://test.edu/u> rdfs:label  "fr BE"@fr-BE, "fr-FR"@fr-FR, "fr CA"@fr-CA, "fr-CH"@fr-CH, "TIB FR ca"@fr-CA-x-tib, "en-US"@en-US, "no tag" .

--- a/api/src/test/resources/edu/cornell/mannlib/vitro/webapp/rdfservice/filter/LangFilteringTestModelPrivateFallback.n3
+++ b/api/src/test/resources/edu/cornell/mannlib/vitro/webapp/rdfservice/filter/LangFilteringTestModelPrivateFallback.n3
@@ -1,0 +1,2 @@
+@prefix rdfs:    <http://www.w3.org/2000/01/rdf-schema#> .
+<http://test.edu/u> rdfs:label "fr"@fr, "fr BE"@fr-BE, "fr-FR"@fr-FR, "fr-CH"@fr-CH, "TIB FR ca"@fr-CA-x-tib, "en-US"@en-US, "no tag" .

--- a/api/src/test/resources/edu/cornell/mannlib/vitro/webapp/rdfservice/filter/LangFilteringTestModelPrivateFallback2.n3
+++ b/api/src/test/resources/edu/cornell/mannlib/vitro/webapp/rdfservice/filter/LangFilteringTestModelPrivateFallback2.n3
@@ -1,0 +1,2 @@
+@prefix rdfs:    <http://www.w3.org/2000/01/rdf-schema#> .
+<http://test.edu/u> rdfs:label "en"@en, "fi FI"@fi-FI, "TIB FR ca"@fr-CA-x-tib, "en-US"@en-US, "no tag" .

--- a/api/src/test/resources/edu/cornell/mannlib/vitro/webapp/rdfservice/filter/LangFilteringTestModelPrivateFallback3.n3
+++ b/api/src/test/resources/edu/cornell/mannlib/vitro/webapp/rdfservice/filter/LangFilteringTestModelPrivateFallback3.n3
@@ -1,0 +1,2 @@
+@prefix rdfs:    <http://www.w3.org/2000/01/rdf-schema#> .
+<http://test.edu/u> rdfs:label "en"@en, "fi FI"@fi-FI, "fr"@fr, "en-US"@en-US, "no tag" .


### PR DESCRIPTION
# What does this pull request do?
Fixes created list of tags for cases with private use sub-tags.
Example
For requested language fr-CA-x-uqam creates list of acceptable [ fr-CA-x-uqam, fr-CA , fr ]

# How should this be tested?
Unit tests are included in this PR

# Interested parties
@chenejac 
@brianjlowe 
