### PR TITLE
support for combining parameters and apostrophe

### DIFF
--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/i18n/TranslationProvider.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/i18n/TranslationProvider.java
@@ -165,7 +165,7 @@ public class TranslationProvider {
 		if (parameters.length == 0) {
 			return textString;
 		} else {
-			return MessageFormat.format(textString, parameters);
+			return MessageFormat.format(textString.replaceAll("''", "'").replaceAll("'", "''"), parameters);
 		}
 	}
 

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/i18n/TranslationProvider.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/i18n/TranslationProvider.java
@@ -165,7 +165,21 @@ public class TranslationProvider {
 		if (parameters.length == 0) {
 			return textString;
 		} else {
-			return MessageFormat.format(textString.replaceAll("''", "'").replaceAll("'", "''"), parameters);
+			return MessageFormat.format(TranslationProvider.preprocessForFormating(textString), parameters);
+		}
+	}
+
+	/**
+	 * This method should prepare the inputText for MessageFormat.format method. At the moment it is replacing single
+	 * apostrophe with double, it might be extented in the future with some additional preprocessing.
+	 * @param inputText - string which should be preprocessed
+	 * @return preprocessed input string, i.e. string with replaced single apostrophe with double
+	 */
+	public static String preprocessForFormating(String inputText){
+		if (inputText != null) {
+			return inputText.replace("''", "'").replace("'", "''");
+		} else {
+			return "";
 		}
 	}
 

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/i18n/freemarker/I18nStringTemplateModel.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/i18n/freemarker/I18nStringTemplateModel.java
@@ -67,7 +67,7 @@ public class I18nStringTemplateModel implements TemplateMethodModelEx,
 				if(isOnlineTranslationsEnabled()) {
 					return getOnlineTranslationsFormattedMessage(textString, unwrappedArgs);
 				} else {
-					return MessageFormat.format(textString, unwrappedArgs);	
+					return MessageFormat.format(textString.replaceAll("''", "'").replaceAll("'", "''"), unwrappedArgs);
 				}
 			} catch (Exception e) {
 				String message = "Can't format '" + key + "', wrong argument types: " + args
@@ -83,13 +83,13 @@ public class I18nStringTemplateModel implements TemplateMethodModelEx,
 	 * and combines preProcessed string back to be used with online translations.
 	 * Substitutes arguments in message which is a part of preProcessed string  
 	 * @param preProcessed String "startSep + key + intSep + textString + intSep + message + endSep"
-	 * @param arguments that should be listed before message and substituted in the message itself 
+	 * @param args that should be listed before message and substituted in the message itself
 	 * @return
 	 */
 	private String getOnlineTranslationsFormattedMessage(String preProcessed, Object[] args) {
 		String[] parts = preProcessed.split(I18nBundle.INT_SEP);
 		final int messageIndex = parts.length -1;
-		String message = MessageFormat.format(parts[messageIndex], args);
+		String message = MessageFormat.format(parts[messageIndex].replaceAll("''", "'").replaceAll("'", "''"), args);
 		String[] arguments = convertToArrayOfStrings(args);
 		parts[messageIndex] = "";
 		String result = String.join(I18nBundle.INT_SEP, parts) + 

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/i18n/freemarker/I18nStringTemplateModel.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/i18n/freemarker/I18nStringTemplateModel.java
@@ -5,6 +5,7 @@ package edu.cornell.mannlib.vitro.webapp.i18n.freemarker;
 import java.text.MessageFormat;
 import java.util.List;
 
+import edu.cornell.mannlib.vitro.webapp.i18n.TranslationProvider;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
@@ -67,7 +68,7 @@ public class I18nStringTemplateModel implements TemplateMethodModelEx,
 				if(isOnlineTranslationsEnabled()) {
 					return getOnlineTranslationsFormattedMessage(textString, unwrappedArgs);
 				} else {
-					return MessageFormat.format(textString.replaceAll("''", "'").replaceAll("'", "''"), unwrappedArgs);
+					return MessageFormat.format(TranslationProvider.preprocessForFormating(textString), unwrappedArgs);
 				}
 			} catch (Exception e) {
 				String message = "Can't format '" + key + "', wrong argument types: " + args
@@ -89,7 +90,7 @@ public class I18nStringTemplateModel implements TemplateMethodModelEx,
 	private String getOnlineTranslationsFormattedMessage(String preProcessed, Object[] args) {
 		String[] parts = preProcessed.split(I18nBundle.INT_SEP);
 		final int messageIndex = parts.length -1;
-		String message = MessageFormat.format(parts[messageIndex].replaceAll("''", "'").replaceAll("'", "''"), args);
+		String message = MessageFormat.format(TranslationProvider.preprocessForFormating(parts[messageIndex]), args);
 		String[] arguments = convertToArrayOfStrings(args);
 		parts[messageIndex] = "";
 		String result = String.join(I18nBundle.INT_SEP, parts) + 


### PR DESCRIPTION
**[VIVO GitHub issue](https://github.com/vivo-project/VIVO/issues)**: [3393](https://github.com/vivo-project/VIVO/issues/3393)

Please, find more about the issue also at this [discussion](https://stackoverflow.com/questions/17569608/format-a-message-using-messageformat-format-in-java)

# What does this pull request do?
Add support for combining apostrophe and parameters:
`Taille maximale de l'image: {0} mégaoctets`

It might be resolved in i18n label files by replacing ' with '', and in some cases it has been [done](https://github.com/vivo-project/Vitro/blob/i18n-redesign/home/src/main/resources/rdf/i18n/en_US/interface-i18n/firsttime/vitro_UiLabel.ttl#L2642), but not in [all cases](https://github.com/vivo-project/Vitro/blob/i18n-redesign/home/src/main/resources/rdf/i18n/en_US/interface-i18n/firsttime/vitro_UiLabel.ttl#L5178). However, this might be also resolved in java files when we are invoking MessageFormat.format method. This PR should support both cases
`Taille maximale de l'image: {0} mégaoctets`
and
`Taille maximale de l''image: {0} mégaoctets`

# What's new?
In the invocation of MessageFormat.format method, firstly all double apostrophe ('') are replaced with single, then single apostrophe is replaced with double. At the end, '' and ' are ''

# How should this be tested?

- Run VIVO application
- Log in
- Open a researcher profile page
- Click on uploading the image
- Change language to French
- Check labels `Taille maximale de l'image: 6 mégaoctets`, `Taille minimale de l'image: 200 par 200 pixels`


# Interested parties
Tag (@ mention) interested parties or, if unsure, @VIVO-project/vivo-committers
