### PR TITLE
adding English as default language

### DIFF
--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/rdfservice/filter/LanguageFilteringUtils.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/rdfservice/filter/LanguageFilteringUtils.java
@@ -71,7 +71,7 @@ public class LanguageFilteringUtils {
 			Locale locale = (Locale) locales.nextElement();
 			langs.add(locale.toString().replace(UNDERSCORE, HYPHEN));
 		}
-		if (langs.isEmpty()) {
+		if (!langs.contains(DEFAULT_LANG_STRING)) {
 			langs.add(DEFAULT_LANG_STRING);
 		}
 


### PR DESCRIPTION
**[VIVO GitHub issue](https://github.com/vivo-project/VIVO/issues)**: [3801](https://github.com/vivo-project/VIVO/issues/3801)

* Other Relevant Links (Mailing list discussion, related pull requests, etc.)

- https://github.com/vivo-project/VIVO/pull/3798#issuecomment-1337278004

# What does this pull request do?
Setting default language used in the case when translation for some data property is not used. For instance, if "es" is selected as the UI language, and there is no translation for some conference title in Spain, the English title of the conference should be displayed.

# How should this be tested?

-  setting runtime.properties :
RDFService.languageFilter = true
languages.selectableLocales = en_US, de_DE, sr_Latn_RS, ru_RU, fr_CA, en_CA, es, pt_BR

- copy sample sample-data-i18n.ttl sample-data-i18n-de_DE.ttl sample-data-i18n-en_CA.ttl sample-data-i18n-en_US.ttl sample-data-i18n-fr_CA.ttl sample-data-i18n-fr_FR.ttl sample-data-i18n-sr_Latn_RS from https://github.com/vivo-project/sample-data/pull/8 to $[VIVO_HOME]/vivo/home/rdf/abox/filegraph
- run tomcat and open VIVO in the web browser
- click on Events
- select Spain language
- In the list of Events there shouldn't be any in German language (only in English or Spain language).

# Interested parties
Tag (@ mention) interested parties or, if unsure, @VIVO-project/vivo-committers
