### PR TITLE
[i18n-3762] Merging language specific home artifacts into Vitro

### DIFF
--- a/home/src/main/resources/rdf/i18n/de_DE/display/firsttime/termsOfUse.n3
+++ b/home/src/main/resources/rdf/i18n/de_DE/display/firsttime/termsOfUse.n3
@@ -1,0 +1,20 @@
+# $This file is distributed under the terms of the license in LICENSE$
+
+@prefix default: <http://vitro.mannlib.cornell.edu/ns/default/pages#> .
+
+default:terms_of_use_dg
+    a   <java:edu.cornell.mannlib.vitro.webapp.utils.dataGetter.FixedHTMLDataGetter> ;
+    <http://vitro.mannlib.cornell.edu/ontologies/display/1.1#htmlValue>
+        """
+	    <p>Die Nutzungsbedingungen sollten hier stehen</p>		
+        """@de-DE ;
+        <http://vitro.mannlib.cornell.edu/ontologies/display/1.1#saveToVar>
+                "termsOfUse" .
+default:terms_of_use
+    a   <http://vitro.mannlib.cornell.edu/ontologies/display/1.1#Page> ;
+    <http://vitro.mannlib.cornell.edu/ontologies/display/1.1#hasDataGetter>
+        default:terms_of_use_dg ;
+    <http://vitro.mannlib.cornell.edu/ontologies/display/1.1#title>
+        "Terms of use"@de-DE ;
+    <http://vitro.mannlib.cornell.edu/ontologies/display/1.1#urlMapping>
+        "/termsOfUse" .

--- a/home/src/main/resources/rdf/i18n/en_CA/display/firsttime/termsOfUse.n3
+++ b/home/src/main/resources/rdf/i18n/en_CA/display/firsttime/termsOfUse.n3
@@ -1,0 +1,20 @@
+# $This file is distributed under the terms of the license in LICENSE$
+
+@prefix default: <http://vitro.mannlib.cornell.edu/ns/default/pages#> .
+
+default:terms_of_use_dg
+    a   <java:edu.cornell.mannlib.vitro.webapp.utils.dataGetter.FixedHTMLDataGetter> ;
+    <http://vitro.mannlib.cornell.edu/ontologies/display/1.1#htmlValue>
+        """
+	    <p>Terms of use should be here</p>		
+        """@en-CA ;
+        <http://vitro.mannlib.cornell.edu/ontologies/display/1.1#saveToVar>
+                "termsOfUse" .
+default:terms_of_use
+    a   <http://vitro.mannlib.cornell.edu/ontologies/display/1.1#Page> ;
+    <http://vitro.mannlib.cornell.edu/ontologies/display/1.1#hasDataGetter>
+        default:terms_of_use_dg ;
+    <http://vitro.mannlib.cornell.edu/ontologies/display/1.1#title>
+        "Terms of use"@en-CA ;
+    <http://vitro.mannlib.cornell.edu/ontologies/display/1.1#urlMapping>
+        "/termsOfUse" .

--- a/home/src/main/resources/rdf/i18n/en_US/display/firsttime/termsOfUse.n3
+++ b/home/src/main/resources/rdf/i18n/en_US/display/firsttime/termsOfUse.n3
@@ -1,0 +1,20 @@
+# $This file is distributed under the terms of the license in LICENSE$
+
+@prefix default: <http://vitro.mannlib.cornell.edu/ns/default/pages#> .
+
+default:terms_of_use_dg
+    a   <java:edu.cornell.mannlib.vitro.webapp.utils.dataGetter.FixedHTMLDataGetter> ;
+    <http://vitro.mannlib.cornell.edu/ontologies/display/1.1#htmlValue>
+        """
+	    <p>Terms of use should be here</p>		
+        """@en-US ;
+        <http://vitro.mannlib.cornell.edu/ontologies/display/1.1#saveToVar>
+                "termsOfUse" .
+default:terms_of_use
+    a   <http://vitro.mannlib.cornell.edu/ontologies/display/1.1#Page> ;
+    <http://vitro.mannlib.cornell.edu/ontologies/display/1.1#hasDataGetter>
+        default:terms_of_use_dg ;
+    <http://vitro.mannlib.cornell.edu/ontologies/display/1.1#title>
+        "Terms of use"@en-US ;
+    <http://vitro.mannlib.cornell.edu/ontologies/display/1.1#urlMapping>
+        "/termsOfUse" .

--- a/home/src/main/resources/rdf/i18n/en_US/tbox/firsttime/fileUploadAnnotations_en_US.n3
+++ b/home/src/main/resources/rdf/i18n/en_US/tbox/firsttime/fileUploadAnnotations_en_US.n3
@@ -1,0 +1,4 @@
+@prefix vitro-public:  <http://vitro.mannlib.cornell.edu/ns/vitro/public#> .
+@prefix rdfs:    <http://www.w3.org/2000/01/rdf-schema#> .
+
+vitro-public:storedFile rdfs:label "stored file"@en-US .

