### PR TITLE
VIVO 3821: Add configuration to disable or enable Map of Science visualization.

### DIFF
--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/individual/IndividualResponseBuilder.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/individual/IndividualResponseBuilder.java
@@ -94,6 +94,7 @@ class IndividualResponseBuilder {
 		body.put("relatedSubject", getRelatedSubject());
 		body.put("namespaces", namespaces);
 		body.put("temporalVisualizationEnabled", getTemporalVisualizationFlag());
+        body.put("mapOfScienceVisualizationEnabled", getMapOfScienceVisualizationFlag());
 		body.put("profilePageTypesEnabled", getprofilePageTypesFlag());
 		body.put("verbosePropertySwitch", getVerbosePropertyValues());
 
@@ -194,6 +195,12 @@ class IndividualResponseBuilder {
 				"visualization.temporal");
 		return "enabled".equals(property);
 	}
+
+    private boolean getMapOfScienceVisualizationFlag() {
+        String property = ConfigurationProperties.getBean(vreq).getProperty(
+                "visualization.mapOfScience");
+        return "enabled".equals(property);
+    }
 
 	private boolean getprofilePageTypesFlag() {
 		String property = ConfigurationProperties.getBean(vreq).getProperty(

--- a/home/src/main/resources/config/example.runtime.properties
+++ b/home/src/main/resources/config/example.runtime.properties
@@ -93,14 +93,6 @@ email.replyTo =
 # listview.usePreciseSubquery = true
 
 #
-# The Map of Science visualization is limited in the number of supported journals.
-# This will generally only be useful for institutions that specifically want this.
-# This is enabled by default.
-# Set this to either "disabled" to not utilize or "enabled" to utilize.
-#
-visualization.mapOfScience = enabled
-
-#
 # The email address of the root user for the VIVO application. The password
 # for this user is initially set to "rootPassword", but you will be asked to
 # change the password the first time you log in.

--- a/home/src/main/resources/config/example.runtime.properties
+++ b/home/src/main/resources/config/example.runtime.properties
@@ -95,10 +95,10 @@ email.replyTo =
 #
 # The Map of Science visualization is limited in the number of supported journals.
 # This will generally only be useful for institutions that specifically want this.
-# This is disabled by default.
+# This is enabled by default.
 # Set this to either "disabled" to not utilize or "enabled" to utilize.
 #
-visualization.mapOfScience = disabled
+visualization.mapOfScience = enabled
 
 #
 # The email address of the root user for the VIVO application. The password

--- a/home/src/main/resources/config/example.runtime.properties
+++ b/home/src/main/resources/config/example.runtime.properties
@@ -93,6 +93,14 @@ email.replyTo =
 # listview.usePreciseSubquery = true
 
 #
+# The Map of Science visualization is limited in the number of supported journals.
+# This will generally only be useful for institutions that specifically want this.
+# This is disabled by default.
+# Set this to either "disabled" to not utilize or "enabled" to utilize.
+#
+visualization.mapOfScience = disabled
+
+#
 # The email address of the root user for the VIVO application. The password
 # for this user is initially set to "rootPassword", but you will be asked to
 # change the password the first time you log in.


### PR DESCRIPTION
**[VIVO GitHub issue](https://github.com/vivo-project/VIVO/issues)**: [3821](https://github.com/vivo-project/VIVO/issues/3821)

Other Relevant Links (Mailing list discussion, related pull requests, etc.)
- For [Vivo PR 3841](https://github.com/vivo-project/VIVO/pull/3841)

# What does this pull request do?
Add an option to not show (disable) Map of Science Visualization link in the same manner as done with the Temporal Visualization link.

This is the Vitro part that adds the required variable to the theme builder code.

# What's new?
A new runtime property `visualization.mapOfScience` is added with the default set to `disabled`.

# How should this be tested?
Change the setting to enabled and disabled and check each theme to confirm behavior is consistent.

# Additional Notes:
I noticed that the Temporal Visualization setting is not applied in Vitro as it is done in Vivo. I added the Map of Science Visualization in the Vitro runtime configuration just like I did for the Vivo runtime configuration. This request is not about applying Temporal Visualization changes and so I left alone the (lack thereof) Temporal Visualization runtime configuration.

# Interested parties
@VIVO-project/vivo-committers
