### PR TITLE
[i18n sprint] Language-neutral help text in autocomplete forms

### DIFF
--- a/webapp/src/main/webapp/templates/freemarker/edit/forms/autoCompleteObjectPropForm.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/edit/forms/autoCompleteObjectPropForm.ftl
@@ -125,7 +125,7 @@ Also multiple types parameter set to true only if more than one type returned-->
     };
     var i18nStrings = {
         selectAnExisting: '${i18n().select_an_existing?js_string}',
-        orCreateNewOne: '${i18n().or_create_new_one?js_string}',
+        selectAnExistingOrCreateNewOne: '${i18n().select_an_existing_or_create_a_new_one?js_string}',
         selectedString: '${i18n().selected?js_string}'
     };
     </script>

--- a/webapp/src/main/webapp/templates/freemarker/edit/forms/js/customFormWithAutocomplete.js
+++ b/webapp/src/main/webapp/templates/freemarker/edit/forms/js/customFormWithAutocomplete.js
@@ -695,10 +695,10 @@ var customForm = {
         // ac fields there are cases where we also have to check if the help text is already there
         if (!$(selectedObj).val() || $(selectedObj).hasClass(this.acHelpTextClass) || $(selectedObj).val().substring(0, 18) == customForm.selectAnExisting ) {
         	typeText = this.getTypeNameForLabels($(selectedObj));
-        	var helpText = customForm.selectAnExisting + " " + typeText + " " + customForm.orCreateNewOne ;
+        	var helpText = customForm.selectAnExistingOrCreateNewOne ;
         	//Different for object property autocomplete
         	if ( this.acSelectOnly ) {
-        		helpText = customForm.selectAnExisting + " " + typeText;
+        		helpText = customForm.selectAnExisting;
         	}
     		$(selectedObj).val(helpText)
     	               .addClass(this.acHelpTextClass);


### PR DESCRIPTION
[Companion Vitro-languages PR](https://github.com/vivo-project/Vitro-languages/pull/64)
[Companion VIVO PR](https://github.com/vivo-project/VIVO/pull/3784)
# What does this pull request do?
Use language-neutral selectAnExistingOrCreateNewOne translation key as help text in autocomplete forms

# Interested parties
@tawahle 
