### PR TITLE
fix for faux data property ranges

### DIFF
--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/edit/FauxPropertyRetryController.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/edit/FauxPropertyRetryController.java
@@ -90,6 +90,7 @@ public class FauxPropertyRetryController extends BaseEditController {
 	}
 
 	private static class EpoPopulator {
+		private static final String LITERAL = "http://www.w3.org/2000/01/rdf-schema#Literal";
 		private final VitroRequest req;
 		private final ServletContext ctx;
 		private final WebappDaoFactory wadf;
@@ -325,7 +326,13 @@ public class FauxPropertyRetryController extends BaseEditController {
 			if (rangeUri == null) {
 				Option option = new Option();
 				option.setValue("");
-				option.setBody("untyped (rdfs:Literal)");
+				option.setBody("Untyped");
+				option.setSelected(true);
+				list.add(option);
+			} else if (rangeUri.equals(LITERAL)) {
+				Option option = new Option();
+				option.setValue(rangeUri);
+				option.setBody("Literal");
 				option.setSelected(true);
 				list.add(option);
 			} else {


### PR DESCRIPTION
Fix for recent [PR](https://github.com/vivo-project/Vitro/pull/352)
# What does this pull request do?
Fixes faux data property range options

# What's new?
Create custom rdfs:literal range option as data property dao returns null for rdfs:literal uri.
Fixed untyped option label

# How should this be tested?
A description of what steps someone could take to:
* Create data property with range rdfs:Literal
* Create faux data property (not error should appear on creation of faux data property)

# Interested parties
@brianjlowe @chenejac @bkampe @VIVO-project/vivo-committers
