### PR TITLE
[ i18n sprint ] autoCompleteObjectPropForm and lib-properties fixes from fr_CA

### DIFF
--- a/webapp/src/main/webapp/templates/freemarker/edit/forms/autoCompleteObjectPropForm.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/edit/forms/autoCompleteObjectPropForm.ftl
@@ -58,7 +58,7 @@
 
             <#---This section should become autocomplete instead-->
             <p>
-				<label for="object"> ${propertyNameForDisplay?capitalize} ${i18n().name_capitalized}<span class='requiredHint'> *</span></label>
+				<label for="object">  ${i18n().name_capitalized?cap_first} <span class='requiredHint'> *</span></label>
 				<input class="acSelector" size="50"  type="text" id="object" name="objectLabel" acGroupName="object" value="${objectLabel}" />
 			</p>
 
@@ -107,26 +107,26 @@ the parameter should not be passed at all to the search.
 Also multiple types parameter set to true only if more than one type returned-->
     <script type="text/javascript">
     var customFormData  = {
-        acUrl: '${urls.base}/autocomplete?tokenize=true',
+        acUrl: "${urls.base}/autocomplete?tokenize=true",
         <#if objectTypesExist = true>
-            acTypes: {object: '${objectTypes}'},
+            acTypes: {object: "${objectTypes}"},
         </#if>
         <#if multipleTypes = true>
-            acMultipleTypes: 'true',
+            acMultipleTypes: "true",
         </#if>
-        editMode: '${editMode}',
-        typeName:'${propertyNameForDisplay}',
-        acSelectOnly: 'true',
-        sparqlForAcFilter: '${sparqlForAcFilter}',
-        sparqlQueryUrl: '${sparqlQueryUrl}',
+        editMode: "${editMode}",
+        typeName:"${propertyNameForDisplay}",
+        acSelectOnly: "true",
+        sparqlForAcFilter: "${sparqlForAcFilter}",
+        sparqlQueryUrl: "${sparqlQueryUrl}",
         acFilterForIndividuals: ${acFilterForIndividuals},
-        defaultTypeName: '${propertyNameForDisplay}', // used in repair mode to generate button text
-        baseHref: '${urls.base}/individual?uri='
+        defaultTypeName: "${propertyNameForDisplay}", // used in repair mode to generate button text
+        baseHref: "${urls.base}/individual?uri="
     };
     var i18nStrings = {
-        selectAnExisting: '${i18n().select_an_existing?js_string}',
-        orCreateNewOne: '${i18n().or_create_new_one?js_string}',
-        selectedString: '${i18n().selected?js_string}'
+        selectAnExisting: "${i18n().select_an_existing?js_string}",
+        orCreateNewOne: "${i18n().or_create_new_one?js_string}",
+        selectedString: "${i18n().selected?js_string}"
     };
     </script>
 <#--

--- a/webapp/src/main/webapp/templates/freemarker/edit/forms/autoCompleteObjectPropForm.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/edit/forms/autoCompleteObjectPropForm.ftl
@@ -107,26 +107,26 @@ the parameter should not be passed at all to the search.
 Also multiple types parameter set to true only if more than one type returned-->
     <script type="text/javascript">
     var customFormData  = {
-        acUrl: "${urls.base}/autocomplete?tokenize=true",
+        acUrl: '${urls.base}/autocomplete?tokenize=true',
         <#if objectTypesExist = true>
-            acTypes: {object: "${objectTypes}"},
+            acTypes: {object: '${objectTypes?js_string}'},
         </#if>
         <#if multipleTypes = true>
-            acMultipleTypes: "true",
+            acMultipleTypes: 'true',
         </#if>
-        editMode: "${editMode}",
-        typeName:"${propertyNameForDisplay}",
-        acSelectOnly: "true",
-        sparqlForAcFilter: "${sparqlForAcFilter}",
-        sparqlQueryUrl: "${sparqlQueryUrl}",
-        acFilterForIndividuals: ${acFilterForIndividuals},
-        defaultTypeName: "${propertyNameForDisplay}", // used in repair mode to generate button text
-        baseHref: "${urls.base}/individual?uri="
+        editMode: '${editMode}',
+        typeName:'${propertyNameForDisplay?js_string}',
+        acSelectOnly: 'true',
+        sparqlForAcFilter: '${sparqlForAcFilter?js_string}',
+        sparqlQueryUrl: '${sparqlQueryUrl?js_string}',
+        acFilterForIndividuals: ${acFilterForIndividuals?js_string},
+        defaultTypeName: '${propertyNameForDisplay?js_string}', // used in repair mode to generate button text
+        baseHref: '${urls.base}/individual?uri='
     };
     var i18nStrings = {
-        selectAnExisting: "${i18n().select_an_existing?js_string}",
-        orCreateNewOne: "${i18n().or_create_new_one?js_string}",
-        selectedString: "${i18n().selected?js_string}"
+        selectAnExisting: '${i18n().select_an_existing?js_string}',
+        orCreateNewOne: '${i18n().or_create_new_one?js_string}',
+        selectedString: '${i18n().selected?js_string}'
     };
     </script>
 <#--

