### PR TITLE
Remove old hack that leads to 500 error

### DIFF
--- a/webapp/src/main/webapp/js/menupage/browseByVClass.js
+++ b/webapp/src/main/webapp/js/menupage/browseByVClass.js
@@ -53,8 +53,7 @@ var browseByVClass = {
         // if the user navigates with the back button
         this.browseVClasses.children('li').each( function() {
            $(this).find('a').click(function () {
-                // the extra space is needed to prevent odd scrolling behavior
-                location.hash = $(this).attr('data-uri') + ' ';
+                location.hash = $(this).attr('data-uri');
            });
         });
 


### PR DESCRIPTION
# What does this pull request do?
Removes space from page urls that lead to error server responses while browsing 
Url example that returns error
https://vivo.tib.eu/vivorc/dataservice?getRenderedSearchIndividualsByVClass=1&vclassId=http%3A%2F%2Fpurl.org%2Fontology%2Fbibo%2FBook%2520&page=1

# What's new?
Just a fix

# How should this be tested?
* Go to class group page https://vivo.tib.eu/vivorc/research
* Click on Book. Verify that there is no %20 at the end of current url
* Open web developer tools
* Reload page
* Verify that there is no 500 error in server responses (or check tomcat logs )

# Interested parties
@chenejac 
