### PR TITLE
Added initial version of dump-restore script.

### DIFF
--- a/home/src/main/resources/scripts/dumpRestore.sh
+++ b/home/src/main/resources/scripts/dumpRestore.sh
@@ -15,8 +15,8 @@ session=$(mktemp -d)
 
 url="$host/$app_name/authenticate"
 
-loginName="email@email.com"
-loginPassword="password"
+loginName="$email"
+loginPassword="$password"
 loginForm="Log in"
 
 # Log in and get session cookies

--- a/home/src/main/resources/scripts/dumpRestore.sh
+++ b/home/src/main/resources/scripts/dumpRestore.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+action="$1"
+models="$2"
+email="$3"
+password="$4"
+
+host="http://localhost:8080" # URL where the VIVO instance is hosted
+purge="true"                 # Will the restoration process purge the models before restoring
+restoration_files="."        # Directory containing the files used for restoration
+dumped_files="."             # Directory containing the backed-up files
+app_name="vivo"              # app-name parameter
+
+session=$(mktemp -d)
+
+url="$host/$app_name/authenticate"
+
+loginName="email@email.com"
+loginPassword="password"
+loginForm="Log in"
+
+# Log in and get session cookies
+curl --cookie-jar "$session/cookies.txt" -d "loginName=$loginName" -d "loginPassword=$loginPassword" -d "loginForm=$loginForm" $url
+
+if [[ "$action" == "dump" ]]; then
+    echo "Starting dump..."
+    curl --cookie "$session/cookies.txt" "$host/$app_name/dumpRestore/dump/$models.nq?which=$models" -o "$dumped_files/$models.nq"
+    echo "Completed successfully."
+elif [[ "$action" == "restore" ]]; then
+    echo "Starting restoration process..."
+
+    url="$host/$app_name/dumpRestore/restore"
+    files=$(echo -n "$restoration_files/$models.nq")
+    params=$(echo -n "which=$models&purge=$purge")
+
+    curl --cookie "$session/cookies.txt" -X POST -F "sourceFile=@$files" "$url?$params" > /dev/null
+
+    if [[ $? -eq 0 ]]; then
+        echo "Restored successfully."
+    else
+        echo "Something went wrong."
+    fi
+fi
+
+rm -rf "$session"


### PR DESCRIPTION
# What's new?
This functionality was only available through UI in admin panel, now, it is available through bash script so that it can be setup as cron job with minimal configuration.

# How should this be tested?
If you are willing to use the script the server has to be running. The CLI arguments are as follows:
```bash dumpRestore.sh <action> <model> <email> <password>```

Action can be: ```dump``` or ```restore```

Model can be: ```CONFIGURATION```, ```CONTENT``` or any other models that you have configured

Email and Password are your admin account email and password

In addition, you must configure some setup parameters. Because these parameters rarely change I figured that someone can just edit the first lines of the script so that the command doesn't get cluttered with a lot of arguments:

```
host="http://example.com/" # URL where the VIVO instance is hosted
purge="true"                 # Will the restoration process purge the models before restoring
restoration_files="."        # Directory containing the files used for restoration
dumped_files="."             # Directory containing the backed-up files
app_name="vitro_or_whatever"              # app-name parameter
```
# Interested parties
@chenejac @milospp 
