### PR TITLE
Fixed check for redundant possible object properties

### DIFF
--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/web/templatemodels/individual/GroupedPropertyList.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/web/templatemodels/individual/GroupedPropertyList.java
@@ -258,10 +258,8 @@ public class GroupedPropertyList extends BaseTemplateModel {
                     if (possibleOP == null) {
                         continue;
                     }
-                    for(ObjectProperty populatedOP : populatedOPs) {
-                    	if (redundant(populatedOP, possibleOP)) {
-                    		continue;
-                    	}
+                    if (isInPopulatedOPs(populatedOPs, possibleOP)) {
+                    	continue;
                     }
                     if (!vClassUris.contains(possibleOP.getDomainVClassURI())) {
                     	continue;
@@ -287,6 +285,15 @@ public class GroupedPropertyList extends BaseTemplateModel {
         }
 		return possibleProperties;
     }
+
+	private boolean isInPopulatedOPs(List<ObjectProperty> populatedOPs, ObjectProperty possibleOP) {
+		for(ObjectProperty populatedOP : populatedOPs) {
+			if (redundant(populatedOP, possibleOP)) {
+				return true;
+			}
+		}
+		return false;
+	}
 
 	/**
 	* Don't know what the real problem is with VIVO-976, but somehow we have the same property


### PR DESCRIPTION
Fix for recent [PR](https://github.com/vivo-project/Vitro/pull/352)
# What does this pull request do?
Fixes check for redundant object properties

# How should this be tested?
A description of what steps someone could take to:
* Log in as admin
* Populate object property
* Verify that populated object property is not listed twice

# Interested parties
@brianjlowe @chenejac @bkampe @VIVO-project/vivo-committers