--- a/webapp/src/main/webapp/templates/freemarker/edit/forms/defaultAddMissingIndividualForm.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/edit/forms/defaultAddMissingIndividualForm.ftl
@@ -1,7 +1,7 @@
 <#-- $This file is distributed under the terms of the license in LICENSE$ -->
 
 <#assign formTitle>
-${i18n.new_entry_for(editConfiguration.propertyPublicDomainTitle, editConfiguration.subjectName)}
+${i18n().new_entry_for(editConfiguration.propertyPublicDomainTitle, editConfiguration.subjectName)}
 </#assign>
 <#if editConfiguration.objectUri?has_content>
     <#assign formTitle>${i18n().edit_capitalized} ${formTitle} </#assign>

--- a/webapp/src/main/webapp/templates/freemarker/edit/forms/defaultAddMissingIndividualForm.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/edit/forms/defaultAddMissingIndividualForm.ftl
@@ -1,7 +1,7 @@
 <#-- $This file is distributed under the terms of the license in LICENSE$ -->
 
 <#assign formTitle>
- "${editConfiguration.propertyPublicDomainTitle}" entry for ${editConfiguration.subjectName}
+${i18n.new_entry_for(editConfiguration.propertyPublicDomainTitle, editConfiguration.subjectName)}
 </#assign>
 <#if editConfiguration.objectUri?has_content>
     <#assign formTitle>${i18n().edit_capitalized} ${formTitle} </#assign>

--- a/webapp/src/main/webapp/templates/freemarker/edit/forms/js/customFormWithAutocomplete.js
+++ b/webapp/src/main/webapp/templates/freemarker/edit/forms/js/customFormWithAutocomplete.js
@@ -630,7 +630,8 @@ var customForm = {
         if ( this.templateDefinedAcTypes && !this.defaultAcType.length ) {
             this.defaultAcType = this.acTypes[acTypeKey];
         }
-        if (selectedType.val().length) {
+        var selectedTypeLength = selectedType.val().length;
+        if ( selectedTypeLength !== 'undefined') {
             this.acTypes[acTypeKey] = selectedType.val();
             this.typeName = selectedType.html();
             if ( this.editMode == 'edit' ) {
@@ -744,5 +745,9 @@ var customForm = {
 };
 
 $(document).ready(function() {
-    customForm.onLoad();
+	try{
+	    customForm.onLoad();
+	} catch(error){
+		console.log(error.message);
+	}
 });

--- a/webapp/src/main/webapp/templates/freemarker/lib/lib-properties.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/lib/lib-properties.ftl
@@ -149,7 +149,7 @@ name will be used as the label. -->
         <a class="add-${propertyLocalName}" href="${url}" title="${i18n().manage_list_of} ${label?lower_case}">
         <img class="add-individual" data-domain="${domainUri}" data-range="${rangeUri}" src="${urls.images}/individual/manage-icon.png" alt="${i18n().manage}" /></a>
     <#else>
-        <a class="add-${propertyLocalName}" href="${url}" title="${i18n().add_new} ${label?lower_case} ${i18n().entry}">
+        <a class="add-${propertyLocalName}" href="${url}" title="${i18n().add_new_entry_for} ${label?lower_case}">
         <img class="add-individual" data-domain="${domainUri}" data-range="${rangeUri}" src="${urls.images}/individual/addIcon.gif" alt="${i18n().add}" /></a>
     </#if>
 </#macro>
@@ -353,5 +353,5 @@ name will be used as the label. -->
 </#function>
 
 <#function capitalizeGroupName propertyGroupName>
-    <#return propertyGroupName?capitalize>
+    <#return propertyGroupName?cap_first>
 </#function>


### PR DESCRIPTION
[Companion PR Vitro-languages](https://github.com/vivo-project/Vitro-languages/pull/63)
[Companion PR VIVO-languages](https://github.com/vivo-project/VIVO-languages/pull/116)
[Companion PR VIVO](https://github.com/vivo-project/VIVO/pull/3783)

# What does this pull request do?
This pull request is one of many efforts to improve language neutral Freemarker templates and thus eliminate the need to support language specific templates
In this PR fixes from the following language specific templates were used:
[customFormWithAutocomplete.js](https://github.com/vivo-project/VIVO-languages/pull/116/files#diff-fdc12ecf5d5a469546772283df02e8eb0c62b9aa2394348b62bc2eba82e61052)
[defaultAddMissingIndividualForm_fr_CA.ftl](https://github.com/vivo-project/VIVO-languages/pull/116/files#diff-c426a780340d83909740bb200dd8860ac6c52813c1654205c67fe7fff2ada59f)
[lib-properties_fr_CA.ftl](https://github.com/vivo-project/Vitro-languages/pull/63/files#diff-da6cd7f327e62a3812834d0a90206caba9abda1c66b4932165f170f385dc89cf)
[autoCompleteObjectPropForm_fr_CA.ftl](https://github.com/vivo-project/Vitro-languages/pull/63/files#diff-2b3384e7b05bb8daa0157b811e82f04f721411748d65ab456bd36bc1336a9989)


# Interested parties
@VIVO-project/vivo-committers
