### PR TITLE
don't create add url if neither of 'select from existing' nor 'provid…

### DIFF
--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/web/templatemodels/individual/ObjectPropertyTemplateModel.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/web/templatemodels/individual/ObjectPropertyTemplateModel.java
@@ -113,7 +113,7 @@ public abstract class ObjectPropertyTemplateModel extends PropertyTemplateModel 
         }
     }
 
-    protected void setAddUrl(Property property) {
+    protected void setAddUrl(ObjectProperty property) {
     	// Is the add link suppressed for this property?
     	if (property.isAddLinkSuppressed()) {
     		return;
@@ -123,6 +123,10 @@ public abstract class ObjectPropertyTemplateModel extends PropertyTemplateModel 
 		RequestedAction action = new AddObjectPropertyStatement(
 				vreq.getJenaOntModel(), subjectUri, property, SOME_URI);
         if ( ! PolicyHelper.isAuthorizedForActions(vreq, action) ) {
+            return;
+        }
+        
+        if (isNotAllowedToCreateOrSelect(property)) {
             return;
         }
 
@@ -150,6 +154,10 @@ public abstract class ObjectPropertyTemplateModel extends PropertyTemplateModel 
 
             addUrl = UrlBuilder.getUrl(EDIT_PATH, params);
         }
+    }
+
+    private boolean isNotAllowedToCreateOrSelect(ObjectProperty property) {
+        return !property.getSelectFromExisting() && !property.getOfferCreateNewOption();
     }
 
 		/**


### PR DESCRIPTION
**[VIVO GitHub issue](https://github.com/vivo-project/VIVO/issues/3858)**

# What does this pull request do?
Prevents creation of button to add new object property if neither of 'select from existing' nor 'provide selection' options are set in  object property configuration

# How should this be tested?
* Remove options to select from existing and provide selection from object property
* Verify that add new object property button is not shown 
* Try the same for faux object property

# Interested parties
@chenejac 
