### PR TITLE
Check if provided path is directory in translation converter

### DIFF
--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/i18n/TranslationConverter.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/i18n/TranslationConverter.java
@@ -152,9 +152,11 @@ public class TranslationConverter {
 		log.debug("prefixesRegex " + prefixesRegex);
 		for (String dir : i18nDirs) {
 			File realDir = new File(ctx.getRealPath(dir));
-			Collection<File> files = FileUtils.listFiles(realDir, new RegexFileFilter(prefixesRegex + ".*\\.properties"), DirectoryFileFilter.DIRECTORY);
-			for (File file : files) {
-				convert(file);
+			if (realDir.isDirectory()) {
+				Collection<File> files = FileUtils.listFiles(realDir, new RegexFileFilter(prefixesRegex + ".*\\.properties"), DirectoryFileFilter.DIRECTORY);
+				for (File file : files) {
+					convert(file);
+				}	
 			}
 		}
 	}


### PR DESCRIPTION
# What does this pull request do?
Check if provided path is directory in translation converter to prevent java.lang.IllegalArgumentException if there is no directory on the path.

# How should this be tested?
* Build vivo without /local/i18n directory
* Verify that exception happend and Vitro|VIVO has started.


# Interested parties
@chenejac 
