### PR TITLE
Propagate selectFromExisting and offerCreateNew settings from base ob…

### DIFF
--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/edit/FauxPropertyRetryController.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/edit/FauxPropertyRetryController.java
@@ -183,8 +183,13 @@ public class FauxPropertyRetryController extends BaseEditController {
 			FauxProperty fp = new FauxProperty(null, baseUri, null);
 			ObjectPropertyDao opDao = wadf.getObjectPropertyDao();
 			DataPropertyDao dpDao = wadf.getDataPropertyDao();
-			Property base = opDao.getObjectPropertyByURI(baseUri);
-			if (base == null) {
+			ObjectProperty objBase = opDao.getObjectPropertyByURI(baseUri);
+			Property base;
+			if (objBase != null) {
+				fp.setSelectFromExisting(objBase.getSelectFromExisting());
+			    fp.setOfferCreateNewOption(objBase.getOfferCreateNewOption());
+			    base = objBase;
+			} else {
 				base = dpDao.getDataPropertyByURI(baseUri);
 			}
 			fp.setGroupURI(base.getGroupURI());

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/edit/FauxPropertyRetryController.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/edit/FauxPropertyRetryController.java
@@ -187,8 +187,8 @@ public class FauxPropertyRetryController extends BaseEditController {
 			Property base;
 			if (objBase != null) {
 				fp.setSelectFromExisting(objBase.getSelectFromExisting());
-			    fp.setOfferCreateNewOption(objBase.getOfferCreateNewOption());
-			    base = objBase;
+				fp.setOfferCreateNewOption(objBase.getOfferCreateNewOption());
+				base = objBase;
 			} else {
 				base = dpDao.getDataPropertyByURI(baseUri);
 			}


### PR DESCRIPTION
…ject property to new faux property.

**[VIVO GitHub issue 3859](https://github.com/vivo-project/VIVO/issues/3859)**:

# What does this pull request do?
Propagates "provide selection" and "offer create option" settings from a base object property to a new faux property that is created from it. 

# How should this be tested?
Log in as admin.
Create a new object property.
Note that "provide selection" is checked near the bottom of the form.  You may also check "offer create option" if you desire.
Press button "Create New Faux Property".
Verify that the "provide selection" and "offer create option" checkboxes match the checked/unchecked state of the base property you created previously.
Create the faux property with at least one checkbox checked and confirm that the property is editable on a profile page.

# Interested parties
@VIVO-project/vivo-committers