--- a/home/src/main/resources/rdf/i18n/es/display/firsttime/termsOfUse.n3
+++ b/home/src/main/resources/rdf/i18n/es/display/firsttime/termsOfUse.n3
@@ -1,0 +1,20 @@
+# $This file is distributed under the terms of the license in LICENSE$
+
+@prefix default: <http://vitro.mannlib.cornell.edu/ns/default/pages#> .
+
+default:terms_of_use_dg
+    a   <java:edu.cornell.mannlib.vitro.webapp.utils.dataGetter.FixedHTMLDataGetter> ;
+    <http://vitro.mannlib.cornell.edu/ontologies/display/1.1#htmlValue>
+        """
+	    <p>Las condiciones de uso deberían estar aquí</p>		
+        """@es ;
+        <http://vitro.mannlib.cornell.edu/ontologies/display/1.1#saveToVar>
+                "termsOfUse" .
+default:terms_of_use
+    a   <http://vitro.mannlib.cornell.edu/ontologies/display/1.1#Page> ;
+    <http://vitro.mannlib.cornell.edu/ontologies/display/1.1#hasDataGetter>
+        default:terms_of_use_dg ;
+    <http://vitro.mannlib.cornell.edu/ontologies/display/1.1#title>
+        "Terms of use"@es ;
+    <http://vitro.mannlib.cornell.edu/ontologies/display/1.1#urlMapping>
+        "/termsOfUse" .

--- a/home/src/main/resources/rdf/i18n/fr_CA/display/firsttime/termsOfUse.n3
+++ b/home/src/main/resources/rdf/i18n/fr_CA/display/firsttime/termsOfUse.n3
@@ -1,0 +1,20 @@
+# $This file is distributed under the terms of the license in LICENSE$
+
+@prefix default: <http://vitro.mannlib.cornell.edu/ns/default/pages#> .
+
+default:terms_of_use_dg
+    a   <java:edu.cornell.mannlib.vitro.webapp.utils.dataGetter.FixedHTMLDataGetter> ;
+    <http://vitro.mannlib.cornell.edu/ontologies/display/1.1#htmlValue>
+        """
+	    <p>Les conditions d'utilisation devraient être ici</p>		
+        """@fr-CA ;
+        <http://vitro.mannlib.cornell.edu/ontologies/display/1.1#saveToVar>
+                "termsOfUse" .
+default:terms_of_use
+    a   <http://vitro.mannlib.cornell.edu/ontologies/display/1.1#Page> ;
+    <http://vitro.mannlib.cornell.edu/ontologies/display/1.1#hasDataGetter>
+        default:terms_of_use_dg ;
+    <http://vitro.mannlib.cornell.edu/ontologies/display/1.1#title>
+        "Terms of use"@fr-CA ;
+    <http://vitro.mannlib.cornell.edu/ontologies/display/1.1#urlMapping>
+        "/termsOfUse" .

--- a/home/src/main/resources/rdf/i18n/pt_BR/display/firsttime/termsOfUse.n3
+++ b/home/src/main/resources/rdf/i18n/pt_BR/display/firsttime/termsOfUse.n3
@@ -1,0 +1,20 @@
+# $This file is distributed under the terms of the license in LICENSE$
+
+@prefix default: <http://vitro.mannlib.cornell.edu/ns/default/pages#> .
+
+default:terms_of_use_dg
+    a   <java:edu.cornell.mannlib.vitro.webapp.utils.dataGetter.FixedHTMLDataGetter> ;
+    <http://vitro.mannlib.cornell.edu/ontologies/display/1.1#htmlValue>
+        """
+	    <p>Os termos de uso devem estar aqui</p>		
+        """@pt-BR ;
+        <http://vitro.mannlib.cornell.edu/ontologies/display/1.1#saveToVar>
+                "termsOfUse" .
+default:terms_of_use
+    a   <http://vitro.mannlib.cornell.edu/ontologies/display/1.1#Page> ;
+    <http://vitro.mannlib.cornell.edu/ontologies/display/1.1#hasDataGetter>
+        default:terms_of_use_dg ;
+    <http://vitro.mannlib.cornell.edu/ontologies/display/1.1#title>
+        "Terms of use"@pt-BR ;
+    <http://vitro.mannlib.cornell.edu/ontologies/display/1.1#urlMapping>
+        "/termsOfUse" .

