### PR TITLE
fixed faux property display order

### DIFF
--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/web/templatemodels/individual/FauxDataPropertyWrapper.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/web/templatemodels/individual/FauxDataPropertyWrapper.java
@@ -162,7 +162,10 @@ public class FauxDataPropertyWrapper extends DataProperty implements FauxPropert
 		innerDP.setExample(example);
 	}
 
-	
+	@Override
+	public int getDisplayTier() {
+		return faux.getDisplayTier();
+	}
 
 	@Override
 	public boolean getFunctional() {

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/web/templatemodels/individual/FauxObjectPropertyWrapper.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/web/templatemodels/individual/FauxObjectPropertyWrapper.java
@@ -372,7 +372,7 @@ public class FauxObjectPropertyWrapper extends ObjectProperty implements FauxPro
 
 	@Override
 	public int getDomainDisplayTier() {
-		return innerOP.getDomainDisplayTier();
+		return faux.getDisplayTier();
 	}
 
 	@Override


### PR DESCRIPTION
Fix for recent [PR](https://github.com/vivo-project/Vitro/pull/352)
# What does this pull request do?
Fixes faux property display rank

# How should this be tested?
A description of what steps someone could take to:
* Set faux object property and faux data property ranks
* Verify that ranks are visible in verbose edit mode, verify that ranks are applied on property sorting

# Interested parties
@brianjlowe @chenejac @bkampe @VIVO-project/vivo-committers
