### PR TITLE
Handle preferred language when creating new class and property groups

### DIFF
--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/dao/jena/PropertyGroupDaoJena.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/dao/jena/PropertyGroupDaoJena.java
@@ -188,9 +188,9 @@ public class PropertyGroupDaoJena extends JenaBaseDao implements PropertyGroupDa
 	            if (group.getPublicDescription() != null
 	                    && group.getPublicDescription().length()>0) {
 		            try {
-		                updatePlainLiteralValue(groupJenaInd, PUBLIC_DESCRIPTION_ANNOT,
-		                        group.getPublicDescription(), getDefaultLanguage());
-		            } catch (Exception ex) {
+                        updatePlainLiteralValue(groupJenaInd, PUBLIC_DESCRIPTION_ANNOT,
+                                group.getPublicDescription(), getDefaultLanguage());
+                    } catch (Exception ex) {
 		                log.error(
 		                        "error setting public description for "
 		                                + groupInd.getURI());
@@ -228,12 +228,12 @@ public class PropertyGroupDaoJena extends JenaBaseDao implements PropertyGroupDa
 	    try {
 	        Individual groupInd = ontModel.getIndividual(group.getURI());
 	        try {
-	            updateRDFSLabel(groupInd, group.getName(), getDefaultLanguage());
+                updateRDFSLabel(groupInd, group.getName(), getDefaultLanguage());
 	        } catch (Exception e) {
 	            log.error("error updating name for "+groupInd.getURI());
 	        }
 	        try {
-	            updatePlainLiteralValue(groupInd, PUBLIC_DESCRIPTION_ANNOT,
+                updatePlainLiteralValue(groupInd, PUBLIC_DESCRIPTION_ANNOT,
 	                    group.getPublicDescription(), getDefaultLanguage());	            
 	        } catch (Exception e) {
 	            log.error("Error updating public description for "+groupInd.getURI());

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/dao/jena/PropertyGroupDaoJena.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/dao/jena/PropertyGroupDaoJena.java
@@ -31,6 +31,7 @@ import edu.cornell.mannlib.vitro.webapp.dao.InsertException;
 import edu.cornell.mannlib.vitro.webapp.dao.ObjectPropertyDao;
 import edu.cornell.mannlib.vitro.webapp.dao.PropertyGroupDao;
 import edu.cornell.mannlib.vitro.webapp.dao.WebappDaoFactory;
+import edu.cornell.mannlib.vitro.webapp.dao.WebappDaoFactoryConfig;
 
 public class PropertyGroupDaoJena extends JenaBaseDao implements PropertyGroupDao {
 
@@ -142,7 +143,7 @@ public class PropertyGroupDaoJena extends JenaBaseDao implements PropertyGroupDa
 
     	edu.cornell.mannlib.vitro.webapp.beans.Individual groupInd =
     		new IndividualImpl(); // We should make a factory for these
-    	groupInd.setNamespace(DEFAULT_NAMESPACE+"vitroPropertyGroup");
+    	groupInd.setNamespace(DEFAULT_NAMESPACE + "vitroPropertyGroup");
     	groupInd.setName(group.getName());
     	groupInd.setVClassURI(PROPERTYGROUP.getURI());
     	groupInd.setURI(group.getURI());
@@ -156,8 +157,12 @@ public class PropertyGroupDaoJena extends JenaBaseDao implements PropertyGroupDa
 
         WebappDaoFactory wadfForURIGeneration = null;
         try {
-            wadfForURIGeneration = new WebappDaoFactoryJena(
-                    unionForURIGeneration);
+            // Ensure that the temporary WebappDaoFactory has the same
+            // preferred languages as the main one for this DAO.
+            WebappDaoFactoryConfig wadfConfig = new WebappDaoFactoryConfig();
+            wadfConfig.setPreferredLanguages(getWebappDaoFactory().getPreferredLanguages());
+            wadfForURIGeneration = new WebappDaoFactoryJena(new SimpleOntModelSelector(
+                    unionForURIGeneration), wadfConfig, null);
             groupURI = wadfForURIGeneration
                     .getIndividualDao().insertNewIndividual(groupInd);
     	} catch (InsertException ie) {
@@ -183,10 +188,8 @@ public class PropertyGroupDaoJena extends JenaBaseDao implements PropertyGroupDa
 	            if (group.getPublicDescription() != null
 	                    && group.getPublicDescription().length()>0) {
 		            try {
-		                groupJenaInd.addProperty(
-		                        PUBLIC_DESCRIPTION_ANNOT,
-		                        group.getPublicDescription(),
-		                        XSDDatatype.XSDstring);
+		                updatePlainLiteralValue(groupJenaInd, PUBLIC_DESCRIPTION_ANNOT,
+		                        group.getPublicDescription(), getDefaultLanguage());
 		            } catch (Exception ex) {
 		                log.error(
 		                        "error setting public description for "
@@ -225,15 +228,13 @@ public class PropertyGroupDaoJena extends JenaBaseDao implements PropertyGroupDa
 	    try {
 	        Individual groupInd = ontModel.getIndividual(group.getURI());
 	        try {
-	            groupInd.setLabel(group.getName(), getDefaultLanguage());
+	            updateRDFSLabel(groupInd, group.getName(), getDefaultLanguage());
 	        } catch (Exception e) {
 	            log.error("error updating name for "+groupInd.getURI());
 	        }
 	        try {
-	            groupInd.removeAll(PUBLIC_DESCRIPTION_ANNOT);
-	            if (group.getPublicDescription()!=null && group.getPublicDescription().length()>0) {
-	                groupInd.addProperty(PUBLIC_DESCRIPTION_ANNOT, group.getPublicDescription(), XSDDatatype.XSDstring);
-	            }
+	            updatePlainLiteralValue(groupInd, PUBLIC_DESCRIPTION_ANNOT,
+	                    group.getPublicDescription(), getDefaultLanguage());	            
 	        } catch (Exception e) {
 	            log.error("Error updating public description for "+groupInd.getURI());
 	        }

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/dao/jena/VClassGroupDaoJena.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/dao/jena/VClassGroupDaoJena.java
@@ -5,14 +5,12 @@ package edu.cornell.mannlib.vitro.webapp.dao.jena;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
-import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.ListIterator;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-
 import org.apache.jena.datatypes.xsd.XSDDatatype;
 import org.apache.jena.ontology.Individual;
 import org.apache.jena.ontology.OntModel;
@@ -30,6 +28,7 @@ import edu.cornell.mannlib.vitro.webapp.dao.InsertException;
 import edu.cornell.mannlib.vitro.webapp.dao.VClassDao;
 import edu.cornell.mannlib.vitro.webapp.dao.VClassGroupDao;
 import edu.cornell.mannlib.vitro.webapp.dao.WebappDaoFactory;
+import edu.cornell.mannlib.vitro.webapp.dao.WebappDaoFactoryConfig;
 
 public class VClassGroupDaoJena extends JenaBaseDao implements VClassGroupDao {
 
@@ -191,9 +190,9 @@ public class VClassGroupDaoJena extends JenaBaseDao implements VClassGroupDao {
     	edu.cornell.mannlib.vitro.webapp.beans.Individual groupInd =
     		new IndividualImpl(); // We should make a factory for these
     	groupInd.setURI(vcg.getURI());
-    	groupInd.setNamespace(DEFAULT_NAMESPACE+"vitroClassGroup");
-    	groupInd.setName(vcg.getPublicName());
+    	groupInd.setNamespace(DEFAULT_NAMESPACE + "vitroClassGroup");
     	groupInd.setVClassURI(CLASSGROUP.getURI());
+    	groupInd.setName(vcg.getPublicName());
 
     	String groupURI = null;
 
@@ -204,8 +203,12 @@ public class VClassGroupDaoJena extends JenaBaseDao implements VClassGroupDao {
 
     	WebappDaoFactory wadfForURIGeneration = null;
     	try {
-    	    wadfForURIGeneration = new WebappDaoFactoryJena(
-    	            unionForURIGeneration);
+    	    // Ensure that the temporary WebappDaoFactory has the same
+    	    // preferred languages as the main one for this DAO.
+    	    WebappDaoFactoryConfig wadfConfig = new WebappDaoFactoryConfig();
+    	    wadfConfig.setPreferredLanguages(getWebappDaoFactory().getPreferredLanguages());
+    	    wadfForURIGeneration = new WebappDaoFactoryJena(new SimpleOntModelSelector(
+                    unionForURIGeneration), wadfConfig, null);
     		groupURI = wadfForURIGeneration
                     .getIndividualDao().insertNewIndividual(groupInd);
     	} catch (InsertException ie) {

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/dao/jena/VClassGroupDaoJena.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/dao/jena/VClassGroupDaoJena.java
@@ -203,10 +203,10 @@ public class VClassGroupDaoJena extends JenaBaseDao implements VClassGroupDao {
 
     	WebappDaoFactory wadfForURIGeneration = null;
     	try {
-    	    // Ensure that the temporary WebappDaoFactory has the same
-    	    // preferred languages as the main one for this DAO.
-    	    WebappDaoFactoryConfig wadfConfig = new WebappDaoFactoryConfig();
-    	    wadfConfig.setPreferredLanguages(getWebappDaoFactory().getPreferredLanguages());
+            // Ensure that the temporary WebappDaoFactory has the same
+            // preferred languages as the main one for this DAO.
+            WebappDaoFactoryConfig wadfConfig = new WebappDaoFactoryConfig();
+            wadfConfig.setPreferredLanguages(getWebappDaoFactory().getPreferredLanguages());
     	    wadfForURIGeneration = new WebappDaoFactoryJena(new SimpleOntModelSelector(
                     unionForURIGeneration), wadfConfig, null);
     		groupURI = wadfForURIGeneration


### PR DESCRIPTION
**[VIVO GitHub issue 3847](https://github.com/vivo-project/VIVO/issues/3847)**: 

# What does this pull request do?
When creating a new class or property group via the UI, uses current locale for label and public description instead of defaulting to en-US.

# What's new?
Propagates preferred languages list to temporary WebappDaoFactory with union models used to insert new groups.  Uses language-aware method for setting property group label and public description.

# How should this be tested?
Log in as admin.
Set locale to something other than en-US.
Create a new class group and property group.
Click through to groups you created.
Copy the value of the uri= parameter in the address bar.
Visit /entityEdit?uri= , pasting in the URI of the group.
View "Raw Statements with This Resource as Subject".
Confirm that label and public description (in case of property group) bear the appropriate language tag.
Switch do a different locale and edit groups.  Inspect triples again to confirm that values in the second language were added without affecting the first.

# Interested parties
@VIVO-project/vivo-committers