--- a/home/src/main/resources/rdf/i18n/ru_RU/display/firsttime/termsOfUse.n3
+++ b/home/src/main/resources/rdf/i18n/ru_RU/display/firsttime/termsOfUse.n3
@@ -1,0 +1,20 @@
+# $This file is distributed under the terms of the license in LICENSE$
+
+@prefix default: <http://vitro.mannlib.cornell.edu/ns/default/pages#> .
+
+default:terms_of_use_dg
+    a   <java:edu.cornell.mannlib.vitro.webapp.utils.dataGetter.FixedHTMLDataGetter> ;
+    <http://vitro.mannlib.cornell.edu/ontologies/display/1.1#htmlValue>
+        """
+	    <p>Условия использования должны находиться здесь</p>		
+        """@ru-RU ;
+        <http://vitro.mannlib.cornell.edu/ontologies/display/1.1#saveToVar>
+                "termsOfUse" .
+default:terms_of_use
+    a   <http://vitro.mannlib.cornell.edu/ontologies/display/1.1#Page> ;
+    <http://vitro.mannlib.cornell.edu/ontologies/display/1.1#hasDataGetter>
+        default:terms_of_use_dg ;
+    <http://vitro.mannlib.cornell.edu/ontologies/display/1.1#title>
+        "Terms of use"@ru-RU ;
+    <http://vitro.mannlib.cornell.edu/ontologies/display/1.1#urlMapping>
+        "/termsOfUse" .

--- a/home/src/main/resources/rdf/i18n/sr_Latn_RS/display/firsttime/termsOfUse.n3
+++ b/home/src/main/resources/rdf/i18n/sr_Latn_RS/display/firsttime/termsOfUse.n3
@@ -1,0 +1,20 @@
+# $This file is distributed under the terms of the license in LICENSE$
+
+@prefix default: <http://vitro.mannlib.cornell.edu/ns/default/pages#> .
+
+default:terms_of_use_dg
+    a   <java:edu.cornell.mannlib.vitro.webapp.utils.dataGetter.FixedHTMLDataGetter> ;
+    <http://vitro.mannlib.cornell.edu/ontologies/display/1.1#htmlValue>
+        """
+	    <p>Uslovi korišćenja bi trebalo da budu ovde</p>		
+        """@sr-Latn-RS ;
+        <http://vitro.mannlib.cornell.edu/ontologies/display/1.1#saveToVar>
+                "termsOfUse" .
+default:terms_of_use
+    a   <http://vitro.mannlib.cornell.edu/ontologies/display/1.1#Page> ;
+    <http://vitro.mannlib.cornell.edu/ontologies/display/1.1#hasDataGetter>
+        default:terms_of_use_dg ;
+    <http://vitro.mannlib.cornell.edu/ontologies/display/1.1#title>
+        "Terms of use"@sr-Latn-RS ;
+    <http://vitro.mannlib.cornell.edu/ontologies/display/1.1#urlMapping>
+        "/termsOfUse" .

--- a/installer/home/pom.xml
+++ b/installer/home/pom.xml
@@ -107,11 +107,5 @@
             <artifactId>vitro-home</artifactId>
             <type>tar.gz</type>
         </dependency>
-        <dependency>
-            <groupId>org.vivoweb</groupId>
-            <artifactId>vitro-languages-home-core</artifactId>
-            <version>${project.version}</version>
-            <type>tar.gz</type>
-        </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
**[VIVO GitHub issue](https://github.com/vivo-project/VIVO/issues)**: [3762](https://github.com/vivo-project/VIVO/issues/3762)

[Companion PR](https://github.com/vivo-project/VIVO/pull/3797)

# What does this pull request do?
Moving language specific home artifacts from Vitro-languages into Vitro (+ adoption of pom files)

# What's new?
home directories from Vitro-languages repository are not needed any more. The next step is to do the same for webapp directories from Vitro-languages. After that, the Vitro-languages repositories might be archived. 

# How should this be tested?

- Checkout https://github.com/chenejac/Vitro-languages/tree/remove_language_home_artifacts as Vitro-languages project
- Remove Vitro home and install the new, fresh instance of Vitro
- Validate it is working as expected
- Try switching between all 8 languages (set in the runtime.properties languages.selectableLocales = en_US, de_DE, sr_Latn_RS, ru_RU, fr_CA, en_CA, es, pt_BR)
- Search [Vitro-home] for xcfv$This - it should return no results (this text is specified under a comment in all n3/ttl files in Vitro-languages from the first point - https://github.com/chenejac/Vitro-languages/blob/remove_language_home_artifacts/en_US/home/src/main/resources/rdf/i18n/en_US/display/firsttime/termsOfUse.n3) 

# Interested parties
Tag (@ mention) interested parties or, if unsure, @VIVO-project/vivo-committers
