### PR TITLE
raised password length limit to 64 characters

### DIFF
--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/beans/UserAccount.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/beans/UserAccount.java
@@ -15,7 +15,7 @@ import org.apache.commons.lang3.RandomStringUtils;
  */
 public class UserAccount {
 	public static final int MIN_PASSWORD_LENGTH = 6;
-	public static final int MAX_PASSWORD_LENGTH = 12;
+	public static final int MAX_PASSWORD_LENGTH = 64;
 
 	public enum Status {
 		ACTIVE, INACTIVE;

--- a/api/src/test/java/edu/cornell/mannlib/vitro/webapp/controller/authenticate/ProgramLoginTest.java
+++ b/api/src/test/java/edu/cornell/mannlib/vitro/webapp/controller/authenticate/ProgramLoginTest.java
@@ -14,6 +14,7 @@ import java.util.Collections;
 
 import javax.servlet.ServletException;
 
+import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.junit.After;
@@ -156,7 +157,7 @@ public class ProgramLoginTest extends AbstractTestClass {
 
 	@Test
 	public void newPasswordTooLong() {
-		executeRequest(NEW_USER_NAME, NEW_USER_PASSWORD, "reallyLongPassword");
+		executeRequest(NEW_USER_NAME, NEW_USER_PASSWORD, RandomStringUtils.randomAlphanumeric(UserAccount.MAX_PASSWORD_LENGTH + 1));
 		assert403();
 	}
 


### PR DESCRIPTION
**[VIVO GitHub issue](https://github.com/vivo-project/VIVO/issues/3830)**
# What does this pull request do?
Increases password limit to 64 characters

# How should this be tested?
* Create a user
* Follow link to set password
* Set password
* Log in
* Go to My account page and try to set new password

# Interested parties
@chenejac 
