### PR TITLE
Regression fix for populated email, telehpone and website faux properties

### DIFF
--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/beans/FauxProperty.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/beans/FauxProperty.java
@@ -23,6 +23,8 @@ public class FauxProperty extends BaseResourceBean implements ResourceBean,
 
 	// Must not be null on insert or update. Partial identifier on delete.
 	private String rangeURI = "";
+	
+	private String rootRangeURI;
 	// May be null. Partial identifier on delete.
 	private String domainURI;
 
@@ -259,5 +261,13 @@ public class FauxProperty extends BaseResourceBean implements ResourceBean,
 	@Override
 	public String getRangeVClassURI() {
 		return getRangeURI();
+	}
+
+	public void setRootRangeUri(String rootRangeUri) {
+		this.rootRangeURI = rootRangeUri;
+	}
+	
+	public String getRootRangeUri() {
+		return rootRangeURI;
 	}
 }

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/dao/jena/FauxPropertyDaoJena.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/dao/jena/FauxPropertyDaoJena.java
@@ -163,7 +163,12 @@ public class FauxPropertyDaoJena extends JenaBaseDao implements FauxPropertyDao 
 			String domainUri = domainUris.isEmpty() ? null : domainUris
 					.iterator().next();
 
+			Collection<String> rootRangeUris = getPropertyResourceURIValues(context, QUALIFIED_BY_ROOT);
+			
 			FauxProperty fp = new FauxProperty(domainUri, baseUri, rangeUri);
+			if (!rootRangeUris.isEmpty()) {
+				fp.setRootRangeUri(rootRangeUris.iterator().next());
+			}
 			fp.setContextUri(contextUri);
 			populateInstance(fp);
 			log.debug("Loaded FauxProperty: " + fp);

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/web/templatemodels/individual/FauxObjectPropertyWrapper.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/web/templatemodels/individual/FauxObjectPropertyWrapper.java
@@ -226,6 +226,10 @@ public class FauxObjectPropertyWrapper extends ObjectProperty implements FauxPro
 
 	@Override
 	public String getRangeEntityURI() {
+		String uri = faux.getRootRangeUri();
+		if (uri != null) {
+			return uri;
+		}
 		return innerOP.getRangeEntityURI();
 	}
 

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/web/templatemodels/individual/GroupedPropertyList.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/web/templatemodels/individual/GroupedPropertyList.java
@@ -176,9 +176,15 @@ public class GroupedPropertyList extends BaseTemplateModel {
         List<FauxObjectPropertyWrapper> filteredAdditions = new ArrayList<FauxObjectPropertyWrapper>();
         for (FauxObjectPropertyWrapper prop : populatedFauxOPs) {
             List<String> allowedTypes = populatedObjTypes.get(prop.getURI());
-            if(allowedTypes != null && (allowedTypes.contains(prop.getRangeVClassURI())
-                    || allowedTypes.contains(prop.getRangeEntityURI()) ) ) {
+            if (allowedTypes == null) {
+            	continue;
+            }
+            String rangeVClassURI = prop.getRangeVClassURI();
+            String rangeEntityURI = prop.getRangeEntityURI();
+            if(allowedTypes.contains(rangeVClassURI) ) {
                 filteredAdditions.add(prop);
+            } else if (allowedTypes.contains(rangeEntityURI)) {
+            	filteredAdditions.add(prop);
             }
         }
         return filteredAdditions;


### PR DESCRIPTION
# What does this pull request do?
Restores hidden populated email, telephone, fax, website properties in individual profiles

# What's new?
Provided qualified by root faux property in FauxProperty class and FauxPropertyObjectWrapper to avoid filtering populated properties in GroupedPropertyList

# How should this be tested?
* Populate email, fax, telephone, website properties
* Open individual profile
* Verify that properties are present in profile

# Interested parties
@brianjlowe @chenejac 
