### PR TITLE
VIVO-3751: Remove ICU4J dependency.

### DIFF
--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/config/RevisionInfoBean.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/config/RevisionInfoBean.java
@@ -2,6 +2,7 @@
 
 package edu.cornell.mannlib.vitro.webapp.config;
 
+import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -13,8 +14,6 @@ import javax.servlet.http.HttpSession;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-
-import com.ibm.icu.text.SimpleDateFormat;
 
 /**
  * Information about the provenance of this application: release, revision

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/admin/ShowBackgroundThreadsController.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/admin/ShowBackgroundThreadsController.java
@@ -2,14 +2,13 @@
 
 package edu.cornell.mannlib.vitro.webapp.controller.admin;
 
+import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.SortedMap;
 import java.util.TreeMap;
-
-import com.ibm.icu.text.SimpleDateFormat;
 
 import edu.cornell.mannlib.vitro.webapp.controller.VitroRequest;
 import edu.cornell.mannlib.vitro.webapp.controller.freemarker.FreemarkerHttpServlet;

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/dao/jena/RDFServiceModelMaker.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/dao/jena/RDFServiceModelMaker.java
@@ -2,6 +2,7 @@
 
 package edu.cornell.mannlib.vitro.webapp.dao.jena;
 
+import java.text.Collator;
 import java.util.Set;
 import java.util.TreeSet;
 
@@ -17,7 +18,6 @@ import org.apache.jena.shared.CannotCreateException;
 import org.apache.jena.shared.DoesNotExistException;
 import org.apache.jena.util.iterator.ExtendedIterator;
 import org.apache.jena.util.iterator.WrappedIterator;
-import com.ibm.icu.text.Collator;
 
 import edu.cornell.mannlib.vitro.webapp.rdfservice.RDFService;
 import edu.cornell.mannlib.vitro.webapp.rdfservice.RDFServiceException;

--- a/api/src/test/java/edu/cornell/mannlib/vitro/webapp/config/RevisionInfoSetupTest.java
+++ b/api/src/test/java/edu/cornell/mannlib/vitro/webapp/config/RevisionInfoSetupTest.java
@@ -7,6 +7,7 @@ import static edu.cornell.mannlib.vitro.webapp.config.RevisionInfoSetup.DATE_FOR
 import static org.junit.Assert.assertEquals;
 
 import java.text.ParseException;
+import java.text.SimpleDateFormat;
 import java.util.Arrays;
 import java.util.Date;
 
@@ -19,8 +20,6 @@ import org.junit.Test;
 
 import stubs.javax.servlet.ServletContextStub;
 import stubs.javax.servlet.http.HttpSessionStub;
-
-import com.ibm.icu.text.SimpleDateFormat;
 
 import edu.cornell.mannlib.vitro.testing.AbstractTestClass;
 import edu.cornell.mannlib.vitro.webapp.config.RevisionInfoBean.LevelRevisionInfo;

--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -66,11 +66,6 @@
 
 
         <dependency>
-            <groupId>com.ibm.icu</groupId>
-            <artifactId>icu4j</artifactId>
-            <version>59.1</version>
-        </dependency>
-        <dependency>
             <groupId>com.twelvemonkeys.imageio</groupId>
             <artifactId>imageio-jpeg</artifactId>
             <version>3.3.2</version>


### PR DESCRIPTION
**[VIVO GitHub issue](https://github.com/vivo-project/VIVO/issues)**: https://github.com/vivo-project/VIVO/issues/3751

# What does this pull request do?
This ICU dependency is only used in a handful of places.
The core java libraries provide the same functionality but with a less exchaustive locale database.

The IBM ICU is more up to date than the Java version but is otherwise identical.

# What's new?
* Replaces
  * `com.ibm.icu.text.SimpleDateFormat` with `java.text.SimpleDateFormat`
  * `com.ibm.icu.text.Collator` with `java.text.Collator`

# How should this be tested?
A description of what steps someone could take to:
* Check maven dependencies to confirm/deny that `icu4j` no longer appears.
* Try different locale-specific settings and check dates.
* Try different locale-specific settings and check sorting (collation).

# Additional Notes:
Any additional information that you think would be helpful when reviewing this PR.

IBM's ICU4J reference material:
- https://unicode-org.github.io/icu/userguide/icu4j/#introduction-to-icu4j

# Interested parties
- @VIVO-project/vivo-committers
