### PR TITLE
Avoid writing the whole model into debug log

### DIFF
--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/modelaccess/impl/ContextModelAccessImpl.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/modelaccess/impl/ContextModelAccessImpl.java
@@ -188,7 +188,7 @@ public class ContextModelAccessImpl implements ContextModelAccess {
 	@Override
 	public OntModel getOntModel(String name) {
 		OntModel ontModel = ontModelCache.getOntModel(name);
-		log.debug("getOntModel: " + ontModel);
+		log.debug("getOntModel: " + name);	
 		return ontModel;
 	}
 

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/modelaccess/impl/ContextModelAccessImpl.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/modelaccess/impl/ContextModelAccessImpl.java
@@ -188,7 +188,7 @@ public class ContextModelAccessImpl implements ContextModelAccess {
 	@Override
 	public OntModel getOntModel(String name) {
 		OntModel ontModel = ontModelCache.getOntModel(name);
-		log.debug("getOntModel: " + name);	
+		log.debug("getOntModel: " + name);
 		return ontModel;
 	}
 


### PR DESCRIPTION
# What does this pull request do?
Fixed log.debug to avoid writing models into log.
Even if log level set to info can significantly delay page response.

# How should this be tested?
A description of what steps someone could take to:
* Increase log level to debug
* Open My account page or /accounts/myAccount or /accountsAdmin page
* Nothing should be in log files

# Interested parties
@chenejac 
