### PR TITLE
Faux data properties and fixes for current faux properties view

### DIFF
--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/beans/DataProperty.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/beans/DataProperty.java
@@ -87,6 +87,11 @@ public class DataProperty extends Property implements Comparable<DataProperty>, 
     public String getRangeDatatypeURI() {
         return rangeDatatypeURI;
     }
+    
+    @Override
+    public String getRangeVClassURI() {
+        return rangeDatatypeURI;
+    }
 
     public void setRangeDatatypeURI(String rangeDatatypeURI) {
         this.rangeDatatypeURI = rangeDatatypeURI;

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/beans/FauxProperty.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/beans/FauxProperty.java
@@ -6,6 +6,8 @@ import static org.apache.jena.rdf.model.ResourceFactory.createResource;
 
 import java.util.Objects;
 
+import org.apache.commons.lang3.StringUtils;
+
 import edu.cornell.mannlib.vitro.webapp.auth.policy.bean.RoleRestrictedProperty;
 
 /**
@@ -20,7 +22,7 @@ public class FauxProperty extends BaseResourceBean implements ResourceBean,
 	private String configUri;
 
 	// Must not be null on insert or update. Partial identifier on delete.
-	private String rangeURI;
+	private String rangeURI = "";
 	// May be null. Partial identifier on delete.
 	private String domainURI;
 
@@ -55,7 +57,7 @@ public class FauxProperty extends BaseResourceBean implements ResourceBean,
 	 */
 	public FauxProperty(String domainURI, String baseURI, String rangeURI) {
 		super(Objects.requireNonNull(baseURI, "baseURI may not be null"));
-		this.rangeURI = rangeURI;
+		this.setRangeURI(rangeURI);
 		this.domainURI = domainURI;
 	}
 
@@ -93,7 +95,11 @@ public class FauxProperty extends BaseResourceBean implements ResourceBean,
 	}
 
 	public void setRangeURI(String rangeURI) {
-		this.rangeURI = rangeURI;
+		if (StringUtils.isEmpty(rangeURI)) {
+			this.rangeURI = "";
+		} else {
+			this.rangeURI = rangeURI;	
+		}
 	}
 
 	public String getBaseLabel() {
@@ -105,7 +111,14 @@ public class FauxProperty extends BaseResourceBean implements ResourceBean,
 	}
 
 	public String getRangeLabel() {
-		return (rangeLabel == null) ? localName(rangeURI) : rangeLabel;
+		if  (StringUtils.isEmpty(rangeLabel)) {
+			if (StringUtils.isEmpty(rangeURI)) {
+				return "untyped";
+			}
+			return localName(rangeURI);
+		} else {
+			return rangeLabel;
+		}
 	}
 
 	public void setRangeLabel(String rangeLabel) {

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/beans/ObjectProperty.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/beans/ObjectProperty.java
@@ -4,7 +4,6 @@ package edu.cornell.mannlib.vitro.webapp.beans;
 
 import java.beans.XMLEncoder;
 import java.text.Collator;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.Date;
 import java.util.Iterator;

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/edit/DatapropEditController.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/edit/DatapropEditController.java
@@ -22,6 +22,7 @@ import edu.cornell.mannlib.vedit.controller.BaseEditController;
 import edu.cornell.mannlib.vitro.webapp.auth.permissions.SimplePermission;
 import edu.cornell.mannlib.vitro.webapp.beans.ApplicationBean;
 import edu.cornell.mannlib.vitro.webapp.beans.DataProperty;
+import edu.cornell.mannlib.vitro.webapp.beans.FauxProperty;
 import edu.cornell.mannlib.vitro.webapp.beans.Ontology;
 import edu.cornell.mannlib.vitro.webapp.beans.PropertyGroup;
 import edu.cornell.mannlib.vitro.webapp.beans.VClass;
@@ -176,6 +177,11 @@ public class DatapropEditController extends BaseEditController {
                 assertionsDpDao.getEquivalentPropertyURIs(dp.getURI()), assertionsDpDao);
         sortForPickList(eqProps, vreq);
         request.setAttribute("equivalentProperties", eqProps);
+	
+        List<FauxProperty> fauxProps = vreq.getUnfilteredAssertionsWebappDaoFactory().getFauxPropertyDao().
+        		getFauxPropertiesForBaseUri(dp.getURI());
+        sortForPickList(fauxProps, vreq);
+        request.setAttribute("fauxproperties", fauxProps);	
 
         ApplicationBean appBean = vreq.getAppBean();
 

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/edit/FauxPropertyRetryController.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/edit/FauxPropertyRetryController.java
@@ -38,6 +38,7 @@ import edu.cornell.mannlib.vitro.webapp.beans.Property;
 import edu.cornell.mannlib.vitro.webapp.beans.PropertyGroup;
 import edu.cornell.mannlib.vitro.webapp.controller.VitroRequest;
 import edu.cornell.mannlib.vitro.webapp.controller.edit.utils.RoleLevelOptionsSetup;
+import edu.cornell.mannlib.vitro.webapp.dao.DataPropertyDao;
 import edu.cornell.mannlib.vitro.webapp.dao.FauxPropertyDao;
 import edu.cornell.mannlib.vitro.webapp.dao.ObjectPropertyDao;
 import edu.cornell.mannlib.vitro.webapp.dao.WebappDaoFactory;
@@ -127,10 +128,16 @@ public class FauxPropertyRetryController extends BaseEditController {
 			this.baseProperty = req.getUnfilteredWebappDaoFactory()
 					.getObjectPropertyDao()
 					.getObjectPropertyByURI(beanForEditing.getURI());
+			if (this.baseProperty == null) {
+				this.baseProperty = req.getUnfilteredWebappDaoFactory()
+						.getDataPropertyDao()
+						.getDataPropertyByURI(beanForEditing.getURI());
+					
+			}
 
 			addCheckboxValuesToTheRequest();
 
-			setFieldValidators();
+			//setFieldValidators();
 			setListeners();
 			setForwarders();
 
@@ -150,8 +157,7 @@ public class FauxPropertyRetryController extends BaseEditController {
 				return newFauxProperty(baseUri);
 			}
 
-			FauxProperty bean = fpDao.getFauxPropertyByUris(domainUri, baseUri,
-					rangeUri);
+			FauxProperty bean = fpDao.getFauxPropertyByUris(domainUri, baseUri,	rangeUri);
 			if (bean == null) {
 				throw new IllegalArgumentException(
 						"FauxProperty does not exist for <" + domainUri
@@ -168,7 +174,11 @@ public class FauxPropertyRetryController extends BaseEditController {
 		private FauxProperty newFauxProperty(String baseUri) {
 			FauxProperty fp = new FauxProperty(null, baseUri, null);
 			ObjectPropertyDao opDao = wadf.getObjectPropertyDao();
-			ObjectProperty base = opDao.getObjectPropertyByURI(baseUri);
+			DataPropertyDao dpDao = wadf.getDataPropertyDao();
+			Property base = opDao.getObjectPropertyByURI(baseUri);
+			if (base == null) {
+				base = dpDao.getDataPropertyByURI(baseUri);
+			}
 			fp.setGroupURI(base.getGroupURI());
 			fp.setRangeURI(base.getRangeVClassURI());
 			fp.setDomainURI(base.getDomainVClassURI());

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/freemarker/ListFauxPropertiesController.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/freemarker/ListFauxPropertiesController.java
@@ -135,7 +135,10 @@ public class ListFauxPropertiesController extends FreemarkerHttpServlet {
 								// No point in getting these unless we have a faux property
 								String baseLabel = getDisplayLabel(op) == null ? "(no name)" : getDisplayLabel(op);
 								String baseLocalName = op.getLocalNameWithPrefix();
-								baseLabel = baseLabel.substring(0,baseLabel.indexOf("("));
+								int indexOf = baseLabel.indexOf("(");
+								if (indexOf > 0) {
+									baseLabel = baseLabel.substring(0,indexOf);	
+								}
 								baseLabel += "(" + baseLocalName + ")";
 								// get the info we need from the faux property
 								FauxProperty fp = fpIt.next();
@@ -194,7 +197,10 @@ public class ListFauxPropertiesController extends FreemarkerHttpServlet {
 						else {
 							String baseLabel = getDisplayLabel(op) == null ? "(no name)" : getDisplayLabel(op);
 							String baseLocalName = op.getLocalNameWithPrefix();
-							baseLabel = baseLabel.substring(0,baseLabel.indexOf("("));
+							int indexOf = baseLabel.indexOf("(");
+							if (indexOf > 0) {
+								baseLabel = baseLabel.substring(0,indexOf);	
+							}
 							baseLabel += "(" + baseLocalName + ")" + "|" + baseURI;
 							while (fpIt.hasNext()) {
 								// get the info we need from the faux property
@@ -254,7 +260,11 @@ public class ListFauxPropertiesController extends FreemarkerHttpServlet {
 								// No point in getting these unless we have a faux property
 								String baseLabel = "(no name)";
 								String baseLocalName = op.getLocalNameWithPrefix();
-								baseLabel = baseLabel.substring(0,baseLabel.indexOf("("));
+								int indexOf = baseLabel.indexOf("(");
+								if (indexOf > 0) {
+									baseLabel = baseLabel.substring(0,indexOf);	
+								}
+								baseLabel = baseLabel.substring(0,indexOf);
 								baseLabel += "(" + baseLocalName + ")";
 								// get the info we need from the faux property
 								FauxProperty fp = fpIt.next();
@@ -311,7 +321,10 @@ public class ListFauxPropertiesController extends FreemarkerHttpServlet {
 						else {
 							String baseLabel = "(no name)";
 							String baseLocalName = op.getLocalNameWithPrefix();
-							baseLabel = baseLabel.substring(0,baseLabel.indexOf("("));
+							int indexOf = baseLabel.indexOf("(");
+							if (indexOf > 0) {
+								baseLabel = baseLabel.substring(0,indexOf);	
+							}
 							baseLabel += "(" + baseLocalName + ")" + "|" + baseURI;
 							while (fpIt.hasNext()) {
 								// get the info we need from the faux property

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/dao/jena/FauxPropertyDaoJena.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/dao/jena/FauxPropertyDaoJena.java
@@ -14,6 +14,7 @@ import java.util.List;
 import java.util.Random;
 import java.util.Set;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.jena.ontology.ObjectProperty;
@@ -152,13 +153,10 @@ public class FauxPropertyDaoJena extends JenaBaseDao implements FauxPropertyDao 
 
 			Collection<String> rangeUris = getPropertyResourceURIValues(
 					context, QUALIFIED_BY_RANGE);
-			if (rangeUris.isEmpty()) {
-				log.debug("'" + contextUri + "' has no value for '"
-						+ QUALIFIED_BY_RANGE + "'");
-				return null;
+			String rangeUri = null;
+			if (!rangeUris.isEmpty()) {
+				rangeUri = rangeUris.iterator().next();
 			}
-			String rangeUri = rangeUris.iterator().next();
-
 			// domainURI is optional.
 			Collection<String> domainUris = getPropertyResourceURIValues(
 					context, QUALIFIED_BY_DOMAIN);
@@ -214,7 +212,7 @@ public class FauxPropertyDaoJena extends JenaBaseDao implements FauxPropertyDao 
 			addPropertyResourceValue(context, RDF.type, CONFIG_CONTEXT);
 			addPropertyResourceURIValue(context, CONFIG_CONTEXT_FOR,
 					fp.getBaseURI());
-			addPropertyResourceURIValue(context, QUALIFIED_BY_RANGE,
+			addPropertyResourceURINotEmpty(context, QUALIFIED_BY_RANGE,
 					fp.getRangeURI());
 			addPropertyResourceURINotEmpty(context, QUALIFIED_BY_DOMAIN,
 					fp.getDomainURI());
@@ -493,31 +491,22 @@ public class FauxPropertyDaoJena extends JenaBaseDao implements FauxPropertyDao 
 	// ConfigContext
 	// ----------------------------------------------------------------------
 
-	private static final String QUERY_LOCATE_CONFIG_CONTEXT_WITH_DOMAIN = "" //
-			+ "PREFIX : <http://vitro.mannlib.cornell.edu/ns/vitro/ApplicationConfiguration#> \n" //
-			+ "\n" //
-			+ "SELECT DISTINCT ?context ?config \n" //
-			+ "WHERE { \n" //
-			+ "    ?context a :ConfigContext ; \n" //
-			+ "        :configContextFor ?baseUri ; \n" //
-			+ "        :qualifiedByDomain ?domainUri ; \n" //
-			+ "        :qualifiedBy ?rangeUri ; \n" //
-			+ "        :hasConfiguration ?config . \n" //
-			+ "} \n"; //
+	private static String queryLocateConfigContext(boolean hasDomain, boolean hasRange) {
+		return  "PREFIX : <http://vitro.mannlib.cornell.edu/ns/vitro/ApplicationConfiguration#> \n" 
+				+ "SELECT DISTINCT ?context ?config \n" 
+				+ "WHERE { \n" 
+				+ "    ?context a :ConfigContext . \n" 
+				+ "    ?context :configContextFor ?baseUri . \n"
+				+ ( hasDomain ? "" : " FILTER NOT EXISTS { \n " ) 
+				+ "    ?context :qualifiedByDomain ?domainUri . \n"
+				+ ( hasDomain ? "" : "} \n" )
+				+ ( hasRange ? "" : " FILTER NOT EXISTS { \n " ) 
+				+ "    ?context :qualifiedBy ?rangeUri . \n"
+				+ ( hasRange ? "" : "} \n" )
+				+ "    ?context :hasConfiguration ?config . \n" 
+				+ "} \n"; 
 
-	private static final String QUERY_LOCATE_CONFIG_CONTEXT_WITH_NO_DOMAIN = "" //
-			+ "PREFIX : <http://vitro.mannlib.cornell.edu/ns/vitro/ApplicationConfiguration#> \n" //
-			+ "\n" //
-			+ "SELECT DISTINCT ?context ?config \n" //
-			+ "WHERE { \n" //
-			+ "    ?context a :ConfigContext ; \n" //
-			+ "        :configContextFor ?baseUri ; \n" //
-			+ "        :qualifiedBy ?rangeUri ; \n" //
-			+ "        :hasConfiguration ?config . \n" //
-			+ "     FILTER NOT EXISTS { \n" //
-			+ "        ?context :qualifiedByDomain ?domainUri \n" //
-			+ "     } \n" //
-			+ "} \n"; //
+	}
 
 	private static class ParserLocateConfigContext extends
 			ResultSetParser<Set<ConfigContext>> {
@@ -556,22 +545,16 @@ public class FauxPropertyDaoJena extends JenaBaseDao implements FauxPropertyDao 
 
 	private static class ConfigContext {
 		public static Set<ConfigContext> findByQualifiers(
-				LockableOntModel lockableDisplayModel, String domainUri,
-				String baseUri, String rangeUri) {
+				LockableOntModel lockableDisplayModel, String domainUri, String baseUri, String rangeUri) {
 			try (LockedOntModel displayModel = lockableDisplayModel.read()) {
-				QueryHolder qHolder;
-				if (domainUri == null || domainUri.trim().isEmpty()
-						|| domainUri.equals(OWL.Thing.getURI())) {
-					qHolder = queryHolder(
-							QUERY_LOCATE_CONFIG_CONTEXT_WITH_NO_DOMAIN)
-							.bindToUri("baseUri", baseUri).bindToUri(
-									"rangeUri", rangeUri);
-				} else {
-					qHolder = queryHolder(
-							QUERY_LOCATE_CONFIG_CONTEXT_WITH_DOMAIN)
-							.bindToUri("baseUri", baseUri)
-							.bindToUri("rangeUri", rangeUri)
-							.bindToUri("domainUri", domainUri);
+				boolean hasDomain = !StringUtils.isEmpty(domainUri) && !domainUri.equals(OWL.Thing.getURI());
+				boolean hasRange = !StringUtils.isEmpty(rangeUri);
+				QueryHolder qHolder = queryHolder(queryLocateConfigContext(hasDomain, hasRange)).bindToUri("baseUri", baseUri);
+				if (hasDomain) {
+					qHolder = qHolder.bindToUri("domainUri", domainUri);
+				}
+				if (hasRange) {
+					qHolder = qHolder.bindToUri("rangeUri", rangeUri);
 				}
 				if (log.isDebugEnabled()) {
 					log.debug("domainUri=" + domainUri + ", baseUri=" + baseUri

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/dao/jena/PropertyDaoJena.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/dao/jena/PropertyDaoJena.java
@@ -813,7 +813,9 @@ public class PropertyDaoJena extends JenaBaseDao implements PropertyDao {
         List<ObjectProperty> stragglers = getAdditionalFauxSubpropertiesForVClasses(
                 vclasses, propInsts);
         for (ObjectProperty op : stragglers) {
-            propInsts.add(makePropInst(op));
+        	if (op != null) {
+        		propInsts.add(makePropInst(op));	
+        	}
         }
 
         return propInsts;

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/dao/jena/VClassDaoJena.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/dao/jena/VClassDaoJena.java
@@ -264,6 +264,7 @@ public class VClassDaoJena extends JenaBaseDao implements VClassDao {
         } catch (ProfileException pe) {
             // Current language profile does not support disjointWith axioms.
             // We'd prefer to return an empty list instead of throwing an exception.
+        	log.error(pe, pe);
         } finally {
             getOntModel().leaveCriticalSection();
         }

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/utils/ApplicationConfigurationOntologyUtils.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/utils/ApplicationConfigurationOntologyUtils.java
@@ -4,6 +4,9 @@ package edu.cornell.mannlib.vitro.webapp.utils;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -18,112 +21,228 @@ import org.apache.jena.query.ResultSet;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
 import org.apache.jena.rdf.model.Resource;
-import org.apache.jena.rdf.model.ResourceFactory;
-import org.apache.jena.vocabulary.RDFS;
 
+import edu.cornell.mannlib.vitro.webapp.beans.DataProperty;
+import edu.cornell.mannlib.vitro.webapp.beans.FauxProperty;
 import edu.cornell.mannlib.vitro.webapp.beans.Individual;
 import edu.cornell.mannlib.vitro.webapp.beans.ObjectProperty;
-import edu.cornell.mannlib.vitro.webapp.beans.VClass;
+import edu.cornell.mannlib.vitro.webapp.beans.Property;
 import edu.cornell.mannlib.vitro.webapp.controller.VitroRequest;
+import edu.cornell.mannlib.vitro.webapp.dao.DataPropertyDao;
+import edu.cornell.mannlib.vitro.webapp.dao.FauxPropertyDao;
 import edu.cornell.mannlib.vitro.webapp.dao.ObjectPropertyDao;
 import edu.cornell.mannlib.vitro.webapp.dao.WebappDaoFactory;
 import edu.cornell.mannlib.vitro.webapp.dao.jena.WebappDaoFactoryJena;
+import edu.cornell.mannlib.vitro.webapp.web.templatemodels.individual.FauxDataPropertyWrapper;
+import edu.cornell.mannlib.vitro.webapp.web.templatemodels.individual.FauxObjectPropertyWrapper;
+import edu.cornell.mannlib.vitro.webapp.web.templatemodels.individual.FauxPropertyWrapper;
 
 public class ApplicationConfigurationOntologyUtils {
 
     private static final Log log = LogFactory.getLog(ApplicationConfigurationOntologyUtils.class);
-
-    public static List<ObjectProperty> getAdditionalFauxSubpropertiesForList(List<ObjectProperty> propList, Individual subject, VitroRequest vreq) {
-		Model displayModel = vreq.getDisplayModel();
-        Model tboxModel = vreq.getOntModelSelector().getTBoxModel();
-        return getAdditionalFauxSubpropertiesForList(propList, subject, displayModel, tboxModel);
-    }
-
-    public static List<ObjectProperty> getAdditionalFauxSubproperties(ObjectProperty prop,
-                                                                         Individual subject,
-                                                                         Model tboxModel,
-                                                                         Model union) {
-
-        List<ObjectProperty> additionalProps = new ArrayList<ObjectProperty>();
-        String queryStr = "PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#> \n" +
+    
+    private static final String getPossibleFauxQuery(boolean isData) {
+    	return
+    			"PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#> \n" +
                 "PREFIX config: <http://vitro.mannlib.cornell.edu/ns/vitro/ApplicationConfiguration#> \n" +
                 "PREFIX vitro: <http://vitro.mannlib.cornell.edu/ns/vitro/0.7#> \n" +
-                "SELECT DISTINCT ?range ?domain ?property WHERE { \n" +
+                "SELECT DISTINCT ?range ?domain ?property ?context ?isData WHERE { \n" +
                 "    ?context config:configContextFor ?property . \n" +
-                "    ?context config:qualifiedBy ?range . \n" +
+                (isData ? 
+                	 "?property a <http://www.w3.org/2002/07/owl#DatatypeProperty> . \n" 
+                		: 
+                	 "?property a <http://www.w3.org/2002/07/owl#ObjectProperty> . \n" ) +
+                "    OPTIONAL {  ?context config:qualifiedBy ?range . } \n " +  
                 "    ?context config:hasConfiguration ?configuration . \n" +
                 "    ?configuration a config:ObjectPropertyDisplayConfig . \n" +
-                "    OPTIONAL { ?context config:qualifiedByDomain ?domain } \n" +
+                "    OPTIONAL { ?context config:qualifiedByDomain ?domain } . \n" +
                 "}";
+    }
+    
+	private static String getFauxPropQuery(String baseUri, boolean optionalRange) {
+		return
+				"PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#> \n" +
+	            "PREFIX config: <http://vitro.mannlib.cornell.edu/ns/vitro/ApplicationConfiguration#> \n" +
+	            "PREFIX vitro: <http://vitro.mannlib.cornell.edu/ns/vitro/0.7#> \n" +
+	            "SELECT DISTINCT ?range ?domain ?context WHERE { \n" +
+	            "    ?context config:configContextFor <" + baseUri + "> . \n" +
+	            (optionalRange ? " OPTIONAL { " : "") +  
+	            "    ?context config:qualifiedBy ?range . \n" +
+	            (optionalRange ? " } " : "") +  
+	            "    ?context config:hasConfiguration ?configuration . \n" +
+	            "    ?configuration a config:ObjectPropertyDisplayConfig . \n" +
+	            "    OPTIONAL { ?context config:qualifiedByDomain ?domain } \n" +
+	            "}";
+	} 		
 
-        if(prop != null) {
-            log.debug("Checking " + prop.getURI() + " for additional properties");
-            queryStr = queryStr.replaceAll("For \\?property", "For <" + prop.getURI() + ">");
-        }
-        log.debug(queryStr);
-        Query q = QueryFactory.create(queryStr);
+    public static List<FauxObjectPropertyWrapper> getPopulatedFauxOPs(List<ObjectProperty> populatedObjectProperties, Individual subject, VitroRequest vreq) {
+		List<FauxObjectPropertyWrapper> fauxProperties = new ArrayList<FauxObjectPropertyWrapper>();
+		for (ObjectProperty op : populatedObjectProperties) {
+		    fauxProperties.addAll(getPopulatedFauxObjectProperties(op, subject, vreq));
+		}
+		return fauxProperties;
+    }
+    
+    public static List<FauxDataPropertyWrapper> getPopulatedFauxDPs(List<DataProperty> populatedDataProperties, Individual subject, VitroRequest vreq) {
+		List<FauxDataPropertyWrapper> fauxProperties = new ArrayList<FauxDataPropertyWrapper>();
+		for (DataProperty dp : populatedDataProperties) {
+		    fauxProperties.addAll(getPopulatedFauxDataProperties(dp, subject, vreq));
+		}
+		return fauxProperties;
+    }
+
+	private static List<FauxObjectPropertyWrapper> getPopulatedFauxObjectProperties(ObjectProperty op, Individual subject, VitroRequest vreq) {
+		Model displayModel = vreq.getDisplayModel();
+        Model tboxModel = vreq.getOntModelSelector().getTBoxModel();
+		Model union = ModelFactory.createUnion(displayModel, tboxModel);
+		WebappDaoFactory wadf = new WebappDaoFactoryJena(ModelFactory.createOntologyModel(OntModelSpec.OWL_MEM, union));
+		FauxPropertyDao fpDao = wadf.getFauxPropertyDao();
+        
+	    Query q = createQuery(op, false);
         QueryExecution qe = QueryExecutionFactory.create(q, union);
-        WebappDaoFactory wadf = new WebappDaoFactoryJena(
-                ModelFactory.createOntologyModel(OntModelSpec.OWL_MEM, union));
-        ObjectPropertyDao opDao = wadf.getObjectPropertyDao();
+	    List<FauxObjectPropertyWrapper> fauxObjectProps = new ArrayList<FauxObjectPropertyWrapper>();
         try {
             ResultSet rs = qe.execSelect();
             while (rs.hasNext()) {
                 QuerySolution qsoln = rs.nextSolution();
                 log.debug(qsoln);
-                String opURI = (prop != null) ? prop.getURI() : qsoln.getResource(
-                        "property").getURI();
                 Resource domainRes = qsoln.getResource("domain");
                 String domainURI = (domainRes != null) ? domainRes.getURI() : null;
-                String rangeURI = qsoln.getResource("range").getURI();
-                if (appropriateDomain(domainRes, subject, tboxModel)) {
-                    ObjectProperty faux = opDao.getObjectPropertyByURIs(
-                            opURI, domainURI, rangeURI, (prop != null) ? prop.clone() : null);
-                    if (faux != null) {
-                        additionalProps.add(faux);
-                    } else {
-                        log.error("Could not retrieve " + opURI + " qualified by " +
-                                " domain " + domainURI + " and range " + rangeURI);
-                    }
+                //String rangeURI = qsoln.getResource("range").getURI();
+                String contextURI = qsoln.getResource("context").getURI();
+                if (isDomainMatchSubject(domainURI, subject)) {
+                    try {
+                        FauxProperty fp = fpDao.getFauxPropertyFromContextUri(contextURI);
+            			if (fp != null) {
+            				 fauxObjectProps.add(new FauxObjectPropertyWrapper(op.clone(), fp));
+            			}
+            		} catch (Exception e) {
+            			log.warn("Couldn't look up the faux property", e);
+            		}
                 }
             }
         } finally {
             qe.close();
         }
-        return additionalProps;
+        return fauxObjectProps;
     }
-
-
-
-    public static List<ObjectProperty> getAdditionalFauxSubpropertiesForList(List<ObjectProperty> propList,
-                                                                         Individual subject,
-                                                                         Model displayModel,
-                                                                         Model tboxModel) {
-
-        List<ObjectProperty> additionalProps = new ArrayList<ObjectProperty>();
-        Model union = ModelFactory.createUnion(displayModel, tboxModel);
-
-        for (ObjectProperty op : propList) {
-            additionalProps.addAll(getAdditionalFauxSubproperties(op, subject, tboxModel, union));
+	
+	private static List<FauxDataPropertyWrapper> getPopulatedFauxDataProperties(DataProperty dp, Individual subject, VitroRequest vreq) {
+		Model displayModel = vreq.getDisplayModel();
+        Model tboxModel = vreq.getOntModelSelector().getTBoxModel();
+		Model union = ModelFactory.createUnion(displayModel, tboxModel);
+		WebappDaoFactory wadf = new WebappDaoFactoryJena(ModelFactory.createOntologyModel(OntModelSpec.OWL_MEM, union));
+		FauxPropertyDao fpDao = wadf.getFauxPropertyDao();
+        
+	    Query q = createQuery(dp, true);
+        QueryExecution qe = QueryExecutionFactory.create(q, union);
+	    List<FauxDataPropertyWrapper> fauxDataProps = new ArrayList<FauxDataPropertyWrapper>();
+        try {
+            ResultSet rs = qe.execSelect();
+            while (rs.hasNext()) {
+                QuerySolution qsoln = rs.nextSolution();
+                log.debug(qsoln);
+                Resource domainRes = qsoln.getResource("domain");
+                String domainURI = (domainRes != null) ? domainRes.getURI() : null;
+                String contextURI = qsoln.getResource("context").getURI();
+                if (isDomainMatchSubject(domainURI, subject)) {
+                    try {
+                        FauxProperty fp = fpDao.getFauxPropertyFromContextUri(contextURI);
+            			if (fp != null) {
+            				 fauxDataProps.add(new FauxDataPropertyWrapper(dp, fp));
+            			}
+            		} catch (Exception e) {
+            			log.warn("Couldn't look up the faux property", e);
+            		}
+                }
+            }
+        } finally {
+            qe.close();
         }
-
-        return additionalProps;
+        return fauxDataProps;
     }
 
-    private static boolean appropriateDomain(Resource domainRes, Individual subject, Model tboxModel) {
-        if (subject == null || domainRes == null) {
+	private static Query createQuery(Property op, boolean optionalRange) {
+		String queryStr = getFauxPropQuery(op.getURI(), optionalRange);
+        log.debug(queryStr);
+        Query q = QueryFactory.create(queryStr);
+		return q;
+	}
+
+    private static boolean isDomainMatchSubject(String domainUri, Individual subject) {
+        if (subject == null || domainUri == null) {
             return true;
         }
-        for (VClass vclass : subject.getVClasses()) {
-            if ((vclass.getURI() != null) &&
-                    ((vclass.getURI().equals(domainRes.getURI()) ||
-                    (tboxModel.contains(
-                            ResourceFactory.createResource(
-                                    vclass.getURI()), RDFS.subClassOf, domainRes))))) {
+        Set<String> vClassUris = subject.getVClasses().stream().map(vclass -> vclass.getURI()).collect(Collectors.toSet());
+		for (String vClassUri : vClassUris) {
+            if (vClassUri != null && vClassUri.equals(domainUri)) {
                 return true;
             }
         }
         return false;
     }
+
+	public static List<Property> getPossibleFauxProps(List<? extends FauxPropertyWrapper> curProps, Individual subject,	VitroRequest vreq, boolean isData) {
+		Model displayModel = vreq.getDisplayModel();
+        Model tboxModel = vreq.getOntModelSelector().getTBoxModel();
+		Model union = ModelFactory.createUnion(displayModel, tboxModel);
+		Map<String, FauxProperty> curPropsMap = curProps.stream().collect(Collectors.toMap(FauxPropertyWrapper::getContextUri, FauxPropertyWrapper::getFauxProperty));
+		WebappDaoFactory wadf = new WebappDaoFactoryJena(ModelFactory.createOntologyModel(OntModelSpec.OWL_MEM, union));
+		FauxPropertyDao fpDao = wadf.getFauxPropertyDao();
+		ObjectPropertyDao opDao = wadf.getObjectPropertyDao();
+		DataPropertyDao dpDao = wadf.getDataPropertyDao();
+        
+	    Query q = QueryFactory.create(getPossibleFauxQuery(isData));
+        QueryExecution qe = QueryExecutionFactory.create(q, union);
+	    List<Property> fauxDataProps = new ArrayList<Property>();
+        try {
+            ResultSet rs = qe.execSelect();
+            while (rs.hasNext()) {
+                QuerySolution qsoln = rs.nextSolution();
+                Resource domainRes = qsoln.getResource("domain");
+                String domainURI = (domainRes != null) ? domainRes.getURI() : null;
+                //Resource rangeRes = qsoln.getResource("range");
+                //String rangeURI = (rangeRes != null) ? rangeRes.getURI() : null;
+                String basePropertyUri = qsoln.getResource("property").getURI();
+                String contextURI = qsoln.getResource("context").getURI();
+                if (isDomainMatchSubject(domainURI, subject) && !curPropsMap.containsKey(contextURI)) {
+                	if (isData) {
+                		addDataProperty(fauxDataProps, basePropertyUri, contextURI, fpDao, dpDao);
+                	} else {
+                		addObjectProperty(fauxDataProps, basePropertyUri, contextURI, fpDao, opDao);
+                	}
+                }
+            }
+        } finally {
+            qe.close();
+        }
+        return fauxDataProps;
+	}
+
+	private static void addObjectProperty(List<Property> fauxProps, String basePropertyUri, String contextURI, FauxPropertyDao fpDao, ObjectPropertyDao opDao) {
+		try {
+            FauxProperty fp = fpDao.getFauxPropertyFromContextUri(contextURI);
+            ObjectProperty op = opDao.getObjectPropertyByURI(basePropertyUri); 
+			if (fp != null && op != null) {
+				 fauxProps.add(new FauxObjectPropertyWrapper(op, fp));
+			}
+		} catch (Exception e) {
+			log.warn("Couldn't look up the faux object property, contextUri " + contextURI, e);
+		}
+		
+	}
+
+	private static void addDataProperty(List<Property> fauxProps, String basePropertyUri, String contextURI, FauxPropertyDao fpDao, DataPropertyDao dpDao) {
+		try {
+            FauxProperty fp = fpDao.getFauxPropertyFromContextUri(contextURI);
+            DataProperty dp = dpDao.getDataPropertyByURI(basePropertyUri); 
+			if (fp != null && dp != null) {
+				 fauxProps.add(new FauxDataPropertyWrapper(dp, fp));
+			}
+		} catch (Exception e) {
+			log.warn("Couldn't look up the faux data property, contextUri " + contextURI, e);
+		}
+		
+	}
 
 }

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/web/templatemodels/individual/FauxDataPropertyWrapper.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/web/templatemodels/individual/FauxDataPropertyWrapper.java
@@ -18,7 +18,7 @@ import edu.cornell.mannlib.vitro.webapp.beans.ObjectPropertyStatement;
  * TODO This is a horrible kluge that should be discarded as soon as we can
  * rewrite GroupedPropertyList.
  */
-public class FauxDataPropertyWrapper extends DataProperty {
+public class FauxDataPropertyWrapper extends DataProperty implements FauxPropertyWrapper{
 	private final DataProperty innerDP;
 	private final FauxProperty faux;
 
@@ -314,6 +314,16 @@ public class FauxDataPropertyWrapper extends DataProperty {
 		} else {
 			return ResourceFactory.createResource(uri).getLocalName();
 		}
+	}
+
+	@Override
+	public FauxProperty getFauxProperty() {
+		return faux;
+	}
+
+	@Override
+	public String getContextUri() {
+		return faux.getContextUri();
 	}
 
 }

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/web/templatemodels/individual/FauxDataPropertyWrapper.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/web/templatemodels/individual/FauxDataPropertyWrapper.java
@@ -1,0 +1,319 @@
+/* $This file is distributed under the terms of the license in LICENSE$ */
+
+package edu.cornell.mannlib.vitro.webapp.web.templatemodels.individual;
+
+import java.util.List;
+import java.util.Objects;
+
+import org.apache.jena.rdf.model.ResourceFactory;
+
+import edu.cornell.mannlib.vitro.webapp.beans.DataProperty;
+import edu.cornell.mannlib.vitro.webapp.beans.DataPropertyStatement;
+import edu.cornell.mannlib.vitro.webapp.beans.FauxProperty;
+import edu.cornell.mannlib.vitro.webapp.beans.ObjectPropertyStatement;
+
+/**
+ * An ObjectProperty that has some of its values overridden by a FauxProperty.
+ *
+ * TODO This is a horrible kluge that should be discarded as soon as we can
+ * rewrite GroupedPropertyList.
+ */
+public class FauxDataPropertyWrapper extends DataProperty {
+	private final DataProperty innerDP;
+	private final FauxProperty faux;
+
+	public FauxDataPropertyWrapper(DataProperty inner, FauxProperty faux) {
+		this.innerDP = inner;
+		this.faux = faux;
+	}
+
+	// ----------------------------------------------------------------------
+	// Methods where FauxProperty overrides.
+	// ----------------------------------------------------------------------
+
+	@Override
+	public String getGroupURI() {
+		String uri = faux.getGroupURI();
+		if (uri != null) {
+			return uri;
+		}
+		return innerDP.getGroupURI();
+	}
+
+	@Override
+	public void setGroupURI(String groupUri) {
+		faux.setGroupURI(groupUri);
+		innerDP.setGroupURI(groupUri);
+	}
+
+	// -------
+
+	@Override
+	public String getDomainVClassURI() {
+		String uri = faux.getDomainVClassURI();
+		if (uri != null) {
+			return uri;
+		}
+		return innerDP.getDomainVClassURI();
+	}
+
+	@Override
+	public void setDomainVClassURI(String domainClassURI) {
+		faux.setDomainURI(domainClassURI);
+		innerDP.setDomainVClassURI(domainClassURI);
+	}
+
+	// -------
+
+	@Override
+	public String getRangeVClassURI() {
+		String uri = faux.getRangeVClassURI();
+		if (uri != null) {
+			return uri;
+		}
+		return innerDP.getRangeVClassURI();
+	}
+
+	@Override
+	public void setRangeVClassURI(String rangeClassURI) {
+		faux.setRangeURI(rangeClassURI);
+		innerDP.setRangeVClassURI(rangeClassURI);
+	}
+
+	// -------
+
+	@Override
+	public String getCustomEntryForm() {
+		String s = faux.getCustomEntryForm();
+		if (s != null) {
+			return s;
+		}
+		return innerDP.getCustomEntryForm();
+	}
+
+	@Override
+	public void setCustomEntryForm(String s) {
+		faux.setCustomEntryForm(s);
+		innerDP.setCustomEntryForm(s);
+	}
+
+	// -------
+
+	
+	@Override
+	public String getPublicDescription() {
+		String s = faux.getPublicDescription();
+		if (s != null) {
+			return s;
+		}
+		return innerDP.getPublicDescription();
+	}
+
+	@Override
+	public void setPublicDescription(String s) {
+		faux.setPublicDescription(s);
+		innerDP.setPublicDescription(s);
+	}
+
+	// -------
+
+	@Override
+	public String getPickListName() {
+		String name = faux.getDisplayName();
+		if (name != null) {
+			return name;
+		}
+		return innerDP.getPickListName();
+	}
+
+	@Override
+	public void setPickListName(String pickListName) {
+		faux.setDisplayName(pickListName);
+		innerDP.setPickListName(pickListName);
+	}
+
+	// ----------------------------------------------------------------------
+	// Methods from ObjectProperty
+	// ----------------------------------------------------------------------
+
+
+	@Override
+	public String getLabel() {
+		return innerDP.getLabel();
+	}
+
+	@Override
+	public String getDescription() {
+		return innerDP.getDescription();
+	}
+
+	@Override
+	public void setDescription(String description) {
+		innerDP.setDescription(description);
+	}
+
+	@Override
+	public String getExample() {
+		return innerDP.getExample();
+	}
+
+	@Override
+	public void setExample(String example) {
+		innerDP.setExample(example);
+	}
+
+	
+
+	@Override
+	public boolean getFunctional() {
+		return innerDP.getFunctional();
+	}
+
+	@Override
+	public void setFunctional(boolean functional) {
+		innerDP.setFunctional(functional);
+	}
+
+	@Override
+	public void setLabel(String label) {
+		innerDP.setLabel(label);
+	}
+
+	@Override
+	public boolean isSubjectSide() {
+		return innerDP.isSubjectSide();
+	}
+
+	@Override
+	public boolean isEditLinkSuppressed() {
+		return innerDP.isEditLinkSuppressed();
+	}
+
+	@Override
+	public boolean isAddLinkSuppressed() {
+		return innerDP.isAddLinkSuppressed();
+	}
+
+	@Override
+	public boolean isDeleteLinkSuppressed() {
+		return innerDP.isDeleteLinkSuppressed();
+	}
+
+	@Override
+	public void setEditLinkSuppressed(boolean editLinkSuppressed) {
+		innerDP.setEditLinkSuppressed(editLinkSuppressed);
+	}
+
+	@Override
+	public void setAddLinkSuppressed(boolean addLinkSuppressed) {
+		innerDP.setAddLinkSuppressed(addLinkSuppressed);
+	}
+
+	@Override
+	public void setDeleteLinkSuppressed(boolean deleteLinkSuppressed) {
+		innerDP.setDeleteLinkSuppressed(deleteLinkSuppressed);
+	}
+
+	@Override
+	public boolean isAnonymous() {
+		return innerDP.isAnonymous();
+	}
+
+	@Override
+	public String getURI() {
+		return innerDP.getURI();
+	}
+
+	@Override
+	public void setURI(String URI) {
+		innerDP.setURI(URI);
+	}
+
+	@Override
+	public String getNamespace() {
+		return innerDP.getNamespace();
+	}
+
+	@Override
+	public void setNamespace(String namespace) {
+		innerDP.setNamespace(namespace);
+	}
+
+	@Override
+	public String getLocalName() {
+		return innerDP.getLocalName();
+	}
+
+	@Override
+	public void setLocalName(String localName) {
+		innerDP.setLocalName(localName);
+	}
+
+	@Override
+	public String getLocalNameWithPrefix() {
+		return innerDP.getLocalNameWithPrefix();
+	}
+
+	@Override
+	public void setLocalNameWithPrefix(String prefixedLocalName) {
+		innerDP.setLocalNameWithPrefix(prefixedLocalName);
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = super.hashCode();
+		result = prime * result + ((faux == null) ? 0 : faux.hashCode());
+		result = prime * result + ((innerDP == null) ? 0 : innerDP.hashCode());
+		return Objects.hash(innerDP, faux);
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj) {
+			return true;
+		}
+		if (!super.equals(obj)) {
+			return false;
+		}
+		if (getClass() != obj.getClass()) {
+			return false;
+		}
+		FauxDataPropertyWrapper that = (FauxDataPropertyWrapper) obj;
+		return Objects.equals(this.innerDP, that.innerDP)
+				&& Objects.equals(this.faux, that.faux);
+	}
+
+	@Override
+	public List<DataPropertyStatement> getDataPropertyStatements() {
+		return innerDP.getDataPropertyStatements();
+	}
+	
+    @Override
+	public String toString() {
+		return String.format("FauxDataPropertyWrapper[ %s ==> %s ==> %s, statementCount=%d, group=%s, customEntryForm=%s ]",
+				localName(getDomainVClassURI()),
+				localName(getURI()), 
+				localName(getRangeVClassURI()),
+				(getDataPropertyStatements() == null ? 0: getDataPropertyStatements().size()),
+				localName(getGroupURI()),
+				simpleName(getCustomEntryForm()));
+	}
+
+	private Object simpleName(String classname) {
+		if (classname == null) {
+			return null;
+		} else {
+			return classname.substring(classname.lastIndexOf(".") + 1);
+		}
+	}
+
+	private Object localName(String uri) {
+		if (uri == null) {
+			return null;
+		} else {
+			return ResourceFactory.createResource(uri).getLocalName();
+		}
+	}
+
+}

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/web/templatemodels/individual/FauxObjectPropertyWrapper.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/web/templatemodels/individual/FauxObjectPropertyWrapper.java
@@ -624,8 +624,11 @@ public class FauxObjectPropertyWrapper extends ObjectProperty {
     @Override
 	public String toString() {
 		return String.format("FauxObjectPropertyWrapper[ %s <==> %s | %s ==> %s ==> %s, statementCount=%d, group=%s, customEntryForm=%s ]",
-				getDomainPublic(), getRangePublic(),
-				localName(getDomainVClassURI()), localName(getURI()), localName(getRangeVClassURI()),
+				getDomainPublic(), 
+				getRangePublic(),
+				localName(getDomainVClassURI()), 
+				localName(getURI()),
+				localName(getRangeVClassURI()),
 				(getObjectPropertyStatements() == null ? 0: getObjectPropertyStatements().size()),
 				localName(getGroupURI()),
 				simpleName(getCustomEntryForm()));

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/web/templatemodels/individual/FauxObjectPropertyWrapper.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/web/templatemodels/individual/FauxObjectPropertyWrapper.java
@@ -18,7 +18,7 @@ import edu.cornell.mannlib.vitro.webapp.beans.VClass;
  * TODO This is a horrible kluge that should be discarded as soon as we can
  * rewrite GroupedPropertyList.
  */
-public class FauxObjectPropertyWrapper extends ObjectProperty {
+public class FauxObjectPropertyWrapper extends ObjectProperty implements FauxPropertyWrapper{
 	private final ObjectProperty innerOP;
 	private final FauxProperty faux;
 
@@ -648,6 +648,16 @@ public class FauxObjectPropertyWrapper extends ObjectProperty {
 		} else {
 			return ResourceFactory.createResource(uri).getLocalName();
 		}
+	}
+
+	@Override
+	public FauxProperty getFauxProperty() {
+		return faux;
+	}
+
+	@Override
+	public String getContextUri() {
+		return faux.getContextUri();
 	}
 
 }

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/web/templatemodels/individual/FauxPropertyWrapper.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/web/templatemodels/individual/FauxPropertyWrapper.java
@@ -1,0 +1,10 @@
+package edu.cornell.mannlib.vitro.webapp.web.templatemodels.individual;
+
+import edu.cornell.mannlib.vitro.webapp.beans.FauxProperty;
+
+public interface FauxPropertyWrapper {
+
+	public FauxProperty getFauxProperty();
+	
+	public String getContextUri();
+}

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/web/templatemodels/individual/GroupedPropertyList.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/web/templatemodels/individual/GroupedPropertyList.java
@@ -296,6 +296,25 @@ public class GroupedPropertyList extends BaseTemplateModel {
 		}
 		return op;
 	}
+	
+	private DataProperty assembleDataProperty(DataProperty dp) {
+		WebappDaoFactory rawWadf = ModelAccess.on(vreq).getWebappDaoFactory();
+		FauxPropertyDao fpDao = rawWadf.getFauxPropertyDao();
+
+		String base = dp.getURI();
+		String domain = dp.getDomainClassURI();
+		String range = dp.getRangeDatatypeURI();
+
+		try {
+			FauxProperty fp = fpDao.getFauxPropertyByUris(domain, base, range);
+			if (fp != null) {
+				return new FauxDataPropertyWrapper(dp, fp);
+			}
+		} catch (Exception e) {
+			log.warn("Couldn't look up the faux property", e);
+		}
+		return dp;
+	}
 
 	/**
 	* Don't know what the real problem is with VIVO-976, but somehow we have the same property
@@ -379,7 +398,8 @@ public class GroupedPropertyList extends BaseTemplateModel {
                     if (dp.getURI() == null) {
                         log.error("DataProperty dp returned with null propertyURI from dpDao.getAllPossibleDatapropsForIndividual()");
                     } else if (!alreadyOnPropertyList(propertyList, dp)) {
-                        propertyList.add(dp);
+                    	DataProperty wrappedDp = assembleDataProperty(dp);
+                        propertyList.add(wrappedDp);
                     }
                 } else {
                     log.error("a data property in the Collection created in DataPropertyDao.getAllPossibleDatapropsForIndividual() is unexpectedly null)");

--- a/webapp/src/main/webapp/templates/edit/specific/dataprops_edit.jsp
+++ b/webapp/src/main/webapp/templates/edit/specific/dataprops_edit.jsp
@@ -72,6 +72,51 @@
 </tr>
 
 <tr><td colspan="3"><hr/></td></tr>
+<!-- _____________________________________________ faux properties __________________________________________ -->
+<tr valign="bottom" align="center">
+	<td colspan="2" valign="bottom" align="left">
+	  <c:if test="${!empty fauxproperties}">
+		<c:forEach var="fauxproperty" items="${fauxproperties}">
+		  <ul style="list-style-type:none;">
+			<li>
+			  <c:choose>
+			    <c:when test="${empty fauxproperty.domainLabel}">
+		          <c:url var="fauxpropertyURL" value="editForm">
+			        <c:param name="controller" value="FauxProperty"/>
+			        <c:param name="baseUri" value="${datatypeProperty.URI}"/>
+			        <c:param name="rangeUri" value="${fauxproperty.rangeURI}" />
+			      </c:url>
+			      <a href="${fauxpropertyURL}">${fauxproperty.pickListName}</a>
+			      no domain,
+			    </c:when>
+			    <c:otherwise>
+		          <c:url var="fauxpropertyURL" value="editForm">
+			        <c:param name="controller" value="FauxProperty"/>
+			        <c:param name="baseUri" value="${datatypeProperty.URI}"/>
+			        <c:param name="domainUri" value="${fauxproperty.domainURI}" />
+			        <c:param name="rangeUri" value="${fauxproperty.rangeURI}" />
+			      </c:url>
+			      <a href="${fauxpropertyURL}">${fauxproperty.pickListName}</a>
+			      domain: ${fauxproperty.domainLabel},
+			    </c:otherwise>
+			  </c:choose>
+			  range: ${fauxproperty.rangeLabel}
+			</li>
+		  </ul>
+		</c:forEach>
+	  </c:if>
+	</td>
+	<td>
+	<form action="editForm" method="get">
+	  <input type="hidden" name="create" value="create"/>
+	  <input type="hidden" name="baseUri" value="${datatypeProperty.URI}"/>
+	  <input type="hidden" name="controller" value="FauxProperty"/>
+	  <input type="submit" class="form-button" value="Create New Faux Property"/>
+	</form>
+	</td>
+</tr>
+
+<tr><td colspan="3"><hr/></td></tr>
 <!-- _____________________________________________ superproperties __________________________________________ -->
 <tr valign="bottom" align="center">
     <td colspan="2" valign="bottom" align="left">

--- a/webapp/src/main/webapp/templates/freemarker/body/siteAdmin/siteAdmin-fauxPropertiesList.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/body/siteAdmin/siteAdmin-fauxPropertiesList.ftl
@@ -40,7 +40,7 @@
         <tbody>
           <tr>
             <td class="classDetail">${i18n().base_property_capitalized}:</td>
-	        <td><a href='propertyEdit?uri=${ks["baseURI"]?url!}'>${ks["base"]!}</a></td>
+	        <td><a href='${ks["editUrl"]}?uri=${ks["baseURI"]?url!}'>${ks["base"]!}</a></td>
 	      </tr>
 	      <tr>
             <td class="classDetail">${i18n().group_capitalized}:</td>
@@ -66,12 +66,13 @@
 		<#assign baseLabel = key?substring(0,key?index_of("|")) />
 		<#assign baseUri = key?substring(key?index_of("|")+1) />
         <div>
-          <a href='propertyEdit?uri=${baseUri?url}'>${baseLabel}</a>
+          <a href='${fauxList["editUrl"]}?uri=${baseUri?url}'>${baseLabel}</a>
         </div>
 	    <#assign keysTwo = fauxList?keys />
 		<#assign firstLoop = true />
 	    <#list keysTwo as k2>
 	      <#assign faux = fauxList[k2] />
+              <#if faux?is_hash >
         <table id="classHierarchy1" class="classHierarchy" <#if !firstLoop >style="margin-top:-16px"</#if>>
           <tbody>
               <tr>
@@ -94,6 +95,7 @@
 		    </tbody>
 		  </table>
 		  <#assign firstLoop = false />
+		</#if>
       </#list>
       </section>
 	</#list>


### PR DESCRIPTION
# What does this pull request do?

- Fixes faux object properties view: now if faux property exists with the same domain, then real property is shadowed and duplicate faux property is shown instead. 
- Extended domain and range options for faux properties to all domains except not disjoint ones.
- Implemented faux properties for data proerties.

# What's new?

In PropertyTemplateModel removed ambiguous check that hidden real object properties.
FauxPropertyDaoJena, ListFauxPropertiesController, siteAdmin-fauxPropertiesList.ftl, dataprops_edit.jsp  modified to support faux data properties
Added code to get not disjoint classes in FormUtils
Created FauxDataPropertyWrapper.java to wrap faux data properties in GroupedPropertyList like it is done in FauxObjectPropertyWrapper for faux object properties
Refactored GroupedPropertyList and added new logic to support faux data properties and correctly list faux object properties
Created an interface FauxPropertyWrapper interface for faux property wrappers.
Refactored and extended ApplicationConfigurationOntologyUtils to get information about populated, not populated object and data faux properties.
Log exceptions in VClassDaoJena
Removed unused import in ObjectProperty 
Added safety check to [PropertyDaoJena.java](https://github.com/vivo-project/Vitro/compare/i18n-redesign...litvinovg:Vitro:faux_properties?expand=1#diff-332b248b5f5e7ea5dcfdb68fab7b467a8712df0e19b66c8a233b508b2c2578ce)
If possible I suggest to deprecate or remove all code from PropertyDaoJena that mixes real and faux properties from [this line](https://github.com/litvinovg/Vitro/blob/65a6ab48f1865829f99f84ce7919517d014a7fe3/api/src/main/java/edu/cornell/mannlib/vitro/webapp/dao/jena/PropertyDaoJena.java#L778). 

# How should this be tested?
Create data and object faux properties, add values. Test that faux properties are available even if domain of base property doesn't match individual types, but domain of faux property match individual type.
Faux data property creation should be available from data property page
Both types of faux properties listings should work.
Faux data properties range should always be the same as base property.
Faux data and object property ranges should be constrained by not disjoint properties.
This change require documentation to be updated

# Interested parties
@bkampe  @brianjlowe @chenejac
