### PR TITLE
[3800 i18n redesign] Supporting private tags

### DIFF
--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/freemarker/ViewLabelsServlet.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/freemarker/ViewLabelsServlet.java
@@ -170,7 +170,7 @@ public class ViewLabelsServlet extends FreemarkerHttpServlet{
 			Locale currentLocale) throws FileNotFoundException {
 		HashMap<String, String> map = new HashMap<String, String>();
 		//Replacing the underscore with a hyphen because that is what is represented in the actual literals
-		map.put("code", locale.toString().replace("_", "-"));
+		map.put("code", locale.toLanguageTag().replace("_", "-"));
 		map.put("label", locale.getDisplayName(currentLocale));
 		return map;
 	}

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/ManageLabelsForIndividualGenerator.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/ManageLabelsForIndividualGenerator.java
@@ -464,7 +464,7 @@ public class ManageLabelsForIndividualGenerator extends BaseEditConfigurationGen
 			Locale currentLocale) throws FileNotFoundException {
 		HashMap<String, String> map = new HashMap<String, String>();
 		//Replacing the underscore with a hyphen because that is what is represented in the actual literals
-		map.put("code", locale.toString().replace("_", "-"));
+		map.put("code", locale.toLanguageTag().replace("_", "-"));
 		map.put("label", locale.getDisplayName(currentLocale));
 		return map;
 	}

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/filters/CachingResponseFilter.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/filters/CachingResponseFilter.java
@@ -284,7 +284,7 @@ public class CachingResponseFilter implements Filter {
 
 		StringBuilder buffer = new StringBuilder("\"").append(rawEtag);
 		for (Locale locale : locales) {
-			buffer.append(locale.toString());
+			buffer.append(locale.toLanguageTag());
 		}
 		buffer.append("\"");
 

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/i18n/selection/LocaleSelectionController.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/i18n/selection/LocaleSelectionController.java
@@ -88,7 +88,7 @@ public class LocaleSelectionController extends HttpServlet {
 		if (!selectables.contains(locale)) {
 			log.warn("User selected a locale '" + locale
 					+ "' that was not in the list: " + selectables);
-		} else if (!LocaleUtils.isAvailableLocale(locale)) {
+		} else if (!LocaleUtils.isAvailableLocale(locale.stripExtensions())) {
 			log.warn("User selected an unrecognized locale: '" + locale + "'");
 		}
 

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/i18n/selection/LocaleSelectionDataGetter.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/i18n/selection/LocaleSelectionDataGetter.java
@@ -81,8 +81,9 @@ public class LocaleSelectionDataGetter implements DataGetter {
 		for(final Locale locale: selectables) {
 			setOfLocalesBase.add(locale.stripExtensions().toLanguageTag());
 		}
-		if (setOfLocalesBase.size() < selectables.size())
+		if (setOfLocalesBase.size() < selectables.size()) {
 			includeAbbreviation = true;
+		}
 		List<Map<String, Object>> list = new ArrayList<>();
 		for (Locale locale : selectables) {
 			try {
@@ -102,8 +103,9 @@ public class LocaleSelectionDataGetter implements DataGetter {
 		map.put("code", locale.toLanguageTag().replace('-','_'));
 		map.put("label", locale.getDisplayLanguage(locale));
 		map.put("country", locale.getDisplayCountry(locale));
-		if (includeAbbreviation)
+		if (includeAbbreviation) {
 			map.put("institution", Optional.ofNullable(locale.getExtension(LocaleSelectionDataGetter.PRIVATE_USE_SUBTAG)).orElse("").toUpperCase());
+		}
 		map.put("selected", currentLocale.equals(locale));
 		return map;
 	}

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/i18n/selection/LocaleSelectionDataGetter.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/i18n/selection/LocaleSelectionDataGetter.java
@@ -3,12 +3,7 @@
 package edu.cornell.mannlib.vitro.webapp.i18n.selection;
 
 import java.io.FileNotFoundException;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
+import java.util.*;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -36,7 +31,8 @@ import edu.cornell.mannlib.vitro.webapp.utils.dataGetter.DataGetter;
  *       {               [a map for each Locale]
  *         code =          [the code for the Locale, e.g. "en_US"]
  *         label =         [the alt text for the Locale, e.g. "Spanish (Spain)"]
- *         imageUrl =      [the URL of the image that represents the Locale]
+ *         country =       [the country for the Locale, e.g. "United States"]
+ *         institution =       [the abbreviation for institution, e.g. "UQAM"]
  *         selected =      [true, if this locale is currently selected]
  *       }
  *     }
@@ -49,6 +45,8 @@ public class LocaleSelectionDataGetter implements DataGetter {
 			.getLog(LocaleSelectionDataGetter.class);
 
 	private final VitroRequest vreq;
+
+	private static final char PRIVATE_USE_SUBTAG = 'x';
 
 	public LocaleSelectionDataGetter(VitroRequest vreq) {
 		this.vreq = vreq;
@@ -73,10 +71,22 @@ public class LocaleSelectionDataGetter implements DataGetter {
 
 	private List<Map<String, Object>> buildLocalesList(List<Locale> selectables) {
 		Locale currentLocale = SelectedLocale.getCurrentLocale(vreq);
+		// The next couple of lines check whether there are locales in the list with the same root.
+		// If yes, the institution abbreviation (private tag) will be displayed in UI.
+		// For instance, if there are fr_CA_x_uqam and fr_CA in a VIVO instance runtime.properties,
+		// the institutional abbreviation (UQAM) will be displayed next to locale name
+		// in the dropdown menu for selection of a UI language.
+		boolean includeAbbreviation = false;
+		Set<String> setOfLocalesBase = new HashSet<>();
+		for(final Locale locale: selectables) {
+			setOfLocalesBase.add(locale.stripExtensions().toLanguageTag());
+		}
+		if (setOfLocalesBase.size() < selectables.size())
+			includeAbbreviation = true;
 		List<Map<String, Object>> list = new ArrayList<>();
 		for (Locale locale : selectables) {
 			try {
-				list.add(buildLocaleMap(locale, currentLocale));
+				list.add(buildLocaleMap(locale, currentLocale, includeAbbreviation));
 			} catch (FileNotFoundException e) {
 				log.warn("Can't show the Locale selector for '" + locale
 						+ "': " + e);
@@ -86,12 +96,14 @@ public class LocaleSelectionDataGetter implements DataGetter {
 	}
 
 	private Map<String, Object> buildLocaleMap(Locale locale,
-			Locale currentLocale) throws FileNotFoundException {
+			Locale currentLocale, boolean includeAbbreviation) throws FileNotFoundException {
 		Map<String, Object> map = new HashMap<>();
         
 		map.put("code", locale.toLanguageTag().replace('-','_'));
 		map.put("label", locale.getDisplayLanguage(locale));
 		map.put("country", locale.getDisplayCountry(locale));
+		if (includeAbbreviation)
+			map.put("institution", Optional.ofNullable(locale.getExtension(LocaleSelectionDataGetter.PRIVATE_USE_SUBTAG)).orElse("").toUpperCase());
 		map.put("selected", currentLocale.equals(locale));
 		return map;
 	}

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/i18n/selection/LocaleSelectionSetup.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/i18n/selection/LocaleSelectionSetup.java
@@ -154,7 +154,7 @@ public class LocaleSelectionSetup implements ServletContextListener {
 		Locale locale = LocaleUtility.languageStringToLocale(localeString);
 
 		if (!"es_GO".equals(localeString) && // No complaint about bogus locale
-				!LocaleUtils.isAvailableLocale(locale)) {
+				!LocaleUtils.isAvailableLocale(locale.stripExtensions())) {
 			ssWarning("'" + locale + "' is not a recognized locale.");
 		}
 

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/rdfservice/filter/LanguageFilteringUtils.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/rdfservice/filter/LanguageFilteringUtils.java
@@ -33,7 +33,7 @@ public class LanguageFilteringUtils {
      * (as in RDF language specifiers).
      */
     public static String localeToLanguage(Locale locale) {
-        return locale.toString().replace(UNDERSCORE, HYPHEN);
+        return locale.toLanguageTag().replace(UNDERSCORE, HYPHEN);
     }
 	
     /**
@@ -69,7 +69,7 @@ public class LanguageFilteringUtils {
 		List<String> langs = new ArrayList<>();
 		while (locales.hasMoreElements()) {
 			Locale locale = (Locale) locales.nextElement();
-			langs.add(locale.toString().replace(UNDERSCORE, HYPHEN));
+			langs.add(locale.toLanguageTag().replace(UNDERSCORE, HYPHEN));
 		}
 		if (!langs.contains(DEFAULT_LANG_STRING)) {
 			langs.add(DEFAULT_LANG_STRING);

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/servlet/setup/RDFFilesLoader.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/servlet/setup/RDFFilesLoader.java
@@ -136,7 +136,17 @@ public class RDFFilesLoader {
 		// Which locales are enabled in runtime.properties?
 		List<Locale> locales = SelectedLocale.getSelectableLocales(ctx);
 		for (Locale locale : locales) {
-			enabledLocales.add(locale.toLanguageTag().replace('-', '_'));
+			String localeString = locale.toLanguageTag().replace('-', '_');
+			if (! enabledLocales.contains(localeString))
+				enabledLocales.add(localeString);
+			// If a locale with fr_CA_x_uqam is used, the locale fr_CA should be also enabled for loading.
+			// Private tags (lang_CountryCode_x_InstitutionAbbreviation) are inteded to be just extension,
+			// therefore the basic locale (lang_CountryCode) should be loaded as well.
+			if(locale.hasExtensions()){
+				localeString = locale.stripExtensions().toLanguageTag().replace('-', '_');
+				if (! enabledLocales.contains(localeString))
+					enabledLocales.add(localeString);
+			}
 		}
 
 		// If no languages were enabled in runtime.properties, add a fallback as the default

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/servlet/setup/RDFFilesLoader.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/servlet/setup/RDFFilesLoader.java
@@ -137,15 +137,17 @@ public class RDFFilesLoader {
 		List<Locale> locales = SelectedLocale.getSelectableLocales(ctx);
 		for (Locale locale : locales) {
 			String localeString = locale.toLanguageTag().replace('-', '_');
-			if (! enabledLocales.contains(localeString))
+			if (! enabledLocales.contains(localeString)) {
 				enabledLocales.add(localeString);
+			}
 			// If a locale with fr_CA_x_uqam is used, the locale fr_CA should be also enabled for loading.
 			// Private tags (lang_CountryCode_x_InstitutionAbbreviation) are inteded to be just extension,
 			// therefore the basic locale (lang_CountryCode) should be loaded as well.
 			if(locale.hasExtensions()){
 				localeString = locale.stripExtensions().toLanguageTag().replace('-', '_');
-				if (! enabledLocales.contains(localeString))
+				if (! enabledLocales.contains(localeString)) {
 					enabledLocales.add(localeString);
+				}
 			}
 		}
 

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/utils/LocaleUtility.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/utils/LocaleUtility.java
@@ -11,18 +11,15 @@ public final class LocaleUtility {
     public static Locale languageStringToLocale(String localeString){
         String[] parsedLoc = localeString.trim().split("_", -1);
         Locale locale = null;
-        //regex pattern for locale tag with script and private-use subtag, e.g. sr_Latn_RS_x_uns
-        if (localeString.matches("^[a-z]{1,3}_[A-Z][a-z]{3}_[A-Z]{2}_x_[a-z]{1,}"))
+        if (localeString.matches("^[a-z]{1,3}_[A-Z][a-z]{3}_[A-Z]{2}_x_[a-z]{1,}")) { //regex pattern for locale tag with script and private-use subtag, e.g. sr_Latn_RS_x_uns
             locale = new Locale.Builder().setLanguage(parsedLoc[0]).setRegion(parsedLoc[2]).setScript(parsedLoc[1]).setExtension('x', parsedLoc[4]).build();
-        //regex pattern for locale tag with script and private-use subtag, e.g. fr_CA_x_uqam
-        if (localeString.matches("^[a-z]{1,3}_[A-Za-z]{2}_x_[a-z]{1,}"))
+        } else if (localeString.matches("^[a-z]{1,3}_[A-Za-z]{2}_x_[a-z]{1,}")) { //regex pattern for locale tag with script and private-use subtag, e.g. fr_CA_x_uqam
             locale = new Locale.Builder().setLanguage(parsedLoc[0]).setRegion(parsedLoc[1]).setExtension('x', parsedLoc[3]).build();
-            //regex pattern for locale tag with script specified, e.g. sr_Latn_RS
-        else if (localeString.matches("^[a-z]{1,3}_[A-Z][a-z]{3}_[A-Z]{2}"))
+        } else if (localeString.matches("^[a-z]{1,3}_[A-Z][a-z]{3}_[A-Z]{2}")) { //regex pattern for locale tag with script specified, e.g. sr_Latn_RS
             locale = new Locale.Builder().setLanguage(parsedLoc[0]).setRegion(parsedLoc[2]).setScript(parsedLoc[1]).build();
-            // other, just languge, e.g. es, or language + region, e.g. en_US, pt_BR, ru_RU, etc.
-        else
+        } else { // other, just languge, e.g. es, or language + region, e.g. en_US, pt_BR, ru_RU, etc.
             locale = LocaleUtils.toLocale(localeString);
+        }
         String localeLang = locale.toLanguageTag();
         return locale;
     }

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/utils/LocaleUtility.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/utils/LocaleUtility.java
@@ -10,10 +10,20 @@ public final class LocaleUtility {
 
     public static Locale languageStringToLocale(String localeString){
         String[] parsedLoc = localeString.trim().split("_", -1);
-        //regex pattern for locale tag with script specified
-        Locale locale = localeString.matches("^[a-z]{1,3}_[A-Z][a-z]{3}_[A-Z]{2}") ?
-            new Locale.Builder().setLanguage(parsedLoc[0]).setRegion(parsedLoc[2]).setScript(parsedLoc[1]).build() :
-            LocaleUtils.toLocale(localeString);
+        Locale locale = null;
+        //regex pattern for locale tag with script and private-use subtag, e.g. sr_Latn_RS_x_uns
+        if (localeString.matches("^[a-z]{1,3}_[A-Z][a-z]{3}_[A-Z]{2}_x_[a-z]{1,}"))
+            locale = new Locale.Builder().setLanguage(parsedLoc[0]).setRegion(parsedLoc[2]).setScript(parsedLoc[1]).setExtension('x', parsedLoc[4]).build();
+        //regex pattern for locale tag with script and private-use subtag, e.g. fr_CA_x_uqam
+        if (localeString.matches("^[a-z]{1,3}_[A-Za-z]{2}_x_[a-z]{1,}"))
+            locale = new Locale.Builder().setLanguage(parsedLoc[0]).setRegion(parsedLoc[1]).setExtension('x', parsedLoc[3]).build();
+            //regex pattern for locale tag with script specified, e.g. sr_Latn_RS
+        else if (localeString.matches("^[a-z]{1,3}_[A-Z][a-z]{3}_[A-Z]{2}"))
+            locale = new Locale.Builder().setLanguage(parsedLoc[0]).setRegion(parsedLoc[2]).setScript(parsedLoc[1]).build();
+            // other, just languge, e.g. es, or language + region, e.g. en_US, pt_BR, ru_RU, etc.
+        else
+            locale = LocaleUtils.toLocale(localeString);
+        String localeLang = locale.toLanguageTag();
         return locale;
     }
 }

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/utils/searchengine/SearchQueryUtils.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/utils/searchengine/SearchQueryUtils.java
@@ -209,11 +209,11 @@ public class SearchQueryUtils {
     }
     
     public static String getSortFieldNameForLocale(Locale locale) {
-        return locale.toString().replace('_', '-') + VitroSearchTermNames.LABEL_SORT_SUFFIX;
+        return locale.toLanguageTag().replace('_', '-') + VitroSearchTermNames.LABEL_SORT_SUFFIX;
     }
     
     public static String getLabelFieldNameForLocale(Locale locale) {
-        return locale.toString().replace('_', '-') + VitroSearchTermNames.LABEL_DISPLAY_SUFFIX;
+        return locale.toLanguageTag().replace('_', '-') + VitroSearchTermNames.LABEL_DISPLAY_SUFFIX;
     }
 
     public static SearchQuery getRandomQuery(List<String> vclassUris, int page, int pageSize){

--- a/webapp/src/main/webapp/templates/freemarker/page/partials/languageSelector.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/page/partials/languageSelector.ftl
@@ -6,7 +6,7 @@
     <#list selectLocale.locales as locale>
 
             <li <#if locale.selected>status="selected"</#if>>
-                	<a href="${selectLocale.selectLocaleUrl}?selection=${locale.code}" title="${i18n().select_locale} -- ${locale.label}">${locale.label?capitalize}<#if locale.country?has_content> (${locale.country})</#if></a>
+                	<a href="${selectLocale.selectLocaleUrl}?selection=${locale.code}" title="${i18n().select_locale} -- ${locale.label}">${locale.label?capitalize}<#if locale.country?has_content> (${locale.country})</#if><#if locale.institution?has_content> - ${locale.institution}</#if></a>
             </li>
     </#list>
     </ul>
@@ -21,6 +21,7 @@
  *       -- code
  *       -- label (tooltip displayed in original locale, not current locale)
  *       -- country (displayed in original locale, not current locale)
+ *       -- institution (abbreviation)
  *       -- selected (boolean)
 -->
 <script type="text/javascript">


### PR DESCRIPTION
**[VIVO GitHub issue](https://github.com/vivo-project/VIVO/issues)**: [3800](https://github.com/vivo-project/VIVO/issues/3800)

[Companion PR](https://github.com/vivo-project/VIVO/pull/3802)

# What does this pull request do?
Adding support for local customization of UI labels by using language tags. It means an institution can add in the directory <VIVO HOME>/rdf/i18n/ its own local customization of translations. Those local, institution-specific translations should be in the directory which name is aligned with language tag specification for private tags (for instance fr_CA_x_uqam or de_DE_x_tib). The idea is similar as for property files and usage of <tomcat>webapps/i18n/local directory. The institution can easily update VIVO version, and continue to use previously customized labels and vocabularies. 

# What's new?
- Adding support for loading of language tag with private subtags (x) in the LocaleUtility.java
- Replacing locale.toString() with locale.toLanguageTag():
`locale.toLanguageTag()` 
produces
`fr-CA-x-uqam`
while the code
`locale.toString()`
produces
`fr_CA_#x-uqam`
We have code which do replacement of _ and - in string representation of locale, therefore, the first one string is needed
- Introduce checking for locale.stripExtensions() when it is needed:
For locale `fr-CA-x-uqam` it produces `fr-CA`, the first one is extension of the second, and usually it includes all labels for the language `fr-CA` plus some extensions for specific cases. 

# How should this be tested?
1. Install VIVO
2. Unzip [this file](https://github.com/vivo-project/Vitro/files/10185798/fr_CA_x_uqam.zip) into <VIVO HOME>/rdf/i18n/
3. Add into runtime properties 
`languages.selectableLocales = en_US, fr_CA, fr_CA_x_uqam`
4. Run tomcat and open VIVO in a web browser
5. Change language between the second and third language in the list
6. At the home page you should found the label "Recherche" and "Recherche uqam" depends on selection of the French variant.
7. If you login, you will also notice that logout option in the menu has been changed to "Déconnexion wilma uqam" when the last language has been selected
8. Also, on some pages labels with uqam sufix will appear. 

Example:
* Does this change require documentation to be updated? **Yes, it should be documented how this feature should be used.**
* Does this change add any new dependencies? **No**
* Does this change require any other modifications to be made to the repository? **No**
* Could this change impact execution of existing code? **I don't think so**
* Large pull requests should be avoided. If this PR is large (more than 1,000 lines of codes), please provide short explanation why your contribution can't be decoupled in smaller PRs. **It is a small PR.** 

# Interested parties
Tag (@ mention) interested parties or, if unsure, @VIVO-project/vivo-committers
