### PR TITLE
Change PropertyKey class name and namespace

### DIFF
--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/i18n/TranslationConverter.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/i18n/TranslationConverter.java
@@ -68,13 +68,13 @@ public class TranslationConverter {
 	protected static final String THEMES_PATH = "/themes/";
 	private static final String TEMPLATE_BODY = ""
 			+ "?uri <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#NamedIndividual> .\n"
-			+ "?uri <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://vivoweb.org/ontology/core/properties/vocabulary#PropertyKey> .\n"
-			+ "?uri <http://vivoweb.org/ontology/core/properties/vocabulary#hasApp> ?application .\n"
-			+ "?uri <http://vivoweb.org/ontology/core/properties/vocabulary#hasKey> ?key .\n";
+			+ "?uri <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://vivoweb.org/ontology/vitro/ui-label/vocabulary#UILabel> .\n"
+			+ "?uri <http://vivoweb.org/ontology/vitro/ui-label/vocabulary#hasApp> ?application .\n"
+			+ "?uri <http://vivoweb.org/ontology/vitro/ui-label/vocabulary#hasKey> ?key .\n";
 	private static final String TEMPLATE_LABEL = ""
 			+ "?uri <http://www.w3.org/2000/01/rdf-schema#label> ?label .\n";
 	private static final String TEMPLATE_THEME = ""
-			+ "?uri <http://vivoweb.org/ontology/core/properties/vocabulary#hasTheme> ?theme .\n";
+			+ "?uri <http://vivoweb.org/ontology/vitro/ui-label/vocabulary#hasTheme> ?theme .\n";
 	
 	private static final String queryWithTheme(String langTag) { 
 		return

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/i18n/TranslationProvider.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/i18n/TranslationProvider.java
@@ -35,7 +35,7 @@ public class TranslationProvider {
 	private static final Log log = LogFactory.getLog(TranslationProvider.class);
 	private static final I18nLogger i18nLogger = new I18nLogger();
 	private static final String QUERY = "" 
-	+ "PREFIX : <http://vivoweb.org/ontology/core/properties/vocabulary#>\n"
+	+ "PREFIX : <http://vivoweb.org/ontology/vitro/ui-label/vocabulary#>\n"
 	+ "PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>\n"
 	+ "PREFIX vitro: <http://vitro.mannlib.cornell.edu/ns/vitro/0.7#> \n"
 	+ "PREFIX xsd: <http://www.w3.org/2001/XMLSchema#> \n" 

--- a/api/src/test/java/edu/cornell/mannlib/vitro/webapp/i18n/TranslationConverterTest.java
+++ b/api/src/test/java/edu/cornell/mannlib/vitro/webapp/i18n/TranslationConverterTest.java
@@ -22,11 +22,11 @@ import stubs.javax.servlet.ServletContextStub;
 public class TranslationConverterTest {
 
 	private static final String WILMA = "wilma";
-	private static final String HAS_THEME = "http://vivoweb.org/ontology/core/properties/vocabulary#hasTheme";
+	private static final String HAS_THEME = "http://vivoweb.org/ontology/vitro/ui-label/vocabulary#hasTheme";
 	private static final String VITRO = "Vitro";
 	private static final String VIVO = "VIVO";
-	private static final String HAS_APP = "http://vivoweb.org/ontology/core/properties/vocabulary#hasApp";
-	private static final String HAS_KEY = "http://vivoweb.org/ontology/core/properties/vocabulary#hasKey";
+	private static final String HAS_APP = "http://vivoweb.org/ontology/vitro/ui-label/vocabulary#hasApp";
+	private static final String HAS_KEY = "http://vivoweb.org/ontology/vitro/ui-label/vocabulary#hasKey";
 	private static final String ROOT_PATH = "src/test/resources/edu/cornell/mannlib/vitro/webapp/i18n/TranslationConverterTest/root";
 	private static final String INIT_N3_FILE = "src/test/resources/edu/cornell/mannlib/vitro/webapp/i18n/TranslationConverterTest/modelInitContent.n3";
 	ServletContextStub ctx = new ServletContextStub();

--- a/api/src/test/resources/edu/cornell/mannlib/vitro/webapp/i18n/TranslationConverterTest/modelInitContent.n3
+++ b/api/src/test/resources/edu/cornell/mannlib/vitro/webapp/i18n/TranslationConverterTest/modelInitContent.n3
@@ -4,9 +4,9 @@
 @prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> .
 
 <urn:uuid:8c80dbf5-adda-41d5-a6fe-d5efde663600>
-        a           owl:NamedIndividual , <http://vivoweb.org/ontology/core/properties/vocabulary#PropertyKey> ;
+        a           owl:NamedIndividual , <http://vivoweb.org/ontology/vitro/ui-label/vocabulary#UILabel> ;
         rdfs:label  "value from n3 file"@en-US ;
-        <http://vivoweb.org/ontology/core/properties/vocabulary#hasApp>
+        <http://vivoweb.org/ontology/vitro/ui-label/vocabulary#hasApp>
                 "VIVO" ;
-        <http://vivoweb.org/ontology/core/properties/vocabulary#hasKey>
+        <http://vivoweb.org/ontology/vitro/ui-label/vocabulary#hasKey>
                 "property_to_overwrite" .

--- a/api/src/test/resources/edu/cornell/mannlib/vitro/webapp/i18n/TranslationProviderTest/modelInitContent.n3
+++ b/api/src/test/resources/edu/cornell/mannlib/vitro/webapp/i18n/TranslationProviderTest/modelInitContent.n3
@@ -4,74 +4,74 @@
 @prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> .
 
 <urn:uuid:8c80dbf5-adda-41d5-a6fe-d5efde663600>
-        a           owl:NamedIndividual , <http://vivoweb.org/ontology/core/properties/vocabulary#PropertyKey> ;
+        a           owl:NamedIndividual , <http://vivoweb.org/ontology/vitro/ui-label/vocabulary#UILabel> ;
         rdfs:label  "testkey VIVO no theme en-US"@en-US ;
         rdfs:label  "testkey VIVO no theme de-DE"@de-DE ;
-        <http://vivoweb.org/ontology/core/properties/vocabulary#hasApp>
+        <http://vivoweb.org/ontology/vitro/ui-label/vocabulary#hasApp>
                 "VIVO" ;
-        <http://vivoweb.org/ontology/core/properties/vocabulary#hasKey>
+        <http://vivoweb.org/ontology/vitro/ui-label/vocabulary#hasKey>
                 "testkey" .
 
 <urn:uuid:8c80dbf5-adda-41d5-a6fe-d5efde663601>
-        a           owl:NamedIndividual , <http://vivoweb.org/ontology/core/properties/vocabulary#PropertyKey> ;
+        a           owl:NamedIndividual , <http://vivoweb.org/ontology/vitro/ui-label/vocabulary#UILabel> ;
         rdfs:label  "testkey Vitro no theme en-US"@en-US ;
         rdfs:label  "testkey Vitro no theme de-DE"@de-DE ;
-        <http://vivoweb.org/ontology/core/properties/vocabulary#hasApp>
+        <http://vivoweb.org/ontology/vitro/ui-label/vocabulary#hasApp>
                 "Vitro" ;
-        <http://vivoweb.org/ontology/core/properties/vocabulary#hasKey>
+        <http://vivoweb.org/ontology/vitro/ui-label/vocabulary#hasKey>
                 "testkey" .
 
 <urn:uuid:8c80dbf5-adda-41d5-a6fe-d5efde663602>
-        a           owl:NamedIndividual , <http://vivoweb.org/ontology/core/properties/vocabulary#PropertyKey> ;
+        a           owl:NamedIndividual , <http://vivoweb.org/ontology/vitro/ui-label/vocabulary#UILabel> ;
         rdfs:label  "testkey VIVO wilma en-US"@en-US ;
         rdfs:label  "testkey VIVO wilma de-DE"@de-DE ;
-        <http://vivoweb.org/ontology/core/properties/vocabulary#hasApp>
+        <http://vivoweb.org/ontology/vitro/ui-label/vocabulary#hasApp>
                 "VIVO" ;
-		 <http://vivoweb.org/ontology/core/properties/vocabulary#hasTheme>
+		 <http://vivoweb.org/ontology/vitro/ui-label/vocabulary#hasTheme>
                 "wilma" ;
-        <http://vivoweb.org/ontology/core/properties/vocabulary#hasKey>
+        <http://vivoweb.org/ontology/vitro/ui-label/vocabulary#hasKey>
                 "testkey" .
 
 <urn:uuid:8c80dbf5-adda-41d5-a6fe-d5efde663603>
-        a           owl:NamedIndividual , <http://vivoweb.org/ontology/core/properties/vocabulary#PropertyKey> ;
+        a           owl:NamedIndividual , <http://vivoweb.org/ontology/vitro/ui-label/vocabulary#UILabel> ;
         rdfs:label  "testkey Vitro wilma en-US"@en-US ;
         rdfs:label  "testkey Vitro wilma de-DE"@de-DE ;
-        <http://vivoweb.org/ontology/core/properties/vocabulary#hasApp>
+        <http://vivoweb.org/ontology/vitro/ui-label/vocabulary#hasApp>
                 "Vitro" ;
-		 <http://vivoweb.org/ontology/core/properties/vocabulary#hasTheme>
+		 <http://vivoweb.org/ontology/vitro/ui-label/vocabulary#hasTheme>
                 "wilma" ;
-        <http://vivoweb.org/ontology/core/properties/vocabulary#hasKey>
+        <http://vivoweb.org/ontology/vitro/ui-label/vocabulary#hasKey>
                 "testkey" .
 
 <urn:uuid:8c80dbf5-adda-41d5-a6fe-d5efde663604>
-        a           owl:NamedIndividual , <http://vivoweb.org/ontology/core/properties/vocabulary#PropertyKey> ;
+        a           owl:NamedIndividual , <http://vivoweb.org/ontology/vitro/ui-label/vocabulary#UILabel> ;
         rdfs:label  "testkey Vitro vitro en-US"@en-US ;
         rdfs:label  "testkey Vitro vitro de-DE"@de-DE ;
-        <http://vivoweb.org/ontology/core/properties/vocabulary#hasApp>
+        <http://vivoweb.org/ontology/vitro/ui-label/vocabulary#hasApp>
                 "Vitro" ;
-		<http://vivoweb.org/ontology/core/properties/vocabulary#hasTheme>
+		<http://vivoweb.org/ontology/vitro/ui-label/vocabulary#hasTheme>
                 "vitro" ;
-        <http://vivoweb.org/ontology/core/properties/vocabulary#hasKey>
+        <http://vivoweb.org/ontology/vitro/ui-label/vocabulary#hasKey>
                 "testkey" .
 
 <urn:uuid:8c80dbf5-adda-41d5-a6fe-d5efde663605>
-        a           owl:NamedIndividual , <http://vivoweb.org/ontology/core/properties/vocabulary#PropertyKey> ;
+        a           owl:NamedIndividual , <http://vivoweb.org/ontology/vitro/ui-label/vocabulary#UILabel> ;
         rdfs:label  "testkey_app_fallback Vitro wilma en-US"@en-US ;
         rdfs:label  "testkey_app_fallback Vitro wilma de-DE"@de-DE ;
-        <http://vivoweb.org/ontology/core/properties/vocabulary#hasApp>
+        <http://vivoweb.org/ontology/vitro/ui-label/vocabulary#hasApp>
                 "Vitro" ;
-		<http://vivoweb.org/ontology/core/properties/vocabulary#hasTheme>
+		<http://vivoweb.org/ontology/vitro/ui-label/vocabulary#hasTheme>
                 "wilma" ;
-        <http://vivoweb.org/ontology/core/properties/vocabulary#hasKey>
+        <http://vivoweb.org/ontology/vitro/ui-label/vocabulary#hasKey>
                 "testkey_app_fallback" .
 
 <urn:uuid:8c80dbf5-adda-41d5-a6fe-d5efde663606>
-        a           owl:NamedIndividual , <http://vivoweb.org/ontology/core/properties/vocabulary#PropertyKey> ;
+        a           owl:NamedIndividual , <http://vivoweb.org/ontology/vitro/ui-label/vocabulary#UILabel> ;
         rdfs:label  "testkey_app_fallback Vitro no theme en-US"@en-US ;
         rdfs:label  "testkey_app_fallback Vitro no theme de-DE"@de-DE ;
-        <http://vivoweb.org/ontology/core/properties/vocabulary#hasApp>
+        <http://vivoweb.org/ontology/vitro/ui-label/vocabulary#hasApp>
                 "Vitro" ;
-        <http://vivoweb.org/ontology/core/properties/vocabulary#hasKey>
+        <http://vivoweb.org/ontology/vitro/ui-label/vocabulary#hasKey>
                 "testkey_app_fallback" .
 
 

--- a/home/src/main/resources/rdf/i18n/de_DE/interface-i18n/firsttime/vitro_UiLabel.ttl
+++ b/home/src/main/resources/rdf/i18n/de_DE/interface-i18n/firsttime/vitro_UiLabel.ttl
@@ -1,6267 +1,6267 @@
 @prefix owl:   <http://www.w3.org/2002/07/owl#> .
 @prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
-@prefix prop-data: <http://vivoweb.org/ontology/core/properties/individual#> .
-@prefix prop:  <http://vivoweb.org/ontology/core/properties/vocabulary#> .
+@prefix uil-data: <http://vivoweb.org/ontology/vitro/ui-label/individual#> .
+@prefix uil:  <http://vivoweb.org/ontology/vitro/ui-label/vocabulary#> .
 @prefix xsd:   <http://www.w3.org/2001/XMLSchema#> .
 @prefix skos:  <http://www.w3.org/2004/02/skos/core#> .
 @prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> .
 
-prop-data:collapse_all.Vitro
+uil-data:collapse_all.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Alle einklappen"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "collapse_all" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "collapse_all" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:no_password_supplied.Vitro
+uil-data:no_password_supplied.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Kein Passwort angegeben."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "no_password_supplied" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "no_password_supplied" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:crop_page_title.Vitro
+uil-data:crop_page_title.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Bild zuschneiden"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "crop_page_title" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "crop_page_title" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:label.dateTimeWithPrecision.month_capitalized.Vitro
+uil-data:label.dateTimeWithPrecision.month_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Monat"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "label.dateTimeWithPrecision.month_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "label.dateTimeWithPrecision.month_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:advanced_search_tip_three.Vitro
+uil-data:advanced_search_tip_three.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Wortgruppensuchen können mit booleschen Operatoren kombiniert werden - z.B. \"<i>Klimaveränderung</i>\" OR \"<i>Globale Erwärmung</i>\"."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "advanced_search_tip_three" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "advanced_search_tip_three" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:file_upload_error_file_size_is_zero.Vitro
+uil-data:file_upload_error_file_size_is_zero.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "file_upload_error_file_size_is_zero" ;
-        prop:hasPackage  "Vitro-languages" .
+        rdf:type         uil:UILabel ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "file_upload_error_file_size_is_zero" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:delete_entry_capitalized.Vitro
+uil-data:delete_entry_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Diesen Eintrag löschen?"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "delete_entry_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "delete_entry_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:remove_selection_title.Vitro
+uil-data:remove_selection_title.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Auswahl entfernen"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "remove_selection_title" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "remove_selection_title" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:powered_by.Vitro
+uil-data:powered_by.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Powered by"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "powered_by" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "powered_by" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:accounts_search_results.Vitro
+uil-data:accounts_search_results.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Suchergebnisse für"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "accounts_search_results" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "accounts_search_results" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:search_individual_results.Vitro
+uil-data:search_individual_results.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Suche Datensätze der Klasse"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "search_individual_results" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "search_individual_results" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:vclassAlpha_not_implemented.Vitro
+uil-data:vclassAlpha_not_implemented.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "vclassAlpha ist derzeit nicht implementiert."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "vclassAlpha_not_implemented" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "vclassAlpha_not_implemented" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_an_existing.Vitro
+uil-data:select_an_existing.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Wählen Sie eine vorhandene"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_an_existing" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_an_existing" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:no_appropriate_entry.Vitro
+uil-data:no_appropriate_entry.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Wenn Sie keinen den entsprechenden Eintrag in der Auswahlliste oben finden"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "no_appropriate_entry" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "no_appropriate_entry" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:descending_order.Vitro
+uil-data:descending_order.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "absteigend"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "descending_order" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "descending_order" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:label.dateTimeWithPrecision.hour_capitalized.Vitro
+uil-data:label.dateTimeWithPrecision.hour_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Stunde"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "label.dateTimeWithPrecision.hour_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "label.dateTimeWithPrecision.hour_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:add_remove_rdf.Vitro
+uil-data:add_remove_rdf.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "RDF-Daten hinzufügen/entfernen"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "add_remove_rdf" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "add_remove_rdf" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:account.Vitro
+uil-data:account.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Konto"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "account" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "account" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:label.Vitro
+uil-data:label.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Label"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "label" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "label" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:no_classes_to_select.Vitro
+uil-data:no_classes_to_select.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Es gibt keine Klassen im System, die zur Auswahl stehen."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "no_classes_to_select" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "no_classes_to_select" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:page_curator_permission_option.Vitro
+uil-data:page_curator_permission_option.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Kuratoren und darüber können diese Seite ansehen"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "page_curator_permission_option" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "page_curator_permission_option" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:individuals_in_system.Vitro
+uil-data:individuals_in_system.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Datensätze in dem System."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "individuals_in_system" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "individuals_in_system" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:search_help.Vitro
+uil-data:search_help.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Suchhilfe"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "search_help" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "search_help" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:there_are_no_entries_starting_with.Vitro
+uil-data:there_are_no_entries_starting_with.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Es gibt keine Einträge, die mit beginnen"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "there_are_no_entries_starting_with" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "there_are_no_entries_starting_with" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:user_accounts_link.Vitro
+uil-data:user_accounts_link.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Benutzerkonten"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "user_accounts_link" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "user_accounts_link" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:ontology_capitalized.Vitro
+uil-data:ontology_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ontologie"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "ontology_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "ontology_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:change_password_to_login.Vitro
+uil-data:change_password_to_login.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Passwort ändern, um einzuloggen"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "change_password_to_login" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "change_password_to_login" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:a_menu_page.Vitro
+uil-data:a_menu_page.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Dies ist eine Menüseite"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "a_menu_page" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "a_menu_page" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:comments.Vitro
+uil-data:comments.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Kommentare"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "comments" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "comments" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:add_new_of_type.Vitro
+uil-data:add_new_of_type.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Hinzufügen eines neuen Elementes diesen Typs"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "add_new_of_type" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "add_new_of_type" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:reset_password_note.Vitro
+uil-data:reset_password_note.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Hinweis: Anweisungen zum Zurücksetzen des Passworts werden an die oben angegebenen Adresse gesendet. Das Passwort wird nicht zurückgesetzt, bis der Benutzer den Link in dieser E-Mail geöffnet hat."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "reset_password_note" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "reset_password_note" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:startup_status.Vitro
+uil-data:startup_status.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Status des Startvorganges"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "startup_status" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "startup_status" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:no_results_returned.Vitro
+uil-data:no_results_returned.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Es wurden keine Ergebnisse zurückgegeben."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "no_results_returned" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "no_results_returned" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:submit_add_new_account.Vitro
+uil-data:submit_add_new_account.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Neues Konto hinzufügen"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "submit_add_new_account" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "submit_add_new_account" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:password_reset_complete_subject.Vitro
+uil-data:password_reset_complete_subject.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ihr {0} Passwort wurde geändert."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "password_reset_complete_subject" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "password_reset_complete_subject" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:file_upload_error_supported_actions.Vitro
+uil-data:file_upload_error_supported_actions.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "file_upload_error_supported_actions" ;
-        prop:hasPackage  "Vitro-languages" .
+        rdf:type         uil:UILabel ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "file_upload_error_supported_actions" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:create_classgroup.Vitro
+uil-data:create_classgroup.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Erstellen Sie eine Klassengruppe"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "create_classgroup" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "create_classgroup" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:accounts.Vitro
+uil-data:accounts.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Konten"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "accounts" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "accounts" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:page_not_created_msg.Vitro
+uil-data:page_not_created_msg.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Es ist ein Fehler beim Erstellen der Seite aufgetreten. Bitte prüfen Sie die Logfiles."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "page_not_created_msg" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "page_not_created_msg" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:login_count.Vitro
+uil-data:login_count.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Login-Zähler"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "login_count" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "login_count" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:not_expected_results.Vitro
+uil-data:not_expected_results.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Nicht die Ergebnisse, die Sie erwartet haben?"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "not_expected_results" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "not_expected_results" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:paging_link_more.Vitro
+uil-data:paging_link_more.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "mehr ..."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "paging_link_more" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "paging_link_more" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:sparql_query_description_1.Vitro
+uil-data:sparql_query_description_1.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "# and (if available) their labels"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "sparql_query_description_1" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "sparql_query_description_1" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:acct_created_email_plain_text.Vitro
+uil-data:acct_created_email_plain_text.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "${userAccount.firstName} ${userAccount.lastName}\n\nHerzlichen Glückwunsch!\n\nWir haben einen Account für  ${siteName} für Sie angelegt.\nIhr Account ist mit der E-Mail-Adresse ${userAccount.emailAddress} verknüpft.\n\nWenn Sie diesen Account nicht beantragt haben, können Sie diese E-Mail ignorieren.\nDiese Anfrage erlischt automatisch nach 30 Tagen.\n\nFügen Sie untenstehenden Link in die Adressleiste Ihres Browsers, um Ihr\nPasswort für Ihr neues Konto auf unserem Server zu erstellen.\n\n${passwordLink}\n\nVielen Dank!\n"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "acct_created_email_plain_text" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "acct_created_email_plain_text" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:all_rights_reserved.Vitro
+uil-data:all_rights_reserved.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Alle Rechte vorbehalten."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "all_rights_reserved" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "all_rights_reserved" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:submit_save.Vitro
+uil-data:submit_save.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Foto speichern"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "submit_save" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "submit_save" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:associate_classes_with_group.Vitro
+uil-data:associate_classes_with_group.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "und verknüpfen Sie die Klassen mit der erstellten Gruppe."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "associate_classes_with_group" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "associate_classes_with_group" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:about.Vitro
+uil-data:about.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Über"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "about" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "about" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:activate_developer_panel.Vitro
+uil-data:activate_developer_panel.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Aktiviere Entwickler-Panel"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "activate_developer_panel" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "activate_developer_panel" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:since.Vitro
+uil-data:since.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Seit"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "since" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "since" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:limit_to.Vitro
+uil-data:limit_to.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Beschränken auf"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "limit_to" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "limit_to" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:password_created_subject.Vitro
+uil-data:password_created_subject.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ihr {0} Passwort wurde erfolgreich erstellt."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "password_created_subject" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "password_created_subject" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:vitro_description.Vitro
+uil-data:vitro_description.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Vitro ist ein universeller Web-basierter Ontologie- und Instanzeditor mit einer anpassbaren öffentlichen Oberfläche. Vitro ist eine Java-Web-Anwendung, die in einem Tomcat-Servlet-Container ausgeführt wird."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "vitro_description" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "vitro_description" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:logins_disabled_for_maintenance.Vitro
+uil-data:logins_disabled_for_maintenance.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Benutzer-Logins sind vorübergehend deaktiviert, während das System gewartet wird."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "logins_disabled_for_maintenance" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "logins_disabled_for_maintenance" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:current_time.Vitro
+uil-data:current_time.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Aktuelle Zeit:"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "current_time" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "current_time" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:release.Vitro
+uil-data:release.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Release"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "release" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "release" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:authenticator.Vitro
+uil-data:authenticator.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Authenticator"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "authenticator" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "authenticator" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:preparing_to_rebuild_index.Vitro
+uil-data:preparing_to_rebuild_index.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Vorbereiten des Aufbauens des Suchindexes."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "preparing_to_rebuild_index" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "preparing_to_rebuild_index" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:login_status.Vitro
+uil-data:login_status.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Anmeldestatus:"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "login_status" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "login_status" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:scroll_to_menus.Vitro
+uil-data:scroll_to_menus.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Zu Gruppenmenüs scrollen "@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "scroll_to_menus" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "scroll_to_menus" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:sparql_query_description_0.Vitro
+uil-data:sparql_query_description_0.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "# This example query gets 20 geographic locations"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "sparql_query_description_0" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "sparql_query_description_0" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:delete_button.Vitro
+uil-data:delete_button.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Löschen"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "delete_button" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "delete_button" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:fixed_html.Vitro
+uil-data:fixed_html.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Fixes HTML"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "fixed_html" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "fixed_html" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:you_can.Vitro
+uil-data:you_can.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Sie können"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "you_can" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "you_can" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:supply_sparql_query.Vitro
+uil-data:supply_sparql_query.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Sie müssen eine Sparql-Anfrage angeben."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "supply_sparql_query" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "supply_sparql_query" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:enter_email_password.Vitro
+uil-data:enter_email_password.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Geben Sie E-Mail-Adresse und Passwort für Ihr internes Vitro-Konto ein."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "enter_email_password" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "enter_email_password" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:selected_editors.Vitro
+uil-data:selected_editors.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ausgewählte Bearbeiter"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "selected_editors" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "selected_editors" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:custom_template_mixed_caps.Vitro
+uil-data:custom_template_mixed_caps.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Benutzerdefinierte Vorlage"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "custom_template_mixed_caps" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "custom_template_mixed_caps" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:animal.Vitro
+uil-data:animal.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Tier:"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "animal" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "animal" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:enter_sparql_query_here.Vitro
+uil-data:enter_sparql_query_here.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Geben Sie hier eine SPARQL-Query ein"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "enter_sparql_query_here" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "enter_sparql_query_here" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:recompute_inferences.Vitro
+uil-data:recompute_inferences.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Schlussfolgerungen neuberechnen"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "recompute_inferences" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "recompute_inferences" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:restrict_logins.Vitro
+uil-data:restrict_logins.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Logins einschränken"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "restrict_logins" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "restrict_logins" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:email_address.Vitro
+uil-data:email_address.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "E-Mail-Adresse"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "email_address" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "email_address" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:alt_confirmation.Vitro
+uil-data:alt_confirmation.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Symbol Bestätigung"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "alt_confirmation" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "alt_confirmation" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:drag_drop_to_reorder_menus.Vitro
+uil-data:drag_drop_to_reorder_menus.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Drag&Drop, um die Menüpunkte neu zu ordnen"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "drag_drop_to_reorder_menus" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "drag_drop_to_reorder_menus" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:most_recent_update.Vitro
+uil-data:most_recent_update.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Die letzte Aktualisierung erfolgte am"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "most_recent_update" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "most_recent_update" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:delete_link.Vitro
+uil-data:delete_link.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Foto löschen"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "delete_link" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "delete_link" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:check_startup_status.Vitro
+uil-data:check_startup_status.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Prüfen Sie die Statusseite des Startvorganges und/oder Tomcat-Protokolle für weitere Informationen."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "check_startup_status" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "check_startup_status" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:no_pages_defined.Vitro
+uil-data:no_pages_defined.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Es gibt derzeit noch keine Seiten."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "no_pages_defined" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "no_pages_defined" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:advanced_search_tip_five.Vitro
+uil-data:advanced_search_tip_five.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Verwenden Sie das Wildcard-Zeichen * um mehr Variationen zu finden - Bsp.: <i>nano*</i> findet <i>Nanotechnology</i> sowie <i>Nanofabrikation</i>."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "advanced_search_tip_five" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "advanced_search_tip_five" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_message.Vitro
+uil-data:error_message.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Fehlermeldung"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_message" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_message" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:double_quote_note_allowed.Vitro
+uil-data:double_quote_note_allowed.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Der Name der Variable darf keine Anführungszeichen beinhalten."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "double_quote_note_allowed" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "double_quote_note_allowed" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:crop_page_title_with_name.Vitro
+uil-data:crop_page_title_with_name.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Bild zuschneiden für {0}"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "crop_page_title_with_name" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "crop_page_title_with_name" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:logins_not_restricted.Vitro
+uil-data:logins_not_restricted.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Logins sind nicht mehr beschränkt."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "logins_not_restricted" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "logins_not_restricted" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:deleted_accounts.Vitro
+uil-data:deleted_accounts.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "{0} {0, Auswahl, 0#Konten|1#Konto|1<Konten} gelöscht ."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "deleted_accounts" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "deleted_accounts" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:whole_number.Vitro
+uil-data:whole_number.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ungültiger Eintrag. Geben Sie eine ganze Zahl ohne Dezimalpunkt oder Tausendertrennzeichen an."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "whole_number" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "whole_number" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:edit_account.Vitro
+uil-data:edit_account.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Konto bearbeiten"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "edit_account" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "edit_account" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:search_tip_two.Vitro
+uil-data:search_tip_two.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Verwenden Sie Anführungszeichen für die Suche nach eine Phrase - z.B. \"<i>protein folding</i>\"."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "search_tip_two" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "search_tip_two" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:email_capitalized.Vitro
+uil-data:email_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "E-Mail"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "email_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "email_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:policies.Vitro
+uil-data:policies.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Richtlinien"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "policies" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "policies" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:failed.Vitro
+uil-data:failed.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Fehlgeschlagen"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "failed" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "failed" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:containers_do_not_pick_up_changes.Vitro
+uil-data:containers_do_not_pick_up_changes.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Container übernehmen keine Änderungen der Werte ihrer Elemente"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "containers_do_not_pick_up_changes" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "containers_do_not_pick_up_changes" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:file_upload_error_media_type_not_allowed.Vitro
+uil-data:file_upload_error_media_type_not_allowed.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "file_upload_error_media_type_not_allowed" ;
-        prop:hasPackage  "Vitro-languages" .
+        rdf:type         uil:UILabel ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "file_upload_error_media_type_not_allowed" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:add_new_classes.Vitro
+uil-data:add_new_classes.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Neue Klasse hinzufügen"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "add_new_classes" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "add_new_classes" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:identifier_factories.Vitro
+uil-data:identifier_factories.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Identifier factories"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "identifier_factories" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "identifier_factories" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:show_subclasses.Vitro
+uil-data:show_subclasses.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Subklassen anzeigen"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "show_subclasses" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "show_subclasses" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:enter_id_to_login.Vitro
+uil-data:enter_id_to_login.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Geben Sie die Benutzer-ID ein, mit der Sie sich anmelden möchten, oder klicken Sie auf Abbrechen."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "enter_id_to_login" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "enter_id_to_login" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:upload_heading.Vitro
+uil-data:upload_heading.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Foto-Upload"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "upload_heading" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "upload_heading" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:warnings_issued.Vitro
+uil-data:warnings_issued.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "{0} ausgegebene Warnungen während des Starts."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "warnings_issued" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "warnings_issued" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:account_management.Vitro
+uil-data:account_management.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Kontenverwaltung"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "account_management" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "account_management" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_content_display.Vitro
+uil-data:select_content_display.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Wählen Sie anzuzeigende Inhalte"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_content_display" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_content_display" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:account_no_longer_exists.Vitro
+uil-data:account_no_longer_exists.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Das Konto, für das Sie versuchen ein Passwort zu setzen, ist nicht mehr verfügbar. Bitte kontaktieren Sie Ihren Systemadministrator, wenn Sie denken, dass dies ein Fehler ist."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "account_no_longer_exists" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "account_no_longer_exists" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:page_select_permission.Vitro
+uil-data:page_select_permission.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Seitenberechtigungen auswählen"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "page_select_permission" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "page_select_permission" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:test_for_logged_in_users.Vitro
+uil-data:test_for_logged_in_users.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Dies ist das Test-Widget für angemeldete Benutzer."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "test_for_logged_in_users" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "test_for_logged_in_users" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:edit_page.Vitro
+uil-data:edit_page.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "{0} Seite bearbeiten"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "edit_page" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "edit_page" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:no_match.Vitro
+uil-data:no_match.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Keine Übereinstimmung"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "no_match" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "no_match" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:add_new_page.Vitro
+uil-data:add_new_page.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Neue Seite hinzufügen"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "add_new_page" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "add_new_page" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:class_groups.Vitro
+uil-data:class_groups.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Klassengruppen"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "class_groups" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "class_groups" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:password_reset_pending_email_subject.Vitro
+uil-data:password_reset_pending_email_subject.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Passwort zurücksetzen für ${siteName}"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "password_reset_pending_email_subject" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "password_reset_pending_email_subject" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:manage.Vitro
+uil-data:manage.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "manage"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "manage" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "manage" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_password_length.Vitro
+uil-data:error_password_length.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Bitte geben Sie ein Passwort zwischen {0} und {1} Zeichen Länge ein."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_password_length" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_password_length" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:view_profile_editors.Vitro
+uil-data:view_profile_editors.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Alle Profilbearbeiter"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "view_profile_editors" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "view_profile_editors" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:subclasses_capitalized.Vitro
+uil-data:subclasses_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Subklassen"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "subclasses_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "subclasses_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:auth_matching_id_label.Vitro
+uil-data:auth_matching_id_label.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Externe Auth. ID / Matching-ID"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "auth_matching_id_label" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "auth_matching_id_label" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:page_editor_permission_option.Vitro
+uil-data:page_editor_permission_option.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Editoren und darüber können diese Seite ansehen"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "page_editor_permission_option" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "page_editor_permission_option" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:delete_page.Vitro
+uil-data:delete_page.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Diese Seite löschen"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "delete_page" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "delete_page" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:for.Vitro
+uil-data:for.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "für"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "for" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "for" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:manage_list_of_labels.Vitro
+uil-data:manage_list_of_labels.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Liste von Labels verwalten"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "manage_list_of_labels" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "manage_list_of_labels" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:content.Vitro
+uil-data:content.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Inhalt"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "content" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "content" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:match_by.Vitro
+uil-data:match_by.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Gefunden in {0}"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "match_by" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "match_by" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:alt_preview_crop.Vitro
+uil-data:alt_preview_crop.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Vorschau des zugeschnittenen Fotos"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "alt_preview_crop" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "alt_preview_crop" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:pretty_url.Vitro
+uil-data:pretty_url.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Lesbare URL"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "pretty_url" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "pretty_url" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:operation_successful.Vitro
+uil-data:operation_successful.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Die Operation war erfolgreich."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "operation_successful" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "operation_successful" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:add_capitalized.Vitro
+uil-data:add_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Hinzufügen"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "add_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "add_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:accounts_per_page.Vitro
+uil-data:accounts_per_page.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Konten pro Seite"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "accounts_per_page" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "accounts_per_page" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_editor_and_profile.Vitro
+uil-data:select_editor_and_profile.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Sie müssen mindestens 1 Bearbeiter und Profil auswählen."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_editor_and_profile" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_editor_and_profile" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:request_failed.Vitro
+uil-data:request_failed.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Anfrage fehlgeschlagen. Bitte kontaktieren Sie Ihren Systemadministrator."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "request_failed" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "request_failed" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:from_site_admin_page.Vitro
+uil-data:from_site_admin_page.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "von der Administrationseite."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "from_site_admin_page" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "from_site_admin_page" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:new_password_capitalized.Vitro
+uil-data:new_password_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Neues Passwort"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "new_password_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "new_password_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:advanced_search_tip_one.Vitro
+uil-data:advanced_search_tip_one.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Wenn Sie mehr als einen Begriff angeben, wird die Suche nur Ergebnisse liefern, die alle Begriffe enthalten, es sei denn Sie ergänzen \"OR\" - z.B. <i>Huhn</i> OR <i>Ei</i>."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "advanced_search_tip_one" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "advanced_search_tip_one" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:password_reset_complete_email_plain_text.Vitro
+uil-data:password_reset_complete_email_plain_text.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "${userAccount.firstName} ${userAccount.lastName}\n\nIhr Passwort wurde geändert.\n\nDas mit dem Account ${userAccount.emailAddress} verknüpfte Passwort wurde geändert.\n\nVielen Dank."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "password_reset_complete_email_plain_text" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "password_reset_complete_email_plain_text" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:application_error_email_subject.Vitro
+uil-data:application_error_email_subject.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Es ist ein Fehler auf der Website ${siteName!} aufgetreten"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "application_error_email_subject" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "application_error_email_subject" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:return_to.Vitro
+uil-data:return_to.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Zurück zu {0}"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "return_to" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "return_to" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:last_login.Vitro
+uil-data:last_login.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Letzte Anmeldung"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "last_login" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "last_login" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:view_profile_in_rdf.Vitro
+uil-data:view_profile_in_rdf.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Profil in RDF-Format anzeigen"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "view_profile_in_rdf" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "view_profile_in_rdf" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:minimum_password_length.Vitro
+uil-data:minimum_password_length.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Mindestens {0} Zeichen, höchstens {1}."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "minimum_password_length" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "minimum_password_length" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:contact_us.Vitro
+uil-data:contact_us.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Kontakt"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "contact_us" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "contact_us" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:download_results.Vitro
+uil-data:download_results.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Suchergebnisse herunterladen"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "download_results" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "download_results" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:selected_profiles.Vitro
+uil-data:selected_profiles.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ausgewählte Profile"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "selected_profiles" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "selected_profiles" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:has_value.Vitro
+uil-data:has_value.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "hat Wert"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "has_value" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "has_value" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:faux_property_listing.Vitro
+uil-data:faux_property_listing.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Faux-Properties"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "faux_property_listing" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "faux_property_listing" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:display_admin_header.Vitro
+uil-data:display_admin_header.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Admin und Konfiguration anzeigen"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "display_admin_header" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "display_admin_header" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_no_password.Vitro
+uil-data:error_no_password.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Bitte geben Sie Ihr Passwort ein."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_no_password" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_no_password" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:remove_capitalized.Vitro
+uil-data:remove_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Entfernen"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "remove_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "remove_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:october.Vitro
+uil-data:october.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Oktober"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "october" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "october" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:file_upload_subject.Vitro
+uil-data:file_upload_subject.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "file_upload_subject" ;
-        prop:hasPackage  "Vitro-languages" .
+        rdf:type         uil:UILabel ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "file_upload_subject" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:manage_site.Vitro
+uil-data:manage_site.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Verwalten dieser Webseite"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "manage_site" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "manage_site" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:confirm_delete_account_plural.Vitro
+uil-data:confirm_delete_account_plural.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Sind Sie sicher, dass Sie diese Konten löschen wollen?"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "confirm_delete_account_plural" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "confirm_delete_account_plural" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:sunday.Vitro
+uil-data:sunday.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Sonntag"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "sunday" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "sunday" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:password_system_has_changed.Vitro
+uil-data:password_system_has_changed.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Unser Passwortsystem wurde aktualisiert, um es sicherer zu machen. Bitte geben Sie ein neues Passwort ein."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "password_system_has_changed" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "password_system_has_changed" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:rebuild_search_index.Vitro
+uil-data:rebuild_search_index.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Suchindex neu aufbauen"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "rebuild_search_index" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "rebuild_search_index" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:password_saved.Vitro
+uil-data:password_saved.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ihr Passwort wurde gespeichert."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "password_saved" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "password_saved" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:supply_query_variable.Vitro
+uil-data:supply_query_variable.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Sie müssen eine Variable angeben, um Anfrageergebnisse zu speichern."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "supply_query_variable" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "supply_query_variable" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:configure_page_if_permissable.Vitro
+uil-data:configure_page_if_permissable.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       ", um diese Seite zu konfigurieren, wenn der Benutzer die Berechtigung hat."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "configure_page_if_permissable" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "configure_page_if_permissable" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:invalid_date_form_msg.Vitro
+uil-data:invalid_date_form_msg.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "muss im gültigen Datumsformat mm/tt/jjjj sein."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "invalid_date_form_msg" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "invalid_date_form_msg" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:manage_list_of.Vitro
+uil-data:manage_list_of.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Liste verwalten von"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "manage_list_of" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "manage_list_of" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:verbose_property_status.Vitro
+uil-data:verbose_property_status.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ausführliche Eigenschaftsanzeige"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "verbose_property_status" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "verbose_property_status" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:sparql_query_select_ask_results.Vitro
+uil-data:sparql_query_select_ask_results.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Format for SELECT and ASK query results"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "sparql_query_select_ask_results" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "sparql_query_select_ask_results" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:individual_not_found.Vitro
+uil-data:individual_not_found.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Datensatz nicht gefunden:"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "individual_not_found" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "individual_not_found" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:classes_by_classgroup.Vitro
+uil-data:classes_by_classgroup.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Klassen nach Klassengruppe"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "classes_by_classgroup" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "classes_by_classgroup" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:confirm_email_changed_email_plain_text.Vitro
+uil-data:confirm_email_changed_email_plain_text.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Sehr geehrte ${userAccount.firstName} ${userAccount.lastName}\n\nSie haben kürzlich die E-Mail-Adresse geändert, die mit\n${userAccount.firstName} ${userAccount.lastName}\nVielen Dank."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "confirm_email_changed_email_plain_text" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "confirm_email_changed_email_plain_text" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:close_capitalized.Vitro
+uil-data:close_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Schließen"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "close_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "close_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:browse_class_group.Vitro
+uil-data:browse_class_group.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Klassengruppe durchsuchen"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "browse_class_group" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "browse_class_group" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:statistics.Vitro
+uil-data:statistics.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Statistiken"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "statistics" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "statistics" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:new_password.Vitro
+uil-data:new_password.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Neues Passwort"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "new_password" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "new_password" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:hide_show_subclasses.Vitro
+uil-data:hide_show_subclasses.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Subklassen verbergen/anzeigen"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "hide_show_subclasses" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "hide_show_subclasses" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:class_hierarchy.Vitro
+uil-data:class_hierarchy.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Klassenhierarchie"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "class_hierarchy" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "class_hierarchy" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:add_content_manage_site.Vitro
+uil-data:add_content_manage_site.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Inhalte hinzufügen und diese Seite verwalten"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "add_content_manage_site" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "add_content_manage_site" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:background_threads.Vitro
+uil-data:background_threads.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Hintergrund-Threads"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "background_threads" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "background_threads" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:create_capitalized.Vitro
+uil-data:create_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Erstellen"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "create_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "create_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_previous_password.Vitro
+uil-data:error_previous_password.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ihr neues Passwort darf nicht dem Aktuellen entsprechen."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_previous_password" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_previous_password" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:change_password.Vitro
+uil-data:change_password.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Sie müssen Ihr Passwort ändern, um sich einzuloggen."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "change_password" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "change_password" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:menu_management.Vitro
+uil-data:menu_management.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Menüverwaltung"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "menu_management" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "menu_management" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:email_change_will_be_confirmed.Vitro
+uil-data:email_change_will_be_confirmed.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Hinweis: Bei Änderung der E-Mail-Adresse, wird eine Bestätigungsmail an die neue E-Mail-Adresse gesendet."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "email_change_will_be_confirmed" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "email_change_will_be_confirmed" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:fake_external_auth.Vitro
+uil-data:fake_external_auth.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Externe Authentifizierung vortäuschen"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "fake_external_auth" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "fake_external_auth" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:run_sdb_setup.Vitro
+uil-data:run_sdb_setup.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Starte SDB-Setup"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "run_sdb_setup" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "run_sdb_setup" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:property_management.Vitro
+uil-data:property_management.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Verwaltung Eigenschaften"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "property_management" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "property_management" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:end_your_Session.Vitro
+uil-data:end_your_Session.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Sitzung beenden"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "end_your_Session" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "end_your_Session" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:search_index_not_connected.Vitro
+uil-data:search_index_not_connected.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Der Suchindex ist nicht verbunden."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "search_index_not_connected" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "search_index_not_connected" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:change_content_type.Vitro
+uil-data:change_content_type.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Wechseln des Inhaltstyps"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "change_content_type" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "change_content_type" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:invalid_search_term.Vitro
+uil-data:invalid_search_term.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Der Suchbegriff war ungültig"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "invalid_search_term" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "invalid_search_term" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:index_recs_completed.Vitro
+uil-data:index_recs_completed.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Abgeschlossen {0} von {1} Index-Datensätze."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "index_recs_completed" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "index_recs_completed" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:add_profile.Vitro
+uil-data:add_profile.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Profil hinzufügen"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "add_profile" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "add_profile" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:view_labels_capitalized.Vitro
+uil-data:view_labels_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Labels anzeigen"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "view_labels_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "view_labels_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:maximum_cardinality.Vitro
+uil-data:maximum_cardinality.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "maximale Kardinalität"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "maximum_cardinality" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "maximum_cardinality" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:please_format_email.Vitro
+uil-data:please_format_email.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Bitte formatieren Sie Ihre E-Mail-Adresse so:"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "please_format_email" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "please_format_email" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:external_auth_only.Vitro
+uil-data:external_auth_only.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Nur extern Authentifizierte"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "external_auth_only" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "external_auth_only" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:return_to_individual.Vitro
+uil-data:return_to_individual.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Zurück zur Seite des Datensatzes"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "return_to_individual" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "return_to_individual" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:all_x_properties.Vitro
+uil-data:all_x_properties.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Alle {0} Eigenschaften"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "all_x_properties" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "all_x_properties" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:password_created_email_plain_text.Vitro
+uil-data:password_created_email_plain_text.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "${userAccount.firstName} ${userAccount.lastName}\n\nPasswort erfolgreich erstellt.\n\nIhr Passwort für den Account ${userAccount.emailAddress}\nwurde erstellt.\n\nVielen Dank."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "password_created_email_plain_text" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "password_created_email_plain_text" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:already_logged_in.Vitro
+uil-data:already_logged_in.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Sie sind bereits angemeldet."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "already_logged_in" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "already_logged_in" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:supply_class_group.Vitro
+uil-data:supply_class_group.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Sie müssen eine Klassengruppe angeben."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "supply_class_group" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "supply_class_group" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:matching_prop_not_defined.Vitro
+uil-data:matching_prop_not_defined.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Matching-Eigenschaft ist nicht definiert"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "matching_prop_not_defined" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "matching_prop_not_defined" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:display_rank.Vitro
+uil-data:display_rank.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Anzeigerang"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "display_rank" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "display_rank" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:profile_editing_title.Vitro
+uil-data:profile_editing_title.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Die Bearbeiter, die Sie auf der linken Seite auswählen, werden die VIVO-Profile bearbeiten können, die Sie auf der rechten Seite auswählen. Sie können mehrere Bearbeiter und mehrere Profile auswählen, aber Sie müssen mindestens jeweils 1 auswählen."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "profile_editing_title" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "profile_editing_title" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:test_for_nonlogged_in_users.Vitro
+uil-data:test_for_nonlogged_in_users.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Dies ist das Test-Widget für nicht angemeldete Benutzer."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "test_for_nonlogged_in_users" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "test_for_nonlogged_in_users" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:insufficient_authorization.Vitro
+uil-data:insufficient_authorization.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Sie sind zur Anzeige der angefragten Seite nicht berechtigt. Wenn Sie denken, dass dies ein Fehler ist, kontaktieren Sie uns bitte und wir helfen Ihnen gerne weiter."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "insufficient_authorization" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "insufficient_authorization" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:supply_content_type.Vitro
+uil-data:supply_content_type.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Sie müssen einen Inhaltstyp angeben"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "supply_content_type" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "supply_content_type" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:back_to_results.Vitro
+uil-data:back_to_results.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Zurück zu den Suchergebnissen"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "back_to_results" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "back_to_results" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:may_not_edit.Vitro
+uil-data:may_not_edit.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Kann nicht bearbeiten"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "may_not_edit" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "may_not_edit" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:four_digit_year.Vitro
+uil-data:four_digit_year.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ungültiger Eintrag. Bitte geben Sie ein Jahr, bestehend aus 4 Zeichen, an."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "four_digit_year" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "four_digit_year" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:browse_page_javascript_two.Vitro
+uil-data:browse_page_javascript_two.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       ", um Informationen zu suchen."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "browse_page_javascript_two" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "browse_page_javascript_two" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:password_created_email_html_text.Vitro
+uil-data:password_created_email_html_text.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "<p>\n ${userAccount.firstName} ${userAccount.lastName}\n </p>\n\n <p>\n <strong>Passwort erfolgreich erstellt.</strong>\n </p>\n\n <p>\n Ihr Passwort für den Account ${userAccount.emailAddress} wurde erstellt.\n </p>\n\n <p>\n Vielen Dank.\n </p>"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "password_created_email_html_text" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "password_created_email_html_text" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:current_photo.Vitro
+uil-data:current_photo.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Aktuelles Foto"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "current_photo" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "current_photo" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_last_name.Vitro
+uil-data:select_last_name.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Wählen Sie einen vorhandenen Nachnamen"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_last_name" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_last_name" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:supply_template.Vitro
+uil-data:supply_template.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Sie müssen eine Vorlage angeben"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "supply_template" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "supply_template" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:view_all_accounts_title.Vitro
+uil-data:view_all_accounts_title.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Alle Konten anzeigen"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "view_all_accounts_title" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "view_all_accounts_title" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:cropping_note.Vitro
+uil-data:cropping_note.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Um Einstellungen vorzunehmen, können Sie das Bild ziehen und an die richtige Größe anpassen. Wenn Sie mit Ihrem Foto zufrieden sind, klicken Sie auf \"Foto speichern\" -Button."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "cropping_note" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "cropping_note" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:page_not_created.Vitro
+uil-data:page_not_created.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Seite konnte nicht erstellt werden"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "page_not_created" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "page_not_created" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_email_already_exists.Vitro
+uil-data:error_email_already_exists.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ein Konto mit dieser E-Mail-Adresse ist bereits vorhanden."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_email_already_exists" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_email_already_exists" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:required_field_empty_msg.Vitro
+uil-data:required_field_empty_msg.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Dieses Feld darf nicht leer sein."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "required_field_empty_msg" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "required_field_empty_msg" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:site_maintenance.Vitro
+uil-data:site_maintenance.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Wartung"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "site_maintenance" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "site_maintenance" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:current_date_time.Vitro
+uil-data:current_date_time.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Aktuelles Datum und Uhrzeit:"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "current_date_time" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "current_date_time" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:page_link.Vitro
+uil-data:page_link.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Seite wählen"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "page_link" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "page_link" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:object_property_hierarchy.Vitro
+uil-data:object_property_hierarchy.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Hierarchie für Objekt-Eigenschaften"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "object_property_hierarchy" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "object_property_hierarchy" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:user_accounts.Vitro
+uil-data:user_accounts.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Benutzerkonten"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "user_accounts" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "user_accounts" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:maximum_file_size.Vitro
+uil-data:maximum_file_size.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Maximale Dateigröße: {0} Megabyte"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "maximum_file_size" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "maximum_file_size" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:add_new_account.Vitro
+uil-data:add_new_account.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Neues Konto hinzufügen"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "add_new_account" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "add_new_account" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:browse_all_starts_with.Vitro
+uil-data:browse_all_starts_with.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Alle Personen durchsuchen, deren Name mit {0} beginnt"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "browse_all_starts_with" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "browse_all_starts_with" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:status.Vitro
+uil-data:status.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Status"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "status" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "status" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:index.Vitro
+uil-data:index.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Index"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "index" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "index" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:verify_this_match_title.Vitro
+uil-data:verify_this_match_title.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Diesen Treffer verifizieren"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "verify_this_match_title" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "verify_this_match_title" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:search_indexer_idle.Vitro
+uil-data:search_indexer_idle.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Die Suchindizierung ist im Leerlauf."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "search_indexer_idle" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "search_indexer_idle" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:start_capitalized.Vitro
+uil-data:start_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Start"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "start_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "start_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:minimum_cardinality.Vitro
+uil-data:minimum_cardinality.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "minimale Kardinalität"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "minimum_cardinality" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "minimum_cardinality" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:manage_affiliated_people_link.Vitro
+uil-data:manage_affiliated_people_link.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Zugehörige Personen verwalten"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "manage_affiliated_people_link" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "manage_affiliated_people_link" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:initial_password.Vitro
+uil-data:initial_password.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Initiales Passwort"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "initial_password" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "initial_password" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:invalid_format.Vitro
+uil-data:invalid_format.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ungültiges Format"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "invalid_format" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "invalid_format" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:menu_orering.Vitro
+uil-data:menu_orering.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Menüsortierung"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "menu_orering" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "menu_orering" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:confirm_entry_deletion_from.Vitro
+uil-data:confirm_entry_deletion_from.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Sind Sie sicher, dass Sie den folgenden Eintrag löschen möchten aus"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "confirm_entry_deletion_from" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "confirm_entry_deletion_from" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:add_types.Vitro
+uil-data:add_types.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ein oder mehrere Typen hinzufügen"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "add_types" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "add_types" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:group_capitalized.Vitro
+uil-data:group_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Gruppe"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "group_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "group_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:entry.Vitro
+uil-data:entry.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Eintrag"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "entry" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "entry" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:search_vitro.Vitro
+uil-data:search_vitro.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Suche in VITRO"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "search_vitro" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "search_vitro" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:version.Vitro
+uil-data:version.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Version"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "version" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "version" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:hide_subclasses.Vitro
+uil-data:hide_subclasses.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Verberge Subklassen"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "hide_subclasses" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "hide_subclasses" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:caused_by.Vitro
+uil-data:caused_by.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Verursacht durch"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "caused_by" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "caused_by" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:show_more_content.Vitro
+uil-data:show_more_content.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Zeige mehr Inhalt"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "show_more_content" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "show_more_content" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:advanced_search_tip_six.Vitro
+uil-data:advanced_search_tip_six.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Die Suche verwendet verkürzte Versionen von Wörtern – z. B. findet eine Suche nach <i>cogniti*</i> nichts, während <i>cognit*</i> sowohl <i>cognitive</i> als auch <i>cognition</i> findet."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "advanced_search_tip_six" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "advanced_search_tip_six" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:myAccount_confirm_changes_plus_note.Vitro
+uil-data:myAccount_confirm_changes_plus_note.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ihre Änderungen wurden gespeichert. Eine Bestätigungsmail wurde an {0} gesendet."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "myAccount_confirm_changes_plus_note" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "myAccount_confirm_changes_plus_note" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:class_management.Vitro
+uil-data:class_management.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Klassen-Verwaltung"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "class_management" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "class_management" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:display_less.Vitro
+uil-data:display_less.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "weniger"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "display_less" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "display_less" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:add_property_group.Vitro
+uil-data:add_property_group.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Füge neue Gruppierung hinzu"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "add_property_group" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "add_property_group" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:browse_by.Vitro
+uil-data:browse_by.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Durchsuchen nach"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "browse_by" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "browse_by" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:class_group_link.Vitro
+uil-data:class_group_link.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Klassengruppe wählen"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "class_group_link" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "class_group_link" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:confirm_password.Vitro
+uil-data:confirm_password.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Neues Passwort bestätigen"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "confirm_password" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "confirm_password" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:saturday.Vitro
+uil-data:saturday.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Samstag"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "saturday" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "saturday" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:_publications_link.Vitro
+uil-data:_publications_link.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "_publications_link" ;
-        prop:hasPackage  "Vitro-languages" .
+        rdf:type         uil:UILabel ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "_publications_link" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:javascript_require_to_edit.Vitro
+uil-data:javascript_require_to_edit.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Um den Inhalt bearbeiten zu können, muss JavaScript aktiviert sein."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "javascript_require_to_edit" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "javascript_require_to_edit" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:fatal_error_detected.Vitro
+uil-data:fatal_error_detected.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "{0} hat ein Fehler während des Starts festgestellt."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "fatal_error_detected" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "fatal_error_detected" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:menu_page.Vitro
+uil-data:menu_page.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Menü-Seite"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "menu_page" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "menu_page" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:create_new_individual_of_the_following_type.Vitro
+uil-data:create_new_individual_of_the_following_type.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Erstellen eines Objekts der Art"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "create_new_individual_of_the_following_type" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "create_new_individual_of_the_following_type" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:logins_not_already_restricted.Vitro
+uil-data:logins_not_already_restricted.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Logins sind bereits nicht eingeschränkt."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "logins_not_already_restricted" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "logins_not_already_restricted" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:stack_trace.Vitro
+uil-data:stack_trace.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Stack Trace"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "stack_trace" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "stack_trace" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:confirm_page_deletion.Vitro
+uil-data:confirm_page_deletion.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Sind Sie sicher, dass Sie diese Seite löschen wollen:"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "confirm_page_deletion" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "confirm_page_deletion" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_locale.Vitro
+uil-data:select_locale.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Sprache wählen"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_locale" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_locale" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:reset_password.Vitro
+uil-data:reset_password.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Passwort zurücksetzen"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "reset_password" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "reset_password" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:vitro_bullet_two.Vitro
+uil-data:vitro_bullet_two.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Bearbeiten von Instanzen und Beziehungen"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "vitro_bullet_two" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "vitro_bullet_two" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:replace_page_title.Vitro
+uil-data:replace_page_title.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Bild ersetzen"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "replace_page_title" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "replace_page_title" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:subproperty.Vitro
+uil-data:subproperty.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Subproperty"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "subproperty" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "subproperty" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:rdf_export.Vitro
+uil-data:rdf_export.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "RDF-Export"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "rdf_export" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "rdf_export" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:click_to_view_larger.Vitro
+uil-data:click_to_view_larger.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Klicken, um das Bild größer zu betrachten"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "click_to_view_larger" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "click_to_view_larger" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:build_date.Vitro
+uil-data:build_date.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Build-Datum"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "build_date" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "build_date" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:flags.Vitro
+uil-data:flags.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Flags"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "flags" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "flags" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:march.Vitro
+uil-data:march.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "März"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "march" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "march" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:display_only.Vitro
+uil-data:display_only.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Zeige nur"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "display_only" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "display_only" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:to_manage_content.Vitro
+uil-data:to_manage_content.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       ", um Inhalt zu verwalten."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "to_manage_content" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "to_manage_content" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:acct_created_email_html_text.Vitro
+uil-data:acct_created_email_html_text.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "<p>\n ${userAccount.firstName} ${userAccount.lastName}\n </p>\n\n <p>\n <strong>Herzlichen Glückwunsch!</strong>\n </p>\n\n <p>\n Wir haben einen Account für ${siteName} für Sie angelegt. Ihr Account ist mit der E-Mail-Adresse ${userAccount.emailAddress} verknüpft.\n </p>\n\n <p>\n Wenn Sie diesen Account nicht beantragt haben, können Sie diese E-Mail ignorieren.\n Diese Anfrage erlischt automatisch nach 30 Tagen.\n </p>\n\n <p>\n Klicken Sie auf den untenstehenden Link, um Ihr Passwort für Ihr neues Konto auf unserem Server zu erstellen.\n </p>\n\n <p>\n <a href=\"${passwordLink}\" title=\"password\">${passwordLink}</a>\n </p>\n\n <p>\n Wenn der obige Link nicht funktioniert, können Sie ihn kopieren und direkt in die Adressleiste Ihres Browsers und einfügen.\n </p>\n\n <p>\n Vielen Dank!\n </p>"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "acct_created_email_html_text" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "acct_created_email_html_text" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:file_upload_confirm_delete.Vitro
+uil-data:file_upload_confirm_delete.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "file_upload_confirm_delete" ;
-        prop:hasPackage  "Vitro-languages" .
+        rdf:type         uil:UILabel ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "file_upload_confirm_delete" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:cropping_caption.Vitro
+uil-data:cropping_caption.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ihr Profilfoto wird wie das Bild unten aussehen."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "cropping_caption" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "cropping_caption" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:browse_capitalized.Vitro
+uil-data:browse_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Durchsuchen"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "browse_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "browse_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:display_options.Vitro
+uil-data:display_options.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Anzeigeoptionen"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "display_options" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "display_options" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:site_config.Vitro
+uil-data:site_config.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Konfiguration"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "site_config" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "site_config" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:undo_camelcasing.Vitro
+uil-data:undo_camelcasing.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "CamelCase-Formatierung rückgängig machen"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "undo_camelcasing" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "undo_camelcasing" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:view_all_capitalized.Vitro
+uil-data:view_all_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Alle anzeigen"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "view_all_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "view_all_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_processing_labels.Vitro
+uil-data:error_processing_labels.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Fehler bei der Verarbeitung der Anfrage: Die deaktivierten Labels konnten nicht gelöscht werden."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_processing_labels" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_processing_labels" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:dates.Vitro
+uil-data:dates.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Termine"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "dates" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "dates" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:myAccount_heading.Vitro
+uil-data:myAccount_heading.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Mein Konto"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "myAccount_heading" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "myAccount_heading" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:roles.Vitro
+uil-data:roles.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Rollen"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "roles" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "roles" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:april.Vitro
+uil-data:april.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "April"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "april" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "april" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:password_reset_pending_subject.Vitro
+uil-data:password_reset_pending_subject.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "{0} Anfrage des Zurücksetzen des Passwortes."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "password_reset_pending_subject" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "password_reset_pending_subject" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:some_values_from.Vitro
+uil-data:some_values_from.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "einige Werte aus"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "some_values_from" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "some_values_from" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:browse_all_public_content.Vitro
+uil-data:browse_all_public_content.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Sie können allen öffentlichen, aktuell im System vorhandenen Inhalt durchsuchen unter Verwendung der"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "browse_all_public_content" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "browse_all_public_content" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:all_values_from.Vitro
+uil-data:all_values_from.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "alle Werte von"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "all_values_from" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "all_values_from" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:updated_account_2.Vitro
+uil-data:updated_account_2.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "wurde aktualisiert."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "updated_account_2" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "updated_account_2" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:alt_error_alert.Vitro
+uil-data:alt_error_alert.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Warnsymbol Fehler "@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "alt_error_alert" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "alt_error_alert" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:year_month.Vitro
+uil-data:year_month.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ungültiger Eintrag. Bitte geben Sie ein Jahr und ein Monat an."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "year_month" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "year_month" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:name.Vitro
+uil-data:name.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Name"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "name" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "name" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:no_image.Vitro
+uil-data:no_image.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "kein Bild"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "no_image" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "no_image" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:sparql_query_save_results.Vitro
+uil-data:sparql_query_save_results.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Save results to file"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "sparql_query_save_results" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "sparql_query_save_results" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:add_new_group.Vitro
+uil-data:add_new_group.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Neue Gruppe hinzufügen"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "add_new_group" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "add_new_group" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:browse_all.Vitro
+uil-data:browse_all.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Alle durchsuchen"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "browse_all" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "browse_all" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:processing_icon.Vitro
+uil-data:processing_icon.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "verarbeite"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "processing_icon" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "processing_icon" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:logins_restricted.Vitro
+uil-data:logins_restricted.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Logins sind nun eingeschränkt."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "logins_restricted" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "logins_restricted" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:search_tip_four.Vitro
+uil-data:search_tip_four.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Wenn Sie sich unsicher über die korrekte Rechtschreibung sind, nutzen Sie ~ am Ende Ihres Suchbegriffes -- Bsp.: <i>cabage~</i> findet <i>cabbage</i>, <i>steven~</i> findet <i>Stephen</i> und <i>Stefan</i> (und andere, ähnliche Namen)."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "search_tip_four" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "search_tip_four" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:imageUpload.errorNoURI.Vitro
+uil-data:imageUpload.errorNoURI.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "keine URI für die Entität angegeben"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "imageUpload.errorNoURI" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "imageUpload.errorNoURI" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:password_saved_please_login.Vitro
+uil-data:password_saved_please_login.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ihr Passwort wurde gespeichert. Bitte loggen Sie sich ein."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "password_saved_please_login" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "password_saved_please_login" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:upload_photo.Vitro
+uil-data:upload_photo.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Foto hochladen"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "upload_photo" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "upload_photo" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:sparql_query_results.Vitro
+uil-data:sparql_query_results.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "SPARQL-Query-Ergebnisse"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "sparql_query_results" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "sparql_query_results" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:enter_new_password.Vitro
+uil-data:enter_new_password.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Bitte geben Sie Ihr neues Passwort für {0} ein."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "enter_new_password" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "enter_new_password" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:display_more_ellipsis.Vitro
+uil-data:display_more_ellipsis.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "... mehr"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "display_more_ellipsis" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "display_more_ellipsis" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:updated_account_1.Vitro
+uil-data:updated_account_1.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Das Konto für"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "updated_account_1" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "updated_account_1" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:add_page.Vitro
+uil-data:add_page.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Seite hinzufügen"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "add_page" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "add_page" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:list_elements_of.Vitro
+uil-data:list_elements_of.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Liste Elemente von"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "list_elements_of" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "list_elements_of" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:class_group_all_caps.Vitro
+uil-data:class_group_all_caps.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Klassengruppe"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "class_group_all_caps" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "class_group_all_caps" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:no_class_restrictions.Vitro
+uil-data:no_class_restrictions.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Es existieren keine Klassen mit einer Einschränkung auf diese Eigenschaft."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "no_class_restrictions" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "no_class_restrictions" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:refresh_page_after_reordering.Vitro
+uil-data:refresh_page_after_reordering.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Laden Sie die Seite erneut, nachdem Sie Menüpunkte neu angeordnet haben."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "refresh_page_after_reordering" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "refresh_page_after_reordering" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:asserted_class_hierarchy.Vitro
+uil-data:asserted_class_hierarchy.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Angenommene Klassenhierarchie (asserted)"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "asserted_class_hierarchy" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "asserted_class_hierarchy" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:page_admin_permission_option.Vitro
+uil-data:page_admin_permission_option.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Nur Administratoren können diese Seite ansehen"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "page_admin_permission_option" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "page_admin_permission_option" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:create_associated_profile.Vitro
+uil-data:create_associated_profile.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Erstellen Sie ein zugehöriges Profil"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "create_associated_profile" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "create_associated_profile" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:password_reset_complete_email_html_text.Vitro
+uil-data:password_reset_complete_email_html_text.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "<p>\n ${userAccount.firstName} ${userAccount.lastName}\n </p>\n\n <p>\n <strong>Ihr Passwort wurde geändert.</strong>\n </p>\n\n <p>\n Das mit dem Account ${userAccount.emailAddress} verknüpfte Passwort wurde geändert.\n </p>\n\n <p>\n Vielen Dank.\n </p>"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "password_reset_complete_email_html_text" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "password_reset_complete_email_html_text" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:first_time_external_email_html_text.Vitro
+uil-data:first_time_external_email_html_text.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "<p>\n ${userAccount.firstName} ${userAccount.lastName}\n </p>\n\n <p>\n <strong>Herzlichen Glückwunsch!</strong>\n </p>\n\n <p>\n Wir haben einen Account für Sie angelegt. Ihr Account ist mit der E-Mail-Adresse ${userAccount.emailAddress} verknüpft.\n </p>\n\n <p>\n Vielen Dank!\n </p>\n"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "first_time_external_email_html_text" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "first_time_external_email_html_text" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:default.Vitro
+uil-data:default.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Default"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "default" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "default" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_password_mismatch.Vitro
+uil-data:error_password_mismatch.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Passwörter stimmen nicht überein."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_password_mismatch" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_password_mismatch" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:and.Vitro
+uil-data:and.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "und"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "and" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "and" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:no_matching_results.Vitro
+uil-data:no_matching_results.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Keine Ergebnisse gefunden."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "no_matching_results" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "no_matching_results" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:internal_class_i_capped.Vitro
+uil-data:internal_class_i_capped.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Institutionelle interne Klasse"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "internal_class_i_capped" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "internal_class_i_capped" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:decimal_only.Vitro
+uil-data:decimal_only.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ungültiger Eintrag. Dezimalpunkte sind erlaubt, aber Tausendertrennzeichen sind es nicht."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "decimal_only" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "decimal_only" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:new_account_2.Vitro
+uil-data:new_account_2.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "wurde erfolgreich erstellt."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "new_account_2" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "new_account_2" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:listed_page_title.Vitro
+uil-data:listed_page_title.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Aufgelisteter Seitentitel"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "listed_page_title" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "listed_page_title" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:delete_profile_editor.Vitro
+uil-data:delete_profile_editor.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Lösche Profilbearbeiter"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "delete_profile_editor" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "delete_profile_editor" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_no_first_name.Vitro
+uil-data:error_no_first_name.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Sie müssen einen Vornamen angeben."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_no_first_name" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_no_first_name" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:browse_all_in_class.Vitro
+uil-data:browse_all_in_class.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Alle Datensätze dieser Klasse durchsuchen"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "browse_all_in_class" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "browse_all_in_class" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:save_entry.Vitro
+uil-data:save_entry.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Eintrag speichern"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "save_entry" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "save_entry" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:confirm_initial_password.Vitro
+uil-data:confirm_initial_password.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Initiales Passwort bestätigen"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "confirm_initial_password" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "confirm_initial_password" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:ingest_tools.Vitro
+uil-data:ingest_tools.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ingest-Tools"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "ingest_tools" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "ingest_tools" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:application_error_email_html_text.Vitro
+uil-data:application_error_email_html_text.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "<p>Zum Zeitpunk ${datetime!} ist ein Fehler auf der Webseite ${siteName!} aufgetreten.</p>\n\n <p>\n <strong>Angeforderte URL:</strong> ${requestedUrl!}\n </p>\n\n <p>\n <#if errorMessage?has_content>\n <strong>Fehlermeldung:</strong> ${errorMessage!}\n </#if>\n </p>\n\n <p>\n <strong>Stack Trace</strong> (Vollständiger Trace verfügbar im Log):\n <pre>${stackTrace!}</pre>\n </p>\n\n <#if cause?has_content>\n <p><strong>Verursacht durch:</strong>\n <pre>${cause!}</pre>\n </p>\n </#if>"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "application_error_email_html_text" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "application_error_email_html_text" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:log_in.Vitro
+uil-data:log_in.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Einloggen"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "log_in" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "log_in" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:new_account_1.Vitro
+uil-data:new_account_1.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ein neues Konto für"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "new_account_1" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "new_account_1" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:imageUpload.errorUnrecognizedFileType.Vitro
+uil-data:imageUpload.errorUnrecognizedFileType.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "'' {0} '' ist kein akzeptierter Bilddateityp. Bitte laden Sie JPEG, GIF oder PNG-Dateien hoch."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "imageUpload.errorUnrecognizedFileType" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "imageUpload.errorUnrecognizedFileType" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:replace_page_title_with_name.Vitro
+uil-data:replace_page_title_with_name.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Bild ersetzen für {0}"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "replace_page_title_with_name" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "replace_page_title_with_name" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:unsupported_ie_version.Vitro
+uil-data:unsupported_ie_version.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Dieses Formular unterstützt keine Versionen des Internet Explorers unter Version 8. Bitte aktualisieren Sie Ihren Browser, oder wechseln Sie zu einem anderen Browser wie FireFox."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "unsupported_ie_version" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "unsupported_ie_version" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:logins_are_restricted.Vitro
+uil-data:logins_are_restricted.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Logins sind eingeschränkt."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "logins_are_restricted" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "logins_are_restricted" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:add_profile_editor.Vitro
+uil-data:add_profile_editor.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Profilbearbeiter hinzufügen"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "add_profile_editor" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "add_profile_editor" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:supply_name.Vitro
+uil-data:supply_name.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Sie müssen einen Titel angeben"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "supply_name" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "supply_name" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:feedback_thanks_text.Vitro
+uil-data:feedback_thanks_text.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Vielen Dank für das Kontaktieren unserer Kuration und des Entwicklungsteams. Wir werden so schnell wie möglich auf Ihre Anfrage reagieren."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "feedback_thanks_text" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "feedback_thanks_text" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_class_for_search.Vitro
+uil-data:select_class_for_search.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Sie müssen eine Klasse wählen, um die zugehörigen Datensätze anzuzeigen."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_class_for_search" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_class_for_search" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:since_elapsed_time.Vitro
+uil-data:since_elapsed_time.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "seit {0}, verstrichene Zeit {1}"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "since_elapsed_time" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "since_elapsed_time" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:unknown_user_name.Vitro
+uil-data:unknown_user_name.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Freund"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "unknown_user_name" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "unknown_user_name" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:faux_property_capitalized.Vitro
+uil-data:faux_property_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Faux-Property"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "faux_property_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "faux_property_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:enter_value_name_field.Vitro
+uil-data:enter_value_name_field.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Bitte geben Sie einen Wert im Namensfeld ein."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "enter_value_name_field" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "enter_value_name_field" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:group_name.Vitro
+uil-data:group_name.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Gruppenname"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "group_name" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "group_name" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:data_property_hierarchy.Vitro
+uil-data:data_property_hierarchy.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Hierarchie für Daten-Eigenschaften"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "data_property_hierarchy" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "data_property_hierarchy" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:external_login_text.Vitro
+uil-data:external_login_text.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Einloggen mittels Shibboleth"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "external_login_text" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "external_login_text" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:imageUpload.errorFileTooBig.Vitro
+uil-data:imageUpload.errorFileTooBig.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Bitte laden Sie ein Bild kleiner als {0} Megabyte hoch."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "imageUpload.errorFileTooBig" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "imageUpload.errorFileTooBig" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:profile_editors.Vitro
+uil-data:profile_editors.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Profilbearbeiter"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "profile_editors" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "profile_editors" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:implement_capitalized.Vitro
+uil-data:implement_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Implementieren"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "implement_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "implement_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:sparql_query_header.Vitro
+uil-data:sparql_query_header.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Query"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "sparql_query_header" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "sparql_query_header" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:view.Vitro
+uil-data:view.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Anzeigen"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "view" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "view" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:manage_profile_editing.Vitro
+uil-data:manage_profile_editing.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Profilbearbeitung verwalten"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "manage_profile_editing" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "manage_profile_editing" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:minimum_image_dimensions.Vitro
+uil-data:minimum_image_dimensions.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Mindestbildabmessungen: {0} x {1} Pixel"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "minimum_image_dimensions" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "minimum_image_dimensions" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:view_list_in_rdf.Vitro
+uil-data:view_list_in_rdf.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Sehen Sie die {0} Liste im RDF-Format"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "view_list_in_rdf" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "view_list_in_rdf" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:more_details_about_site.Vitro
+uil-data:more_details_about_site.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Mehr Details über diese Seite"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "more_details_about_site" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "more_details_about_site" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:new_entry_for.Vitro
+uil-data:new_entry_for.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "\"{0}\" für {1}"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "new_entry_for" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "new_entry_for" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:july.Vitro
+uil-data:july.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Juli"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "july" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "july" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:page_uri.Vitro
+uil-data:page_uri.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "URI der Seite"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "page_uri" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "page_uri" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:edit_date_time_value.Vitro
+uil-data:edit_date_time_value.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Bearbeite Datum/Zeit-Wert"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "edit_date_time_value" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "edit_date_time_value" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:limited_to_type.Vitro
+uil-data:limited_to_type.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "beschränkt auf den Typ"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "limited_to_type" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "limited_to_type" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:class_name.Vitro
+uil-data:class_name.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Klassenname"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "class_name" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "class_name" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:create_date_time_value.Vitro
+uil-data:create_date_time_value.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Erstelle Datum/Zeit-Wert"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "create_date_time_value" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "create_date_time_value" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:there_are_no_entries_for_selection.Vitro
+uil-data:there_are_no_entries_for_selection.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Es stehen keine Einträge zur Auswahl."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "there_are_no_entries_for_selection" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "there_are_no_entries_for_selection" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:edit_this_individual.Vitro
+uil-data:edit_this_individual.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Diesen Datensatz bearbeiten"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "edit_this_individual" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "edit_this_individual" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:start_interval_must_precede_end_earlier.Vitro
+uil-data:start_interval_must_precede_end_earlier.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Das Start-Intervall muss früher als das Ende-Intervall sein."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "start_interval_must_precede_end_earlier" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "start_interval_must_precede_end_earlier" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:type_capitalized.Vitro
+uil-data:type_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Typ"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "type_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "type_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:selected.Vitro
+uil-data:selected.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "ausgewählt"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "selected" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "selected" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:submit_upload.Vitro
+uil-data:submit_upload.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Foto hochladen"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "submit_upload" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "submit_upload" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:confirm_individual_deletion.Vitro
+uil-data:confirm_individual_deletion.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "confirm_individual_deletion" ;
-        prop:hasPackage  "Vitro-languages" .
+        rdf:type         uil:UILabel ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "confirm_individual_deletion" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:september.Vitro
+uil-data:september.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "September"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "september" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "september" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:verbose_turn_off.Vitro
+uil-data:verbose_turn_off.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ausschalten"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "verbose_turn_off" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "verbose_turn_off" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_type.Vitro
+uil-data:select_type.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Wählen Sie einen Typ"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_type" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_type" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:comments_questions.Vitro
+uil-data:comments_questions.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Kommentare, Fragen oder Anregungen"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "comments_questions" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "comments_questions" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:send_mail.Vitro
+uil-data:send_mail.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Mail senden"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "send_mail" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "send_mail" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:change_profile.Vitro
+uil-data:change_profile.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Profil wechseln"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "change_profile" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "change_profile" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:logins_already_restricted.Vitro
+uil-data:logins_already_restricted.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Logins sind bereits eingeschränkt."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "logins_already_restricted" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "logins_already_restricted" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:photo_types.Vitro
+uil-data:photo_types.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "(JPEG, GIF oder PNG)"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "photo_types" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "photo_types" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:search_term_error_near.Vitro
+uil-data:search_term_error_near.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Der Suchbegriff enthält einen Fehler bei"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "search_term_error_near" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "search_term_error_near" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:share_profile_uri.Vitro
+uil-data:share_profile_uri.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Die URI für dieses Profil teilen"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "share_profile_uri" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "share_profile_uri" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:no_html_specified.Vitro
+uil-data:no_html_specified.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Kein HTML angegeben."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "no_html_specified" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "no_html_specified" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:first_name.Vitro
+uil-data:first_name.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Vorname"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "first_name" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "first_name" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:class_link.Vitro
+uil-data:class_link.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Klasse wählen"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "class_link" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "class_link" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:view_profile_page_for.Vitro
+uil-data:view_profile_page_for.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Zeige die Profilseite von"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "view_profile_page_for" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "view_profile_page_for" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_classes_to_display.Vitro
+uil-data:select_classes_to_display.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Sie müssen die anzuzeigenden Klassen auswählen."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_classes_to_display" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_classes_to_display" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:password_mismatch.Vitro
+uil-data:password_mismatch.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Passwörter stimmen nicht überein."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "password_mismatch" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "password_mismatch" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:page_management.Vitro
+uil-data:page_management.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Einzelseiten-Verwaltung"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "page_management" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "page_management" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:resource_uri.Vitro
+uil-data:resource_uri.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ressource URI"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "resource_uri" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "resource_uri" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:sparql_query_run_query.Vitro
+uil-data:sparql_query_run_query.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Run Query"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "sparql_query_run_query" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "sparql_query_run_query" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:enter_fixed_html_here.Vitro
+uil-data:enter_fixed_html_here.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Geben Sie hier fixes HTML ein"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "enter_fixed_html_here" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "enter_fixed_html_here" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:verify_this_match.Vitro
+uil-data:verify_this_match.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Diesen Treffer verifizieren"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "verify_this_match" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "verify_this_match" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:properties_capitalized.Vitro
+uil-data:properties_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Eigenschaften"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "properties_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "properties_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:raw_string_literals.Vitro
+uil-data:raw_string_literals.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Reine Stringliterale"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "raw_string_literals" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "raw_string_literals" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:no_content_create_groups_classes.Vitro
+uil-data:no_content_create_groups_classes.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Es gibt derzeit keine Inhalte im System oder Sie müssen Klassengruppen erstellen und Ihre Klassen zu ihnen zuweisen."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "no_content_create_groups_classes" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "no_content_create_groups_classes" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:home_page.Vitro
+uil-data:home_page.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Startseite"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "home_page" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "home_page" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:restriction_on.Vitro
+uil-data:restriction_on.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Einschränkung auf"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "restriction_on" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "restriction_on" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:processing_indicator.Vitro
+uil-data:processing_indicator.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Bearbeite Zeitindikator"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "processing_indicator" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "processing_indicator" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:selected_page_content_type.Vitro
+uil-data:selected_page_content_type.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ausgewählter Inhaltstyp für die zugehörige Seite"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "selected_page_content_type" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "selected_page_content_type" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:create_entry.Vitro
+uil-data:create_entry.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Eintrag erstellen"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "create_entry" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "create_entry" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:password_change_not_pending.Vitro
+uil-data:password_change_not_pending.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Das Passwort für {0} wurde bereits zurückgesetzt."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "password_change_not_pending" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "password_change_not_pending" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:javascript_instructions.Vitro
+uil-data:javascript_instructions.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "JavaScript-Anweisungen"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "javascript_instructions" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "javascript_instructions" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_invalid_email.Vitro
+uil-data:error_invalid_email.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "''{0}'' is not a valid email address."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_invalid_email" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_invalid_email" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:new_pwd_matches_existing.Vitro
+uil-data:new_pwd_matches_existing.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ihr neues Passwort muss sich von Ihrem bestehenden Passwort unterscheiden."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "new_pwd_matches_existing" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "new_pwd_matches_existing" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:or.Vitro
+uil-data:or.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "oder"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "or" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "or" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:search_form.Vitro
+uil-data:search_form.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Suchformular"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "search_form" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "search_form" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:menu_item_name.Vitro
+uil-data:menu_item_name.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Name des Menüpunktes"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "menu_item_name" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "menu_item_name" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:june.Vitro
+uil-data:june.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Juni"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "june" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "june" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:last_name.Vitro
+uil-data:last_name.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Nachname"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "last_name" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "last_name" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:placeholder_image.Vitro
+uil-data:placeholder_image.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Platzhalter Bild"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "placeholder_image" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "placeholder_image" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:requested_url.Vitro
+uil-data:requested_url.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Angeforderte URL"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "requested_url" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "requested_url" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:first_time_login_note.Vitro
+uil-data:first_time_login_note.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Hinweis: Es wird eine E-Mail an die oben angegebene Adresse gesendet um Ihnen mitzuteilen, dass ein Konto erstellt wurde."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "first_time_login_note" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "first_time_login_note" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_external_auth_already_exists.Vitro
+uil-data:error_external_auth_already_exists.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Es ist bereits ein Konto mit dieser externen Berechtigungs-ID vorhanden."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_external_auth_already_exists" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_external_auth_already_exists" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:contains_no_pears.Vitro
+uil-data:contains_no_pears.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "enthält keine Birnen"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "contains_no_pears" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "contains_no_pears" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:index_page.Vitro
+uil-data:index_page.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Indexseite"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "index_page" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "index_page" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:search_tip_one.Vitro
+uil-data:search_tip_one.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Halten Sie es einfach! Verwenden Sie kurze, einzelne Begriffe, wenn ihre Suche zu viele Ergebnisse liefert."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "search_tip_one" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "search_tip_one" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:sparql_query_construct_describe_results.Vitro
+uil-data:sparql_query_construct_describe_results.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Format for CONSTRUCT and DESCRIBE query results"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "sparql_query_construct_describe_results" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "sparql_query_construct_describe_results" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:password_capitalized.Vitro
+uil-data:password_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Passwort"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "password_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "password_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:file_upload_submit_label.Vitro
+uil-data:file_upload_submit_label.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "file_upload_submit_label" ;
-        prop:hasPackage  "Vitro-languages" .
+        rdf:type         uil:UILabel ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "file_upload_submit_label" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:please.Vitro
+uil-data:please.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Bitte"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "please" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "please" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:account_created.Vitro
+uil-data:account_created.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ihr {0} Konto wurde erstellt."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "account_created" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "account_created" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:add.Vitro
+uil-data:add.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "hinzufügen"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "add" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "add" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:limit.Vitro
+uil-data:limit.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Beschränken von"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "limit" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "limit" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:november.Vitro
+uil-data:november.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "November"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "november" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "november" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:confirm_delete.Vitro
+uil-data:confirm_delete.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Sind Sie sicher, dass Sie das Foto löschen wollen?"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "confirm_delete" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "confirm_delete" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:login_welcome_message.Vitro
+uil-data:login_welcome_message.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Willkommen {1, choice, 1# | 1< zurück}, {0}"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "login_welcome_message" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "login_welcome_message" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:password_changed_subject.Vitro
+uil-data:password_changed_subject.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Passwort geändert."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "password_changed_subject" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "password_changed_subject" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:incorrect_email_password.Vitro
+uil-data:incorrect_email_password.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "E-Mail oder Passwort ist falsch."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "incorrect_email_password" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "incorrect_email_password" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:identifiers.Vitro
+uil-data:identifiers.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Identifiers"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "identifiers" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "identifiers" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:javascript_ie_alert_text.Vitro
+uil-data:javascript_ie_alert_text.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Diese Seite nutzt HTML-Elemente, die von Internet Explorer 8 und darunter sowie ohne Javascript nicht unterstützt werden. Im Ergebnis wird die Seite nicht richtig wiedergegeben werden. Um dies zu korrigieren, aktivieren Sie bitte entweder JavaScript, aktualisieren Sie auf Internet Explorer 9 oder verwenden Sie einen anderen Browser."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "javascript_ie_alert_text" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "javascript_ie_alert_text" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:zoo_two.Vitro
+uil-data:zoo_two.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Zoo 2"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "zoo_two" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "zoo_two" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:verbose_turn_on.Vitro
+uil-data:verbose_turn_on.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Einschalten"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "verbose_turn_on" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "verbose_turn_on" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:selection_in_process.Vitro
+uil-data:selection_in_process.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ihre Auswahl wird verarbeitet."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "selection_in_process" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "selection_in_process" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:please_create.Vitro
+uil-data:please_create.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Bitte erstellen Sie "@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "please_create" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "please_create" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:verbose_status_off.Vitro
+uil-data:verbose_status_off.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "aus"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "verbose_status_off" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "verbose_status_off" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:page_not_configured.Vitro
+uil-data:page_not_configured.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Diese Seite ist noch nicht konfiguriert."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "page_not_configured" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "page_not_configured" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:new_account_notification.Vitro
+uil-data:new_account_notification.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "An {0} wurde eine Benachrichtigungs-E-Mail mit einer Anleitung zur Konten-Aktivierung und zur Erstellung eines Passwort gesendet."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "new_account_notification" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "new_account_notification" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:full_list_startup.Vitro
+uil-data:full_list_startup.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Die vollständige Liste der Startereignisse und Nachrichten."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "full_list_startup" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "full_list_startup" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:user_role.Vitro
+uil-data:user_role.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Rolle"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "user_role" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "user_role" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:or_enter_valid_address.Vitro
+uil-data:or_enter_valid_address.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "oder geben Sie eine andere vollständige und gültige E-Mail-Adresse ein."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "or_enter_valid_address" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "or_enter_valid_address" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:all.Vitro
+uil-data:all.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Alle"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "all" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "all" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:logged_in_but_no_profile.Vitro
+uil-data:logged_in_but_no_profile.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Sie haben sich angemeldet, aber das System enthält für Sie kein Profil."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "logged_in_but_no_profile" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "logged_in_but_no_profile" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:page_text.Vitro
+uil-data:page_text.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Seitentext"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "page_text" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "page_text" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:create_new_entry.Vitro
+uil-data:create_new_entry.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Bitte einen neuen Eintrag erstellen."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "create_new_entry" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "create_new_entry" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:enter_in_security_field.Vitro
+uil-data:enter_in_security_field.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Bitte geben Sie die unten angezeigten Buchstaben in das Sicherheitsfeld ein"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "enter_in_security_field" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "enter_in_security_field" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_an_existing_or_create_a_new_one.Vitro
+uil-data:select_an_existing_or_create_a_new_one.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Wählen Sie eine vorhandene oder erstellen Sie eine neue."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_an_existing_or_create_a_new_one" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_an_existing_or_create_a_new_one" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:not.Vitro
+uil-data:not.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "nicht"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "not" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "not" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:range_data_type.Vitro
+uil-data:range_data_type.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Range Data Type"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "range_data_type" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "range_data_type" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:august.Vitro
+uil-data:august.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "August"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "august" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "august" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:terms_of_use.Vitro
+uil-data:terms_of_use.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Nutzungsbedingungen"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "terms_of_use" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "terms_of_use" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:dump_restore.Vitro
+uil-data:dump_restore.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Sichern/Rückspielen der Anwendung"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "dump_restore" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "dump_restore" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:show_properties.Vitro
+uil-data:show_properties.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Properties anzeigen"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "show_properties" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "show_properties" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:associated_individuals.Vitro
+uil-data:associated_individuals.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Zugehörige Personen"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "associated_individuals" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "associated_individuals" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:name_capitalized.Vitro
+uil-data:name_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Name"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "name_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "name_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:manage_labels.Vitro
+uil-data:manage_labels.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Labels verwalten"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "manage_labels" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "manage_labels" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:current_user.Vitro
+uil-data:current_user.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Aktueller Benutzer"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "current_user" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "current_user" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:minimum_ymd.Vitro
+uil-data:minimum_ymd.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ungültiger Eintrag. Bitte geben Sie mindestens ein Jahr, Monat und Tag an."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "minimum_ymd" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "minimum_ymd" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:try_another_letter.Vitro
+uil-data:try_another_letter.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Bitte versuchen Sie einen anderen Buchstaben oder suchen Sie nach allen."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "try_another_letter" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "try_another_letter" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:alt_image_to_crop.Vitro
+uil-data:alt_image_to_crop.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Zuzuschneidendes Foto"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "alt_image_to_crop" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "alt_image_to_crop" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:current_task.Vitro
+uil-data:current_task.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "{0} der Suchindex"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "current_task" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "current_task" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:imageUpload.errorNoImageForCropping.Vitro
+uil-data:imageUpload.errorNoImageForCropping.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Es ist keine Bilddatei vorhanden, die zugeschnitten werden könnte."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "imageUpload.errorNoImageForCropping" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "imageUpload.errorNoImageForCropping" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:we_have_an_error.Vitro
+uil-data:we_have_an_error.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Es ein Fehler im System aufgetreten."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "we_have_an_error" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "we_have_an_error" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_another_class.Vitro
+uil-data:select_another_class.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Bitte wählen Sie eine andere Klasse aus der Liste."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_another_class" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_another_class" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:manage_labels_for.Vitro
+uil-data:manage_labels_for.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Labels verwalten für"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "manage_labels_for" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "manage_labels_for" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:revision_info.Vitro
+uil-data:revision_info.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Revisionsinformation"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "revision_info" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "revision_info" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:rebuild_vis_cache.Vitro
+uil-data:rebuild_vis_cache.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Visualisierungs-Cache neu aufbauen"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "rebuild_vis_cache" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "rebuild_vis_cache" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:delete.Vitro
+uil-data:delete.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Löschen"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "delete" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "delete" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:update_button.Vitro
+uil-data:update_button.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Aktualisieren"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "update_button" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "update_button" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:imageUpload.errorNoPhotoSelected.Vitro
+uil-data:imageUpload.errorNoPhotoSelected.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Bitte wählen Sie ein Foto aus."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "imageUpload.errorNoPhotoSelected" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "imageUpload.errorNoPhotoSelected" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:imageUpload.errorUnrecognizedURI.Vitro
+uil-data:imageUpload.errorUnrecognizedURI.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Diese URI konnte keiner Entität zugeordnet werden: '' {0} ''"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "imageUpload.errorUnrecognizedURI" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "imageUpload.errorUnrecognizedURI" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:menu_item.Vitro
+uil-data:menu_item.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Menüpunkt"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "menu_item" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "menu_item" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:auth_id_label.Vitro
+uil-data:auth_id_label.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Externe Authentifizierungs-ID"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "auth_id_label" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "auth_id_label" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:may.Vitro
+uil-data:may.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Mai"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "may" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "may" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:what_is_vitro.Vitro
+uil-data:what_is_vitro.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Was ist VITRO?"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "what_is_vitro" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "what_is_vitro" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_a_language.Vitro
+uil-data:select_a_language.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Eine Sprache auswählen"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_a_language" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_a_language" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:ip_address.Vitro
+uil-data:ip_address.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "IP-Adresse"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "ip_address" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "ip_address" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:unrecognized_user.Vitro
+uil-data:unrecognized_user.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Unbekannter Benutzer"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "unrecognized_user" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "unrecognized_user" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:password_change_invalid_key.Vitro
+uil-data:password_change_invalid_key.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Der Link, den Sie für {0} verwendet haben, ist ungültig. Bitten Sie den Site-Administrator, den Link erneut zu senden. "@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "password_change_invalid_key" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "password_change_invalid_key" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:change_text_for.Vitro
+uil-data:change_text_for.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Text ändern für:"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "change_text_for" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "change_text_for" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:to_enable_javascript.Vitro
+uil-data:to_enable_javascript.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Hier gelangen Sie zu Anleitungen zur Aktivierung von JavaScript in Ihrem Web-Browser"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "to_enable_javascript" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "to_enable_javascript" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:warning.Vitro
+uil-data:warning.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Warnung"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "warning" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "warning" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:revision.Vitro
+uil-data:revision.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Revision"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "revision" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "revision" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:filter_by_roles.Vitro
+uil-data:filter_by_roles.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Nach Rollen filtern"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "filter_by_roles" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "filter_by_roles" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:page_uri_missing_msg.Vitro
+uil-data:page_uri_missing_msg.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Konnte Seite nicht generieren, weil unklar war, welche Seite angefragt wurde. Es fehlt eventuell ein URL-Mapping."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "page_uri_missing_msg" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "page_uri_missing_msg" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:fatal_error.Vitro
+uil-data:fatal_error.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Fatal Error"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "fatal_error" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "fatal_error" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:page_select_permission_option.Vitro
+uil-data:page_select_permission_option.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Berechtigung auswählen"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "page_select_permission_option" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "page_select_permission_option" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:january.Vitro
+uil-data:january.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Januar"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "january" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "january" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:property.Vitro
+uil-data:property.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Eigenschaft"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "property" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "property" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:external_auth_id.Vitro
+uil-data:external_auth_id.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "externe Auth ID"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "external_auth_id" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "external_auth_id" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:date_time_value_for.Vitro
+uil-data:date_time_value_for.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Datum/Zeit-Wert für"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "date_time_value_for" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "date_time_value_for" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:sparql_query_title.Vitro
+uil-data:sparql_query_title.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "SPARQL Query"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "sparql_query_title" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "sparql_query_title" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:previous.Vitro
+uil-data:previous.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Zurück"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "previous" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "previous" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:upload_page_title_with_name.Vitro
+uil-data:upload_page_title_with_name.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Bild hochladen für {0}"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "upload_page_title_with_name" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "upload_page_title_with_name" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:cant_change_password_while_logged_in.Vitro
+uil-data:cant_change_password_while_logged_in.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Sie können das Passwort für {0} nicht zurücksetzen während Sie als {1} angemeldet sind. Bitte melden Sie ab und versuchen Sie es erneut."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "cant_change_password_while_logged_in" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "cant_change_password_while_logged_in" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:rejected_spam.Vitro
+uil-data:rejected_spam.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "ABGELEHNT - SPAM"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "rejected_spam" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "rejected_spam" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:logins_are_open.Vitro
+uil-data:logins_are_open.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Logins sind offen für alle."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "logins_are_open" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "logins_are_open" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:confirm_delete_account_singular.Vitro
+uil-data:confirm_delete_account_singular.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Sind Sie sicher, dass Sie dieses Konto löschen wollen?"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "confirm_delete_account_singular" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "confirm_delete_account_singular" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:all_capitalized.Vitro
+uil-data:all_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Alle"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "all_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "all_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:of_the_results.Vitro
+uil-data:of_the_results.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "der Ergebnisse"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "of_the_results" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "of_the_results" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_content_type.Vitro
+uil-data:select_content_type.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Sie müssen Inhalte auswählen, die auf die Seite aufgenommen werden"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_content_type" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_content_type" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:visit_project_website.Vitro
+uil-data:visit_project_website.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Besuchen Sie die nationale Projektwebseite"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "visit_project_website" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "visit_project_website" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:view_labels_for.Vitro
+uil-data:view_labels_for.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Labels anzeigen für"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "view_labels_for" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "view_labels_for" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:new_account_note.Vitro
+uil-data:new_account_note.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Hinweis: An die oben angegebene Adresse wird eine E-Mail gesendet, um darüber zu informieren, dass ein Konto erstellt wurde. Es enthält Anweisungen für die Aktivierung des Kontos und Erstellung eines Passwortes."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "new_account_note" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "new_account_note" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_alert_icon.Vitro
+uil-data:error_alert_icon.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Warnsymbol Fehler "@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_alert_icon" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_alert_icon" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:imageUpload.errorImageTooSmall.Vitro
+uil-data:imageUpload.errorImageTooSmall.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Das hochgeladene Bild sollte mindestens {0} Pixel hoch und {1} Pixel breit sein."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "imageUpload.errorImageTooSmall" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "imageUpload.errorImageTooSmall" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_account_to_delete.Vitro
+uil-data:select_account_to_delete.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Wählen Sie diesen Account, um ihn zu löschen"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_account_to_delete" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_account_to_delete" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:interest_thanks.Vitro
+uil-data:interest_thanks.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Vielen Dank für Ihr Interesse an {0}. Bitte senden Sie das Formular mit Fragen, Kommentaren oder Feedback über den Inhalt dieser Seite."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "interest_thanks" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "interest_thanks" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:year_numeric.Vitro
+uil-data:year_numeric.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ungültiger Eintrag. Das Jahr muss numerisch sein."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "year_numeric" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "year_numeric" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_an_existing_document.Vitro
+uil-data:select_an_existing_document.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Wählen Sie ein vorhandenes Dokument"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_an_existing_document" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_an_existing_document" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:password_length.Vitro
+uil-data:password_length.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Passwort muss zwischen {0} und {1} Zeichen lang sein."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "password_length" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "password_length" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:monday.Vitro
+uil-data:monday.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Montag"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "monday" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "monday" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:account_created_subject.Vitro
+uil-data:account_created_subject.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ihr {0} Konto wurde erstellt."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "account_created_subject" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "account_created_subject" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:vitro_bullet_three.Vitro
+uil-data:vitro_bullet_three.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Aufbauen einer öffentlich zugänglichen Webseite zur Anzeeige Ihrer Daten"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "vitro_bullet_three" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "vitro_bullet_three" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:photo.Vitro
+uil-data:photo.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Foto"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "photo" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "photo" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:file_must_be_entered_msg.Vitro
+uil-data:file_must_be_entered_msg.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "für dieses Feld muss eine Datei eingegeben werden."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "file_must_be_entered_msg" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "file_must_be_entered_msg" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:entity_to_query_for.Vitro
+uil-data:entity_to_query_for.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Diese ID ist die ID der Entität die angefragt wird, netid funktioniert auch."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "entity_to_query_for" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "entity_to_query_for" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:manage_grants_and_projects_link.Vitro
+uil-data:manage_grants_and_projects_link.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Stipendien und Projekte verwalten"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "manage_grants_and_projects_link" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "manage_grants_and_projects_link" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:manage_labels_intro.Vitro
+uil-data:manage_labels_intro.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Wenn mehrere Labels in der gleichen Sprache existieren, nutzen Sie bitte den Entfernen-Link, um die Labels zu entfernen, die Sie nicht auf der Profilseite der angegebenen Sprache anzeigen möchten."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "manage_labels_intro" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "manage_labels_intro" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:hide_show_properties.Vitro
+uil-data:hide_show_properties.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Eigenschaften verbergen/anzeigen"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "hide_show_properties" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "hide_show_properties" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:untitled.Vitro
+uil-data:untitled.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "-unbetitelt-"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "untitled" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "untitled" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:manage_publications_link.Vitro
+uil-data:manage_publications_link.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Publikationen verwalten"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "manage_publications_link" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "manage_publications_link" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_all.Vitro
+uil-data:select_all.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Alle auswählen"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_all" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_all" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:local_name.Vitro
+uil-data:local_name.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Local Name"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "local_name" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "local_name" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:end_interval_must_follow_start_interval.Vitro
+uil-data:end_interval_must_follow_start_interval.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Das Ende-Intervall muss nach dem Start-Intervall liegen."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "end_interval_must_follow_start_interval" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "end_interval_must_follow_start_interval" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:view_page.Vitro
+uil-data:view_page.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Seite anzeigen"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "view_page" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "view_page" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:browse_page_javascript_one.Vitro
+uil-data:browse_page_javascript_one.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Diese Seite benötigt Javascript, aber in Ihrem Browser ist Javascript deaktiviert. Entweder aktivieren Sie Javascript oder verwenden Sie"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "browse_page_javascript_one" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "browse_page_javascript_one" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:sparql_query_builder.Vitro
+uil-data:sparql_query_builder.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "SPARQL Query Builder"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "sparql_query_builder" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "sparql_query_builder" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:sub_properties.Vitro
+uil-data:sub_properties.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Subproperties"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "sub_properties" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "sub_properties" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:add_label_for_language.Vitro
+uil-data:add_label_for_language.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Sprache"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "add_label_for_language" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "add_label_for_language" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:file_upload_error_file_not_found.Vitro
+uil-data:file_upload_error_file_not_found.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "file_upload_error_file_not_found" ;
-        prop:hasPackage  "Vitro-languages" .
+        rdf:type         uil:UILabel ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "file_upload_error_file_not_found" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:file_upload_predicate.Vitro
+uil-data:file_upload_predicate.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "file_upload_predicate" ;
-        prop:hasPackage  "Vitro-languages" .
+        rdf:type         uil:UILabel ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "file_upload_predicate" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:start_with_leading_slash.Vitro
+uil-data:start_with_leading_slash.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Muss mit einem Slash beginnen (z.B. /Personen)"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "start_with_leading_slash" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "start_with_leading_slash" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:trace_available.Vitro
+uil-data:trace_available.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Vollständiger Trace verfügbar im VIVO-Log"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "trace_available" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "trace_available" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:editing_prohibited.Vitro
+uil-data:editing_prohibited.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Diese Eigenschaft ist derzeit so konfiguriert, dass die Bearbeitung zu verboten ist."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "editing_prohibited" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "editing_prohibited" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:verbose_status_on.Vitro
+uil-data:verbose_status_on.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "ein"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "verbose_status_on" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "verbose_status_on" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:use_capitalized.Vitro
+uil-data:use_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Verwenden"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "use_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "use_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:search_index_status.Vitro
+uil-data:search_index_status.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Suchindex-Status"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "search_index_status" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "search_index_status" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:filter_search.Vitro
+uil-data:filter_search.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Suche filtern"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "filter_search" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "filter_search" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:with_vitro.Vitro
+uil-data:with_vitro.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Mit Vitro können Sie:"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "with_vitro" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "with_vitro" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:site_information.Vitro
+uil-data:site_information.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Metadaten"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "site_information" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "site_information" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:logins_temporarily_disabled.Vitro
+uil-data:logins_temporarily_disabled.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Während das System gewartet wird, sind Benutzer-Logins vorübergehend deaktiviert ."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "logins_temporarily_disabled" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "logins_temporarily_disabled" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:leave_password_unchanged.Vitro
+uil-data:leave_password_unchanged.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Wenn Sie dieses Feld leer lassen, wird das Passwort nicht verändert."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "leave_password_unchanged" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "leave_password_unchanged" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:query_model.Vitro
+uil-data:query_model.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Query-Modell"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "query_model" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "query_model" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:restrict_logins_mixed_caps.Vitro
+uil-data:restrict_logins_mixed_caps.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Anmeldungen einschränken"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "restrict_logins_mixed_caps" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "restrict_logins_mixed_caps" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:wednesday.Vitro
+uil-data:wednesday.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Mittwoch"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "wednesday" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "wednesday" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:berries.Vitro
+uil-data:berries.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Beeren:"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "berries" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "berries" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:full_name.Vitro
+uil-data:full_name.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Vollständiger Name"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "full_name" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "full_name" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:no_email_supplied.Vitro
+uil-data:no_email_supplied.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Keine E-Mail angegeben."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "no_email_supplied" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "no_email_supplied" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_was_reported.Vitro
+uil-data:error_was_reported.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Dieser Fehler wurde dem Administrator gemeldet."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_was_reported" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_was_reported" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:search_results_for.Vitro
+uil-data:search_results_for.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Suchergebnisse für"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "search_results_for" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "search_results_for" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:search_tip_three.Vitro
+uil-data:search_tip_three.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Mit Ausnahme boolescher Operatoren, sind Suchen <strong>nicht</strong> case-sensitive, also sind \"Genf\" und \"genf\" identisch."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "search_tip_three" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "search_tip_three" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:view_profile_for_page.Vitro
+uil-data:view_profile_for_page.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Personenprofil für diese Seite anzeigen"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "view_profile_for_page" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "view_profile_for_page" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:reordering_menus_failed.Vitro
+uil-data:reordering_menus_failed.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Neuanordnung von Menüpunkten ist fehlgeschlagen."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "reordering_menus_failed" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "reordering_menus_failed" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:verbose_control.Vitro
+uil-data:verbose_control.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ausführliche Prüfung"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "verbose_control" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "verbose_control" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:ontology_list.Vitro
+uil-data:ontology_list.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ontologien"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "ontology_list" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "ontology_list" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:edit_entry.Vitro
+uil-data:edit_entry.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Diesen Eintrag bearbeiten"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "edit_entry" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "edit_entry" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:label.dateTimeWithPrecision.minutes_capitalized.Vitro
+uil-data:label.dateTimeWithPrecision.minutes_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Minuten"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "label.dateTimeWithPrecision.minutes_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "label.dateTimeWithPrecision.minutes_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:object.Vitro
+uil-data:object.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Objekt"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "object" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "object" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:confirm_email_changed_email_html_text.Vitro
+uil-data:confirm_email_changed_email_html_text.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "<p>\n Sehr geehrte ${userAccount.firstName} ${userAccount.lastName}\n </p>\n\n <p>\n Sie haben kürzlich die E-Mail-Adresse geändert, die mit \n ${userAccount.firstName} ${userAccount.lastName}\n </p>\n\n <p>\n Vielen Dank.\n </p>"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "confirm_email_changed_email_html_text" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "confirm_email_changed_email_html_text" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_no_new_password.Vitro
+uil-data:error_no_new_password.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Bitte geben Sie ihr neues Passwort ein."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_no_new_password" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_no_new_password" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:page_loggedin_permission_option.Vitro
+uil-data:page_loggedin_permission_option.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Eingeloggte Personen können diese Seite ansehen"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "page_loggedin_permission_option" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "page_loggedin_permission_option" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:expecting_content.Vitro
+uil-data:expecting_content.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Erwarteter Inhalt?"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "expecting_content" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "expecting_content" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:required_fields.Vitro
+uil-data:required_fields.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Pflichtfelder"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "required_fields" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "required_fields" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:edit_page_title.Vitro
+uil-data:edit_page_title.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Edit"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "edit_page_title" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "edit_page_title" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_existing.Vitro
+uil-data:select_existing.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Wähle existierenden"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_existing" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_existing" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:invalid_url_msg.Vitro
+uil-data:invalid_url_msg.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Diese URL muss mit http:// oder https:// beginnen."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "invalid_url_msg" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "invalid_url_msg" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:search_button.Vitro
+uil-data:search_button.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Suchen"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "search_button" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "search_button" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:advanced_search_tips_header.Vitro
+uil-data:advanced_search_tips_header.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Tipps für Fortgeschrittene"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "advanced_search_tips_header" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "advanced_search_tips_header" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:supply_url.Vitro
+uil-data:supply_url.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Sie müssen eine lesbare URL angeben"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "supply_url" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "supply_url" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_profiles.Vitro
+uil-data:select_profiles.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Profile auswählen"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_profiles" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_profiles" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_one.Vitro
+uil-data:select_one.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Wählen Sie ein"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_one" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_one" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:continue.Vitro
+uil-data:continue.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Weiter"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "continue" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "continue" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:language_selection_failed.Vitro
+uil-data:language_selection_failed.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Es ein Problem im System aufgetreten. Ihre Sprachwahl wurde zurückgewiesen."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "language_selection_failed" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "language_selection_failed" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:display_has_element_error.Vitro
+uil-data:display_has_element_error.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Es ist ein Fehler im System aufgetreten. Die Eigenschaft \"display:hasElement\" konnte nicht abgerufen werden."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "display_has_element_error" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "display_has_element_error" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:file_upload_error_file_is_too_big.Vitro
+uil-data:file_upload_error_file_is_too_big.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "file_upload_error_file_is_too_big" ;
-        prop:hasPackage  "Vitro-languages" .
+        rdf:type         uil:UILabel ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "file_upload_error_file_is_too_big" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:template_capitalized.Vitro
+uil-data:template_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Vorlage"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "template_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "template_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:file_upload_supported_media.Vitro
+uil-data:file_upload_supported_media.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "file_upload_supported_media" ;
-        prop:hasPackage  "Vitro-languages" .
+        rdf:type         uil:UILabel ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "file_upload_supported_media" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:user_accounts_title.Vitro
+uil-data:user_accounts_title.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Benutzerkonten"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "user_accounts_title" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "user_accounts_title" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:create_your_password.Vitro
+uil-data:create_your_password.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Erstellen Sie Ihr Passwort"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "create_your_password" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "create_your_password" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:create_account.Vitro
+uil-data:create_account.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Konto erstellen"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "create_account" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "create_account" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:remove_menu_item.Vitro
+uil-data:remove_menu_item.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Menüpunkt entfernen"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "remove_menu_item" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "remove_menu_item" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:click_to_view_account.Vitro
+uil-data:click_to_view_account.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Klicken, um Kontodaten anzuzeigen"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "click_to_view_account" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "click_to_view_account" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:add_new_entry_for.Vitro
+uil-data:add_new_entry_for.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Neuen Eintrag hinzufügen für:"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "add_new_entry_for" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "add_new_entry_for" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:menu_ordering.Vitro
+uil-data:menu_ordering.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Menü-Sortierung"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "menu_ordering" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "menu_ordering" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:map_processor_error.Vitro
+uil-data:map_processor_error.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ein Fehler ist aufgetreten und die Map von Prozessoren für diesen Inhalt fehlt. Bitte kontaktieren Sie den Administrator"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "map_processor_error" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "map_processor_error" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:change_profile_title.Vitro
+uil-data:change_profile_title.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Profil wechseln"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "change_profile_title" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "change_profile_title" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:domain_class.Vitro
+uil-data:domain_class.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Domain-Klasse"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "domain_class" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "domain_class" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:manage_labels_capitalized.Vitro
+uil-data:manage_labels_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Labels verwalten"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "manage_labels_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "manage_labels_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_passwords_dont_match.Vitro
+uil-data:error_passwords_dont_match.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Die eingegebenen Passwörter stimmen nicht überein."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_passwords_dont_match" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_passwords_dont_match" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:save_profile_changes.Vitro
+uil-data:save_profile_changes.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Speichere Änderungen zu Profilen"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "save_profile_changes" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "save_profile_changes" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:site_administration.Vitro
+uil-data:site_administration.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Seitenadministration"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "site_administration" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "site_administration" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:vitro_bullet_one.Vitro
+uil-data:vitro_bullet_one.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Erstellen oder Laden von Ontologien im OWL-Format"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "vitro_bullet_one" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "vitro_bullet_one" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:pages.Vitro
+uil-data:pages.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Seiten"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "pages" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "pages" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:inferred_class_hierarchy.Vitro
+uil-data:inferred_class_hierarchy.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Gefolgerte Klassenhierarchie (inferred)"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "inferred_class_hierarchy" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "inferred_class_hierarchy" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:auth_id_in_use.Vitro
+uil-data:auth_id_in_use.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Dieser Identifier wird bereits verwendet."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "auth_id_in_use" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "auth_id_in_use" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:data_input.Vitro
+uil-data:data_input.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Dateneingabe"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "data_input" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "data_input" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:recompute_inferences_mixed_caps.Vitro
+uil-data:recompute_inferences_mixed_caps.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Schlussfolgerungen (inferences) neuberechnen"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "recompute_inferences_mixed_caps" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "recompute_inferences_mixed_caps" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:individual_name.Vitro
+uil-data:individual_name.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "individual name"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "individual_name" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "individual_name" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:thursday.Vitro
+uil-data:thursday.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Donnerstag"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "thursday" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "thursday" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:alert_icon.Vitro
+uil-data:alert_icon.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Alarm-Symbol"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "alert_icon" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "alert_icon" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:if_blank_page_title_used.Vitro
+uil-data:if_blank_page_title_used.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "wenn leer gelassen, wird der Seitentitel verwendet werden."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "if_blank_page_title_used" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "if_blank_page_title_used" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:password_reset_pending_email_plain_text.Vitro
+uil-data:password_reset_pending_email_plain_text.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Sehr geehrte/r ${userAccount.firstName} ${userAccount.lastName}:\n\nWir haben eine Anfrage erhalten, Ihr Passwort für Ihren Account\n(${userAccount.emailAddress}) auf ${siteName} zurückzusetzen.\n\nBitte folgen Sie den Anweisungen unten, um mit dem Zurücksetzen Ihres Passworts fortzufahren.\n\nWenn Sie dies nicht beantragt haben, können Sie diese E-Mail ignorieren.\nDiese Anfrage erlischt innerhalb von 30 Tagen, wenn sie nicht beantwortet wird.\n\nFügen Sie den untenstehenden Link in die Adressleiste Ihres Browsers ein,\num Ihr Passwort über unseren Server zurückzusetzen.\n\n${passwordLink}\n\nVielen Dank!\n"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "password_reset_pending_email_plain_text" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "password_reset_pending_email_plain_text" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:hide_properties.Vitro
+uil-data:hide_properties.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Verberge Eigenschaften"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "hide_properties" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "hide_properties" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:file_upload_error_file_type_not_recognized.Vitro
+uil-data:file_upload_error_file_type_not_recognized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "file_upload_error_file_type_not_recognized" ;
-        prop:hasPackage  "Vitro-languages" .
+        rdf:type         uil:UILabel ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "file_upload_error_file_type_not_recognized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_no_role.Vitro
+uil-data:error_no_role.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Sie müssen eine Rolle auswählen."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_no_role" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_no_role" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:new_account_title.Vitro
+uil-data:new_account_title.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Neues Konto"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "new_account_title" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "new_account_title" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:file_upload_no_allowed_media.Vitro
+uil-data:file_upload_no_allowed_media.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "file_upload_no_allowed_media" ;
-        prop:hasPackage  "Vitro-languages" .
+        rdf:type         uil:UILabel ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "file_upload_no_allowed_media" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:property_groups.Vitro
+uil-data:property_groups.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Gruppierung der Eigenschaften"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "property_groups" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "property_groups" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:startup_trace.Vitro
+uil-data:startup_trace.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Protokoll des Startvorganges"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "startup_trace" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "startup_trace" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:search_accounts_button.Vitro
+uil-data:search_accounts_button.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Konten suchen"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "search_accounts_button" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "search_accounts_button" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:operation_unsuccessful.Vitro
+uil-data:operation_unsuccessful.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Die Operation war nicht erfolgreich. Ausführliche Informationen finden Sie im Systemprotokoll."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "operation_unsuccessful" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "operation_unsuccessful" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:submit_button.Vitro
+uil-data:submit_button.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Senden"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "submit_button" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "submit_button" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:page_uri_missing.Vitro
+uil-data:page_uri_missing.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Keine Seiten-URI angegeben"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "page_uri_missing" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "page_uri_missing" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_no_email_address.Vitro
+uil-data:error_no_email_address.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Bitte geben Sie Ihre E-Mail-Adresse ein."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_no_email_address" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_no_email_address" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:controls.Vitro
+uil-data:controls.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Kontrolelemente"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "controls" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "controls" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:fruit.Vitro
+uil-data:fruit.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Obst"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "fruit" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "fruit" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:admin_panel.Vitro
+uil-data:admin_panel.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Admin-Panel"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "admin_panel" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "admin_panel" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:the_range_class_does_not_exist.Vitro
+uil-data:the_range_class_does_not_exist.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Der Klassenbereich für diese Eigenschaft ist im System nicht vorhanden."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "the_range_class_does_not_exist" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "the_range_class_does_not_exist" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:reset_your_password.Vitro
+uil-data:reset_your_password.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Setzen Sie Ihr Passwort zurück"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "reset_your_password" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "reset_your_password" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:advanced_search_tip_two.Vitro
+uil-data:advanced_search_tip_two.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "\"NOT\" kann zur Einschränkung der Suche verwendet werden, - z.B. <i>Klima</i> NOT <i>Veränderung</i>."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "advanced_search_tip_two" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "advanced_search_tip_two" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:save_new_page.Vitro
+uil-data:save_new_page.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Neue Seite speichern"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "save_new_page" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "save_new_page" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:book_title.Vitro
+uil-data:book_title.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Buchtitel:"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "book_title" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "book_title" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:view_content_index.Vitro
+uil-data:view_content_index.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Sehen Sie einen Überblick über den Inhalt dieser Website"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "view_content_index" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "view_content_index" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:or_create_new_one.Vitro
+uil-data:or_create_new_one.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "oder eine neue erstellen."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "or_create_new_one" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "or_create_new_one" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:remove_selection.Vitro
+uil-data:remove_selection.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Auswahl entfernen"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "remove_selection" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "remove_selection" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:cardinality.Vitro
+uil-data:cardinality.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Kardinalität"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "cardinality" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "cardinality" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:apostrophe_not_allowed.Vitro
+uil-data:apostrophe_not_allowed.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Der Name der Variable darf keinen Apostroph beinhalten."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "apostrophe_not_allowed" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "apostrophe_not_allowed" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:confirm_menu_item_delete.Vitro
+uil-data:confirm_menu_item_delete.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Sind Sie sicher, dass Sie entfernen möchten"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "confirm_menu_item_delete" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "confirm_menu_item_delete" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:work_level.Vitro
+uil-data:work_level.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Arbeitsebene"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "work_level" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "work_level" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:acct_created_external_only_email_html_text.Vitro
+uil-data:acct_created_external_only_email_html_text.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "<p>\n ${userAccount.firstName} ${userAccount.lastName}\n </p>\n\n <p>\n <strong>Herzlichen Glückwunsch!</strong>\n </p>\n\n <p>\n Wir haben einen Account für Sie angelegt. Ihr Account ist mit der E-Mail-Adresse ${userAccount.emailAddress} verknüpft.\n </p>\n\n <p>\n Vielen Dank!\n </p>"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "acct_created_external_only_email_html_text" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "acct_created_external_only_email_html_text" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:friday.Vitro
+uil-data:friday.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Freitag"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "friday" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "friday" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:return_to_the.Vitro
+uil-data:return_to_the.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Zurück zu"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "return_to_the" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "return_to_the" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:sparql_query.Vitro
+uil-data:sparql_query.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "SPARQL Query"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "sparql_query" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "sparql_query" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:myAccount_confirm_changes.Vitro
+uil-data:myAccount_confirm_changes.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ihre Änderungen wurden gespeichert."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "myAccount_confirm_changes" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "myAccount_confirm_changes" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:to.Vitro
+uil-data:to.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "auf"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "to" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "to" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:login_to_manage_site.Vitro
+uil-data:login_to_manage_site.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Einloggen, um die Seite zu verwalten"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "login_to_manage_site" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "login_to_manage_site" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:a_classgroup.Vitro
+uil-data:a_classgroup.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "eine Klassengruppe"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "a_classgroup" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "a_classgroup" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:upload_page_title.Vitro
+uil-data:upload_page_title.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Bild hochladen"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "upload_page_title" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "upload_page_title" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_existing_collaborator.Vitro
+uil-data:select_existing_collaborator.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Wählen Sie einen vorhandenen Mitarbeiter für {0}"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_existing_collaborator" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_existing_collaborator" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:label.dateTimeWithPrecision.day_capitalized.Vitro
+uil-data:label.dateTimeWithPrecision.day_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Tag"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "label.dateTimeWithPrecision.day_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "label.dateTimeWithPrecision.day_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:login_button.Vitro
+uil-data:login_button.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Anmelden"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "login_button" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "login_button" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:internal_login.Vitro
+uil-data:internal_login.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Interner Login"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "internal_login" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "internal_login" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_occurred.Vitro
+uil-data:error_occurred.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Es ist ein Fehler auf der VIVO-Website aufgetreten"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_occurred" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_occurred" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:advanced_search_tip_four.Vitro
+uil-data:advanced_search_tip_four.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Wortvariationen werden auch gefunden - Bsp.: <i>Sequenz</i> findet <i>Sequenzen</i> und <i>Sequenzierung</i>."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "advanced_search_tip_four" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "advanced_search_tip_four" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:updated_account_title.Vitro
+uil-data:updated_account_title.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Aktualisiertes Konto"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "updated_account_title" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "updated_account_title" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:year_month_day.Vitro
+uil-data:year_month_day.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ungültiger Eintrag. Bitte geben Sie ein Jahr, Monat und Tag an."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "year_month_day" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "year_month_day" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:log_out.Vitro
+uil-data:log_out.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Abmelden"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "log_out" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "log_out" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:application_error_email_plain_text.Vitro
+uil-data:application_error_email_plain_text.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Zum Zeitpunk ${datetime!} ist ein Fehler auf der Webseite ${siteName!} aufgetreten.\nAngeforderte URL: ${requestedUrl!}\n\n<#if errorMessage?has_content>\n Fehlermeldung: ${errorMessage!}\n</#if>\n\nStack Trace (Vollständiger Trace verfügbar im Log):\n${stackTrace!}\n\n<#if cause?has_content>\nVerursacht durch:\n${cause!}\n</#if>"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "application_error_email_plain_text" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "application_error_email_plain_text" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_vclass_uri.Vitro
+uil-data:select_vclass_uri.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "VClass auswählen"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_vclass_uri" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_vclass_uri" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:custom_template_requiring_content.Vitro
+uil-data:custom_template_requiring_content.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Benutzerdefinierte Vorlage erfordert Inhalt"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "custom_template_requiring_content" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "custom_template_requiring_content" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:file_upload_error_uri_not_exists.Vitro
+uil-data:file_upload_error_uri_not_exists.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "file_upload_error_uri_not_exists" ;
-        prop:hasPackage  "Vitro-languages" .
+        rdf:type         uil:UILabel ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "file_upload_error_uri_not_exists" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:external_id_not_provided.Vitro
+uil-data:external_id_not_provided.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Anmeldung fehlgeschlagen - Externe ID wurde nicht gefunden."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "external_id_not_provided" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "external_id_not_provided" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:imageUpload.errorBadMultipartRequest.Vitro
+uil-data:imageUpload.errorBadMultipartRequest.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Parsen der Multi-Part-Anfrage für den Bild-Upload fehlgeschlagen."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "imageUpload.errorBadMultipartRequest" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "imageUpload.errorBadMultipartRequest" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:view_all_accounts.Vitro
+uil-data:view_all_accounts.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Alle Konten anzeigen"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "view_all_accounts" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "view_all_accounts" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:file_upload_file.Vitro
+uil-data:file_upload_file.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "file_upload_file" ;
-        prop:hasPackage  "Vitro-languages" .
+        rdf:type         uil:UILabel ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "file_upload_file" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:search_failed.Vitro
+uil-data:search_failed.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Suche fehlgeschlagen."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "search_failed" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "search_failed" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:minimum_hour.Vitro
+uil-data:minimum_hour.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ungültiger Eintrag. Bitte geben Sie mindestens eine Stunde an."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "minimum_hour" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "minimum_hour" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:faux_property_alpha.Vitro
+uil-data:faux_property_alpha.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Faux-Properties alphabetisch"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "faux_property_alpha" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "faux_property_alpha" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:info_icon.Vitro
+uil-data:info_icon.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Info-Icon"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "info_icon" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "info_icon" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:save_button.Vitro
+uil-data:save_button.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Speichern"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "save_button" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "save_button" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:who_can_edit_profile.Vitro
+uil-data:who_can_edit_profile.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Wer kann mein Profil bearbeiten"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "who_can_edit_profile" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "who_can_edit_profile" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:add_an_entry_to.Vitro
+uil-data:add_an_entry_to.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Füge einen Eintrag hinzu vom Typ"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "add_an_entry_to" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "add_an_entry_to" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:page_not_found_msg.Vitro
+uil-data:page_not_found_msg.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Die Seite wurde im System nicht gefunden."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "page_not_found_msg" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "page_not_found_msg" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:no_content_in_system.Vitro
+uil-data:no_content_in_system.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Es gibt derzeit keine {0} Inhalte im System"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "no_content_in_system" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "no_content_in_system" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:rdf.Vitro
+uil-data:rdf.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "RDF"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "rdf" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "rdf" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:datetime_year_required.Vitro
+uil-data:datetime_year_required.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Date/time-Intervalle müssen mit einem Jahr beginnen. Geben Sie entweder ein Startjahr, Endjahr oder beides an."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "datetime_year_required" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "datetime_year_required" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:external_auth_name.Vitro
+uil-data:external_auth_name.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Externer Authentifizierungsname"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "external_auth_name" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "external_auth_name" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:external_login_failed.Vitro
+uil-data:external_login_failed.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Externe Anmeldung fehlgeschlagen"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "external_login_failed" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "external_login_failed" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:label.dateTimeWithPrecision.seconds_capitalized.Vitro
+uil-data:label.dateTimeWithPrecision.seconds_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Sekunden"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "label.dateTimeWithPrecision.seconds_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "label.dateTimeWithPrecision.seconds_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:custom_template.Vitro
+uil-data:custom_template.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Benutzerdefinierte Vorlage"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "custom_template" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "custom_template" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:associated_profile_label.Vitro
+uil-data:associated_profile_label.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Zugehöriges Profil:"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "associated_profile_label" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "associated_profile_label" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:page_not_found.Vitro
+uil-data:page_not_found.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Seite nicht gefunden"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "page_not_found" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "page_not_found" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_existing_last_name.Vitro
+uil-data:select_existing_last_name.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Wählen Sie einen vorhandenen Nachnamen"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_existing_last_name" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_existing_last_name" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:title_capitalized.Vitro
+uil-data:title_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Titel"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "title_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "title_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:file_upload_error_no_action.Vitro
+uil-data:file_upload_error_no_action.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "file_upload_error_no_action" ;
-        prop:hasPackage  "Vitro-languages" .
+        rdf:type         uil:UILabel ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "file_upload_error_no_action" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:change_entry_for.Vitro
+uil-data:change_entry_for.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Eintrag ändern für:"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "change_entry_for" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "change_entry_for" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:cause.Vitro
+uil-data:cause.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ursache:"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "cause" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "cause" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:may_edit.Vitro
+uil-data:may_edit.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Kann bearbeiten"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "may_edit" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "may_edit" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:properties.Vitro
+uil-data:properties.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Eigenschaften"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "properties" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "properties" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:add_new.Vitro
+uil-data:add_new.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Hinzufügen"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "add_new" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "add_new" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:apples.Vitro
+uil-data:apples.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Äpfel"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "apples" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "apples" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:tuesday.Vitro
+uil-data:tuesday.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Dienstag"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "tuesday" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "tuesday" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:email_changed_subject.Vitro
+uil-data:email_changed_subject.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ihr {0} E-Mail-Konto wurde geändert."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "email_changed_subject" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "email_changed_subject" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:site_admin.Vitro
+uil-data:site_admin.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Site-Admin"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "site_admin" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "site_admin" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:code_processing_error.Vitro
+uil-data:code_processing_error.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Es ist ein Fehler aufgetreten ist und dem Code zur Verarbeitung dieses Inhaltes fehlt eine Komponente."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "code_processing_error" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "code_processing_error" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:base_property_capitalized.Vitro
+uil-data:base_property_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Base-Property"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "base_property_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "base_property_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:username.Vitro
+uil-data:username.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Benutzername"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "username" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "username" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:to_order_menu_items.Vitro
+uil-data:to_order_menu_items.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       ", um die Reihenfolge der Menüpunkte zu setzen."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "to_order_menu_items" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "to_order_menu_items" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:none.Vitro
+uil-data:none.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "keine"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "none" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "none" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:classes_capitalized.Vitro
+uil-data:classes_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Klassen"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "classes_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "classes_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:cancel_link.Vitro
+uil-data:cancel_link.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Abbrechen"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "cancel_link" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "cancel_link" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:send_feedback_questions.Vitro
+uil-data:send_feedback_questions.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Senden Sie uns Ihr Feedback oder eine Frage"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "send_feedback_questions" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "send_feedback_questions" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:account_already_activated.Vitro
+uil-data:account_already_activated.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Das Konto für {0} wurde bereits aktiviert."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "account_already_activated" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "account_already_activated" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:page.Vitro
+uil-data:page.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Seite"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "page" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "page" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:type_more_characters.Vitro
+uil-data:type_more_characters.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Tippen Sie mehr Zeichen"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "type_more_characters" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "type_more_characters" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:search_tips_header.Vitro
+uil-data:search_tips_header.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Suchtipps"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "search_tips_header" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "search_tips_header" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:data_not_past_msg.Vitro
+uil-data:data_not_past_msg.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Bitte geben Sie ein zukünftiges Zieldatum für die Veröffentlichung ein (vergangene Daten sind ungültig)."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "data_not_past_msg" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "data_not_past_msg" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_associated_profile.Vitro
+uil-data:select_associated_profile.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Wählen Sie das zugehörige Profil"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_associated_profile" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_associated_profile" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:edit_capitalized.Vitro
+uil-data:edit_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Bearbeiten"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "edit_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "edit_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:site_name.Vitro
+uil-data:site_name.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Site-Name"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "site_name" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "site_name" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:replace_photo.Vitro
+uil-data:replace_photo.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Foto ersetzen "@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "replace_photo" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "replace_photo" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:rebuild_button.Vitro
+uil-data:rebuild_button.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Neu aufbauen"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "rebuild_button" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "rebuild_button" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:numbers.Vitro
+uil-data:numbers.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Zahlen"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "numbers" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "numbers" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:acct_created_external_only_email_plain_text.Vitro
+uil-data:acct_created_external_only_email_plain_text.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "${userAccount.firstName} ${userAccount.lastName}\n\nHerzlichen Glückwunsch!\n\nWir haben einen Account für Sie angelegt. Ihr Account ist mit\nder E-Mail-Adresse ${userAccount.emailAddress} verknüpft.\n\nVielen Dank!"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "acct_created_external_only_email_plain_text" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "acct_created_external_only_email_plain_text" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:auth_id_explanation.Vitro
+uil-data:auth_id_explanation.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Kann genutzt werden, um das Konto dem Profil des Benutzers mittels übereinstimmender Properties zuzuordnen"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "auth_id_explanation" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "auth_id_explanation" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:support.Vitro
+uil-data:support.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Unterstützung"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "support" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "support" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:enter_search_term.Vitro
+uil-data:enter_search_term.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Bitte geben Sie einen Suchbegriff ein."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "enter_search_term" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "enter_search_term" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:feedback_thanks_heading.Vitro
+uil-data:feedback_thanks_heading.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Vielen Dank für Ihr Feedback"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "feedback_thanks_heading" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "feedback_thanks_heading" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:updated_account_notification.Vitro
+uil-data:updated_account_notification.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "An {0} wurde eine Bestätigungs-E-Mail mit einer Anleitung zum Zurücksetzen des Passwortes gesendet. Das Passwort wird nicht zurückgesetzt, bis der Benutzer den Link in dieser E-Mail geöffnet hat."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "updated_account_notification" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "updated_account_notification" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:menu_ordering_mixed_caps.Vitro
+uil-data:menu_ordering_mixed_caps.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Menüsortierung"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "menu_ordering_mixed_caps" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "menu_ordering_mixed_caps" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:expand_all.Vitro
+uil-data:expand_all.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Alle erweitern"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "expand_all" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "expand_all" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:confirm_password_capitalized.Vitro
+uil-data:confirm_password_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Passwort bestätigen"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "confirm_password_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "confirm_password_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:uri_not_defined.Vitro
+uil-data:uri_not_defined.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "URI für die Seite nicht definiert"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "uri_not_defined" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "uri_not_defined" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:a_link.Vitro
+uil-data:a_link.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "ein Link"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "a_link" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "a_link" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:view_list_of_labels.Vitro
+uil-data:view_list_of_labels.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Liste der Labels anzeigen"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "view_list_of_labels" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "view_list_of_labels" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:not_logged_in.Vitro
+uil-data:not_logged_in.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Nicht angemeldet"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "not_logged_in" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "not_logged_in" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:page_public_permission_option.Vitro
+uil-data:page_public_permission_option.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Jeder kann diese Seite ansehen"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "page_public_permission_option" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "page_public_permission_option" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:file_upload_error_uri_not_given.Vitro
+uil-data:file_upload_error_uri_not_given.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "file_upload_error_uri_not_given" ;
-        prop:hasPackage  "Vitro-languages" .
+        rdf:type         uil:UILabel ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "file_upload_error_uri_not_given" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:file_upload_heading.Vitro
+uil-data:file_upload_heading.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "file_upload_heading" ;
-        prop:hasPackage  "Vitro-languages" .
+        rdf:type         uil:UILabel ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "file_upload_heading" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:save_this_content.Vitro
+uil-data:save_this_content.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Inhalt speichern"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "save_this_content" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "save_this_content" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:data.Vitro
+uil-data:data.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Daten"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "data" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "data" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_incorrect_credentials.Vitro
+uil-data:error_incorrect_credentials.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Die E-Mail oder das Passwort ist falsch."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_incorrect_credentials" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_incorrect_credentials" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:start_url_with_slash.Vitro
+uil-data:start_url_with_slash.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Die lesbare URL muss mit einem Schrägstrich beginnen"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "start_url_with_slash" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "start_url_with_slash" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:february.Vitro
+uil-data:february.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Februar"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "february" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "february" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:delete_entry.Vitro
+uil-data:delete_entry.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Diesen Eintrag löschen"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "delete_entry" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "delete_entry" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:imageUpload.errorFormFieldMissing.Vitro
+uil-data:imageUpload.errorFormFieldMissing.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Das Formular enthielt kein '' {0} '' Feld. \""@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "imageUpload.errorFormFieldMissing" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "imageUpload.errorFormFieldMissing" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:formatted_date_time.Vitro
+uil-data:formatted_date_time.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Formatierte Datum-Zeit"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "formatted_date_time" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "formatted_date_time" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:imageUpload.errorUnknown.Vitro
+uil-data:imageUpload.errorUnknown.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Leider waren wir nicht in der Lage, das bereitgestellte Foto zu verarbeiten. Bitte versuchen Sie es mit einem anderen Foto."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "imageUpload.errorUnknown" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "imageUpload.errorUnknown" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:password_reset_pending_email_html_text.Vitro
+uil-data:password_reset_pending_email_html_text.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "<p>\n Sehr geehrte/r ${userAccount.firstName} ${userAccount.lastName}:\n </p>\n\n <p>\n Wir haben eine Anfrage erhalten, Ihr Passwort für Ihren Account (${userAccount.emailAddress}) auf ${siteName} zurückzusetzen.\n </p>\n\n <p>\n Bitte folgen Sie den Anweisungen unten, um mit dem Zurücksetzen Ihres Passworts fortzufahren.\n </p>\n\n <p>\n Wenn Sie diesen Account nicht beantragt haben, können Sie diese E-Mail ignorieren.\nDiese Anfrage erlischt automatisch nach 30 Tagen.\n </p>\n\n <p>\n\n Fügen Sie den untenstehenden Link in die Adressleiste Ihres Browsers ein,\n um Ihr Passwort über unseren Server zurückzusetzen.\n </p>\n\n <p><a href=\"${passwordLink}\" title=\"password\">${passwordLink}</a> </p>\n\n <p>Vielen Dank!</p>"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "password_reset_pending_email_html_text" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "password_reset_pending_email_html_text" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:ontology_editor.Vitro
+uil-data:ontology_editor.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ontologie-Editor"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "ontology_editor" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "ontology_editor" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:from_capitalized.Vitro
+uil-data:from_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Von"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "from_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "from_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:logged_out.Vitro
+uil-data:logged_out.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Sie haben sich abgemeldet."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "logged_out" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "logged_out" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:search_for.Vitro
+uil-data:search_for.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Suche nach '' {0} ''"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "search_for" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "search_for" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:other.Vitro
+uil-data:other.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "anderes"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "other" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "other" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:supply_variable_name.Vitro
+uil-data:supply_variable_name.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Sie müssen eine Variable angeben, um HTML-Inhalt zu speichern."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "supply_variable_name" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "supply_variable_name" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:remove_restrictions.Vitro
+uil-data:remove_restrictions.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Einschränkungen entfernen"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "remove_restrictions" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "remove_restrictions" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:variable_name_all_caps.Vitro
+uil-data:variable_name_all_caps.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Variablenname"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "variable_name_all_caps" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "variable_name_all_caps" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:levels.Vitro
+uil-data:levels.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ebenen"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "levels" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "levels" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:range_class.Vitro
+uil-data:range_class.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Range Class"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "range_class" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "range_class" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:type_more_chars.Vitro
+uil-data:type_more_chars.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Mehr Zeichen eingeben"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "type_more_chars" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "type_more_chars" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:advanced_data_tools.Vitro
+uil-data:advanced_data_tools.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Erweiterte Datentools"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "advanced_data_tools" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "advanced_data_tools" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:current_date.Vitro
+uil-data:current_date.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Aktuelles Datum:"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "current_date" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "current_date" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:since_elapsed_time_est_total.Vitro
+uil-data:since_elapsed_time_est_total.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "seit {0}, verstrichene Zeit {1}, geschätzte Gesamtzeit {2}"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "since_elapsed_time_est_total" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "since_elapsed_time_est_total" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:close.Vitro
+uil-data:close.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "schließen"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "close" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "close" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:change_selection.Vitro
+uil-data:change_selection.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Auswahl ändern"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "change_selection" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "change_selection" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:copyright.Vitro
+uil-data:copyright.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Copyright"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "copyright" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "copyright" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_page_content_type.Vitro
+uil-data:select_page_content_type.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Wählen Sie Inhaltstyp für die zugehörige Seite"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_page_content_type" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_page_content_type" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:zoo_one.Vitro
+uil-data:zoo_one.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Zoo 1"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "zoo_one" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "zoo_one" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:cancel_title.Vitro
+uil-data:cancel_title.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Abbrechen"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "cancel_title" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "cancel_title" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:add_individual_of_class.Vitro
+uil-data:add_individual_of_class.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Einen Datensatz dieser Klasse hinzufügen"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "add_individual_of_class" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "add_individual_of_class" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:label.dateTimeWithPrecision.year_capitalized.Vitro
+uil-data:label.dateTimeWithPrecision.year_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Jahr"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "label.dateTimeWithPrecision.year_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "label.dateTimeWithPrecision.year_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:relate_editors_profiles.Vitro
+uil-data:relate_editors_profiles.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Verknüpfe Profil-Editoren und Profile"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "relate_editors_profiles" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "relate_editors_profiles" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:vitro_bullet_four.Vitro
+uil-data:vitro_bullet_four.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Suchen Ihrer Daten"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "vitro_bullet_four" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "vitro_bullet_four" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:save_changes.Vitro
+uil-data:save_changes.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Änderungen speichern"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "save_changes" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "save_changes" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:cant_activate_while_logged_in.Vitro
+uil-data:cant_activate_while_logged_in.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Sie können das Konto für {0} nicht aktivieren während Sie als {1} angemeldet sind. Bitte melden Sie ab und versuchen Sie es erneut."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "cant_activate_while_logged_in" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "cant_activate_while_logged_in" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:next_capitalized.Vitro
+uil-data:next_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Weiter"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "next_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "next_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:end_capitalized.Vitro
+uil-data:end_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ende"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "end_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "end_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:custom_template_containing_content.Vitro
+uil-data:custom_template_containing_content.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Benutzerdefinierte Vorlage enthält allen Inhalte"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "custom_template_containing_content" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "custom_template_containing_content" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:name_of.Vitro
+uil-data:name_of.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "name_of" ;
-        prop:hasPackage  "Vitro-languages" .
+        rdf:type         uil:UILabel ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "name_of" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:content_type.Vitro
+uil-data:content_type.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Inhaltstyp"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "content_type" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "content_type" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:add_label.Vitro
+uil-data:add_label.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Beschriftung hinzufügen"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "add_label" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "add_label" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:activate_developer_panel_mixed_caps.Vitro
+uil-data:activate_developer_panel_mixed_caps.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Aktiviere Entwickler-Panel"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "activate_developer_panel_mixed_caps" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "activate_developer_panel_mixed_caps" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:reset_search_index.Vitro
+uil-data:reset_search_index.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Suchindex zurücksetzen und erneut befüllen."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "reset_search_index" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "reset_search_index" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:please_provide_contact_information.Vitro
+uil-data:please_provide_contact_information.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Bitte geben Sie Ihre Kontaktdaten ein, um die Erstellung Ihres Kontos abzuschließen."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "please_provide_contact_information" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "please_provide_contact_information" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:continued.Vitro
+uil-data:continued.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Fortsetzung"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "continued" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "continued" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_no_email.Vitro
+uil-data:error_no_email.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Sie müssen eine E-Mail-Adresse angeben."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_no_email" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_no_email" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_no_last_name.Vitro
+uil-data:error_no_last_name.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Sie müssen einen Nachnamen angeben."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_no_last_name" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_no_last_name" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:december.Vitro
+uil-data:december.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Dezember"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "december" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "december" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:multiple_content_default_template_error.Vitro
+uil-data:multiple_content_default_template_error.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Bei verschiedenen Inhaltstypen müssen Sie eine benutzerdefinierte Vorlage angeben."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "multiple_content_default_template_error" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "multiple_content_default_template_error" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:all_classes.Vitro
+uil-data:all_classes.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Alle Klassen"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "all_classes" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "all_classes" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:viewing_page.Vitro
+uil-data:viewing_page.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Wahrscheinlich betrachtete Seite"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "viewing_page" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "viewing_page" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:individual_not_found_msg.Vitro
+uil-data:individual_not_found_msg.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Der Datensatz wurde im System nicht gefunden."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "individual_not_found_msg" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "individual_not_found_msg" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:setup_navigation_menu.Vitro
+uil-data:setup_navigation_menu.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Konfiguration des primären Navigationsmenü für Ihre Webseite"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "setup_navigation_menu" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "setup_navigation_menu" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:external_id_already_in_use.Vitro
+uil-data:external_id_already_in_use.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Benutzerkonto existiert bereits für '' {0} ''"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "external_id_already_in_use" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "external_id_already_in_use" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:ascending_order.Vitro
+uil-data:ascending_order.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "aufsteigend"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "ascending_order" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "ascending_order" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:browse_all_content.Vitro
+uil-data:browse_all_content.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Alle Inhalte durchsuchen"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "browse_all_content" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "browse_all_content" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:begin_with_slash_no_example.Vitro
+uil-data:begin_with_slash_no_example.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Muss mit einem Slash beginnen"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "begin_with_slash_no_example" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "begin_with_slash_no_example" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_occurred_at.Vitro
+uil-data:error_occurred_at.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Es ist ein Fehler auf Ihrer VIVO-Website unter {0} aufgetreten."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_occurred_at" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_occurred_at" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_editors.Vitro
+uil-data:select_editors.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Wähle Editoren"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_editors" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_editors" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:supply_html.Vitro
+uil-data:supply_html.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Sie müssen HTML oder Text angeben."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "supply_html" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "supply_html" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:slash_example.Vitro
+uil-data:slash_example.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "(z.B. /Personen)"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "slash_example" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "slash_example" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:property_hierarchy.Vitro
+uil-data:property_hierarchy.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Objekthierarchie"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "property_hierarchy" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "property_hierarchy" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:try_rebuilding_index.Vitro
+uil-data:try_rebuilding_index.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Versuchen Sie, den Suchindex wieder aufzubauen"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "try_rebuilding_index" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "try_rebuilding_index" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_in_search_request.Vitro
+uil-data:error_in_search_request.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Die Suchanfrage enthielt Fehler."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_in_search_request" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_in_search_request" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:first_time_login.Vitro
+uil-data:first_time_login.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Erstmalige Anmeldung am"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "first_time_login" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "first_time_login" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:first_time_external_email_plain_text.Vitro
+uil-data:first_time_external_email_plain_text.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "${userAccount.firstName} ${userAccount.lastName}\n\nHerzlichen Glückwunsch!\n\nWir haben einen Account für Sie angelegt. Ihr Account ist\nmit der E-Mail-Adresse ${userAccount.emailAddress} verknüpft.\n\nVielen Dank!"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "first_time_external_email_plain_text" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "first_time_external_email_plain_text" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:faux_property_by_base.Vitro
+uil-data:faux_property_by_base.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Faux-Properties je Base-Property"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "faux_property_by_base" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "faux_property_by_base" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:alt_thumbnail_photo.Vitro
+uil-data:alt_thumbnail_photo.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Foto Person"@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "alt_thumbnail_photo" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "alt_thumbnail_photo" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:no_individual_associated_with_id.Vitro
+uil-data:no_individual_associated_with_id.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Aus irgendeinem Grund gibt es keinen Personendatensatz in VIVO, der Ihrer Net-ID zugeordnet ist. Bitte kontaktieren Sie Ihren VIVO-Administrator kontaktieren."@de-DE ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "no_individual_associated_with_id" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "no_individual_associated_with_id" ;
+        uil:hasPackage  "Vitro-languages" .

--- a/home/src/main/resources/rdf/i18n/en_CA/interface-i18n/firsttime/vitro_UiLabel.ttl
+++ b/home/src/main/resources/rdf/i18n/en_CA/interface-i18n/firsttime/vitro_UiLabel.ttl
@@ -1,6283 +1,6283 @@
 @prefix owl:   <http://www.w3.org/2002/07/owl#> .
 @prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
-@prefix prop-data: <http://vivoweb.org/ontology/core/properties/individual#> .
-@prefix prop:  <http://vivoweb.org/ontology/core/properties/vocabulary#> .
+@prefix uil-data: <http://vivoweb.org/ontology/vitro/ui-label/individual#> .
+@prefix uil:  <http://vivoweb.org/ontology/vitro/ui-label/vocabulary#> .
 @prefix xsd:   <http://www.w3.org/2001/XMLSchema#> .
 @prefix skos:  <http://www.w3.org/2004/02/skos/core#> .
 @prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> .
 
-prop-data:collapse_all.Vitro
+uil-data:collapse_all.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "collapse all"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "collapse_all" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "collapse_all" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:no_password_supplied.Vitro
+uil-data:no_password_supplied.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "No password supplied."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "no_password_supplied" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "no_password_supplied" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:crop_page_title.Vitro
+uil-data:crop_page_title.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Crop image"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "crop_page_title" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "crop_page_title" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:label.dateTimeWithPrecision.month_capitalized.Vitro
+uil-data:label.dateTimeWithPrecision.month_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Month"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "label.dateTimeWithPrecision.month_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "label.dateTimeWithPrecision.month_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:advanced_search_tip_three.Vitro
+uil-data:advanced_search_tip_three.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Phrase searches may be combined with Boolean operators -- e.g. \"<i>climate change</i>\" OR \"<i>global warming</i>\"."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "advanced_search_tip_three" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "advanced_search_tip_three" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:file_upload_error_file_size_is_zero.Vitro
+uil-data:file_upload_error_file_size_is_zero.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Uploaded file size is 0"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "file_upload_error_file_size_is_zero" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "file_upload_error_file_size_is_zero" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:delete_entry_capitalized.Vitro
+uil-data:delete_entry_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Delete this entry?"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "delete_entry_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "delete_entry_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:remove_selection_title.Vitro
+uil-data:remove_selection_title.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "remove selection"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "remove_selection_title" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "remove_selection_title" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:powered_by.Vitro
+uil-data:powered_by.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Powered by"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "powered_by" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "powered_by" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:accounts_search_results.Vitro
+uil-data:accounts_search_results.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Search results for"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "accounts_search_results" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "accounts_search_results" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:search_individual_results.Vitro
+uil-data:search_individual_results.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Search Class Individuals"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "search_individual_results" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "search_individual_results" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:vclassAlpha_not_implemented.Vitro
+uil-data:vclassAlpha_not_implemented.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "vclassAlpha is not yet implemented."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "vclassAlpha_not_implemented" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "vclassAlpha_not_implemented" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_an_existing.Vitro
+uil-data:select_an_existing.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Select an existing"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_an_existing" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_an_existing" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:no_appropriate_entry.Vitro
+uil-data:no_appropriate_entry.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "If you don't find the appropriate entry on the selection list above"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "no_appropriate_entry" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "no_appropriate_entry" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:descending_order.Vitro
+uil-data:descending_order.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "descending order"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "descending_order" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "descending_order" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:label.dateTimeWithPrecision.hour_capitalized.Vitro
+uil-data:label.dateTimeWithPrecision.hour_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Hour"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "label.dateTimeWithPrecision.hour_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "label.dateTimeWithPrecision.hour_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:add_remove_rdf.Vitro
+uil-data:add_remove_rdf.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Add/Remove RDF data"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "add_remove_rdf" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "add_remove_rdf" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:account.Vitro
+uil-data:account.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "account"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "account" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "account" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:label.Vitro
+uil-data:label.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "label"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "label" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "label" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:no_classes_to_select.Vitro
+uil-data:no_classes_to_select.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "There are no Classes in the system from which to select."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "no_classes_to_select" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "no_classes_to_select" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:page_curator_permission_option.Vitro
+uil-data:page_curator_permission_option.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Curators and above can view this page"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "page_curator_permission_option" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "page_curator_permission_option" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:individuals_in_system.Vitro
+uil-data:individuals_in_system.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "individuals in the system."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "individuals_in_system" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "individuals_in_system" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:search_help.Vitro
+uil-data:search_help.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "search help"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "search_help" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "search_help" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:there_are_no_entries_starting_with.Vitro
+uil-data:there_are_no_entries_starting_with.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "There are no entries starting with"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "there_are_no_entries_starting_with" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "there_are_no_entries_starting_with" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:user_accounts_link.Vitro
+uil-data:user_accounts_link.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "User accounts"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "user_accounts_link" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "user_accounts_link" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:ontology_capitalized.Vitro
+uil-data:ontology_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ontology"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "ontology_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "ontology_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:change_password_to_login.Vitro
+uil-data:change_password_to_login.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Change Password to Log in"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "change_password_to_login" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "change_password_to_login" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:a_menu_page.Vitro
+uil-data:a_menu_page.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "This is a menu page"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "a_menu_page" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "a_menu_page" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:comments.Vitro
+uil-data:comments.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Comments"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "comments" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "comments" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:add_new_of_type.Vitro
+uil-data:add_new_of_type.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Add a new item of this type"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "add_new_of_type" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "add_new_of_type" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:reset_password_note.Vitro
+uil-data:reset_password_note.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Note: Instructions for resetting the password will be emailed to the address entered above. The password will not be reset until the user follows the link provided in this email."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "reset_password_note" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "reset_password_note" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:startup_status.Vitro
+uil-data:startup_status.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Startup status"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "startup_status" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "startup_status" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:no_results_returned.Vitro
+uil-data:no_results_returned.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "No results were returned."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "no_results_returned" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "no_results_returned" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:submit_add_new_account.Vitro
+uil-data:submit_add_new_account.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Add new account"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "submit_add_new_account" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "submit_add_new_account" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:password_reset_complete_subject.Vitro
+uil-data:password_reset_complete_subject.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Your {0} password changed."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "password_reset_complete_subject" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "password_reset_complete_subject" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:file_upload_error_supported_actions.Vitro
+uil-data:file_upload_error_supported_actions.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Only delete and upload actions supported"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "file_upload_error_supported_actions" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "file_upload_error_supported_actions" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:create_classgroup.Vitro
+uil-data:create_classgroup.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Create a class group"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "create_classgroup" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "create_classgroup" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:accounts.Vitro
+uil-data:accounts.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "accounts"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "accounts" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "accounts" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:page_not_created_msg.Vitro
+uil-data:page_not_created_msg.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "There was an error while creating the page, please check the logs."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "page_not_created_msg" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "page_not_created_msg" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:login_count.Vitro
+uil-data:login_count.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Login count"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "login_count" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "login_count" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:not_expected_results.Vitro
+uil-data:not_expected_results.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Not the results you expected?"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "not_expected_results" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "not_expected_results" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:paging_link_more.Vitro
+uil-data:paging_link_more.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "more..."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "paging_link_more" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "paging_link_more" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:sparql_query_description_1.Vitro
+uil-data:sparql_query_description_1.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "# and (if available) their labels"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "sparql_query_description_1" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "sparql_query_description_1" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:acct_created_email_plain_text.Vitro
+uil-data:acct_created_email_plain_text.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "${userAccount.firstName} ${userAccount.lastName}\n\nCongratulations!\n\nWe have created your new account on ${siteName},\nassociated with ${userAccount.emailAddress}.\n\nIf you did not request this new account you can safely ignore this email.\nThis request will expire if not acted upon for 30 days.\n\nPaste the link below into your browser's address bar to create your password\nfor your new account using our secure server.\n\n${passwordLink}\n\nThanks!"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "acct_created_email_plain_text" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "acct_created_email_plain_text" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:all_rights_reserved.Vitro
+uil-data:all_rights_reserved.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "All Rights Reserved."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "all_rights_reserved" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "all_rights_reserved" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:submit_save.Vitro
+uil-data:submit_save.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Save photo"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "submit_save" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "submit_save" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:associate_classes_with_group.Vitro
+uil-data:associate_classes_with_group.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "and associate classes with the group created."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "associate_classes_with_group" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "associate_classes_with_group" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:about.Vitro
+uil-data:about.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "About"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "about" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "about" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:activate_developer_panel.Vitro
+uil-data:activate_developer_panel.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Activate developer panel"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "activate_developer_panel" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "activate_developer_panel" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:since.Vitro
+uil-data:since.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Since"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "since" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "since" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:limit_to.Vitro
+uil-data:limit_to.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Limit to"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "limit_to" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "limit_to" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:password_created_subject.Vitro
+uil-data:password_created_subject.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Your {0} password has successfully been created."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "password_created_subject" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "password_created_subject" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:vitro_description.Vitro
+uil-data:vitro_description.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Vitro is a general-purpose web-based ontology and instance editor with customizable public browsing. Vitro is a Java web application that runs in a Tomcat servlet container."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "vitro_description" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "vitro_description" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:logins_disabled_for_maintenance.Vitro
+uil-data:logins_disabled_for_maintenance.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "User logins are temporarily disabled while the system is being maintained."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "logins_disabled_for_maintenance" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "logins_disabled_for_maintenance" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:current_time.Vitro
+uil-data:current_time.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Current time:"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "current_time" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "current_time" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:release.Vitro
+uil-data:release.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "release"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "release" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "release" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:authenticator.Vitro
+uil-data:authenticator.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Authenticator"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "authenticator" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "authenticator" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:preparing_to_rebuild_index.Vitro
+uil-data:preparing_to_rebuild_index.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Preparing to rebuild the search index."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "preparing_to_rebuild_index" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "preparing_to_rebuild_index" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:login_status.Vitro
+uil-data:login_status.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Login status:"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "login_status" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "login_status" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:scroll_to_menus.Vitro
+uil-data:scroll_to_menus.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "scroll to property group menus"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "scroll_to_menus" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "scroll_to_menus" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:sparql_query_description_0.Vitro
+uil-data:sparql_query_description_0.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "# This example query gets 20 geographic locations"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "sparql_query_description_0" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "sparql_query_description_0" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:delete_button.Vitro
+uil-data:delete_button.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Delete"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "delete_button" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "delete_button" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:fixed_html.Vitro
+uil-data:fixed_html.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Fixed HTML"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "fixed_html" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "fixed_html" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:you_can.Vitro
+uil-data:you_can.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "You can"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "you_can" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "you_can" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:supply_sparql_query.Vitro
+uil-data:supply_sparql_query.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "You must supply a Sparql query."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "supply_sparql_query" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "supply_sparql_query" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:enter_email_password.Vitro
+uil-data:enter_email_password.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Enter the email address and password for your internal Vitro account."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "enter_email_password" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "enter_email_password" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:selected_editors.Vitro
+uil-data:selected_editors.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Selected editors"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "selected_editors" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "selected_editors" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:custom_template_mixed_caps.Vitro
+uil-data:custom_template_mixed_caps.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Custom template"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "custom_template_mixed_caps" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "custom_template_mixed_caps" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:animal.Vitro
+uil-data:animal.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Animal:"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "animal" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "animal" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:enter_sparql_query_here.Vitro
+uil-data:enter_sparql_query_here.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Enter SPARQL query here"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "enter_sparql_query_here" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "enter_sparql_query_here" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:recompute_inferences.Vitro
+uil-data:recompute_inferences.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Recompute Inferences"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "recompute_inferences" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "recompute_inferences" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:restrict_logins.Vitro
+uil-data:restrict_logins.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Restrict Logins"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "restrict_logins" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "restrict_logins" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:email_address.Vitro
+uil-data:email_address.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Email address"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "email_address" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "email_address" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:alt_confirmation.Vitro
+uil-data:alt_confirmation.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Confirmation icon"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "alt_confirmation" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "alt_confirmation" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:drag_drop_to_reorder_menus.Vitro
+uil-data:drag_drop_to_reorder_menus.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Drag and drop to reorder menu items"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "drag_drop_to_reorder_menus" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "drag_drop_to_reorder_menus" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:most_recent_update.Vitro
+uil-data:most_recent_update.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "The most recent update was at"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "most_recent_update" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "most_recent_update" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:delete_link.Vitro
+uil-data:delete_link.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Delete photo"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "delete_link" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "delete_link" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:check_startup_status.Vitro
+uil-data:check_startup_status.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Check startup status page and/or Tomcat logs for more information."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "check_startup_status" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "check_startup_status" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:no_pages_defined.Vitro
+uil-data:no_pages_defined.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "There are no pages defined yet."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "no_pages_defined" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "no_pages_defined" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:advanced_search_tip_five.Vitro
+uil-data:advanced_search_tip_five.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Use the wildcard * character to match an even wider variation -- e.g., <i>nano*</i> will match both <i>nanotechnology</i> and <i>nanofabrication</i>."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "advanced_search_tip_five" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "advanced_search_tip_five" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_message.Vitro
+uil-data:error_message.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Error message"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_message" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_message" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:double_quote_note_allowed.Vitro
+uil-data:double_quote_note_allowed.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "The variable name should not have a double quote."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "double_quote_note_allowed" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "double_quote_note_allowed" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:crop_page_title_with_name.Vitro
+uil-data:crop_page_title_with_name.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Crop image for {0}"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "crop_page_title_with_name" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "crop_page_title_with_name" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:logins_not_restricted.Vitro
+uil-data:logins_not_restricted.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Logins are no longer restricted."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "logins_not_restricted" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "logins_not_restricted" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:deleted_accounts.Vitro
+uil-data:deleted_accounts.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Deleted {0} {0, choice, 0#accounts|1#account|1<accounts}."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "deleted_accounts" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "deleted_accounts" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:whole_number.Vitro
+uil-data:whole_number.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Invalid entry. Enter a whole number with no decimal point or thousands-separators."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "whole_number" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "whole_number" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:edit_account.Vitro
+uil-data:edit_account.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Edit account"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "edit_account" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "edit_account" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:search_tip_two.Vitro
+uil-data:search_tip_two.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Use quotes to search for an entire phrase -- e.g., \"<i>protein folding</i>\"."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "search_tip_two" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "search_tip_two" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:email_capitalized.Vitro
+uil-data:email_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Email"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "email_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "email_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:policies.Vitro
+uil-data:policies.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Policies"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "policies" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "policies" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:failed.Vitro
+uil-data:failed.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "failed"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "failed" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "failed" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:containers_do_not_pick_up_changes.Vitro
+uil-data:containers_do_not_pick_up_changes.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Containers do not pick up changes to the value of their elements"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "containers_do_not_pick_up_changes" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "containers_do_not_pick_up_changes" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:file_upload_error_media_type_not_allowed.Vitro
+uil-data:file_upload_error_media_type_not_allowed.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "File media type is not allowed. Current file media type is {0}."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "file_upload_error_media_type_not_allowed" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "file_upload_error_media_type_not_allowed" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:add_new_classes.Vitro
+uil-data:add_new_classes.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Add New Class"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "add_new_classes" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "add_new_classes" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:identifier_factories.Vitro
+uil-data:identifier_factories.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Identifier factories"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "identifier_factories" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "identifier_factories" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:show_subclasses.Vitro
+uil-data:show_subclasses.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "show subclasses"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "show_subclasses" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "show_subclasses" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:enter_id_to_login.Vitro
+uil-data:enter_id_to_login.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Enter the userID that you want to sign in as, or click Cancel."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "enter_id_to_login" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "enter_id_to_login" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:upload_heading.Vitro
+uil-data:upload_heading.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Photo Upload"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "upload_heading" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "upload_heading" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:warnings_issued.Vitro
+uil-data:warnings_issued.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "{0} issued warnings during startup."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "warnings_issued" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "warnings_issued" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:account_management.Vitro
+uil-data:account_management.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Account Management"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "account_management" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "account_management" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_content_display.Vitro
+uil-data:select_content_display.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Select content to display"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_content_display" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_content_display" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:account_no_longer_exists.Vitro
+uil-data:account_no_longer_exists.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "The account you are trying to set a password on is no longer available. Please contact your system administrator if you think this is an error."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "account_no_longer_exists" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "account_no_longer_exists" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:page_select_permission.Vitro
+uil-data:page_select_permission.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Select page permissions"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "page_select_permission" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "page_select_permission" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:test_for_logged_in_users.Vitro
+uil-data:test_for_logged_in_users.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "This is the test widget for logged-in users."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "test_for_logged_in_users" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "test_for_logged_in_users" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:edit_page.Vitro
+uil-data:edit_page.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Edit {0} Page"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "edit_page" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "edit_page" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:no_match.Vitro
+uil-data:no_match.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "no match"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "no_match" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "no_match" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:add_new_page.Vitro
+uil-data:add_new_page.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Add New Page"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "add_new_page" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "add_new_page" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:class_groups.Vitro
+uil-data:class_groups.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Class groups"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "class_groups" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "class_groups" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:password_reset_pending_email_subject.Vitro
+uil-data:password_reset_pending_email_subject.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "${siteName} reset password request"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "password_reset_pending_email_subject" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "password_reset_pending_email_subject" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:manage.Vitro
+uil-data:manage.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "manage"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "manage" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "manage" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_password_length.Vitro
+uil-data:error_password_length.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Please enter a password between {0} and {1} characters in length."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_password_length" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_password_length" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:view_profile_editors.Vitro
+uil-data:view_profile_editors.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "View all profile editors"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "view_profile_editors" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "view_profile_editors" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:subclasses_capitalized.Vitro
+uil-data:subclasses_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Subclasses"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "subclasses_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "subclasses_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:auth_matching_id_label.Vitro
+uil-data:auth_matching_id_label.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "External Auth. ID / Matching ID"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "auth_matching_id_label" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "auth_matching_id_label" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:page_editor_permission_option.Vitro
+uil-data:page_editor_permission_option.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Editors and above can view this page"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "page_editor_permission_option" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "page_editor_permission_option" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:delete_page.Vitro
+uil-data:delete_page.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "delete this page"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "delete_page" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "delete_page" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:for.Vitro
+uil-data:for.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "for"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "for" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "for" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:manage_list_of_labels.Vitro
+uil-data:manage_list_of_labels.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "manage list of labels"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "manage_list_of_labels" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "manage_list_of_labels" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:content.Vitro
+uil-data:content.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "content"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "content" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "content" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:match_by.Vitro
+uil-data:match_by.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "match by {0}"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "match_by" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "match_by" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:alt_preview_crop.Vitro
+uil-data:alt_preview_crop.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Preview of photo cropped"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "alt_preview_crop" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "alt_preview_crop" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:pretty_url.Vitro
+uil-data:pretty_url.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Pretty URL"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "pretty_url" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "pretty_url" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:operation_successful.Vitro
+uil-data:operation_successful.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "The operation was successful."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "operation_successful" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "operation_successful" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:add_capitalized.Vitro
+uil-data:add_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Add"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "add_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "add_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:accounts_per_page.Vitro
+uil-data:accounts_per_page.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "accounts per page"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "accounts_per_page" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "accounts_per_page" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_editor_and_profile.Vitro
+uil-data:select_editor_and_profile.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "You must select a minimum of 1 editor and profile."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_editor_and_profile" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_editor_and_profile" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:request_failed.Vitro
+uil-data:request_failed.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Request failed. Please contact your system administrator."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "request_failed" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "request_failed" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:from_site_admin_page.Vitro
+uil-data:from_site_admin_page.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "from the Site Administration page."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "from_site_admin_page" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "from_site_admin_page" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:new_password_capitalized.Vitro
+uil-data:new_password_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "New Password"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "new_password_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "new_password_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:advanced_search_tip_one.Vitro
+uil-data:advanced_search_tip_one.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "When you enter more than one term, search will return results containing all of them unless you add the Boolean \"OR\" -- e.g., <i>chicken</i> OR <i>egg</i>."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "advanced_search_tip_one" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "advanced_search_tip_one" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:password_reset_complete_email_plain_text.Vitro
+uil-data:password_reset_complete_email_plain_text.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "${userAccount.firstName} ${userAccount.lastName}\n\nPassword successfully changed.\n\nYour new password associated with ${userAccount.emailAddress}\nhas been changed"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "password_reset_complete_email_plain_text" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "password_reset_complete_email_plain_text" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:application_error_email_subject.Vitro
+uil-data:application_error_email_subject.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "An error occurred on your ${siteName!} web site"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "application_error_email_subject" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "application_error_email_subject" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:return_to.Vitro
+uil-data:return_to.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "return to {0}"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "return_to" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "return_to" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:last_login.Vitro
+uil-data:last_login.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Last Login"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "last_login" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "last_login" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:view_profile_in_rdf.Vitro
+uil-data:view_profile_in_rdf.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "view profile in RDF format"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "view_profile_in_rdf" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "view_profile_in_rdf" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:minimum_password_length.Vitro
+uil-data:minimum_password_length.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Minimum of {0} characters in length; maximum of {1}."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "minimum_password_length" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "minimum_password_length" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:contact_us.Vitro
+uil-data:contact_us.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Contact Us"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "contact_us" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "contact_us" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:download_results.Vitro
+uil-data:download_results.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Download Results"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "download_results" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "download_results" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:selected_profiles.Vitro
+uil-data:selected_profiles.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Selected profiles"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "selected_profiles" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "selected_profiles" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:has_value.Vitro
+uil-data:has_value.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "has value"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "has_value" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "has_value" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:faux_property_listing.Vitro
+uil-data:faux_property_listing.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Faux Property Listing"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "faux_property_listing" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "faux_property_listing" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:display_admin_header.Vitro
+uil-data:display_admin_header.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Display Admin and Configuration"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "display_admin_header" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "display_admin_header" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_no_password.Vitro
+uil-data:error_no_password.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Please enter your password."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_no_password" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_no_password" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:remove_capitalized.Vitro
+uil-data:remove_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Remove"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "remove_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "remove_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:october.Vitro
+uil-data:october.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "October"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "october" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "october" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:file_upload_subject.Vitro
+uil-data:file_upload_subject.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "subject"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "file_upload_subject" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "file_upload_subject" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:manage_site.Vitro
+uil-data:manage_site.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Manage this site"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "manage_site" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "manage_site" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:confirm_delete_account_plural.Vitro
+uil-data:confirm_delete_account_plural.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Are you sure you want to delete these accounts?"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "confirm_delete_account_plural" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "confirm_delete_account_plural" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:sunday.Vitro
+uil-data:sunday.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Sunday"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "sunday" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "sunday" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:password_system_has_changed.Vitro
+uil-data:password_system_has_changed.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "password_system_has_changed" ;
-        prop:hasPackage  "Vitro-languages" .
+        rdf:type         uil:UILabel ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "password_system_has_changed" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:rebuild_search_index.Vitro
+uil-data:rebuild_search_index.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Rebuild search index"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "rebuild_search_index" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "rebuild_search_index" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:password_saved.Vitro
+uil-data:password_saved.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Your password has been saved."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "password_saved" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "password_saved" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:supply_query_variable.Vitro
+uil-data:supply_query_variable.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "You must supply a variable to save query results."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "supply_query_variable" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "supply_query_variable" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:configure_page_if_permissable.Vitro
+uil-data:configure_page_if_permissable.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "to configure this page if the user has permission."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "configure_page_if_permissable" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "configure_page_if_permissable" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:invalid_date_form_msg.Vitro
+uil-data:invalid_date_form_msg.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "must be in valid date format mm/dd/yyyy."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "invalid_date_form_msg" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "invalid_date_form_msg" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:manage_list_of.Vitro
+uil-data:manage_list_of.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Manage list of"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "manage_list_of" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "manage_list_of" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:verbose_property_status.Vitro
+uil-data:verbose_property_status.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Verbose property display is"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "verbose_property_status" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "verbose_property_status" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:sparql_query_select_ask_results.Vitro
+uil-data:sparql_query_select_ask_results.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Format for SELECT and ASK query results"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "sparql_query_select_ask_results" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "sparql_query_select_ask_results" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:individual_not_found.Vitro
+uil-data:individual_not_found.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Individual not found"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "individual_not_found" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "individual_not_found" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:classes_by_classgroup.Vitro
+uil-data:classes_by_classgroup.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Classes by Class Group"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "classes_by_classgroup" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "classes_by_classgroup" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:confirm_email_changed_email_plain_text.Vitro
+uil-data:confirm_email_changed_email_plain_text.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Dear ${userAccount.firstName} ${userAccount.lastName}\n\nYou recently changed the email address associated with\n${userAccount.firstName} ${userAccount.lastName}\n\nThank you."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "confirm_email_changed_email_plain_text" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "confirm_email_changed_email_plain_text" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:close_capitalized.Vitro
+uil-data:close_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Close"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "close_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "close_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:browse_class_group.Vitro
+uil-data:browse_class_group.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Browse Class Group"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "browse_class_group" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "browse_class_group" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:statistics.Vitro
+uil-data:statistics.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Statistics"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "statistics" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "statistics" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:new_password.Vitro
+uil-data:new_password.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "New password"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "new_password" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "new_password" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:hide_show_subclasses.Vitro
+uil-data:hide_show_subclasses.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "hide/show subclasses"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "hide_show_subclasses" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "hide_show_subclasses" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:class_hierarchy.Vitro
+uil-data:class_hierarchy.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Class hierarchy"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "class_hierarchy" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "class_hierarchy" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:add_content_manage_site.Vitro
+uil-data:add_content_manage_site.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "add content and manage this site"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "add_content_manage_site" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "add_content_manage_site" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:background_threads.Vitro
+uil-data:background_threads.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Background Threads"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "background_threads" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "background_threads" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:create_capitalized.Vitro
+uil-data:create_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Create"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "create_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "create_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_previous_password.Vitro
+uil-data:error_previous_password.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Your new password cannot match the current one."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_previous_password" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_previous_password" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:change_password.Vitro
+uil-data:change_password.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "You must change your password to log in."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "change_password" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "change_password" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:menu_management.Vitro
+uil-data:menu_management.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Menu Management"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "menu_management" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "menu_management" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:email_change_will_be_confirmed.Vitro
+uil-data:email_change_will_be_confirmed.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Note: if email changes, a confirmation email will be sent to the new email address entered above."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "email_change_will_be_confirmed" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "email_change_will_be_confirmed" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:fake_external_auth.Vitro
+uil-data:fake_external_auth.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Fake External Authentication"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "fake_external_auth" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "fake_external_auth" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:run_sdb_setup.Vitro
+uil-data:run_sdb_setup.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Run SDB Setup"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "run_sdb_setup" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "run_sdb_setup" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:property_management.Vitro
+uil-data:property_management.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Property Management"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "property_management" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "property_management" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:end_your_Session.Vitro
+uil-data:end_your_Session.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "End your session"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "end_your_Session" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "end_your_Session" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:search_index_not_connected.Vitro
+uil-data:search_index_not_connected.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "The search index is not connected."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "search_index_not_connected" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "search_index_not_connected" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:change_content_type.Vitro
+uil-data:change_content_type.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Change content type"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "change_content_type" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "change_content_type" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:invalid_search_term.Vitro
+uil-data:invalid_search_term.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Search term was invalid"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "invalid_search_term" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "invalid_search_term" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:index_recs_completed.Vitro
+uil-data:index_recs_completed.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Completed {0} out of {1} index records."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "index_recs_completed" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "index_recs_completed" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:add_profile.Vitro
+uil-data:add_profile.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Add profile"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "add_profile" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "add_profile" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:view_labels_capitalized.Vitro
+uil-data:view_labels_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "View Labels"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "view_labels_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "view_labels_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:maximum_cardinality.Vitro
+uil-data:maximum_cardinality.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "maximum cardinality"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "maximum_cardinality" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "maximum_cardinality" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:please_format_email.Vitro
+uil-data:please_format_email.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Please format your e-mail address as:"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "please_format_email" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "please_format_email" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:external_auth_only.Vitro
+uil-data:external_auth_only.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Externally Authenticated Only"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "external_auth_only" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "external_auth_only" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:return_to_individual.Vitro
+uil-data:return_to_individual.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Return to Individual Page"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "return_to_individual" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "return_to_individual" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:all_x_properties.Vitro
+uil-data:all_x_properties.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "All {0} Properties"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "all_x_properties" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "all_x_properties" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:password_created_email_plain_text.Vitro
+uil-data:password_created_email_plain_text.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "${userAccount.firstName} ${userAccount.lastName}\n\nPassword successfully created.\n\nYour new password associated with ${userAccount.emailAddress}\nhas been created.\n\nThank you."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "password_created_email_plain_text" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "password_created_email_plain_text" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:already_logged_in.Vitro
+uil-data:already_logged_in.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "You are already logged in."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "already_logged_in" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "already_logged_in" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:supply_class_group.Vitro
+uil-data:supply_class_group.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "You must supply a class group."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "supply_class_group" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "supply_class_group" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:matching_prop_not_defined.Vitro
+uil-data:matching_prop_not_defined.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "matching property is not defined"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "matching_prop_not_defined" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "matching_prop_not_defined" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:display_rank.Vitro
+uil-data:display_rank.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Display Rank"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "display_rank" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "display_rank" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:profile_editing_title.Vitro
+uil-data:profile_editing_title.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "The editors you select on the left hand side will have the ability to edit the VIVO profiles you select on the right hand side. You can select multiple editors and multiple profiles, but you must select a minimum of 1 each."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "profile_editing_title" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "profile_editing_title" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:test_for_nonlogged_in_users.Vitro
+uil-data:test_for_nonlogged_in_users.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "This is the test widget for non-logged-in users."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "test_for_nonlogged_in_users" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "test_for_nonlogged_in_users" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:insufficient_authorization.Vitro
+uil-data:insufficient_authorization.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "We're sorry, but you are not authorized to view the page you requested. If you think this is an error, please contact us and we'll be happy to help."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "insufficient_authorization" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "insufficient_authorization" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:supply_content_type.Vitro
+uil-data:supply_content_type.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "You must supply a content type"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "supply_content_type" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "supply_content_type" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:back_to_results.Vitro
+uil-data:back_to_results.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Back to results"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "back_to_results" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "back_to_results" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:may_not_edit.Vitro
+uil-data:may_not_edit.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "May not edit"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "may_not_edit" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "may_not_edit" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:four_digit_year.Vitro
+uil-data:four_digit_year.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Invalid entry. Please enter a 4-digit Year."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "four_digit_year" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "four_digit_year" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:browse_page_javascript_two.Vitro
+uil-data:browse_page_javascript_two.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "to browse for information."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "browse_page_javascript_two" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "browse_page_javascript_two" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:password_created_email_html_text.Vitro
+uil-data:password_created_email_html_text.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "<p>\n ${userAccount.firstName} ${userAccount.lastName}\n </p>\n\n <p>\n <strong>Password successfully created.</strong>\n </p>\n\n <p>\n Your new password associated with ${userAccount.emailAddress} has been created.\n </p>\n\n <p>\n Thank you.\n </p>"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "password_created_email_html_text" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "password_created_email_html_text" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:current_photo.Vitro
+uil-data:current_photo.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Current Photo"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "current_photo" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "current_photo" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_last_name.Vitro
+uil-data:select_last_name.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Select an existing last name"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_last_name" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_last_name" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:supply_template.Vitro
+uil-data:supply_template.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "You must supply a template"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "supply_template" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "supply_template" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:view_all_accounts_title.Vitro
+uil-data:view_all_accounts_title.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "view all accounts"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "view_all_accounts_title" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "view_all_accounts_title" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:cropping_note.Vitro
+uil-data:cropping_note.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "To make adjustments, you can drag around and resize the photo to the right. When you are happy with your photo click the \"Save Photo\" button."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "cropping_note" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "cropping_note" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:page_not_created.Vitro
+uil-data:page_not_created.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Page could not be created"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "page_not_created" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "page_not_created" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_email_already_exists.Vitro
+uil-data:error_email_already_exists.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "An account with that email address already exists."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_email_already_exists" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_email_already_exists" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:required_field_empty_msg.Vitro
+uil-data:required_field_empty_msg.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "This field must not be empty."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "required_field_empty_msg" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "required_field_empty_msg" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:site_maintenance.Vitro
+uil-data:site_maintenance.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Site Maintenance"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "site_maintenance" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "site_maintenance" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:current_date_time.Vitro
+uil-data:current_date_time.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Current date & time:"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "current_date_time" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "current_date_time" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:page_link.Vitro
+uil-data:page_link.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "page link"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "page_link" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "page_link" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:object_property_hierarchy.Vitro
+uil-data:object_property_hierarchy.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Object property hierarchy"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "object_property_hierarchy" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "object_property_hierarchy" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:user_accounts.Vitro
+uil-data:user_accounts.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "User accounts"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "user_accounts" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "user_accounts" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:maximum_file_size.Vitro
+uil-data:maximum_file_size.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Maximum file size: {0} megabytes"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "maximum_file_size" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "maximum_file_size" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:add_new_account.Vitro
+uil-data:add_new_account.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Add new account"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "add_new_account" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "add_new_account" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:browse_all_starts_with.Vitro
+uil-data:browse_all_starts_with.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Browse all individuals whose name starts with {0}"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "browse_all_starts_with" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "browse_all_starts_with" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:status.Vitro
+uil-data:status.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Status"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "status" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "status" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:index.Vitro
+uil-data:index.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Index"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "index" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "index" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:verify_this_match_title.Vitro
+uil-data:verify_this_match_title.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "verify this match"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "verify_this_match_title" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "verify_this_match_title" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:search_indexer_idle.Vitro
+uil-data:search_indexer_idle.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "The search indexer is idle."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "search_indexer_idle" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "search_indexer_idle" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:start_capitalized.Vitro
+uil-data:start_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Start"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "start_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "start_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:minimum_cardinality.Vitro
+uil-data:minimum_cardinality.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "minimum cardinality"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "minimum_cardinality" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "minimum_cardinality" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:manage_affiliated_people_link.Vitro
+uil-data:manage_affiliated_people_link.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "manage affiliated people"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "manage_affiliated_people_link" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "manage_affiliated_people_link" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:initial_password.Vitro
+uil-data:initial_password.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Initial password"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "initial_password" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "initial_password" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:invalid_format.Vitro
+uil-data:invalid_format.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Invalid format"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "invalid_format" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "invalid_format" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:menu_orering.Vitro
+uil-data:menu_orering.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Menu Ordering"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "menu_orering" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "menu_orering" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:confirm_entry_deletion_from.Vitro
+uil-data:confirm_entry_deletion_from.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Are you sure you want to delete the following entry from"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "confirm_entry_deletion_from" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "confirm_entry_deletion_from" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:add_types.Vitro
+uil-data:add_types.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Add one or more types"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "add_types" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "add_types" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:group_capitalized.Vitro
+uil-data:group_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Group"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "group_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "group_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:entry.Vitro
+uil-data:entry.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "entry"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "entry" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "entry" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:search_vitro.Vitro
+uil-data:search_vitro.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Search VITRO"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "search_vitro" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "search_vitro" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:version.Vitro
+uil-data:version.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Version"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "version" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "version" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:hide_subclasses.Vitro
+uil-data:hide_subclasses.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "hide subclasses"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "hide_subclasses" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "hide_subclasses" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:caused_by.Vitro
+uil-data:caused_by.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Caused by"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "caused_by" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "caused_by" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:show_more_content.Vitro
+uil-data:show_more_content.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "show more content"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "show_more_content" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "show_more_content" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:advanced_search_tip_six.Vitro
+uil-data:advanced_search_tip_six.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Search uses shortened versions of words -- e.g., a search for <i>cogniti*</i> finds nothing, while <i>cognit*</i> finds both <i>cognitive</i> and <i>cognition</i>."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "advanced_search_tip_six" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "advanced_search_tip_six" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:myAccount_confirm_changes_plus_note.Vitro
+uil-data:myAccount_confirm_changes_plus_note.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Your changes have been saved. A confirmation email has been sent to {0}."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "myAccount_confirm_changes_plus_note" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "myAccount_confirm_changes_plus_note" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:class_management.Vitro
+uil-data:class_management.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Class Management"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "class_management" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "class_management" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:display_less.Vitro
+uil-data:display_less.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "less"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "display_less" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "display_less" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:add_property_group.Vitro
+uil-data:add_property_group.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Add new property group"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "add_property_group" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "add_property_group" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:browse_by.Vitro
+uil-data:browse_by.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Browse by"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "browse_by" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "browse_by" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:class_group_link.Vitro
+uil-data:class_group_link.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "class group link"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "class_group_link" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "class_group_link" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:confirm_password.Vitro
+uil-data:confirm_password.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Confirm new password"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "confirm_password" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "confirm_password" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:saturday.Vitro
+uil-data:saturday.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Saturday"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "saturday" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "saturday" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:_publications_link.Vitro
+uil-data:_publications_link.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "_publications_link" ;
-        prop:hasPackage  "Vitro-languages" .
+        rdf:type         uil:UILabel ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "_publications_link" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:javascript_require_to_edit.Vitro
+uil-data:javascript_require_to_edit.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "In order to edit content, you'll need to enable JavaScript."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "javascript_require_to_edit" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "javascript_require_to_edit" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:fatal_error_detected.Vitro
+uil-data:fatal_error_detected.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "{0} detected a fatal error during startup."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "fatal_error_detected" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "fatal_error_detected" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:menu_page.Vitro
+uil-data:menu_page.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Menu Page"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "menu_page" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "menu_page" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:create_new_individual_of_the_following_type.Vitro
+uil-data:create_new_individual_of_the_following_type.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Create an object of the following type"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "create_new_individual_of_the_following_type" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "create_new_individual_of_the_following_type" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:logins_not_already_restricted.Vitro
+uil-data:logins_not_already_restricted.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Logins are already not restricted."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "logins_not_already_restricted" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "logins_not_already_restricted" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:stack_trace.Vitro
+uil-data:stack_trace.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Stack trace"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "stack_trace" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "stack_trace" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:confirm_page_deletion.Vitro
+uil-data:confirm_page_deletion.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Are you sure you wish to delete this page:"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "confirm_page_deletion" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "confirm_page_deletion" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_locale.Vitro
+uil-data:select_locale.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "select locale"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_locale" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_locale" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:reset_password.Vitro
+uil-data:reset_password.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Reset password"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "reset_password" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "reset_password" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:vitro_bullet_two.Vitro
+uil-data:vitro_bullet_two.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Edit instances and relationships"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "vitro_bullet_two" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "vitro_bullet_two" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:replace_page_title.Vitro
+uil-data:replace_page_title.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Replace image"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "replace_page_title" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "replace_page_title" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:subproperty.Vitro
+uil-data:subproperty.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "subproperty"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "subproperty" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "subproperty" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:rdf_export.Vitro
+uil-data:rdf_export.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "RDF export"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "rdf_export" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "rdf_export" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:click_to_view_larger.Vitro
+uil-data:click_to_view_larger.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "click to view larger image"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "click_to_view_larger" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "click_to_view_larger" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:build_date.Vitro
+uil-data:build_date.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Build date"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "build_date" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "build_date" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:flags.Vitro
+uil-data:flags.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Flags"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "flags" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "flags" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:march.Vitro
+uil-data:march.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "March"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "march" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "march" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:display_only.Vitro
+uil-data:display_only.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Display Only"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "display_only" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "display_only" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:to_manage_content.Vitro
+uil-data:to_manage_content.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "to manage content."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "to_manage_content" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "to_manage_content" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:acct_created_email_html_text.Vitro
+uil-data:acct_created_email_html_text.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "<p>\n ${userAccount.firstName} ${userAccount.lastName}\n </p>\n\n <p>\n <strong>Congratulations!</strong>\n </p>\n\n <p>\n We have created your new account on ${siteName}, associated with ${userAccount.emailAddress}.\n </p>\n\n <p>\n If you did not request this new account you can safely ignore this email.\n This request will expire if not acted upon for 30 days.\n </p>\n\n <p>\n Click the link below to create your password for your new account using our secure server.\n </p>\n\n <p>\n <a href=\"${passwordLink}\" title=\"password\">${passwordLink}</a>\n </p>\n\n <p>\n If the link above doesn't work, you can copy and paste the link directly into your browser's address bar.\n </p>\n\n <p>\n Thanks!\n </p>"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "acct_created_email_html_text" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "acct_created_email_html_text" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:file_upload_confirm_delete.Vitro
+uil-data:file_upload_confirm_delete.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Are you sure you want to delete this file?"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "file_upload_confirm_delete" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "file_upload_confirm_delete" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:cropping_caption.Vitro
+uil-data:cropping_caption.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Your profile photo will look like the image below."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "cropping_caption" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "cropping_caption" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:browse_capitalized.Vitro
+uil-data:browse_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Browse"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "browse_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "browse_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:display_options.Vitro
+uil-data:display_options.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Display Options"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "display_options" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "display_options" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:site_config.Vitro
+uil-data:site_config.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Site Configuration"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "site_config" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "site_config" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:undo_camelcasing.Vitro
+uil-data:undo_camelcasing.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Uncamelcasing"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "undo_camelcasing" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "undo_camelcasing" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:view_all_capitalized.Vitro
+uil-data:view_all_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "View All"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "view_all_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "view_all_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_processing_labels.Vitro
+uil-data:error_processing_labels.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Error processing request: the unchecked labels could not be deleted."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_processing_labels" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_processing_labels" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:dates.Vitro
+uil-data:dates.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Dates"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "dates" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "dates" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:myAccount_heading.Vitro
+uil-data:myAccount_heading.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "My account"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "myAccount_heading" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "myAccount_heading" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:roles.Vitro
+uil-data:roles.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Roles"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "roles" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "roles" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:april.Vitro
+uil-data:april.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "April"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "april" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "april" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:password_reset_pending_subject.Vitro
+uil-data:password_reset_pending_subject.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "{0} reset password request"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "password_reset_pending_subject" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "password_reset_pending_subject" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:some_values_from.Vitro
+uil-data:some_values_from.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "some values from"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "some_values_from" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "some_values_from" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:browse_all_public_content.Vitro
+uil-data:browse_all_public_content.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "You can browse all of the public content currently in the system using the"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "browse_all_public_content" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "browse_all_public_content" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:all_values_from.Vitro
+uil-data:all_values_from.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "all values from"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "all_values_from" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "all_values_from" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:updated_account_2.Vitro
+uil-data:updated_account_2.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "has been updated."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "updated_account_2" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "updated_account_2" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:alt_error_alert.Vitro
+uil-data:alt_error_alert.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Error alert icon"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "alt_error_alert" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "alt_error_alert" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:year_month.Vitro
+uil-data:year_month.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Invalid entry. Please enter a Year and Month."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "year_month" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "year_month" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:name.Vitro
+uil-data:name.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "name"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "name" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "name" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:no_image.Vitro
+uil-data:no_image.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "no image"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "no_image" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "no_image" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:sparql_query_save_results.Vitro
+uil-data:sparql_query_save_results.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Save results to file"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "sparql_query_save_results" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "sparql_query_save_results" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:add_new_group.Vitro
+uil-data:add_new_group.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Add New Group"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "add_new_group" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "add_new_group" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:browse_all.Vitro
+uil-data:browse_all.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Browse all"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "browse_all" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "browse_all" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:processing_icon.Vitro
+uil-data:processing_icon.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "processing"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "processing_icon" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "processing_icon" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:logins_restricted.Vitro
+uil-data:logins_restricted.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Logins are now restricted."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "logins_restricted" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "logins_restricted" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:search_tip_four.Vitro
+uil-data:search_tip_four.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "If you are unsure of the correct spelling, put ~ at the end of your search term -- e.g., <i>cabage~</i> finds <i>cabbage</i>, <i>steven~</i> finds <i>Stephen</i> and <i>Stefan</i> (as well as other similar names)."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "search_tip_four" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "search_tip_four" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:imageUpload.errorNoURI.Vitro
+uil-data:imageUpload.errorNoURI.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "No entity URI was provided"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "imageUpload.errorNoURI" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "imageUpload.errorNoURI" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:password_saved_please_login.Vitro
+uil-data:password_saved_please_login.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Your password has been saved. Please log in."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "password_saved_please_login" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "password_saved_please_login" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:upload_photo.Vitro
+uil-data:upload_photo.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Upload a photo"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "upload_photo" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "upload_photo" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:sparql_query_results.Vitro
+uil-data:sparql_query_results.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Sparql Query Results"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "sparql_query_results" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "sparql_query_results" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:enter_new_password.Vitro
+uil-data:enter_new_password.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Please enter your new password for {0}"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "enter_new_password" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "enter_new_password" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:display_more_ellipsis.Vitro
+uil-data:display_more_ellipsis.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "... more"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "display_more_ellipsis" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "display_more_ellipsis" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:updated_account_1.Vitro
+uil-data:updated_account_1.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "The account for"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "updated_account_1" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "updated_account_1" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:add_page.Vitro
+uil-data:add_page.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Add Page"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "add_page" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "add_page" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:list_elements_of.Vitro
+uil-data:list_elements_of.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "List elements of"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "list_elements_of" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "list_elements_of" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:class_group_all_caps.Vitro
+uil-data:class_group_all_caps.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Class Group"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "class_group_all_caps" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "class_group_all_caps" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:no_class_restrictions.Vitro
+uil-data:no_class_restrictions.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "There are no classes with a restriction on this property."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "no_class_restrictions" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "no_class_restrictions" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:refresh_page_after_reordering.Vitro
+uil-data:refresh_page_after_reordering.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Refresh page after reordering menu items"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "refresh_page_after_reordering" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "refresh_page_after_reordering" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:asserted_class_hierarchy.Vitro
+uil-data:asserted_class_hierarchy.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Asserted Class Hierarchy"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "asserted_class_hierarchy" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "asserted_class_hierarchy" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:page_admin_permission_option.Vitro
+uil-data:page_admin_permission_option.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Only admins can view this page"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "page_admin_permission_option" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "page_admin_permission_option" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:create_associated_profile.Vitro
+uil-data:create_associated_profile.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Create the associated profile"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "create_associated_profile" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "create_associated_profile" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:password_reset_complete_email_html_text.Vitro
+uil-data:password_reset_complete_email_html_text.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "<p>\n ${userAccount.firstName} ${userAccount.lastName}\n </p>\n\n <p>\n <strong>Password successfully changed.</strong>\n </p>\n\n <p>\n Your new password associated with ${userAccount.emailAddress} has been changed.\n </p>\n\n <p>\n Thank you.\n </p>"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "password_reset_complete_email_html_text" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "password_reset_complete_email_html_text" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:first_time_external_email_html_text.Vitro
+uil-data:first_time_external_email_html_text.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "<p>\n ${userAccount.firstName} ${userAccount.lastName}\n </p>\n\n <p>\n <strong>Congratulations!</strong>\n </p>\n\n <p>\n We have created your new VIVO account associated with ${userAccount.emailAddress}.\n </p>\n\n <p>\n Thanks!\n </p>"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "first_time_external_email_html_text" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "first_time_external_email_html_text" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:default.Vitro
+uil-data:default.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Default"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "default" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "default" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_password_mismatch.Vitro
+uil-data:error_password_mismatch.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Passwords do not match."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_password_mismatch" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_password_mismatch" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:and.Vitro
+uil-data:and.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "and"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "and" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "and" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:no_matching_results.Vitro
+uil-data:no_matching_results.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "No matching results."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "no_matching_results" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "no_matching_results" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:internal_class_i_capped.Vitro
+uil-data:internal_class_i_capped.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Institutional internal class"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "internal_class_i_capped" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "internal_class_i_capped" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:decimal_only.Vitro
+uil-data:decimal_only.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Invalid entry.  A decimal point is allowed, but thousands-separators are not."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "decimal_only" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "decimal_only" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:new_account_2.Vitro
+uil-data:new_account_2.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "was successfully created."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "new_account_2" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "new_account_2" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:listed_page_title.Vitro
+uil-data:listed_page_title.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "listed page title"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "listed_page_title" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "listed_page_title" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:delete_profile_editor.Vitro
+uil-data:delete_profile_editor.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Delete profile editor"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "delete_profile_editor" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "delete_profile_editor" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_no_first_name.Vitro
+uil-data:error_no_first_name.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "You must supply a first name."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_no_first_name" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_no_first_name" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:browse_all_in_class.Vitro
+uil-data:browse_all_in_class.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Browse all individuals in this class"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "browse_all_in_class" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "browse_all_in_class" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:save_entry.Vitro
+uil-data:save_entry.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Save entry"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "save_entry" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "save_entry" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:confirm_initial_password.Vitro
+uil-data:confirm_initial_password.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Confirm initial password"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "confirm_initial_password" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "confirm_initial_password" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:ingest_tools.Vitro
+uil-data:ingest_tools.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ingest tools"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "ingest_tools" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "ingest_tools" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:application_error_email_html_text.Vitro
+uil-data:application_error_email_html_text.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "<p>An error occurred on your ${siteName!} web site at ${datetime!}\n </p>\n\n <p>\n <strong>Requested url:</strong> ${requestedUrl!}\n </p>\n\n <p>\n <#if errorMessage?has_content>\n <strong>Error message:</strong> ${errorMessage!}\n </#if>\n </p>\n\n <p>\n <strong>Stack trace</strong> (full trace available in the log):\n <pre>${stackTrace!}</pre>\n </p>\n\n <#if cause?has_content>\n <p><strong>Caused by:</strong>\n <pre>${cause!}</pre>\n </p>\n </#if>"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "application_error_email_html_text" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "application_error_email_html_text" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:log_in.Vitro
+uil-data:log_in.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "log in"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "log_in" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "log_in" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:new_account_1.Vitro
+uil-data:new_account_1.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "A new account for"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "new_account_1" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "new_account_1" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:imageUpload.errorUnrecognizedFileType.Vitro
+uil-data:imageUpload.errorUnrecognizedFileType.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "''{0}'' is not a recognized image file type. Please upload JPEG, GIF, or PNG files only."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "imageUpload.errorUnrecognizedFileType" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "imageUpload.errorUnrecognizedFileType" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:replace_page_title_with_name.Vitro
+uil-data:replace_page_title_with_name.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Replace image for {0}"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "replace_page_title_with_name" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "replace_page_title_with_name" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:unsupported_ie_version.Vitro
+uil-data:unsupported_ie_version.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "This form is not supported in versions of Internet Explorer below version 8. Please upgrade your browser, or switch to another browser, such as FireFox."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "unsupported_ie_version" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "unsupported_ie_version" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:logins_are_restricted.Vitro
+uil-data:logins_are_restricted.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Logins are restricted."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "logins_are_restricted" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "logins_are_restricted" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:add_profile_editor.Vitro
+uil-data:add_profile_editor.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Add profile editor"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "add_profile_editor" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "add_profile_editor" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:supply_name.Vitro
+uil-data:supply_name.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "You must supply a title"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "supply_name" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "supply_name" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:feedback_thanks_text.Vitro
+uil-data:feedback_thanks_text.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Thank you for contacting our curation and development team. We will respond to your inquiry as soon as possible."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "feedback_thanks_text" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "feedback_thanks_text" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_class_for_search.Vitro
+uil-data:select_class_for_search.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "You must select a class to display its individuals."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_class_for_search" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_class_for_search" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:since_elapsed_time.Vitro
+uil-data:since_elapsed_time.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "since {0}, elapsed time {1}"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "since_elapsed_time" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "since_elapsed_time" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:unknown_user_name.Vitro
+uil-data:unknown_user_name.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "friend"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "unknown_user_name" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "unknown_user_name" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:faux_property_capitalized.Vitro
+uil-data:faux_property_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Faux Property"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "faux_property_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "faux_property_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:enter_value_name_field.Vitro
+uil-data:enter_value_name_field.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Please enter a value in the name field."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "enter_value_name_field" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "enter_value_name_field" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:group_name.Vitro
+uil-data:group_name.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "group name"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "group_name" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "group_name" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:data_property_hierarchy.Vitro
+uil-data:data_property_hierarchy.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Data property hierarchy"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "data_property_hierarchy" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "data_property_hierarchy" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:external_login_text.Vitro
+uil-data:external_login_text.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Log in using BearCat Shibboleth"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "external_login_text" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "external_login_text" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:imageUpload.errorFileTooBig.Vitro
+uil-data:imageUpload.errorFileTooBig.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Please upload an image smaller than {0} megabytes."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "imageUpload.errorFileTooBig" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "imageUpload.errorFileTooBig" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:profile_editors.Vitro
+uil-data:profile_editors.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Profile editors"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "profile_editors" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "profile_editors" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:implement_capitalized.Vitro
+uil-data:implement_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Implement"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "implement_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "implement_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:sparql_query_header.Vitro
+uil-data:sparql_query_header.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Query"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "sparql_query_header" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "sparql_query_header" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:view.Vitro
+uil-data:view.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "view"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "view" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "view" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:manage_profile_editing.Vitro
+uil-data:manage_profile_editing.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Manage profile editing"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "manage_profile_editing" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "manage_profile_editing" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:minimum_image_dimensions.Vitro
+uil-data:minimum_image_dimensions.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Minimum image dimensions: {0} x {1} pixels"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "minimum_image_dimensions" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "minimum_image_dimensions" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:view_list_in_rdf.Vitro
+uil-data:view_list_in_rdf.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "View the {0} list in RDF format"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "view_list_in_rdf" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "view_list_in_rdf" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:more_details_about_site.Vitro
+uil-data:more_details_about_site.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "More details about this site"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "more_details_about_site" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "more_details_about_site" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:new_entry_for.Vitro
+uil-data:new_entry_for.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "\"{0}\" entry for {1}"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "new_entry_for" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "new_entry_for" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:july.Vitro
+uil-data:july.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "July"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "july" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "july" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:page_uri.Vitro
+uil-data:page_uri.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "page URI"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "page_uri" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "page_uri" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:edit_date_time_value.Vitro
+uil-data:edit_date_time_value.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Edit Date/Time Value"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "edit_date_time_value" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "edit_date_time_value" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:limited_to_type.Vitro
+uil-data:limited_to_type.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "limited to type"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "limited_to_type" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "limited_to_type" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:class_name.Vitro
+uil-data:class_name.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "class name"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "class_name" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "class_name" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:create_date_time_value.Vitro
+uil-data:create_date_time_value.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Create Date/Time Value"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "create_date_time_value" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "create_date_time_value" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:there_are_no_entries_for_selection.Vitro
+uil-data:there_are_no_entries_for_selection.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "There are no entries in the system from which to select."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "there_are_no_entries_for_selection" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "there_are_no_entries_for_selection" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:edit_this_individual.Vitro
+uil-data:edit_this_individual.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Edit this individual"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "edit_this_individual" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "edit_this_individual" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:start_interval_must_precede_end_earlier.Vitro
+uil-data:start_interval_must_precede_end_earlier.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "The Start interval must be earlier than the End interval."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "start_interval_must_precede_end_earlier" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "start_interval_must_precede_end_earlier" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:type_capitalized.Vitro
+uil-data:type_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Type"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "type_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "type_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:selected.Vitro
+uil-data:selected.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Selected"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "selected" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "selected" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:submit_upload.Vitro
+uil-data:submit_upload.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Upload photo"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "submit_upload" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "submit_upload" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:confirm_individual_deletion.Vitro
+uil-data:confirm_individual_deletion.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Are you sure you want to delete the following individual? "@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "confirm_individual_deletion" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "confirm_individual_deletion" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:september.Vitro
+uil-data:september.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "September"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "september" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "september" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:verbose_turn_off.Vitro
+uil-data:verbose_turn_off.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Turn off"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "verbose_turn_off" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "verbose_turn_off" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_type.Vitro
+uil-data:select_type.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Select a type"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_type" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_type" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:comments_questions.Vitro
+uil-data:comments_questions.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Comments, questions, or suggestions"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "comments_questions" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "comments_questions" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:send_mail.Vitro
+uil-data:send_mail.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Send Mail"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "send_mail" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "send_mail" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:change_profile.Vitro
+uil-data:change_profile.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "change profile"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "change_profile" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "change_profile" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:logins_already_restricted.Vitro
+uil-data:logins_already_restricted.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Logins are already restricted."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "logins_already_restricted" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "logins_already_restricted" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:photo_types.Vitro
+uil-data:photo_types.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "(JPEG, GIF or PNG)"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "photo_types" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "photo_types" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:search_term_error_near.Vitro
+uil-data:search_term_error_near.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "The search term had an error near"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "search_term_error_near" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "search_term_error_near" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:share_profile_uri.Vitro
+uil-data:share_profile_uri.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "share the URI for this profile"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "share_profile_uri" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "share_profile_uri" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:no_html_specified.Vitro
+uil-data:no_html_specified.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "No HTML specified."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "no_html_specified" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "no_html_specified" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:first_name.Vitro
+uil-data:first_name.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "First name"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "first_name" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "first_name" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:class_link.Vitro
+uil-data:class_link.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "class link"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "class_link" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "class_link" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:view_profile_page_for.Vitro
+uil-data:view_profile_page_for.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "View the profile page for"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "view_profile_page_for" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "view_profile_page_for" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_classes_to_display.Vitro
+uil-data:select_classes_to_display.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "You must select the classes to display."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_classes_to_display" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_classes_to_display" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:password_mismatch.Vitro
+uil-data:password_mismatch.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Passwords do not match."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "password_mismatch" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "password_mismatch" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:page_management.Vitro
+uil-data:page_management.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Page management"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "page_management" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "page_management" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:resource_uri.Vitro
+uil-data:resource_uri.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Resource URI"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "resource_uri" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "resource_uri" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:sparql_query_run_query.Vitro
+uil-data:sparql_query_run_query.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Run Query"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "sparql_query_run_query" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "sparql_query_run_query" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:enter_fixed_html_here.Vitro
+uil-data:enter_fixed_html_here.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Enter fixed HTML here"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "enter_fixed_html_here" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "enter_fixed_html_here" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:verify_this_match.Vitro
+uil-data:verify_this_match.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "verify this match"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "verify_this_match" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "verify_this_match" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:properties_capitalized.Vitro
+uil-data:properties_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Properties"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "properties_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "properties_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:raw_string_literals.Vitro
+uil-data:raw_string_literals.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Raw String Literals"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "raw_string_literals" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "raw_string_literals" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:no_content_create_groups_classes.Vitro
+uil-data:no_content_create_groups_classes.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "There is currently no content in the system, or you need to create class groups and assign your classes to them."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "no_content_create_groups_classes" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "no_content_create_groups_classes" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:home_page.Vitro
+uil-data:home_page.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "home page"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "home_page" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "home_page" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:restriction_on.Vitro
+uil-data:restriction_on.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "restriction on"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "restriction_on" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "restriction_on" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:processing_indicator.Vitro
+uil-data:processing_indicator.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "processing time indicator"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "processing_indicator" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "processing_indicator" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:selected_page_content_type.Vitro
+uil-data:selected_page_content_type.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Selected content type for the associated page"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "selected_page_content_type" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "selected_page_content_type" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:create_entry.Vitro
+uil-data:create_entry.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Create Entry"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "create_entry" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "create_entry" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:password_change_not_pending.Vitro
+uil-data:password_change_not_pending.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "The password for {0} has already been reset."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "password_change_not_pending" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "password_change_not_pending" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:javascript_instructions.Vitro
+uil-data:javascript_instructions.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "java script instructions"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "javascript_instructions" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "javascript_instructions" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_invalid_email.Vitro
+uil-data:error_invalid_email.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "''{0}'' is not a valid email address."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_invalid_email" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_invalid_email" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:new_pwd_matches_existing.Vitro
+uil-data:new_pwd_matches_existing.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Your new password must be different from your existing password."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "new_pwd_matches_existing" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "new_pwd_matches_existing" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:or.Vitro
+uil-data:or.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "or"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "or" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "or" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:search_form.Vitro
+uil-data:search_form.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Search form"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "search_form" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "search_form" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:menu_item_name.Vitro
+uil-data:menu_item_name.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Menu Item Name"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "menu_item_name" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "menu_item_name" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:june.Vitro
+uil-data:june.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "June"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "june" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "june" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:last_name.Vitro
+uil-data:last_name.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Last name"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "last_name" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "last_name" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:placeholder_image.Vitro
+uil-data:placeholder_image.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "placeholder image"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "placeholder_image" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "placeholder_image" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:requested_url.Vitro
+uil-data:requested_url.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Requested url"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "requested_url" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "requested_url" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:first_time_login_note.Vitro
+uil-data:first_time_login_note.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Note: An email will be sent to the address entered above notifying that an account has been created."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "first_time_login_note" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "first_time_login_note" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_external_auth_already_exists.Vitro
+uil-data:error_external_auth_already_exists.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "An account with that external authorization ID already exists."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_external_auth_already_exists" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_external_auth_already_exists" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:contains_no_pears.Vitro
+uil-data:contains_no_pears.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "contains no pears"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "contains_no_pears" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "contains_no_pears" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:index_page.Vitro
+uil-data:index_page.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "index page"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "index_page" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "index_page" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:search_tip_one.Vitro
+uil-data:search_tip_one.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Keep it simple! Use short, single terms unless your searches are returning too many results."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "search_tip_one" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "search_tip_one" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:sparql_query_construct_describe_results.Vitro
+uil-data:sparql_query_construct_describe_results.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Format for CONSTRUCT and DESCRIBE query results"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "sparql_query_construct_describe_results" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "sparql_query_construct_describe_results" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:password_capitalized.Vitro
+uil-data:password_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Password"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "password_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "password_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:file_upload_submit_label.Vitro
+uil-data:file_upload_submit_label.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Upload"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "file_upload_submit_label" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "file_upload_submit_label" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:please.Vitro
+uil-data:please.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Please"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "please" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "please" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:account_created.Vitro
+uil-data:account_created.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Your {0} account has been created."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "account_created" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "account_created" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:add.Vitro
+uil-data:add.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "add"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "add" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "add" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:limit.Vitro
+uil-data:limit.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Limit"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "limit" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "limit" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:november.Vitro
+uil-data:november.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "November"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "november" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "november" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:confirm_delete.Vitro
+uil-data:confirm_delete.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Are you sure you want to delete this photo?"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "confirm_delete" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "confirm_delete" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:login_welcome_message.Vitro
+uil-data:login_welcome_message.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Welcome{1, choice, 1# |1< back}, {0}"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "login_welcome_message" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "login_welcome_message" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:password_changed_subject.Vitro
+uil-data:password_changed_subject.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Password changed."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "password_changed_subject" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "password_changed_subject" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:incorrect_email_password.Vitro
+uil-data:incorrect_email_password.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Email or Password was incorrect."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "incorrect_email_password" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "incorrect_email_password" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:identifiers.Vitro
+uil-data:identifiers.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Identifiers"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "identifiers" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "identifiers" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:javascript_ie_alert_text.Vitro
+uil-data:javascript_ie_alert_text.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "This site uses HTML elements that are not recognized by Internet Explorer 8 and below in the absence of JavaScript. As a result, the site will not be rendered appropriately. To correct this, please either enable JavaScript, upgrade to Internet Explorer 9, or use another browser."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "javascript_ie_alert_text" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "javascript_ie_alert_text" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:zoo_two.Vitro
+uil-data:zoo_two.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Zoo 2"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "zoo_two" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "zoo_two" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:verbose_turn_on.Vitro
+uil-data:verbose_turn_on.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Turn on"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "verbose_turn_on" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "verbose_turn_on" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:selection_in_process.Vitro
+uil-data:selection_in_process.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Your selection is being processed."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "selection_in_process" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "selection_in_process" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:please_create.Vitro
+uil-data:please_create.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Please create"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "please_create" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "please_create" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:verbose_status_off.Vitro
+uil-data:verbose_status_off.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "off"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "verbose_status_off" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "verbose_status_off" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:page_not_configured.Vitro
+uil-data:page_not_configured.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "This page is not yet configured."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "page_not_configured" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "page_not_configured" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:new_account_notification.Vitro
+uil-data:new_account_notification.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "A notification email has been sent to {0} with instructions for activating the account and creating a password."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "new_account_notification" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "new_account_notification" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:full_list_startup.Vitro
+uil-data:full_list_startup.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "The full list of startup events and messages."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "full_list_startup" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "full_list_startup" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:user_role.Vitro
+uil-data:user_role.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Role"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "user_role" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "user_role" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:or_enter_valid_address.Vitro
+uil-data:or_enter_valid_address.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "or enter another complete and valid email address."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "or_enter_valid_address" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "or_enter_valid_address" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:all.Vitro
+uil-data:all.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "all"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "all" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "all" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:logged_in_but_no_profile.Vitro
+uil-data:logged_in_but_no_profile.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "You have logged in, but the system contains no profile for you."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "logged_in_but_no_profile" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "logged_in_but_no_profile" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:page_text.Vitro
+uil-data:page_text.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "page text"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "page_text" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "page_text" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:create_new_entry.Vitro
+uil-data:create_new_entry.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Please create a new entry."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "create_new_entry" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "create_new_entry" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:enter_in_security_field.Vitro
+uil-data:enter_in_security_field.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Please enter the letters displayed below into the security field"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "enter_in_security_field" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "enter_in_security_field" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_an_existing_or_create_a_new_one.Vitro
+uil-data:select_an_existing_or_create_a_new_one.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Select an existing or create a new one"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_an_existing_or_create_a_new_one" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_an_existing_or_create_a_new_one" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:not.Vitro
+uil-data:not.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "not"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "not" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "not" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:range_data_type.Vitro
+uil-data:range_data_type.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Range Data Type"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "range_data_type" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "range_data_type" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:august.Vitro
+uil-data:august.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "August"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "august" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "august" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:terms_of_use.Vitro
+uil-data:terms_of_use.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Terms of Use"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "terms_of_use" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "terms_of_use" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:dump_restore.Vitro
+uil-data:dump_restore.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Dump/Restore application"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "dump_restore" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "dump_restore" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:show_properties.Vitro
+uil-data:show_properties.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "show properties"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "show_properties" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "show_properties" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:associated_individuals.Vitro
+uil-data:associated_individuals.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Associated Individuals"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "associated_individuals" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "associated_individuals" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:name_capitalized.Vitro
+uil-data:name_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Name"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "name_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "name_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:manage_labels.Vitro
+uil-data:manage_labels.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "manage labels"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "manage_labels" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "manage_labels" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:current_user.Vitro
+uil-data:current_user.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Current user"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "current_user" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "current_user" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:minimum_ymd.Vitro
+uil-data:minimum_ymd.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Invalid entry. Please enter at least a Year, Month and Day."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "minimum_ymd" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "minimum_ymd" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:try_another_letter.Vitro
+uil-data:try_another_letter.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Please try another letter or browse all."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "try_another_letter" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "try_another_letter" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:alt_image_to_crop.Vitro
+uil-data:alt_image_to_crop.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Image to be cropped"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "alt_image_to_crop" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "alt_image_to_crop" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:current_task.Vitro
+uil-data:current_task.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "{0} the search index"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "current_task" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "current_task" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:imageUpload.errorNoImageForCropping.Vitro
+uil-data:imageUpload.errorNoImageForCropping.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "There is no image file to be cropped."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "imageUpload.errorNoImageForCropping" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "imageUpload.errorNoImageForCropping" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:we_have_an_error.Vitro
+uil-data:we_have_an_error.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "There was an error in the system."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "we_have_an_error" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "we_have_an_error" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_another_class.Vitro
+uil-data:select_another_class.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Please select another class from the list."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_another_class" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_another_class" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:manage_labels_for.Vitro
+uil-data:manage_labels_for.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Manage Labels for"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "manage_labels_for" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "manage_labels_for" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:revision_info.Vitro
+uil-data:revision_info.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Revision Information"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "revision_info" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "revision_info" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:rebuild_vis_cache.Vitro
+uil-data:rebuild_vis_cache.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Rebuild visualization cache"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "rebuild_vis_cache" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "rebuild_vis_cache" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:delete.Vitro
+uil-data:delete.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "delete"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "delete" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "delete" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:update_button.Vitro
+uil-data:update_button.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Update"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "update_button" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "update_button" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:imageUpload.errorNoPhotoSelected.Vitro
+uil-data:imageUpload.errorNoPhotoSelected.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Please browse and select a photo."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "imageUpload.errorNoPhotoSelected" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "imageUpload.errorNoPhotoSelected" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:imageUpload.errorUnrecognizedURI.Vitro
+uil-data:imageUpload.errorUnrecognizedURI.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "This URI is not recognized as belonging to anyone: ''{0}''"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "imageUpload.errorUnrecognizedURI" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "imageUpload.errorUnrecognizedURI" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:menu_item.Vitro
+uil-data:menu_item.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "menu item"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "menu_item" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "menu_item" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:auth_id_label.Vitro
+uil-data:auth_id_label.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "External Authentication ID"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "auth_id_label" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "auth_id_label" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:may.Vitro
+uil-data:may.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "May"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "may" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "may" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:what_is_vitro.Vitro
+uil-data:what_is_vitro.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "What is VITRO?"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "what_is_vitro" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "what_is_vitro" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_a_language.Vitro
+uil-data:select_a_language.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Select a language"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_a_language" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_a_language" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:ip_address.Vitro
+uil-data:ip_address.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "IP address"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "ip_address" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "ip_address" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:unrecognized_user.Vitro
+uil-data:unrecognized_user.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Unrecognized user"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "unrecognized_user" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "unrecognized_user" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:password_change_invalid_key.Vitro
+uil-data:password_change_invalid_key.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "The link you used for {0} is invalid. Please ask your system administrator to resend the link."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "password_change_invalid_key" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "password_change_invalid_key" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:change_text_for.Vitro
+uil-data:change_text_for.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Change text for:"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "change_text_for" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "change_text_for" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:to_enable_javascript.Vitro
+uil-data:to_enable_javascript.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Here are the instructions for enabling JavaScript in your web browser"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "to_enable_javascript" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "to_enable_javascript" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:warning.Vitro
+uil-data:warning.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Warning"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "warning" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "warning" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:revision.Vitro
+uil-data:revision.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "revision"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "revision" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "revision" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:filter_by_roles.Vitro
+uil-data:filter_by_roles.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Filter by roles"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "filter_by_roles" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "filter_by_roles" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:page_uri_missing_msg.Vitro
+uil-data:page_uri_missing_msg.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Could not generate page beacause it was unclear what page was being requested.  A URL mapping may be missing."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "page_uri_missing_msg" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "page_uri_missing_msg" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:fatal_error.Vitro
+uil-data:fatal_error.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Fatal Error"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "fatal_error" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "fatal_error" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:page_select_permission_option.Vitro
+uil-data:page_select_permission_option.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Select permission"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "page_select_permission_option" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "page_select_permission_option" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:january.Vitro
+uil-data:january.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "January"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "january" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "january" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:property.Vitro
+uil-data:property.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "property"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "property" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "property" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:external_auth_id.Vitro
+uil-data:external_auth_id.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "External Auth ID"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "external_auth_id" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "external_auth_id" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:date_time_value_for.Vitro
+uil-data:date_time_value_for.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "date time value for"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "date_time_value_for" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "date_time_value_for" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:sparql_query_title.Vitro
+uil-data:sparql_query_title.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "SPARQL Query"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "sparql_query_title" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "sparql_query_title" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:previous.Vitro
+uil-data:previous.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Previous"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "previous" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "previous" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:upload_page_title_with_name.Vitro
+uil-data:upload_page_title_with_name.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Upload image for {0}"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "upload_page_title_with_name" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "upload_page_title_with_name" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:cant_change_password_while_logged_in.Vitro
+uil-data:cant_change_password_while_logged_in.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "You may not reset the password for {0} while you are logged in as {1}. Please log out and try again."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "cant_change_password_while_logged_in" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "cant_change_password_while_logged_in" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:rejected_spam.Vitro
+uil-data:rejected_spam.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "REJECTED - SPAM"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "rejected_spam" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "rejected_spam" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:logins_are_open.Vitro
+uil-data:logins_are_open.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Logins are open to all."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "logins_are_open" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "logins_are_open" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:confirm_delete_account_singular.Vitro
+uil-data:confirm_delete_account_singular.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Are you sure you want to delete this account?"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "confirm_delete_account_singular" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "confirm_delete_account_singular" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:all_capitalized.Vitro
+uil-data:all_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "All"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "all_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "all_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:of_the_results.Vitro
+uil-data:of_the_results.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "of the results"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "of_the_results" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "of_the_results" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_content_type.Vitro
+uil-data:select_content_type.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "You must select content to be included on the page"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_content_type" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_content_type" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:visit_project_website.Vitro
+uil-data:visit_project_website.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Visit the national project web site"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "visit_project_website" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "visit_project_website" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:view_labels_for.Vitro
+uil-data:view_labels_for.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "View Labels for"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "view_labels_for" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "view_labels_for" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:new_account_note.Vitro
+uil-data:new_account_note.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Note: An email will be sent to the address entered above notifying that an account has been created. It will include instructions for activating the account and creating a password."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "new_account_note" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "new_account_note" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_alert_icon.Vitro
+uil-data:error_alert_icon.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Error alert icon"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_alert_icon" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_alert_icon" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:imageUpload.errorImageTooSmall.Vitro
+uil-data:imageUpload.errorImageTooSmall.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "The uploaded image should be at least {0} pixels high and {1} pixels wide."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "imageUpload.errorImageTooSmall" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "imageUpload.errorImageTooSmall" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_account_to_delete.Vitro
+uil-data:select_account_to_delete.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "select this account to delete it"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_account_to_delete" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_account_to_delete" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:interest_thanks.Vitro
+uil-data:interest_thanks.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Thank you for your interest in {0}. Please submit this form with questions, comments, or feedback about the content of this site."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "interest_thanks" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "interest_thanks" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:year_numeric.Vitro
+uil-data:year_numeric.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Invalid entry. The Year must be numeric."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "year_numeric" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "year_numeric" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_an_existing_document.Vitro
+uil-data:select_an_existing_document.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Select an existing document"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_an_existing_document" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_an_existing_document" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:password_length.Vitro
+uil-data:password_length.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Password must be between {0} and {1} characters."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "password_length" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "password_length" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:monday.Vitro
+uil-data:monday.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Monday"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "monday" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "monday" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:account_created_subject.Vitro
+uil-data:account_created_subject.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Your {0} account has been created."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "account_created_subject" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "account_created_subject" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:vitro_bullet_three.Vitro
+uil-data:vitro_bullet_three.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Build a public web site to display your data"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "vitro_bullet_three" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "vitro_bullet_three" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:photo.Vitro
+uil-data:photo.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Photo"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "photo" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "photo" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:file_must_be_entered_msg.Vitro
+uil-data:file_must_be_entered_msg.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "a file must be entered for this field."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "file_must_be_entered_msg" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "file_must_be_entered_msg" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:entity_to_query_for.Vitro
+uil-data:entity_to_query_for.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "This id is the id of the entity to query for. netid also works."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "entity_to_query_for" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "entity_to_query_for" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:manage_grants_and_projects_link.Vitro
+uil-data:manage_grants_and_projects_link.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "manage grants & projects"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "manage_grants_and_projects_link" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "manage_grants_and_projects_link" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:manage_labels_intro.Vitro
+uil-data:manage_labels_intro.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "In the case where multiple labels exist in the same language, please use the remove link to delete the labels you do not want displayed on the profile page for a given language."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "manage_labels_intro" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "manage_labels_intro" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:hide_show_properties.Vitro
+uil-data:hide_show_properties.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "hide/show properties"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "hide_show_properties" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "hide_show_properties" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:untitled.Vitro
+uil-data:untitled.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "-untitled-"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "untitled" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "untitled" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:manage_publications_link.Vitro
+uil-data:manage_publications_link.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "manage publications"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "manage_publications_link" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "manage_publications_link" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_all.Vitro
+uil-data:select_all.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "select all"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_all" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_all" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:local_name.Vitro
+uil-data:local_name.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Local Name"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "local_name" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "local_name" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:end_interval_must_follow_start_interval.Vitro
+uil-data:end_interval_must_follow_start_interval.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "The End interval must be later than the Start interval."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "end_interval_must_follow_start_interval" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "end_interval_must_follow_start_interval" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:view_page.Vitro
+uil-data:view_page.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "View page"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "view_page" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "view_page" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:browse_page_javascript_one.Vitro
+uil-data:browse_page_javascript_one.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "This browse page requires javascript, but your browser is set to disable javascript. Either enable javascript or use the"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "browse_page_javascript_one" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "browse_page_javascript_one" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:sparql_query_builder.Vitro
+uil-data:sparql_query_builder.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "SPARQL query builder"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "sparql_query_builder" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "sparql_query_builder" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:sub_properties.Vitro
+uil-data:sub_properties.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Subproperties"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "sub_properties" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "sub_properties" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:add_label_for_language.Vitro
+uil-data:add_label_for_language.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Language"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "add_label_for_language" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "add_label_for_language" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:file_upload_error_file_not_found.Vitro
+uil-data:file_upload_error_file_not_found.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "File to upload not found"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "file_upload_error_file_not_found" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "file_upload_error_file_not_found" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:file_upload_predicate.Vitro
+uil-data:file_upload_predicate.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "predicate"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "file_upload_predicate" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "file_upload_predicate" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:start_with_leading_slash.Vitro
+uil-data:start_with_leading_slash.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Must begin with a leading forward slash: / (e.g., /people)"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "start_with_leading_slash" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "start_with_leading_slash" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:trace_available.Vitro
+uil-data:trace_available.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "full trace available in the vivo log"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "trace_available" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "trace_available" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:editing_prohibited.Vitro
+uil-data:editing_prohibited.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "This property is currently configured to prohibit editing."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "editing_prohibited" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "editing_prohibited" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:verbose_status_on.Vitro
+uil-data:verbose_status_on.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "on"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "verbose_status_on" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "verbose_status_on" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:use_capitalized.Vitro
+uil-data:use_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Use"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "use_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "use_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:search_index_status.Vitro
+uil-data:search_index_status.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Search Index Status"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "search_index_status" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "search_index_status" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:filter_search.Vitro
+uil-data:filter_search.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "filter search"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "filter_search" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "filter_search" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:with_vitro.Vitro
+uil-data:with_vitro.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "With Vitro, you can:"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "with_vitro" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "with_vitro" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:site_information.Vitro
+uil-data:site_information.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Site information"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "site_information" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "site_information" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:logins_temporarily_disabled.Vitro
+uil-data:logins_temporarily_disabled.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "User logins are temporarily disabled while the system is being maintained."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "logins_temporarily_disabled" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "logins_temporarily_disabled" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:leave_password_unchanged.Vitro
+uil-data:leave_password_unchanged.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Leaving this blank means that the password will not be changed."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "leave_password_unchanged" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "leave_password_unchanged" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:query_model.Vitro
+uil-data:query_model.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Query Model"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "query_model" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "query_model" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:restrict_logins_mixed_caps.Vitro
+uil-data:restrict_logins_mixed_caps.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Restrict logins"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "restrict_logins_mixed_caps" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "restrict_logins_mixed_caps" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:wednesday.Vitro
+uil-data:wednesday.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Wednesday"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "wednesday" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "wednesday" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:berries.Vitro
+uil-data:berries.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Berries:"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "berries" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "berries" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:full_name.Vitro
+uil-data:full_name.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Full name"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "full_name" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "full_name" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:no_email_supplied.Vitro
+uil-data:no_email_supplied.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "No email supplied."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "no_email_supplied" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "no_email_supplied" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_was_reported.Vitro
+uil-data:error_was_reported.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "This error has been reported to the site administrator."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_was_reported" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_was_reported" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:search_results_for.Vitro
+uil-data:search_results_for.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Search results for"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "search_results_for" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "search_results_for" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:search_tip_three.Vitro
+uil-data:search_tip_three.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Except for boolean operators, searches are <strong>not</strong> case-sensitive, so \"Geneva\" and \"geneva\" are equivalent."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "search_tip_three" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "search_tip_three" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:view_profile_for_page.Vitro
+uil-data:view_profile_for_page.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "view the individual profile for this page"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "view_profile_for_page" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "view_profile_for_page" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:reordering_menus_failed.Vitro
+uil-data:reordering_menus_failed.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Reordering of menu items failed."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "reordering_menus_failed" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "reordering_menus_failed" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:verbose_control.Vitro
+uil-data:verbose_control.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "verbose control"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "verbose_control" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "verbose_control" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:ontology_list.Vitro
+uil-data:ontology_list.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ontology list"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "ontology_list" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "ontology_list" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:edit_entry.Vitro
+uil-data:edit_entry.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "edit this entry"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "edit_entry" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "edit_entry" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:label.dateTimeWithPrecision.minutes_capitalized.Vitro
+uil-data:label.dateTimeWithPrecision.minutes_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Minutes"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "label.dateTimeWithPrecision.minutes_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "label.dateTimeWithPrecision.minutes_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:object.Vitro
+uil-data:object.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "object"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "object" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "object" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:confirm_email_changed_email_html_text.Vitro
+uil-data:confirm_email_changed_email_html_text.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "<p>\n Dear ${userAccount.firstName} ${userAccount.lastName}\n </p>\n\n <p>\n You recently changed the email address associated with\n ${userAccount.firstName} ${userAccount.lastName}\n </p>\n\n <p>\n Thank you.\n </p>"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "confirm_email_changed_email_html_text" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "confirm_email_changed_email_html_text" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_no_new_password.Vitro
+uil-data:error_no_new_password.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Please enter your new password."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_no_new_password" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_no_new_password" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:page_loggedin_permission_option.Vitro
+uil-data:page_loggedin_permission_option.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Logged in individuals can view this page"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "page_loggedin_permission_option" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "page_loggedin_permission_option" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:expecting_content.Vitro
+uil-data:expecting_content.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Expecting content?"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "expecting_content" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "expecting_content" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:required_fields.Vitro
+uil-data:required_fields.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "required fields"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "required_fields" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "required_fields" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:edit_page_title.Vitro
+uil-data:edit_page_title.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "edit_page_title" ;
-        prop:hasPackage  "Vitro-languages" .
+        rdf:type         uil:UILabel ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "edit_page_title" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_existing.Vitro
+uil-data:select_existing.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Select existing"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_existing" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_existing" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:invalid_url_msg.Vitro
+uil-data:invalid_url_msg.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "This URL must start with http:// or https://"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "invalid_url_msg" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "invalid_url_msg" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:search_button.Vitro
+uil-data:search_button.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Search"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "search_button" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "search_button" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:advanced_search_tips_header.Vitro
+uil-data:advanced_search_tips_header.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Advanced Tips"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "advanced_search_tips_header" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "advanced_search_tips_header" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:supply_url.Vitro
+uil-data:supply_url.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "You must supply a pretty URL"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "supply_url" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "supply_url" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_profiles.Vitro
+uil-data:select_profiles.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Select profiles"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_profiles" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_profiles" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_one.Vitro
+uil-data:select_one.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Select one"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_one" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_one" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:continue.Vitro
+uil-data:continue.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Continue"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "continue" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "continue" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:language_selection_failed.Vitro
+uil-data:language_selection_failed.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "There was a problem in the system. Your language choice was rejected."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "language_selection_failed" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "language_selection_failed" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:display_has_element_error.Vitro
+uil-data:display_has_element_error.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "There was an error in the system. The display:hasElement property could not be retrieved."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "display_has_element_error" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "display_has_element_error" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:file_upload_error_file_is_too_big.Vitro
+uil-data:file_upload_error_file_is_too_big.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Uploaded file is too big. Maximum file size is {0} bytes. Uploaded file is {1} bytes."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "file_upload_error_file_is_too_big" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "file_upload_error_file_is_too_big" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:template_capitalized.Vitro
+uil-data:template_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Template"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "template_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "template_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:file_upload_supported_media.Vitro
+uil-data:file_upload_supported_media.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Allowed media types:"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "file_upload_supported_media" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "file_upload_supported_media" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:user_accounts_title.Vitro
+uil-data:user_accounts_title.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "user accounts"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "user_accounts_title" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "user_accounts_title" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:create_your_password.Vitro
+uil-data:create_your_password.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Create your Password"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "create_your_password" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "create_your_password" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:create_account.Vitro
+uil-data:create_account.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Create account"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "create_account" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "create_account" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:remove_menu_item.Vitro
+uil-data:remove_menu_item.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Remove menu item"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "remove_menu_item" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "remove_menu_item" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:click_to_view_account.Vitro
+uil-data:click_to_view_account.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "click to view account details"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "click_to_view_account" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "click_to_view_account" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:add_new_entry_for.Vitro
+uil-data:add_new_entry_for.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Add new entry for:"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "add_new_entry_for" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "add_new_entry_for" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:menu_ordering.Vitro
+uil-data:menu_ordering.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Menu Ordering"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "menu_ordering" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "menu_ordering" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:map_processor_error.Vitro
+uil-data:map_processor_error.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "An error has occurred and the map of processors for this content is missing. Please contact the administrator"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "map_processor_error" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "map_processor_error" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:change_profile_title.Vitro
+uil-data:change_profile_title.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "change profile"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "change_profile_title" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "change_profile_title" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:domain_class.Vitro
+uil-data:domain_class.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Domain Class"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "domain_class" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "domain_class" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:manage_labels_capitalized.Vitro
+uil-data:manage_labels_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Manage Labels"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "manage_labels_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "manage_labels_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_passwords_dont_match.Vitro
+uil-data:error_passwords_dont_match.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "The passwords entered do not match."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_passwords_dont_match" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_passwords_dont_match" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:save_profile_changes.Vitro
+uil-data:save_profile_changes.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Save changes to profiles"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "save_profile_changes" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "save_profile_changes" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:site_administration.Vitro
+uil-data:site_administration.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Site Administration"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "site_administration" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "site_administration" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:vitro_bullet_one.Vitro
+uil-data:vitro_bullet_one.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Create or load ontologies in OWL format"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "vitro_bullet_one" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "vitro_bullet_one" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:pages.Vitro
+uil-data:pages.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "pages"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "pages" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "pages" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:inferred_class_hierarchy.Vitro
+uil-data:inferred_class_hierarchy.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Inferred Class Hierarchy"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "inferred_class_hierarchy" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "inferred_class_hierarchy" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:auth_id_in_use.Vitro
+uil-data:auth_id_in_use.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "This Identifier is already in use."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "auth_id_in_use" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "auth_id_in_use" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:data_input.Vitro
+uil-data:data_input.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Data Input"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "data_input" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "data_input" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:recompute_inferences_mixed_caps.Vitro
+uil-data:recompute_inferences_mixed_caps.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Recompute inferences"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "recompute_inferences_mixed_caps" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "recompute_inferences_mixed_caps" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:individual_name.Vitro
+uil-data:individual_name.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "individual name"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "individual_name" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "individual_name" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:thursday.Vitro
+uil-data:thursday.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Thursday"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "thursday" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "thursday" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:alert_icon.Vitro
+uil-data:alert_icon.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Alert Icon"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "alert_icon" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "alert_icon" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:if_blank_page_title_used.Vitro
+uil-data:if_blank_page_title_used.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "If left blank, the page title will be used."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "if_blank_page_title_used" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "if_blank_page_title_used" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:password_reset_pending_email_plain_text.Vitro
+uil-data:password_reset_pending_email_plain_text.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Dear ${userAccount.firstName} ${userAccount.lastName}:\n\nWe have received a request to reset the password for your ${siteName} account\n(${userAccount.emailAddress}).\n\nPlease follow the instructions below to proceed with your password reset.\n\nIf you did not request this new account you can safely ignore this email.\nThis request will expire if not acted upon within 30 days.\n\nPaste the link below into your browser's address bar to reset your password\nusing our secure server.\n\n${passwordLink}\n\nThank you!\n"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "password_reset_pending_email_plain_text" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "password_reset_pending_email_plain_text" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:hide_properties.Vitro
+uil-data:hide_properties.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "hide properties"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "hide_properties" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "hide_properties" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:file_upload_error_file_type_not_recognized.Vitro
+uil-data:file_upload_error_file_type_not_recognized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "File type not recognised"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "file_upload_error_file_type_not_recognized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "file_upload_error_file_type_not_recognized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_no_role.Vitro
+uil-data:error_no_role.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "You must select a role."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_no_role" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_no_role" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:new_account_title.Vitro
+uil-data:new_account_title.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "new account"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "new_account_title" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "new_account_title" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:file_upload_no_allowed_media.Vitro
+uil-data:file_upload_no_allowed_media.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "No allowed media types defined in runtime.properties"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "file_upload_no_allowed_media" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "file_upload_no_allowed_media" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:property_groups.Vitro
+uil-data:property_groups.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Property groups"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "property_groups" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "property_groups" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:startup_trace.Vitro
+uil-data:startup_trace.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Startup trace"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "startup_trace" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "startup_trace" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:search_accounts_button.Vitro
+uil-data:search_accounts_button.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Search accounts"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "search_accounts_button" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "search_accounts_button" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:operation_unsuccessful.Vitro
+uil-data:operation_unsuccessful.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "The operation was unsuccessful. Full details can be found in the system log."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "operation_unsuccessful" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "operation_unsuccessful" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:submit_button.Vitro
+uil-data:submit_button.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Submit"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "submit_button" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "submit_button" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:page_uri_missing.Vitro
+uil-data:page_uri_missing.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "No page URI specified"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "page_uri_missing" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "page_uri_missing" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_no_email_address.Vitro
+uil-data:error_no_email_address.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Please enter your email address."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_no_email_address" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_no_email_address" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:controls.Vitro
+uil-data:controls.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Controls"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "controls" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "controls" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:fruit.Vitro
+uil-data:fruit.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Fruit"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "fruit" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "fruit" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:admin_panel.Vitro
+uil-data:admin_panel.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Admin Panel"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "admin_panel" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "admin_panel" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:the_range_class_does_not_exist.Vitro
+uil-data:the_range_class_does_not_exist.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "The range class for this property does not exist in the system."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "the_range_class_does_not_exist" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "the_range_class_does_not_exist" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:reset_your_password.Vitro
+uil-data:reset_your_password.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Reset your Password"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "reset_your_password" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "reset_your_password" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:advanced_search_tip_two.Vitro
+uil-data:advanced_search_tip_two.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "\"NOT\" can help limit searches -- e.g., <i>climate</i> NOT <i>change</i>."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "advanced_search_tip_two" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "advanced_search_tip_two" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:save_new_page.Vitro
+uil-data:save_new_page.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Save new page"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "save_new_page" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "save_new_page" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:book_title.Vitro
+uil-data:book_title.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Book Title:"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "book_title" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "book_title" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:view_content_index.Vitro
+uil-data:view_content_index.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "View an outline of the content in this site"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "view_content_index" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "view_content_index" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:or_create_new_one.Vitro
+uil-data:or_create_new_one.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "or create a new one."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "or_create_new_one" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "or_create_new_one" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:remove_selection.Vitro
+uil-data:remove_selection.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Remove selection"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "remove_selection" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "remove_selection" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:cardinality.Vitro
+uil-data:cardinality.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "cardinality"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "cardinality" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "cardinality" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:apostrophe_not_allowed.Vitro
+uil-data:apostrophe_not_allowed.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "The variable name should not have an apostrophe."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "apostrophe_not_allowed" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "apostrophe_not_allowed" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:confirm_menu_item_delete.Vitro
+uil-data:confirm_menu_item_delete.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Are you sure you want to remove"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "confirm_menu_item_delete" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "confirm_menu_item_delete" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:work_level.Vitro
+uil-data:work_level.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Work level"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "work_level" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "work_level" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:acct_created_external_only_email_html_text.Vitro
+uil-data:acct_created_external_only_email_html_text.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "<p>\n ${userAccount.firstName} ${userAccount.lastName}\n </p>\n\n <p>\n <strong>Congratulations!</strong>\n </p>\n\n <p>\n We have created your new VIVO account associated with ${userAccount.emailAddress}.\n </p>\n\n <p>\n Thanks!\n </p>"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "acct_created_external_only_email_html_text" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "acct_created_external_only_email_html_text" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:friday.Vitro
+uil-data:friday.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Friday"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "friday" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "friday" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:return_to_the.Vitro
+uil-data:return_to_the.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Return to the"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "return_to_the" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "return_to_the" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:sparql_query.Vitro
+uil-data:sparql_query.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "SPARQL query"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "sparql_query" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "sparql_query" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:myAccount_confirm_changes.Vitro
+uil-data:myAccount_confirm_changes.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Your changes have been saved."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "myAccount_confirm_changes" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "myAccount_confirm_changes" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:to.Vitro
+uil-data:to.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "to"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "to" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "to" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:login_to_manage_site.Vitro
+uil-data:login_to_manage_site.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "log in to manage this site"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "login_to_manage_site" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "login_to_manage_site" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:a_classgroup.Vitro
+uil-data:a_classgroup.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "a class group"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "a_classgroup" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "a_classgroup" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:upload_page_title.Vitro
+uil-data:upload_page_title.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Upload image"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "upload_page_title" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "upload_page_title" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_existing_collaborator.Vitro
+uil-data:select_existing_collaborator.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Select an existing Collaborator for {0}"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_existing_collaborator" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_existing_collaborator" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:label.dateTimeWithPrecision.day_capitalized.Vitro
+uil-data:label.dateTimeWithPrecision.day_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Day"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "label.dateTimeWithPrecision.day_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "label.dateTimeWithPrecision.day_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:login_button.Vitro
+uil-data:login_button.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Log in"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "login_button" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "login_button" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:internal_login.Vitro
+uil-data:internal_login.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Internal Login"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "internal_login" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "internal_login" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_occurred.Vitro
+uil-data:error_occurred.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "An error occurred on the VIVO site"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_occurred" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_occurred" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:advanced_search_tip_four.Vitro
+uil-data:advanced_search_tip_four.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Close word variations will also be found -- e.g., <i>sequence</i> matches <i>sequences</i> and <i>sequencing</i>."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "advanced_search_tip_four" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "advanced_search_tip_four" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:updated_account_title.Vitro
+uil-data:updated_account_title.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "updated account"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "updated_account_title" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "updated_account_title" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:year_month_day.Vitro
+uil-data:year_month_day.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Invalid entry. Please enter a Year, Month and Day."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "year_month_day" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "year_month_day" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:log_out.Vitro
+uil-data:log_out.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Log out"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "log_out" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "log_out" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:application_error_email_plain_text.Vitro
+uil-data:application_error_email_plain_text.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "An error occurred on your ${siteName!} web site at ${datetime!}\n\nRequested url: ${requestedUrl!}\n\n<#if errorMessage?has_content>\n Error message: ${errorMessage!}\n</#if>\n\nStack trace (full trace available in the log):\n${stackTrace!}\n\n<#if cause?has_content>\nCaused by:\n${cause!}\n</#if>"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "application_error_email_plain_text" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "application_error_email_plain_text" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_vclass_uri.Vitro
+uil-data:select_vclass_uri.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Select VClass"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_vclass_uri" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_vclass_uri" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:custom_template_requiring_content.Vitro
+uil-data:custom_template_requiring_content.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Custom template requiring content"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "custom_template_requiring_content" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "custom_template_requiring_content" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:file_upload_error_uri_not_exists.Vitro
+uil-data:file_upload_error_uri_not_exists.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Uri {0} doesn't exist."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "file_upload_error_uri_not_exists" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "file_upload_error_uri_not_exists" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:external_id_not_provided.Vitro
+uil-data:external_id_not_provided.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Login failed - External ID is not found."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "external_id_not_provided" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "external_id_not_provided" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:imageUpload.errorBadMultipartRequest.Vitro
+uil-data:imageUpload.errorBadMultipartRequest.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Failed to parse the multi-part request for uploading an image."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "imageUpload.errorBadMultipartRequest" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "imageUpload.errorBadMultipartRequest" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:view_all_accounts.Vitro
+uil-data:view_all_accounts.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "View all accounts"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "view_all_accounts" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "view_all_accounts" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:file_upload_file.Vitro
+uil-data:file_upload_file.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "file"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "file_upload_file" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "file_upload_file" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:search_failed.Vitro
+uil-data:search_failed.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Search failed."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "search_failed" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "search_failed" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:minimum_hour.Vitro
+uil-data:minimum_hour.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Invalid entry. Please specify at least an Hour."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "minimum_hour" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "minimum_hour" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:faux_property_alpha.Vitro
+uil-data:faux_property_alpha.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "faux properties alphabetically"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "faux_property_alpha" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "faux_property_alpha" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:info_icon.Vitro
+uil-data:info_icon.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "info icon"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "info_icon" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "info_icon" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:save_button.Vitro
+uil-data:save_button.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Save"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "save_button" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "save_button" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:who_can_edit_profile.Vitro
+uil-data:who_can_edit_profile.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Who can edit my profile"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "who_can_edit_profile" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "who_can_edit_profile" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:add_an_entry_to.Vitro
+uil-data:add_an_entry_to.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Add an entry of type"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "add_an_entry_to" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "add_an_entry_to" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:page_not_found_msg.Vitro
+uil-data:page_not_found_msg.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "The page was not found in the system."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "page_not_found_msg" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "page_not_found_msg" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:no_content_in_system.Vitro
+uil-data:no_content_in_system.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "There is currently no {0} content in the system"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "no_content_in_system" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "no_content_in_system" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:rdf.Vitro
+uil-data:rdf.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "RDF"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "rdf" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "rdf" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:datetime_year_required.Vitro
+uil-data:datetime_year_required.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Date/time intervals must begin with a year. Enter either a Start Year, an End Year or both."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "datetime_year_required" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "datetime_year_required" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:external_auth_name.Vitro
+uil-data:external_auth_name.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "external authentication name"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "external_auth_name" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "external_auth_name" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:external_login_failed.Vitro
+uil-data:external_login_failed.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "External login failed"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "external_login_failed" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "external_login_failed" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:label.dateTimeWithPrecision.seconds_capitalized.Vitro
+uil-data:label.dateTimeWithPrecision.seconds_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Seconds"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "label.dateTimeWithPrecision.seconds_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "label.dateTimeWithPrecision.seconds_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:custom_template.Vitro
+uil-data:custom_template.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Custom Template"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "custom_template" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "custom_template" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:associated_profile_label.Vitro
+uil-data:associated_profile_label.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Associated profile:"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "associated_profile_label" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "associated_profile_label" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:page_not_found.Vitro
+uil-data:page_not_found.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Page Not Found"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "page_not_found" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "page_not_found" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_existing_last_name.Vitro
+uil-data:select_existing_last_name.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Select an existing last name"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_existing_last_name" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_existing_last_name" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:title_capitalized.Vitro
+uil-data:title_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Title"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "title_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "title_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:file_upload_error_no_action.Vitro
+uil-data:file_upload_error_no_action.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "No action specified"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "file_upload_error_no_action" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "file_upload_error_no_action" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:change_entry_for.Vitro
+uil-data:change_entry_for.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Change entry for:"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "change_entry_for" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "change_entry_for" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:cause.Vitro
+uil-data:cause.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Cause:"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "cause" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "cause" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:may_edit.Vitro
+uil-data:may_edit.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "May edit"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "may_edit" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "may_edit" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:properties.Vitro
+uil-data:properties.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "properties"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "properties" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "properties" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:add_new.Vitro
+uil-data:add_new.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Add new"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "add_new" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "add_new" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:apples.Vitro
+uil-data:apples.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Apples"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "apples" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "apples" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:tuesday.Vitro
+uil-data:tuesday.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Tuesday"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "tuesday" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "tuesday" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:email_changed_subject.Vitro
+uil-data:email_changed_subject.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Your {0} email account has been changed."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "email_changed_subject" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "email_changed_subject" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:site_admin.Vitro
+uil-data:site_admin.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Site Admin"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "site_admin" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "site_admin" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:code_processing_error.Vitro
+uil-data:code_processing_error.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "An error has occurred and the code for processing this content is missing a component. Please contact the administrator."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "code_processing_error" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "code_processing_error" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:base_property_capitalized.Vitro
+uil-data:base_property_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Base Property"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "base_property_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "base_property_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:username.Vitro
+uil-data:username.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Username"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "username" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "username" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:to_order_menu_items.Vitro
+uil-data:to_order_menu_items.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "to set the order of menu items."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "to_order_menu_items" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "to_order_menu_items" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:none.Vitro
+uil-data:none.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "none"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "none" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "none" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:classes_capitalized.Vitro
+uil-data:classes_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Classes"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "classes_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "classes_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:cancel_link.Vitro
+uil-data:cancel_link.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Cancel"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "cancel_link" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "cancel_link" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:send_feedback_questions.Vitro
+uil-data:send_feedback_questions.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Send us your feedback or ask a question"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "send_feedback_questions" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "send_feedback_questions" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:account_already_activated.Vitro
+uil-data:account_already_activated.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "The account for {0} has already been activated."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "account_already_activated" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "account_already_activated" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:page.Vitro
+uil-data:page.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "page"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "page" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "page" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:type_more_characters.Vitro
+uil-data:type_more_characters.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "type more characters"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "type_more_characters" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "type_more_characters" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:search_tips_header.Vitro
+uil-data:search_tips_header.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Search Tips"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "search_tips_header" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "search_tips_header" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:data_not_past_msg.Vitro
+uil-data:data_not_past_msg.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Please enter a future target date for publication (past dates are invalid)."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "data_not_past_msg" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "data_not_past_msg" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_associated_profile.Vitro
+uil-data:select_associated_profile.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Select the associated profile"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_associated_profile" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_associated_profile" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:edit_capitalized.Vitro
+uil-data:edit_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Edit"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "edit_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "edit_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:site_name.Vitro
+uil-data:site_name.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "site name"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "site_name" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "site_name" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:replace_photo.Vitro
+uil-data:replace_photo.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Replace Photo"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "replace_photo" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "replace_photo" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:rebuild_button.Vitro
+uil-data:rebuild_button.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Rebuild"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "rebuild_button" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "rebuild_button" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:numbers.Vitro
+uil-data:numbers.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Numbers"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "numbers" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "numbers" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:acct_created_external_only_email_plain_text.Vitro
+uil-data:acct_created_external_only_email_plain_text.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "${userAccount.firstName} ${userAccount.lastName}\n\nCongratulations!\n\nWe have created your new VIVO account associated with\n${userAccount.emailAddress}.\n\nThanks!\n"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "acct_created_external_only_email_plain_text" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "acct_created_external_only_email_plain_text" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:auth_id_explanation.Vitro
+uil-data:auth_id_explanation.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Can be used to associate the account with the user's profile via the matching property."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "auth_id_explanation" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "auth_id_explanation" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:support.Vitro
+uil-data:support.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Support"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "support" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "support" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:enter_search_term.Vitro
+uil-data:enter_search_term.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Please enter a search term."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "enter_search_term" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "enter_search_term" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:feedback_thanks_heading.Vitro
+uil-data:feedback_thanks_heading.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Thank you for your feedback"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "feedback_thanks_heading" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "feedback_thanks_heading" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:updated_account_notification.Vitro
+uil-data:updated_account_notification.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "A confirmation email has been sent to {0} with instructions for resetting a password. The password will not be reset until the user follows the link provided in this email."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "updated_account_notification" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "updated_account_notification" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:menu_ordering_mixed_caps.Vitro
+uil-data:menu_ordering_mixed_caps.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Menu ordering"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "menu_ordering_mixed_caps" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "menu_ordering_mixed_caps" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:expand_all.Vitro
+uil-data:expand_all.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "expand all"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "expand_all" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "expand_all" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:confirm_password_capitalized.Vitro
+uil-data:confirm_password_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Confirm Password"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "confirm_password_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "confirm_password_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:uri_not_defined.Vitro
+uil-data:uri_not_defined.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "URI for page not defined"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "uri_not_defined" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "uri_not_defined" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:a_link.Vitro
+uil-data:a_link.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "a link"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "a_link" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "a_link" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:view_list_of_labels.Vitro
+uil-data:view_list_of_labels.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "view list of labels"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "view_list_of_labels" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "view_list_of_labels" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:not_logged_in.Vitro
+uil-data:not_logged_in.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Not logged in"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "not_logged_in" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "not_logged_in" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:page_public_permission_option.Vitro
+uil-data:page_public_permission_option.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Anyone can view this page"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "page_public_permission_option" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "page_public_permission_option" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:file_upload_error_uri_not_given.Vitro
+uil-data:file_upload_error_uri_not_given.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "No {0} uri was given."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "file_upload_error_uri_not_given" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "file_upload_error_uri_not_given" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:file_upload_heading.Vitro
+uil-data:file_upload_heading.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "File uploading"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "file_upload_heading" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "file_upload_heading" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:save_this_content.Vitro
+uil-data:save_this_content.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Save this content"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "save_this_content" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "save_this_content" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:data.Vitro
+uil-data:data.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "data"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "data" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "data" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_incorrect_credentials.Vitro
+uil-data:error_incorrect_credentials.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "The email or password you entered is incorrect."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_incorrect_credentials" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_incorrect_credentials" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:start_url_with_slash.Vitro
+uil-data:start_url_with_slash.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "The pretty URL must begin with a leading forward slash"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "start_url_with_slash" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "start_url_with_slash" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:february.Vitro
+uil-data:february.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "February"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "february" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "february" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:delete_entry.Vitro
+uil-data:delete_entry.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "delete this entry"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "delete_entry" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "delete_entry" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:imageUpload.errorFormFieldMissing.Vitro
+uil-data:imageUpload.errorFormFieldMissing.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "The form did not contain a ''{0}'' field.\""@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "imageUpload.errorFormFieldMissing" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "imageUpload.errorFormFieldMissing" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:formatted_date_time.Vitro
+uil-data:formatted_date_time.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Formatted date-time"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "formatted_date_time" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "formatted_date_time" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:imageUpload.errorUnknown.Vitro
+uil-data:imageUpload.errorUnknown.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Sorry, we were unable to process the photo you provided. Please try another photo."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "imageUpload.errorUnknown" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "imageUpload.errorUnknown" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:password_reset_pending_email_html_text.Vitro
+uil-data:password_reset_pending_email_html_text.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "<p>\n Dear ${userAccount.firstName} ${userAccount.lastName}:\n </p>\n\n <p>\n We have received a request to reset the password for your ${siteName} account (${userAccount.emailAddress}).\n </p>\n\n <p>\n Please follow the instructions below to proceed with your password reset.\n </p>\n\n <p>\n If you did not request this new account you can safely ignore this email.\n This request will expire if not acted upon within 30 days.\n </p>\n\n <p>\n Click on the link below or paste it into your browser's address bar to reset your password\n using our secure server.\n </p>\n\n <p><a href=\"${passwordLink}\" title=\"password\">${passwordLink}</a> </p>\n\n <p>Thank you!</p>"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "password_reset_pending_email_html_text" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "password_reset_pending_email_html_text" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:ontology_editor.Vitro
+uil-data:ontology_editor.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ontology Editor"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "ontology_editor" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "ontology_editor" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:from_capitalized.Vitro
+uil-data:from_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "From"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "from_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "from_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:logged_out.Vitro
+uil-data:logged_out.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "You have logged out."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "logged_out" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "logged_out" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:search_for.Vitro
+uil-data:search_for.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Search for ''{0}''"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "search_for" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "search_for" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:other.Vitro
+uil-data:other.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "other"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "other" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "other" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:supply_variable_name.Vitro
+uil-data:supply_variable_name.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "You must supply a variable to save HTML content."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "supply_variable_name" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "supply_variable_name" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:remove_restrictions.Vitro
+uil-data:remove_restrictions.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Remove Restrictions"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "remove_restrictions" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "remove_restrictions" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:variable_name_all_caps.Vitro
+uil-data:variable_name_all_caps.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Variable Name"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "variable_name_all_caps" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "variable_name_all_caps" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:levels.Vitro
+uil-data:levels.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Levels"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "levels" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "levels" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:range_class.Vitro
+uil-data:range_class.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Range Class"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "range_class" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "range_class" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:type_more_chars.Vitro
+uil-data:type_more_chars.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "type more character"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "type_more_chars" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "type_more_chars" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:advanced_data_tools.Vitro
+uil-data:advanced_data_tools.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Advanced Data Tools"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "advanced_data_tools" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "advanced_data_tools" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:current_date.Vitro
+uil-data:current_date.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Current date:"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "current_date" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "current_date" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:since_elapsed_time_est_total.Vitro
+uil-data:since_elapsed_time_est_total.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "since {0}, elapsed time {1}, estimated total time {2}"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "since_elapsed_time_est_total" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "since_elapsed_time_est_total" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:close.Vitro
+uil-data:close.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "close"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "close" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "close" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:change_selection.Vitro
+uil-data:change_selection.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "change selection"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "change_selection" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "change_selection" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:copyright.Vitro
+uil-data:copyright.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "copyright"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "copyright" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "copyright" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_page_content_type.Vitro
+uil-data:select_page_content_type.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Select content type for the associated page"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_page_content_type" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_page_content_type" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:zoo_one.Vitro
+uil-data:zoo_one.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Zoo 1"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "zoo_one" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "zoo_one" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:cancel_title.Vitro
+uil-data:cancel_title.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "cancel"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "cancel_title" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "cancel_title" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:add_individual_of_class.Vitro
+uil-data:add_individual_of_class.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Add individual of this class"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "add_individual_of_class" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "add_individual_of_class" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:label.dateTimeWithPrecision.year_capitalized.Vitro
+uil-data:label.dateTimeWithPrecision.year_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Year"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "label.dateTimeWithPrecision.year_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "label.dateTimeWithPrecision.year_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:relate_editors_profiles.Vitro
+uil-data:relate_editors_profiles.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Relate profile editors and profiles"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "relate_editors_profiles" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "relate_editors_profiles" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:vitro_bullet_four.Vitro
+uil-data:vitro_bullet_four.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Search your data"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "vitro_bullet_four" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "vitro_bullet_four" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:save_changes.Vitro
+uil-data:save_changes.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Save changes"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "save_changes" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "save_changes" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:cant_activate_while_logged_in.Vitro
+uil-data:cant_activate_while_logged_in.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "You may not activate the account for {0} while you are logged in as {1}. Please log out and try again."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "cant_activate_while_logged_in" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "cant_activate_while_logged_in" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:next_capitalized.Vitro
+uil-data:next_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Next"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "next_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "next_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:end_capitalized.Vitro
+uil-data:end_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "End"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "end_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "end_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:custom_template_containing_content.Vitro
+uil-data:custom_template_containing_content.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Custom template containing all content"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "custom_template_containing_content" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "custom_template_containing_content" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:name_of.Vitro
+uil-data:name_of.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "name_of" ;
-        prop:hasPackage  "Vitro-languages" .
+        rdf:type         uil:UILabel ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "name_of" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:content_type.Vitro
+uil-data:content_type.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Content Type"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "content_type" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "content_type" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:add_label.Vitro
+uil-data:add_label.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Add Label"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "add_label" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "add_label" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:activate_developer_panel_mixed_caps.Vitro
+uil-data:activate_developer_panel_mixed_caps.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Activate developer panel"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "activate_developer_panel_mixed_caps" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "activate_developer_panel_mixed_caps" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:reset_search_index.Vitro
+uil-data:reset_search_index.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Reset the search index and re-populate it."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "reset_search_index" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "reset_search_index" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:please_provide_contact_information.Vitro
+uil-data:please_provide_contact_information.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Please provide your contact information to finish creating your account."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "please_provide_contact_information" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "please_provide_contact_information" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:continued.Vitro
+uil-data:continued.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "cont'd"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "continued" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "continued" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_no_email.Vitro
+uil-data:error_no_email.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "You must supply an email address."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_no_email" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_no_email" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_no_last_name.Vitro
+uil-data:error_no_last_name.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "You must supply a last name."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_no_last_name" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_no_last_name" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:december.Vitro
+uil-data:december.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "December"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "december" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "december" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:multiple_content_default_template_error.Vitro
+uil-data:multiple_content_default_template_error.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "With multiple content types, you must specify a custom template."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "multiple_content_default_template_error" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "multiple_content_default_template_error" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:all_classes.Vitro
+uil-data:all_classes.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "All Classes"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "all_classes" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "all_classes" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:viewing_page.Vitro
+uil-data:viewing_page.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Likely viewing page"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "viewing_page" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "viewing_page" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:individual_not_found_msg.Vitro
+uil-data:individual_not_found_msg.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "The individual was not found in the system."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "individual_not_found_msg" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "individual_not_found_msg" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:setup_navigation_menu.Vitro
+uil-data:setup_navigation_menu.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Setup the primary navigation menu for your website"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "setup_navigation_menu" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "setup_navigation_menu" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:external_id_already_in_use.Vitro
+uil-data:external_id_already_in_use.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "User account already exists for ''{0}''"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "external_id_already_in_use" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "external_id_already_in_use" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:ascending_order.Vitro
+uil-data:ascending_order.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "ascending order"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "ascending_order" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "ascending_order" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:browse_all_content.Vitro
+uil-data:browse_all_content.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "browse all content"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "browse_all_content" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "browse_all_content" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:begin_with_slash_no_example.Vitro
+uil-data:begin_with_slash_no_example.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Must begin with a leading forward slash: /"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "begin_with_slash_no_example" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "begin_with_slash_no_example" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_occurred_at.Vitro
+uil-data:error_occurred_at.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "An error occurred on your VIVO site at {0}."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_occurred_at" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_occurred_at" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_editors.Vitro
+uil-data:select_editors.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Select editors"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_editors" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_editors" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:supply_html.Vitro
+uil-data:supply_html.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "You must supply some HTML or text."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "supply_html" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "supply_html" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:slash_example.Vitro
+uil-data:slash_example.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "(e.g., /people)"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "slash_example" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "slash_example" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:property_hierarchy.Vitro
+uil-data:property_hierarchy.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Property Hierarchy"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "property_hierarchy" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "property_hierarchy" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:try_rebuilding_index.Vitro
+uil-data:try_rebuilding_index.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Try rebuilding the search index"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "try_rebuilding_index" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "try_rebuilding_index" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_in_search_request.Vitro
+uil-data:error_in_search_request.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "The search request contained errors."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_in_search_request" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_in_search_request" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:first_time_login.Vitro
+uil-data:first_time_login.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "First time log in"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "first_time_login" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "first_time_login" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:first_time_external_email_plain_text.Vitro
+uil-data:first_time_external_email_plain_text.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "${userAccount.firstName} ${userAccount.lastName}\n\nCongratulations!\n\nWe have created your new VIVO account associated with\n${userAccount.emailAddress}.\n\nThanks!"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "first_time_external_email_plain_text" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "first_time_external_email_plain_text" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:faux_property_by_base.Vitro
+uil-data:faux_property_by_base.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "faux properties by base property"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "faux_property_by_base" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "faux_property_by_base" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:alt_thumbnail_photo.Vitro
+uil-data:alt_thumbnail_photo.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Individual photo"@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "alt_thumbnail_photo" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "alt_thumbnail_photo" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:no_individual_associated_with_id.Vitro
+uil-data:no_individual_associated_with_id.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "For some reason, there is no individual in VIVO that is associated with your Net ID. Perhaps you should contact your VIVO administrator."@en-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "no_individual_associated_with_id" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "no_individual_associated_with_id" ;
+        uil:hasPackage  "Vitro-languages" .

--- a/home/src/main/resources/rdf/i18n/en_US/interface-i18n/firsttime/vitro_UiLabel.ttl
+++ b/home/src/main/resources/rdf/i18n/en_US/interface-i18n/firsttime/vitro_UiLabel.ttl
@@ -1,6284 +1,6284 @@
 @prefix owl:   <http://www.w3.org/2002/07/owl#> .
 @prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
-@prefix prop-data: <http://vivoweb.org/ontology/core/properties/individual#> .
-@prefix prop:  <http://vivoweb.org/ontology/core/properties/vocabulary#> .
+@prefix uil-data: <http://vivoweb.org/ontology/vitro/ui-label/individual#> .
+@prefix uil:  <http://vivoweb.org/ontology/vitro/ui-label/vocabulary#> .
 @prefix xsd:   <http://www.w3.org/2001/XMLSchema#> .
 @prefix skos:  <http://www.w3.org/2004/02/skos/core#> .
 @prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> .
 
-prop-data:collapse_all.Vitro
+uil-data:collapse_all.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "collapse all"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "collapse_all" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "collapse_all" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:no_password_supplied.Vitro
+uil-data:no_password_supplied.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "No password supplied."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "no_password_supplied" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "no_password_supplied" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:crop_page_title.Vitro
+uil-data:crop_page_title.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Crop image"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "crop_page_title" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "crop_page_title" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:label.dateTimeWithPrecision.month_capitalized.Vitro
+uil-data:label.dateTimeWithPrecision.month_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Month"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "label.dateTimeWithPrecision.month_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "label.dateTimeWithPrecision.month_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:advanced_search_tip_three.Vitro
+uil-data:advanced_search_tip_three.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Phrase searches may be combined with Boolean operators -- e.g. \"<i>climate change</i>\" OR \"<i>global warming</i>\"."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "advanced_search_tip_three" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "advanced_search_tip_three" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:file_upload_error_file_size_is_zero.Vitro
+uil-data:file_upload_error_file_size_is_zero.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Uploaded file size is 0"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "file_upload_error_file_size_is_zero" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "file_upload_error_file_size_is_zero" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:delete_entry_capitalized.Vitro
+uil-data:delete_entry_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Delete this entry?"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "delete_entry_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "delete_entry_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:remove_selection_title.Vitro
+uil-data:remove_selection_title.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "remove selection"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "remove_selection_title" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "remove_selection_title" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:powered_by.Vitro
+uil-data:powered_by.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Powered by"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "powered_by" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "powered_by" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:accounts_search_results.Vitro
+uil-data:accounts_search_results.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Search results for"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "accounts_search_results" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "accounts_search_results" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:search_individual_results.Vitro
+uil-data:search_individual_results.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Search Class Individuals"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "search_individual_results" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "search_individual_results" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:vclassAlpha_not_implemented.Vitro
+uil-data:vclassAlpha_not_implemented.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "vclassAlpha is not yet implemented."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "vclassAlpha_not_implemented" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "vclassAlpha_not_implemented" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_an_existing.Vitro
+uil-data:select_an_existing.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Select an existing"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_an_existing" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_an_existing" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:no_appropriate_entry.Vitro
+uil-data:no_appropriate_entry.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "If you don't find the appropriate entry on the selection list above"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "no_appropriate_entry" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "no_appropriate_entry" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:descending_order.Vitro
+uil-data:descending_order.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "descending order"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "descending_order" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "descending_order" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:label.dateTimeWithPrecision.hour_capitalized.Vitro
+uil-data:label.dateTimeWithPrecision.hour_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Hour"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "label.dateTimeWithPrecision.hour_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "label.dateTimeWithPrecision.hour_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:add_remove_rdf.Vitro
+uil-data:add_remove_rdf.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Add/Remove RDF data"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "add_remove_rdf" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "add_remove_rdf" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:account.Vitro
+uil-data:account.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "account"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "account" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "account" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:label.Vitro
+uil-data:label.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "label"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "label" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "label" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:no_classes_to_select.Vitro
+uil-data:no_classes_to_select.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "There are no Classes in the system from which to select."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "no_classes_to_select" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "no_classes_to_select" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:page_curator_permission_option.Vitro
+uil-data:page_curator_permission_option.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Curators and above can view this page"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "page_curator_permission_option" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "page_curator_permission_option" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:individuals_in_system.Vitro
+uil-data:individuals_in_system.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "individuals in the system."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "individuals_in_system" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "individuals_in_system" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:search_help.Vitro
+uil-data:search_help.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "search help"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "search_help" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "search_help" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:there_are_no_entries_starting_with.Vitro
+uil-data:there_are_no_entries_starting_with.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "There are no entries starting with"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "there_are_no_entries_starting_with" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "there_are_no_entries_starting_with" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:user_accounts_link.Vitro
+uil-data:user_accounts_link.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "User accounts"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "user_accounts_link" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "user_accounts_link" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:ontology_capitalized.Vitro
+uil-data:ontology_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ontology"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "ontology_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "ontology_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:change_password_to_login.Vitro
+uil-data:change_password_to_login.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Change Password to Log in"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "change_password_to_login" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "change_password_to_login" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:a_menu_page.Vitro
+uil-data:a_menu_page.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "This is a menu page"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "a_menu_page" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "a_menu_page" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:comments.Vitro
+uil-data:comments.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Comments"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "comments" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "comments" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:add_new_of_type.Vitro
+uil-data:add_new_of_type.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Add a new item of this type"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "add_new_of_type" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "add_new_of_type" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:reset_password_note.Vitro
+uil-data:reset_password_note.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Note: Instructions for resetting the password will be emailed to the address entered above. The password will not be reset until the user follows the link provided in this email."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "reset_password_note" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "reset_password_note" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:startup_status.Vitro
+uil-data:startup_status.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Startup status"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "startup_status" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "startup_status" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:no_results_returned.Vitro
+uil-data:no_results_returned.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "No results were returned."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "no_results_returned" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "no_results_returned" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:submit_add_new_account.Vitro
+uil-data:submit_add_new_account.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Add new account"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "submit_add_new_account" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "submit_add_new_account" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:password_reset_complete_subject.Vitro
+uil-data:password_reset_complete_subject.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Your {0} password changed."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "password_reset_complete_subject" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "password_reset_complete_subject" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:file_upload_error_supported_actions.Vitro
+uil-data:file_upload_error_supported_actions.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Only delete and upload actions supported"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "file_upload_error_supported_actions" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "file_upload_error_supported_actions" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:create_classgroup.Vitro
+uil-data:create_classgroup.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Create a class group"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "create_classgroup" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "create_classgroup" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:accounts.Vitro
+uil-data:accounts.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "accounts"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "accounts" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "accounts" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:page_not_created_msg.Vitro
+uil-data:page_not_created_msg.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "There was an error while creating the page, please check the logs."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "page_not_created_msg" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "page_not_created_msg" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:login_count.Vitro
+uil-data:login_count.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Login count"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "login_count" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "login_count" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:not_expected_results.Vitro
+uil-data:not_expected_results.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Not the results you expected?"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "not_expected_results" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "not_expected_results" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:paging_link_more.Vitro
+uil-data:paging_link_more.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "more..."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "paging_link_more" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "paging_link_more" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:sparql_query_description_1.Vitro
+uil-data:sparql_query_description_1.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "# and (if available) their labels"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "sparql_query_description_1" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "sparql_query_description_1" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:acct_created_email_plain_text.Vitro
+uil-data:acct_created_email_plain_text.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "${userAccount.firstName} ${userAccount.lastName}\n\nCongratulations!\n\nWe have created your new account on ${siteName},\nassociated with ${userAccount.emailAddress}.\n\nIf you did not request this new account you can safely ignore this email.\nThis request will expire if not acted upon for 30 days.\n\nPaste the link below into your browser's address bar to create your password\nfor your new account using our secure server.\n\n${passwordLink}\n\nThanks!"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "acct_created_email_plain_text" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "acct_created_email_plain_text" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:all_rights_reserved.Vitro
+uil-data:all_rights_reserved.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "All Rights Reserved."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "all_rights_reserved" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "all_rights_reserved" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:submit_save.Vitro
+uil-data:submit_save.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Save photo"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "submit_save" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "submit_save" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:associate_classes_with_group.Vitro
+uil-data:associate_classes_with_group.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "and associate classes with the group created."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "associate_classes_with_group" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "associate_classes_with_group" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:about.Vitro
+uil-data:about.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "About"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "about" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "about" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:activate_developer_panel.Vitro
+uil-data:activate_developer_panel.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Activate developer panel"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "activate_developer_panel" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "activate_developer_panel" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:since.Vitro
+uil-data:since.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Since"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "since" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "since" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:limit_to.Vitro
+uil-data:limit_to.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Limit to"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "limit_to" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "limit_to" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:password_created_subject.Vitro
+uil-data:password_created_subject.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Your {0} password has successfully been created."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "password_created_subject" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "password_created_subject" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:vitro_description.Vitro
+uil-data:vitro_description.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Vitro is a general-purpose web-based ontology and instance editor with customizable public browsing. Vitro is a Java web application that runs in a Tomcat servlet container."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "vitro_description" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "vitro_description" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:logins_disabled_for_maintenance.Vitro
+uil-data:logins_disabled_for_maintenance.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "User logins are temporarily disabled while the system is being maintained."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "logins_disabled_for_maintenance" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "logins_disabled_for_maintenance" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:current_time.Vitro
+uil-data:current_time.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Current time:"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "current_time" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "current_time" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:release.Vitro
+uil-data:release.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "release"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "release" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "release" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:authenticator.Vitro
+uil-data:authenticator.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Authenticator"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "authenticator" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "authenticator" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:preparing_to_rebuild_index.Vitro
+uil-data:preparing_to_rebuild_index.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Preparing to rebuild the search index."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "preparing_to_rebuild_index" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "preparing_to_rebuild_index" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:login_status.Vitro
+uil-data:login_status.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Login status:"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "login_status" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "login_status" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:scroll_to_menus.Vitro
+uil-data:scroll_to_menus.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "scroll to property group menus"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "scroll_to_menus" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "scroll_to_menus" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:sparql_query_description_0.Vitro
+uil-data:sparql_query_description_0.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "# This example query gets 20 geographic locations"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "sparql_query_description_0" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "sparql_query_description_0" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:delete_button.Vitro
+uil-data:delete_button.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Delete"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "delete_button" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "delete_button" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:fixed_html.Vitro
+uil-data:fixed_html.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Fixed HTML"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "fixed_html" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "fixed_html" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:you_can.Vitro
+uil-data:you_can.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "You can"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "you_can" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "you_can" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:supply_sparql_query.Vitro
+uil-data:supply_sparql_query.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "You must supply a Sparql query."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "supply_sparql_query" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "supply_sparql_query" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:enter_email_password.Vitro
+uil-data:enter_email_password.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Enter the email address and password for your internal Vitro account."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "enter_email_password" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "enter_email_password" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:selected_editors.Vitro
+uil-data:selected_editors.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Selected editors"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "selected_editors" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "selected_editors" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:custom_template_mixed_caps.Vitro
+uil-data:custom_template_mixed_caps.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Custom template"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "custom_template_mixed_caps" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "custom_template_mixed_caps" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:animal.Vitro
+uil-data:animal.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Animal:"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "animal" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "animal" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:enter_sparql_query_here.Vitro
+uil-data:enter_sparql_query_here.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Enter SPARQL query here"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "enter_sparql_query_here" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "enter_sparql_query_here" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:recompute_inferences.Vitro
+uil-data:recompute_inferences.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Recompute Inferences"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "recompute_inferences" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "recompute_inferences" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:restrict_logins.Vitro
+uil-data:restrict_logins.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Restrict Logins"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "restrict_logins" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "restrict_logins" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:email_address.Vitro
+uil-data:email_address.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Email address"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "email_address" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "email_address" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:alt_confirmation.Vitro
+uil-data:alt_confirmation.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Confirmation icon"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "alt_confirmation" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "alt_confirmation" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:drag_drop_to_reorder_menus.Vitro
+uil-data:drag_drop_to_reorder_menus.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Drag and drop to reorder menu items"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "drag_drop_to_reorder_menus" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "drag_drop_to_reorder_menus" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:most_recent_update.Vitro
+uil-data:most_recent_update.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "The most recent update was at"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "most_recent_update" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "most_recent_update" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:delete_link.Vitro
+uil-data:delete_link.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Delete photo"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "delete_link" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "delete_link" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:check_startup_status.Vitro
+uil-data:check_startup_status.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Check startup status page and/or Tomcat logs for more information."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "check_startup_status" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "check_startup_status" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:no_pages_defined.Vitro
+uil-data:no_pages_defined.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "There are no pages defined yet."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "no_pages_defined" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "no_pages_defined" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:advanced_search_tip_five.Vitro
+uil-data:advanced_search_tip_five.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Use the wildcard * character to match an even wider variation -- e.g., <i>nano*</i> will match both <i>nanotechnology</i> and <i>nanofabrication</i>."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "advanced_search_tip_five" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "advanced_search_tip_five" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_message.Vitro
+uil-data:error_message.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Error message"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_message" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_message" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:double_quote_note_allowed.Vitro
+uil-data:double_quote_note_allowed.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "The variable name should not have a double quote."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "double_quote_note_allowed" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "double_quote_note_allowed" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:crop_page_title_with_name.Vitro
+uil-data:crop_page_title_with_name.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Crop image for {0}"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "crop_page_title_with_name" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "crop_page_title_with_name" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:logins_not_restricted.Vitro
+uil-data:logins_not_restricted.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Logins are no longer restricted."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "logins_not_restricted" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "logins_not_restricted" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:deleted_accounts.Vitro
+uil-data:deleted_accounts.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Deleted {0} {0, choice, 0#accounts|1#account|1<accounts}."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "deleted_accounts" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "deleted_accounts" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:whole_number.Vitro
+uil-data:whole_number.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Invalid entry. Enter a whole number with no decimal point or thousands-separators."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "whole_number" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "whole_number" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:edit_account.Vitro
+uil-data:edit_account.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Edit account"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "edit_account" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "edit_account" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:search_tip_two.Vitro
+uil-data:search_tip_two.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Use quotes to search for an entire phrase -- e.g., \"<i>protein folding</i>\"."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "search_tip_two" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "search_tip_two" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:email_capitalized.Vitro
+uil-data:email_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Email"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "email_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "email_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:policies.Vitro
+uil-data:policies.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Policies"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "policies" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "policies" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:failed.Vitro
+uil-data:failed.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "failed"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "failed" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "failed" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:containers_do_not_pick_up_changes.Vitro
+uil-data:containers_do_not_pick_up_changes.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Containers do not pick up changes to the value of their elements"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "containers_do_not_pick_up_changes" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "containers_do_not_pick_up_changes" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:file_upload_error_media_type_not_allowed.Vitro
+uil-data:file_upload_error_media_type_not_allowed.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "File media type is not allowed. Current file media type is {0}."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "file_upload_error_media_type_not_allowed" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "file_upload_error_media_type_not_allowed" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:add_new_classes.Vitro
+uil-data:add_new_classes.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Add New Class"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "add_new_classes" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "add_new_classes" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:identifier_factories.Vitro
+uil-data:identifier_factories.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Identifier factories"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "identifier_factories" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "identifier_factories" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:show_subclasses.Vitro
+uil-data:show_subclasses.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "show subclasses"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "show_subclasses" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "show_subclasses" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:enter_id_to_login.Vitro
+uil-data:enter_id_to_login.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Enter the userID that you want to sign in as, or click Cancel."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "enter_id_to_login" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "enter_id_to_login" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:upload_heading.Vitro
+uil-data:upload_heading.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Photo Upload"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "upload_heading" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "upload_heading" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:warnings_issued.Vitro
+uil-data:warnings_issued.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "{0} issued warnings during startup."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "warnings_issued" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "warnings_issued" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:account_management.Vitro
+uil-data:account_management.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Account Management"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "account_management" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "account_management" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_content_display.Vitro
+uil-data:select_content_display.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Select content to display"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_content_display" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_content_display" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:account_no_longer_exists.Vitro
+uil-data:account_no_longer_exists.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "The account you are trying to set a password on is no longer available. Please contact your system administrator if you think this is an error."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "account_no_longer_exists" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "account_no_longer_exists" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:page_select_permission.Vitro
+uil-data:page_select_permission.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Select page permissions"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "page_select_permission" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "page_select_permission" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:test_for_logged_in_users.Vitro
+uil-data:test_for_logged_in_users.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "This is the test widget for logged-in users."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "test_for_logged_in_users" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "test_for_logged_in_users" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:edit_page.Vitro
+uil-data:edit_page.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Edit {0} Page"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "edit_page" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "edit_page" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:no_match.Vitro
+uil-data:no_match.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "no match"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "no_match" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "no_match" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:add_new_page.Vitro
+uil-data:add_new_page.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Add New Page"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "add_new_page" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "add_new_page" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:class_groups.Vitro
+uil-data:class_groups.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Class groups"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "class_groups" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "class_groups" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:password_reset_pending_email_subject.Vitro
+uil-data:password_reset_pending_email_subject.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "${siteName} reset password request"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "password_reset_pending_email_subject" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "password_reset_pending_email_subject" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:manage.Vitro
+uil-data:manage.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "manage"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "manage" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "manage" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_password_length.Vitro
+uil-data:error_password_length.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Please enter a password between {0} and {1} characters in length."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_password_length" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_password_length" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:view_profile_editors.Vitro
+uil-data:view_profile_editors.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "View all profile editors"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "view_profile_editors" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "view_profile_editors" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:subclasses_capitalized.Vitro
+uil-data:subclasses_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Subclasses"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "subclasses_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "subclasses_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:auth_matching_id_label.Vitro
+uil-data:auth_matching_id_label.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "External Auth. ID / Matching ID"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "auth_matching_id_label" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "auth_matching_id_label" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:page_editor_permission_option.Vitro
+uil-data:page_editor_permission_option.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Editors and above can view this page"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "page_editor_permission_option" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "page_editor_permission_option" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:delete_page.Vitro
+uil-data:delete_page.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "delete this page"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "delete_page" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "delete_page" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:for.Vitro
+uil-data:for.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "for"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "for" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "for" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:manage_list_of_labels.Vitro
+uil-data:manage_list_of_labels.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "manage list of labels"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "manage_list_of_labels" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "manage_list_of_labels" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:content.Vitro
+uil-data:content.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "content"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "content" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "content" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:match_by.Vitro
+uil-data:match_by.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "match by {0}"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "match_by" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "match_by" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:alt_preview_crop.Vitro
+uil-data:alt_preview_crop.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Preview of photo cropped"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "alt_preview_crop" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "alt_preview_crop" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:pretty_url.Vitro
+uil-data:pretty_url.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Pretty URL"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "pretty_url" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "pretty_url" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:operation_successful.Vitro
+uil-data:operation_successful.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "The operation was successful."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "operation_successful" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "operation_successful" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:add_capitalized.Vitro
+uil-data:add_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Add"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "add_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "add_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:accounts_per_page.Vitro
+uil-data:accounts_per_page.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "accounts per page"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "accounts_per_page" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "accounts_per_page" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_editor_and_profile.Vitro
+uil-data:select_editor_and_profile.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "You must select a minimum of 1 editor and profile."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_editor_and_profile" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_editor_and_profile" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:request_failed.Vitro
+uil-data:request_failed.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Request failed. Please contact your system administrator."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "request_failed" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "request_failed" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:from_site_admin_page.Vitro
+uil-data:from_site_admin_page.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "from the Site Administration page."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "from_site_admin_page" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "from_site_admin_page" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:new_password_capitalized.Vitro
+uil-data:new_password_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "New Password"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "new_password_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "new_password_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:advanced_search_tip_one.Vitro
+uil-data:advanced_search_tip_one.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "When you enter more than one term, search will return results containing all of them unless you add the Boolean \"OR\" -- e.g., <i>chicken</i> OR <i>egg</i>."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "advanced_search_tip_one" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "advanced_search_tip_one" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:password_reset_complete_email_plain_text.Vitro
+uil-data:password_reset_complete_email_plain_text.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "${userAccount.firstName} ${userAccount.lastName}\n\nPassword successfully changed.\n\nYour new password associated with ${userAccount.emailAddress}\nhas been changed"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "password_reset_complete_email_plain_text" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "password_reset_complete_email_plain_text" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:application_error_email_subject.Vitro
+uil-data:application_error_email_subject.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "An error occurred on your ${siteName!} web site"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "application_error_email_subject" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "application_error_email_subject" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:return_to.Vitro
+uil-data:return_to.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "return to {0}"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "return_to" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "return_to" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:last_login.Vitro
+uil-data:last_login.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Last Login"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "last_login" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "last_login" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:view_profile_in_rdf.Vitro
+uil-data:view_profile_in_rdf.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "view profile in RDF format"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "view_profile_in_rdf" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "view_profile_in_rdf" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:minimum_password_length.Vitro
+uil-data:minimum_password_length.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Minimum of {0} characters in length; maximum of {1}."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "minimum_password_length" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "minimum_password_length" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:contact_us.Vitro
+uil-data:contact_us.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Contact Us"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "contact_us" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "contact_us" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:download_results.Vitro
+uil-data:download_results.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Download Results"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "download_results" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "download_results" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:selected_profiles.Vitro
+uil-data:selected_profiles.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Selected profiles"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "selected_profiles" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "selected_profiles" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:has_value.Vitro
+uil-data:has_value.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "has value"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "has_value" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "has_value" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:faux_property_listing.Vitro
+uil-data:faux_property_listing.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Faux Property Listing"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "faux_property_listing" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "faux_property_listing" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:display_admin_header.Vitro
+uil-data:display_admin_header.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Display Admin and Configuration"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "display_admin_header" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "display_admin_header" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_no_password.Vitro
+uil-data:error_no_password.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Please enter your password."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_no_password" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_no_password" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:remove_capitalized.Vitro
+uil-data:remove_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Remove"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "remove_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "remove_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:october.Vitro
+uil-data:october.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "October"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "october" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "october" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:file_upload_subject.Vitro
+uil-data:file_upload_subject.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "subject"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "file_upload_subject" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "file_upload_subject" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:manage_site.Vitro
+uil-data:manage_site.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Manage this site"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "manage_site" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "manage_site" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:confirm_delete_account_plural.Vitro
+uil-data:confirm_delete_account_plural.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Are you sure you want to delete these accounts?"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "confirm_delete_account_plural" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "confirm_delete_account_plural" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:sunday.Vitro
+uil-data:sunday.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Sunday"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "sunday" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "sunday" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:password_system_has_changed.Vitro
+uil-data:password_system_has_changed.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "password_system_has_changed" ;
-        prop:hasPackage  "Vitro-languages" .
+        rdf:type         uil:UILabel ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "password_system_has_changed" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:rebuild_search_index.Vitro
+uil-data:rebuild_search_index.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Rebuild search index"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "rebuild_search_index" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "rebuild_search_index" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:password_saved.Vitro
+uil-data:password_saved.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Your password has been saved."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "password_saved" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "password_saved" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:supply_query_variable.Vitro
+uil-data:supply_query_variable.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "You must supply a variable to save query results."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "supply_query_variable" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "supply_query_variable" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:configure_page_if_permissable.Vitro
+uil-data:configure_page_if_permissable.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "to configure this page if the user has permission."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "configure_page_if_permissable" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "configure_page_if_permissable" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:invalid_date_form_msg.Vitro
+uil-data:invalid_date_form_msg.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "must be in valid date format mm/dd/yyyy."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "invalid_date_form_msg" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "invalid_date_form_msg" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:manage_list_of.Vitro
+uil-data:manage_list_of.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Manage list of"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "manage_list_of" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "manage_list_of" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:verbose_property_status.Vitro
+uil-data:verbose_property_status.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Verbose property display is"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "verbose_property_status" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "verbose_property_status" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:sparql_query_select_ask_results.Vitro
+uil-data:sparql_query_select_ask_results.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Format for SELECT and ASK query results"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "sparql_query_select_ask_results" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "sparql_query_select_ask_results" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:individual_not_found.Vitro
+uil-data:individual_not_found.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Individual not found"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "individual_not_found" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "individual_not_found" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:classes_by_classgroup.Vitro
+uil-data:classes_by_classgroup.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Classes by Class Group"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "classes_by_classgroup" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "classes_by_classgroup" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:confirm_email_changed_email_plain_text.Vitro
+uil-data:confirm_email_changed_email_plain_text.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Dear ${userAccount.firstName} ${userAccount.lastName}\n\nYou recently changed the email address associated with\n${userAccount.firstName} ${userAccount.lastName}\n\nThank you."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "confirm_email_changed_email_plain_text" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "confirm_email_changed_email_plain_text" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:close_capitalized.Vitro
+uil-data:close_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Close"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "close_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "close_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:browse_class_group.Vitro
+uil-data:browse_class_group.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Browse Class Group"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "browse_class_group" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "browse_class_group" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:statistics.Vitro
+uil-data:statistics.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Statistics"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "statistics" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "statistics" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:new_password.Vitro
+uil-data:new_password.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "New password"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "new_password" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "new_password" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:hide_show_subclasses.Vitro
+uil-data:hide_show_subclasses.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "hide/show subclasses"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "hide_show_subclasses" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "hide_show_subclasses" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:class_hierarchy.Vitro
+uil-data:class_hierarchy.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Class hierarchy"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "class_hierarchy" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "class_hierarchy" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:add_content_manage_site.Vitro
+uil-data:add_content_manage_site.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "add content and manage this site"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "add_content_manage_site" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "add_content_manage_site" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:background_threads.Vitro
+uil-data:background_threads.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Background Threads"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "background_threads" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "background_threads" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:create_capitalized.Vitro
+uil-data:create_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Create"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "create_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "create_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_previous_password.Vitro
+uil-data:error_previous_password.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Your new password cannot match the current one."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_previous_password" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_previous_password" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:change_password.Vitro
+uil-data:change_password.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "You must change your password to log in."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "change_password" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "change_password" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:menu_management.Vitro
+uil-data:menu_management.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Menu Management"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "menu_management" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "menu_management" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:email_change_will_be_confirmed.Vitro
+uil-data:email_change_will_be_confirmed.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Note: if email changes, a confirmation email will be sent to the new email address entered above."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "email_change_will_be_confirmed" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "email_change_will_be_confirmed" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:fake_external_auth.Vitro
+uil-data:fake_external_auth.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Fake External Authentication"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "fake_external_auth" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "fake_external_auth" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:run_sdb_setup.Vitro
+uil-data:run_sdb_setup.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Run SDB Setup"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "run_sdb_setup" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "run_sdb_setup" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:property_management.Vitro
+uil-data:property_management.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Property Management"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "property_management" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "property_management" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:end_your_Session.Vitro
+uil-data:end_your_Session.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "End your session"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "end_your_Session" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "end_your_Session" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:search_index_not_connected.Vitro
+uil-data:search_index_not_connected.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "The search index is not connected."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "search_index_not_connected" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "search_index_not_connected" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:change_content_type.Vitro
+uil-data:change_content_type.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Change content type"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "change_content_type" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "change_content_type" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:invalid_search_term.Vitro
+uil-data:invalid_search_term.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Search term was invalid"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "invalid_search_term" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "invalid_search_term" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:index_recs_completed.Vitro
+uil-data:index_recs_completed.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Completed {0} out of {1} index records."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "index_recs_completed" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "index_recs_completed" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:add_profile.Vitro
+uil-data:add_profile.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Add profile"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "add_profile" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "add_profile" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:view_labels_capitalized.Vitro
+uil-data:view_labels_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "View Labels"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "view_labels_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "view_labels_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:maximum_cardinality.Vitro
+uil-data:maximum_cardinality.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "maximum cardinality"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "maximum_cardinality" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "maximum_cardinality" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:please_format_email.Vitro
+uil-data:please_format_email.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Please format your e-mail address as:"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "please_format_email" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "please_format_email" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:external_auth_only.Vitro
+uil-data:external_auth_only.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Externally Authenticated Only"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "external_auth_only" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "external_auth_only" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:return_to_individual.Vitro
+uil-data:return_to_individual.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Return to Individual Page"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "return_to_individual" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "return_to_individual" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:all_x_properties.Vitro
+uil-data:all_x_properties.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "All {0} Properties"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "all_x_properties" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "all_x_properties" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:password_created_email_plain_text.Vitro
+uil-data:password_created_email_plain_text.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "${userAccount.firstName} ${userAccount.lastName}\n\nPassword successfully created.\n\nYour new password associated with ${userAccount.emailAddress}\nhas been created.\n\nThank you."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "password_created_email_plain_text" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "password_created_email_plain_text" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:already_logged_in.Vitro
+uil-data:already_logged_in.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "You are already logged in."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "already_logged_in" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "already_logged_in" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:supply_class_group.Vitro
+uil-data:supply_class_group.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "You must supply a class group."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "supply_class_group" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "supply_class_group" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:matching_prop_not_defined.Vitro
+uil-data:matching_prop_not_defined.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "matching property is not defined"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "matching_prop_not_defined" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "matching_prop_not_defined" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:display_rank.Vitro
+uil-data:display_rank.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Display Rank"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "display_rank" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "display_rank" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:profile_editing_title.Vitro
+uil-data:profile_editing_title.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "The editors you select on the left hand side will have the ability to edit the VIVO profiles you select on the right hand side. You can select multiple editors and multiple profiles, but you must select a minimum of 1 each."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "profile_editing_title" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "profile_editing_title" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:test_for_nonlogged_in_users.Vitro
+uil-data:test_for_nonlogged_in_users.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "This is the test widget for non-logged-in users."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "test_for_nonlogged_in_users" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "test_for_nonlogged_in_users" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:insufficient_authorization.Vitro
+uil-data:insufficient_authorization.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "We're sorry, but you are not authorized to view the page you requested. If you think this is an error, please contact us and we'll be happy to help."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "insufficient_authorization" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "insufficient_authorization" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:supply_content_type.Vitro
+uil-data:supply_content_type.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "You must supply a content type"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "supply_content_type" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "supply_content_type" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:back_to_results.Vitro
+uil-data:back_to_results.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Back to results"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "back_to_results" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "back_to_results" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:may_not_edit.Vitro
+uil-data:may_not_edit.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "May not edit"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "may_not_edit" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "may_not_edit" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:four_digit_year.Vitro
+uil-data:four_digit_year.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Invalid entry. Please enter a 4-digit Year."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "four_digit_year" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "four_digit_year" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:browse_page_javascript_two.Vitro
+uil-data:browse_page_javascript_two.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "to browse for information."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "browse_page_javascript_two" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "browse_page_javascript_two" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:password_created_email_html_text.Vitro
+uil-data:password_created_email_html_text.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "<p>\n ${userAccount.firstName} ${userAccount.lastName}\n </p>\n\n <p>\n <strong>Password successfully created.</strong>\n </p>\n\n <p>\n Your new password associated with ${userAccount.emailAddress} has been created.\n </p>\n\n <p>\n Thank you.\n </p>"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "password_created_email_html_text" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "password_created_email_html_text" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:current_photo.Vitro
+uil-data:current_photo.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Current Photo"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "current_photo" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "current_photo" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_last_name.Vitro
+uil-data:select_last_name.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Select an existing last name"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_last_name" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_last_name" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:supply_template.Vitro
+uil-data:supply_template.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "You must supply a template"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "supply_template" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "supply_template" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:view_all_accounts_title.Vitro
+uil-data:view_all_accounts_title.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "view all accounts"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "view_all_accounts_title" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "view_all_accounts_title" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:cropping_note.Vitro
+uil-data:cropping_note.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "To make adjustments, you can drag around and resize the photo to the right. When you are happy with your photo click the \"Save Photo\" button."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "cropping_note" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "cropping_note" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:page_not_created.Vitro
+uil-data:page_not_created.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Page could not be created"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "page_not_created" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "page_not_created" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_email_already_exists.Vitro
+uil-data:error_email_already_exists.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "An account with that email address already exists."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_email_already_exists" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_email_already_exists" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:required_field_empty_msg.Vitro
+uil-data:required_field_empty_msg.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "This field must not be empty."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "required_field_empty_msg" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "required_field_empty_msg" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:site_maintenance.Vitro
+uil-data:site_maintenance.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Site Maintenance"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "site_maintenance" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "site_maintenance" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:current_date_time.Vitro
+uil-data:current_date_time.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Current date & time:"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "current_date_time" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "current_date_time" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:page_link.Vitro
+uil-data:page_link.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "page link"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "page_link" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "page_link" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:object_property_hierarchy.Vitro
+uil-data:object_property_hierarchy.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Object property hierarchy"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "object_property_hierarchy" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "object_property_hierarchy" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:user_accounts.Vitro
+uil-data:user_accounts.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "User accounts"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "user_accounts" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "user_accounts" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:maximum_file_size.Vitro
+uil-data:maximum_file_size.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Maximum file size: {0} megabytes"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "maximum_file_size" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "maximum_file_size" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:add_new_account.Vitro
+uil-data:add_new_account.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Add new account"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "add_new_account" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "add_new_account" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:browse_all_starts_with.Vitro
+uil-data:browse_all_starts_with.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Browse all individuals whose name starts with {0}"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "browse_all_starts_with" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "browse_all_starts_with" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:status.Vitro
+uil-data:status.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Status"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "status" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "status" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:index.Vitro
+uil-data:index.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Index"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "index" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "index" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:verify_this_match_title.Vitro
+uil-data:verify_this_match_title.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "verify this match"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "verify_this_match_title" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "verify_this_match_title" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:search_indexer_idle.Vitro
+uil-data:search_indexer_idle.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "The search indexer is idle."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "search_indexer_idle" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "search_indexer_idle" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:start_capitalized.Vitro
+uil-data:start_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Start"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "start_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "start_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:minimum_cardinality.Vitro
+uil-data:minimum_cardinality.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "minimum cardinality"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "minimum_cardinality" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "minimum_cardinality" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:manage_affiliated_people_link.Vitro
+uil-data:manage_affiliated_people_link.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "manage affiliated people"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "manage_affiliated_people_link" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "manage_affiliated_people_link" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:initial_password.Vitro
+uil-data:initial_password.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Initial password"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "initial_password" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "initial_password" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:invalid_format.Vitro
+uil-data:invalid_format.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Invalid format"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "invalid_format" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "invalid_format" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:menu_orering.Vitro
+uil-data:menu_orering.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Menu Ordering"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "menu_orering" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "menu_orering" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:confirm_entry_deletion_from.Vitro
+uil-data:confirm_entry_deletion_from.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Are you sure you want to delete the following entry from"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "confirm_entry_deletion_from" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "confirm_entry_deletion_from" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:add_types.Vitro
+uil-data:add_types.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Add one or more types"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "add_types" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "add_types" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:group_capitalized.Vitro
+uil-data:group_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Group"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "group_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "group_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:entry.Vitro
+uil-data:entry.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "entry"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "entry" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "entry" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:search_vitro.Vitro
+uil-data:search_vitro.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Search VITRO"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "search_vitro" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "search_vitro" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:version.Vitro
+uil-data:version.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Version"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "version" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "version" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:hide_subclasses.Vitro
+uil-data:hide_subclasses.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "hide subclasses"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "hide_subclasses" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "hide_subclasses" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:caused_by.Vitro
+uil-data:caused_by.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Caused by"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "caused_by" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "caused_by" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:show_more_content.Vitro
+uil-data:show_more_content.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "show more content"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "show_more_content" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "show_more_content" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:advanced_search_tip_six.Vitro
+uil-data:advanced_search_tip_six.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Search uses shortened versions of words -- e.g., a search for <i>cogniti*</i> finds nothing, while <i>cognit*</i> finds both <i>cognitive</i> and <i>cognition</i>."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "advanced_search_tip_six" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "advanced_search_tip_six" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:myAccount_confirm_changes_plus_note.Vitro
+uil-data:myAccount_confirm_changes_plus_note.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Your changes have been saved. A confirmation email has been sent to {0}."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "myAccount_confirm_changes_plus_note" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "myAccount_confirm_changes_plus_note" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:class_management.Vitro
+uil-data:class_management.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Class Management"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "class_management" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "class_management" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:display_less.Vitro
+uil-data:display_less.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "less"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "display_less" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "display_less" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:add_property_group.Vitro
+uil-data:add_property_group.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Add new property group"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "add_property_group" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "add_property_group" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:browse_by.Vitro
+uil-data:browse_by.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Browse by"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "browse_by" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "browse_by" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:class_group_link.Vitro
+uil-data:class_group_link.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "class group link"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "class_group_link" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "class_group_link" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:confirm_password.Vitro
+uil-data:confirm_password.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Confirm new password"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "confirm_password" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "confirm_password" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:saturday.Vitro
+uil-data:saturday.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Saturday"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "saturday" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "saturday" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:_publications_link.Vitro
+uil-data:_publications_link.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "_publications_link" ;
-        prop:hasPackage  "Vitro-languages" .
+        rdf:type         uil:UILabel ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "_publications_link" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:javascript_require_to_edit.Vitro
+uil-data:javascript_require_to_edit.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "In order to edit content, you'll need to enable JavaScript."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "javascript_require_to_edit" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "javascript_require_to_edit" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:fatal_error_detected.Vitro
+uil-data:fatal_error_detected.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "{0} detected a fatal error during startup."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "fatal_error_detected" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "fatal_error_detected" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:menu_page.Vitro
+uil-data:menu_page.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Menu Page"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "menu_page" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "menu_page" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:create_new_individual_of_the_following_type.Vitro
+uil-data:create_new_individual_of_the_following_type.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Create an object of the following type"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "create_new_individual_of_the_following_type" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "create_new_individual_of_the_following_type" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:logins_not_already_restricted.Vitro
+uil-data:logins_not_already_restricted.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Logins are already not restricted."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "logins_not_already_restricted" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "logins_not_already_restricted" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:stack_trace.Vitro
+uil-data:stack_trace.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Stack trace"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "stack_trace" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "stack_trace" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:confirm_page_deletion.Vitro
+uil-data:confirm_page_deletion.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Are you sure you wish to delete this page:"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "confirm_page_deletion" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "confirm_page_deletion" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_locale.Vitro
+uil-data:select_locale.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "select locale"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_locale" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_locale" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:reset_password.Vitro
+uil-data:reset_password.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Reset password"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "reset_password" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "reset_password" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:vitro_bullet_two.Vitro
+uil-data:vitro_bullet_two.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Edit instances and relationships"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "vitro_bullet_two" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "vitro_bullet_two" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:replace_page_title.Vitro
+uil-data:replace_page_title.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Replace image"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "replace_page_title" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "replace_page_title" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:subproperty.Vitro
+uil-data:subproperty.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "subproperty"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "subproperty" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "subproperty" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:rdf_export.Vitro
+uil-data:rdf_export.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "RDF export"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "rdf_export" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "rdf_export" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:click_to_view_larger.Vitro
+uil-data:click_to_view_larger.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "click to view larger image"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "click_to_view_larger" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "click_to_view_larger" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:build_date.Vitro
+uil-data:build_date.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Build date"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "build_date" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "build_date" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:flags.Vitro
+uil-data:flags.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Flags"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "flags" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "flags" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:march.Vitro
+uil-data:march.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "March"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "march" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "march" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:display_only.Vitro
+uil-data:display_only.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Display Only"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "display_only" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "display_only" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:to_manage_content.Vitro
+uil-data:to_manage_content.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "to manage content."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "to_manage_content" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "to_manage_content" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:acct_created_email_html_text.Vitro
+uil-data:acct_created_email_html_text.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "<p>\n ${userAccount.firstName} ${userAccount.lastName}\n </p>\n\n <p>\n <strong>Congratulations!</strong>\n </p>\n\n <p>\n We have created your new account on ${siteName}, associated with ${userAccount.emailAddress}.\n </p>\n\n <p>\n If you did not request this new account you can safely ignore this email.\n This request will expire if not acted upon for 30 days.\n </p>\n\n <p>\n Click the link below to create your password for your new account using our secure server.\n </p>\n\n <p>\n <a href=\"${passwordLink}\" title=\"password\">${passwordLink}</a>\n </p>\n\n <p>\n If the link above doesn't work, you can copy and paste the link directly into your browser's address bar.\n </p>\n\n <p>\n Thanks!\n </p>"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "acct_created_email_html_text" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "acct_created_email_html_text" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:file_upload_confirm_delete.Vitro
+uil-data:file_upload_confirm_delete.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Are you sure you want to delete this file?"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "file_upload_confirm_delete" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "file_upload_confirm_delete" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:cropping_caption.Vitro
+uil-data:cropping_caption.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Your profile photo will look like the image below."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "cropping_caption" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "cropping_caption" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:browse_capitalized.Vitro
+uil-data:browse_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Browse"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "browse_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "browse_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:display_options.Vitro
+uil-data:display_options.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Display Options"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "display_options" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "display_options" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:site_config.Vitro
+uil-data:site_config.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Site Configuration"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "site_config" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "site_config" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:undo_camelcasing.Vitro
+uil-data:undo_camelcasing.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Uncamelcasing"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "undo_camelcasing" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "undo_camelcasing" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:view_all_capitalized.Vitro
+uil-data:view_all_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "View All"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "view_all_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "view_all_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_processing_labels.Vitro
+uil-data:error_processing_labels.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Error processing request: the unchecked labels could not be deleted."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_processing_labels" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_processing_labels" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:dates.Vitro
+uil-data:dates.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Dates"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "dates" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "dates" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:myAccount_heading.Vitro
+uil-data:myAccount_heading.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "My account"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "myAccount_heading" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "myAccount_heading" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:roles.Vitro
+uil-data:roles.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Roles"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "roles" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "roles" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:april.Vitro
+uil-data:april.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "April"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "april" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "april" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:password_reset_pending_subject.Vitro
+uil-data:password_reset_pending_subject.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "{0} reset password request"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "password_reset_pending_subject" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "password_reset_pending_subject" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:some_values_from.Vitro
+uil-data:some_values_from.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "some values from"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "some_values_from" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "some_values_from" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:browse_all_public_content.Vitro
+uil-data:browse_all_public_content.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "You can browse all of the public content currently in the system using the"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "browse_all_public_content" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "browse_all_public_content" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:all_values_from.Vitro
+uil-data:all_values_from.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "all values from"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "all_values_from" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "all_values_from" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:updated_account_2.Vitro
+uil-data:updated_account_2.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "has been updated."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "updated_account_2" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "updated_account_2" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:alt_error_alert.Vitro
+uil-data:alt_error_alert.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Error alert icon"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "alt_error_alert" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "alt_error_alert" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:year_month.Vitro
+uil-data:year_month.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Invalid entry. Please enter a Year and Month."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "year_month" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "year_month" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:name.Vitro
+uil-data:name.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "name"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "name" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "name" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:no_image.Vitro
+uil-data:no_image.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "no image"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "no_image" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "no_image" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:sparql_query_save_results.Vitro
+uil-data:sparql_query_save_results.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Save results to file"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "sparql_query_save_results" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "sparql_query_save_results" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:add_new_group.Vitro
+uil-data:add_new_group.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Add New Group"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "add_new_group" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "add_new_group" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:browse_all.Vitro
+uil-data:browse_all.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Browse all"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "browse_all" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "browse_all" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:processing_icon.Vitro
+uil-data:processing_icon.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "processing"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "processing_icon" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "processing_icon" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:logins_restricted.Vitro
+uil-data:logins_restricted.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Logins are now restricted."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "logins_restricted" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "logins_restricted" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:search_tip_four.Vitro
+uil-data:search_tip_four.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "If you are unsure of the correct spelling, put ~ at the end of your search term -- e.g., <i>cabage~</i> finds <i>cabbage</i>, <i>steven~</i> finds <i>Stephen</i> and <i>Stefan</i> (as well as other similar names)."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "search_tip_four" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "search_tip_four" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:imageUpload.errorNoURI.Vitro
+uil-data:imageUpload.errorNoURI.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "No entity URI was provided"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "imageUpload.errorNoURI" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "imageUpload.errorNoURI" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:password_saved_please_login.Vitro
+uil-data:password_saved_please_login.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Your password has been saved. Please log in."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "password_saved_please_login" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "password_saved_please_login" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:upload_photo.Vitro
+uil-data:upload_photo.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Upload a photo"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "upload_photo" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "upload_photo" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:sparql_query_results.Vitro
+uil-data:sparql_query_results.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Sparql Query Results"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "sparql_query_results" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "sparql_query_results" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:enter_new_password.Vitro
+uil-data:enter_new_password.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Please enter your new password for {0}"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "enter_new_password" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "enter_new_password" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:display_more_ellipsis.Vitro
+uil-data:display_more_ellipsis.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "... more"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "display_more_ellipsis" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "display_more_ellipsis" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:updated_account_1.Vitro
+uil-data:updated_account_1.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "The account for"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "updated_account_1" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "updated_account_1" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:add_page.Vitro
+uil-data:add_page.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Add Page"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "add_page" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "add_page" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:list_elements_of.Vitro
+uil-data:list_elements_of.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "List elements of"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "list_elements_of" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "list_elements_of" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:class_group_all_caps.Vitro
+uil-data:class_group_all_caps.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Class Group"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "class_group_all_caps" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "class_group_all_caps" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:no_class_restrictions.Vitro
+uil-data:no_class_restrictions.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "There are no classes with a restriction on this property."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "no_class_restrictions" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "no_class_restrictions" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:refresh_page_after_reordering.Vitro
+uil-data:refresh_page_after_reordering.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Refresh page after reordering menu items"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "refresh_page_after_reordering" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "refresh_page_after_reordering" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:asserted_class_hierarchy.Vitro
+uil-data:asserted_class_hierarchy.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Asserted Class Hierarchy"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "asserted_class_hierarchy" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "asserted_class_hierarchy" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:page_admin_permission_option.Vitro
+uil-data:page_admin_permission_option.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Only admins can view this page"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "page_admin_permission_option" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "page_admin_permission_option" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:create_associated_profile.Vitro
+uil-data:create_associated_profile.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Create the associated profile"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "create_associated_profile" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "create_associated_profile" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:password_reset_complete_email_html_text.Vitro
+uil-data:password_reset_complete_email_html_text.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "<p>\n ${userAccount.firstName} ${userAccount.lastName}\n </p>\n\n <p>\n <strong>Password successfully changed.</strong>\n </p>\n\n <p>\n Your new password associated with ${userAccount.emailAddress} has been changed.\n </p>\n\n <p>\n Thank you.\n </p>"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "password_reset_complete_email_html_text" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "password_reset_complete_email_html_text" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:first_time_external_email_html_text.Vitro
+uil-data:first_time_external_email_html_text.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "<p>\n ${userAccount.firstName} ${userAccount.lastName}\n </p>\n\n <p>\n <strong>Congratulations!</strong>\n </p>\n\n <p>\n We have created your new VIVO account associated with ${userAccount.emailAddress}.\n </p>\n\n <p>\n Thanks!\n </p>"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "first_time_external_email_html_text" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "first_time_external_email_html_text" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:default.Vitro
+uil-data:default.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Default"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "default" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "default" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_password_mismatch.Vitro
+uil-data:error_password_mismatch.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Passwords do not match."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_password_mismatch" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_password_mismatch" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:and.Vitro
+uil-data:and.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "and"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "and" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "and" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:no_matching_results.Vitro
+uil-data:no_matching_results.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "No matching results."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "no_matching_results" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "no_matching_results" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:internal_class_i_capped.Vitro
+uil-data:internal_class_i_capped.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Institutional internal class"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "internal_class_i_capped" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "internal_class_i_capped" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:decimal_only.Vitro
+uil-data:decimal_only.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Invalid entry.  A decimal point is allowed, but thousands-separators are not."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "decimal_only" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "decimal_only" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:new_account_2.Vitro
+uil-data:new_account_2.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "was successfully created."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "new_account_2" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "new_account_2" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:listed_page_title.Vitro
+uil-data:listed_page_title.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "listed page title"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "listed_page_title" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "listed_page_title" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:delete_profile_editor.Vitro
+uil-data:delete_profile_editor.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Delete profile editor"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "delete_profile_editor" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "delete_profile_editor" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_no_first_name.Vitro
+uil-data:error_no_first_name.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "You must supply a first name."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_no_first_name" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_no_first_name" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:browse_all_in_class.Vitro
+uil-data:browse_all_in_class.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Browse all individuals in this class"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "browse_all_in_class" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "browse_all_in_class" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:save_entry.Vitro
+uil-data:save_entry.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Save entry"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "save_entry" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "save_entry" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:confirm_initial_password.Vitro
+uil-data:confirm_initial_password.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Confirm initial password"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "confirm_initial_password" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "confirm_initial_password" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:ingest_tools.Vitro
+uil-data:ingest_tools.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ingest tools"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "ingest_tools" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "ingest_tools" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:application_error_email_html_text.Vitro
+uil-data:application_error_email_html_text.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "<p>An error occurred on your ${siteName!} web site at ${datetime!}\n </p>\n\n <p>\n <strong>Requested url:</strong> ${requestedUrl!}\n </p>\n\n <p>\n <#if errorMessage?has_content>\n <strong>Error message:</strong> ${errorMessage!}\n </#if>\n </p>\n\n <p>\n <strong>Stack trace</strong> (full trace available in the log):\n <pre>${stackTrace!}</pre>\n </p>\n\n <#if cause?has_content>\n <p><strong>Caused by:</strong>\n <pre>${cause!}</pre>\n </p>\n </#if>"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "application_error_email_html_text" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "application_error_email_html_text" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:log_in.Vitro
+uil-data:log_in.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "log in"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "log_in" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "log_in" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:new_account_1.Vitro
+uil-data:new_account_1.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "A new account for"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "new_account_1" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "new_account_1" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:imageUpload.errorUnrecognizedFileType.Vitro
+uil-data:imageUpload.errorUnrecognizedFileType.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "''{0}'' is not a recognized image file type. Please upload JPEG, GIF, or PNG files only."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "imageUpload.errorUnrecognizedFileType" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "imageUpload.errorUnrecognizedFileType" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:replace_page_title_with_name.Vitro
+uil-data:replace_page_title_with_name.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Replace image for {0}"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "replace_page_title_with_name" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "replace_page_title_with_name" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:unsupported_ie_version.Vitro
+uil-data:unsupported_ie_version.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "This form is not supported in versions of Internet Explorer below version 8. Please upgrade your browser, or switch to another browser, such as FireFox."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "unsupported_ie_version" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "unsupported_ie_version" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:logins_are_restricted.Vitro
+uil-data:logins_are_restricted.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Logins are restricted."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "logins_are_restricted" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "logins_are_restricted" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:add_profile_editor.Vitro
+uil-data:add_profile_editor.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Add profile editor"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "add_profile_editor" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "add_profile_editor" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:supply_name.Vitro
+uil-data:supply_name.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "You must supply a title"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "supply_name" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "supply_name" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:feedback_thanks_text.Vitro
+uil-data:feedback_thanks_text.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Thank you for contacting our curation and development team. We will respond to your inquiry as soon as possible."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "feedback_thanks_text" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "feedback_thanks_text" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_class_for_search.Vitro
+uil-data:select_class_for_search.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "You must select a class to display its individuals."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_class_for_search" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_class_for_search" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:since_elapsed_time.Vitro
+uil-data:since_elapsed_time.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "since {0}, elapsed time {1}"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "since_elapsed_time" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "since_elapsed_time" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:unknown_user_name.Vitro
+uil-data:unknown_user_name.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "friend"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "unknown_user_name" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "unknown_user_name" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:faux_property_capitalized.Vitro
+uil-data:faux_property_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Faux Property"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "faux_property_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "faux_property_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:enter_value_name_field.Vitro
+uil-data:enter_value_name_field.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Please enter a value in the name field."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "enter_value_name_field" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "enter_value_name_field" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:group_name.Vitro
+uil-data:group_name.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "group name"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "group_name" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "group_name" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:data_property_hierarchy.Vitro
+uil-data:data_property_hierarchy.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Data property hierarchy"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "data_property_hierarchy" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "data_property_hierarchy" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:external_login_text.Vitro
+uil-data:external_login_text.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Log in using BearCat Shibboleth"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "external_login_text" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "external_login_text" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:imageUpload.errorFileTooBig.Vitro
+uil-data:imageUpload.errorFileTooBig.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Please upload an image smaller than {0} megabytes."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "imageUpload.errorFileTooBig" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "imageUpload.errorFileTooBig" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:profile_editors.Vitro
+uil-data:profile_editors.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Profile editors"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "profile_editors" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "profile_editors" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:implement_capitalized.Vitro
+uil-data:implement_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Implement"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "implement_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "implement_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:sparql_query_header.Vitro
+uil-data:sparql_query_header.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Query"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "sparql_query_header" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "sparql_query_header" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:view.Vitro
+uil-data:view.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "view"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "view" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "view" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:manage_profile_editing.Vitro
+uil-data:manage_profile_editing.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Manage profile editing"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "manage_profile_editing" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "manage_profile_editing" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:minimum_image_dimensions.Vitro
+uil-data:minimum_image_dimensions.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Minimum image dimensions: {0} x {1} pixels"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "minimum_image_dimensions" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "minimum_image_dimensions" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:view_list_in_rdf.Vitro
+uil-data:view_list_in_rdf.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "View the {0} list in RDF format"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "view_list_in_rdf" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "view_list_in_rdf" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:more_details_about_site.Vitro
+uil-data:more_details_about_site.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "More details about this site"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "more_details_about_site" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "more_details_about_site" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:new_entry_for.Vitro
+uil-data:new_entry_for.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "\"{0}\" entry for {1}"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "new_entry_for" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "new_entry_for" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:july.Vitro
+uil-data:july.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "July"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "july" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "july" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:page_uri.Vitro
+uil-data:page_uri.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "page URI"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "page_uri" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "page_uri" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:edit_date_time_value.Vitro
+uil-data:edit_date_time_value.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Edit Date/Time Value"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "edit_date_time_value" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "edit_date_time_value" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:limited_to_type.Vitro
+uil-data:limited_to_type.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "limited to type"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "limited_to_type" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "limited_to_type" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:class_name.Vitro
+uil-data:class_name.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "class name"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "class_name" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "class_name" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:create_date_time_value.Vitro
+uil-data:create_date_time_value.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Create Date/Time Value"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "create_date_time_value" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "create_date_time_value" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:there_are_no_entries_for_selection.Vitro
+uil-data:there_are_no_entries_for_selection.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "There are no entries in the system from which to select."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "there_are_no_entries_for_selection" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "there_are_no_entries_for_selection" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:edit_this_individual.Vitro
+uil-data:edit_this_individual.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Edit this individual"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "edit_this_individual" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "edit_this_individual" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:start_interval_must_precede_end_earlier.Vitro
+uil-data:start_interval_must_precede_end_earlier.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "The Start interval must be earlier than the End interval."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "start_interval_must_precede_end_earlier" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "start_interval_must_precede_end_earlier" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:type_capitalized.Vitro
+uil-data:type_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Type"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "type_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "type_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:selected.Vitro
+uil-data:selected.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Selected"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "selected" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "selected" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:submit_upload.Vitro
+uil-data:submit_upload.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Upload photo"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "submit_upload" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "submit_upload" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:confirm_individual_deletion.Vitro
+uil-data:confirm_individual_deletion.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Are you sure you want to delete the following individual? "@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "confirm_individual_deletion" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "confirm_individual_deletion" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:september.Vitro
+uil-data:september.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "September"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "september" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "september" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:verbose_turn_off.Vitro
+uil-data:verbose_turn_off.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Turn off"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "verbose_turn_off" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "verbose_turn_off" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_type.Vitro
+uil-data:select_type.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Select a type"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_type" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_type" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:comments_questions.Vitro
+uil-data:comments_questions.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Comments, questions, or suggestions"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "comments_questions" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "comments_questions" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:send_mail.Vitro
+uil-data:send_mail.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Send Mail"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "send_mail" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "send_mail" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:change_profile.Vitro
+uil-data:change_profile.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "change profile"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "change_profile" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "change_profile" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:logins_already_restricted.Vitro
+uil-data:logins_already_restricted.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Logins are already restricted."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "logins_already_restricted" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "logins_already_restricted" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:photo_types.Vitro
+uil-data:photo_types.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "(JPEG, GIF or PNG)"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "photo_types" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "photo_types" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:search_term_error_near.Vitro
+uil-data:search_term_error_near.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "The search term had an error near"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "search_term_error_near" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "search_term_error_near" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:share_profile_uri.Vitro
+uil-data:share_profile_uri.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "share the URI for this profile"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "share_profile_uri" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "share_profile_uri" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:no_html_specified.Vitro
+uil-data:no_html_specified.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "No HTML specified."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "no_html_specified" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "no_html_specified" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:first_name.Vitro
+uil-data:first_name.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "First name"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "first_name" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "first_name" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:class_link.Vitro
+uil-data:class_link.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "class link"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "class_link" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "class_link" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:view_profile_page_for.Vitro
+uil-data:view_profile_page_for.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "View the profile page for"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "view_profile_page_for" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "view_profile_page_for" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_classes_to_display.Vitro
+uil-data:select_classes_to_display.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "You must select the classes to display."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_classes_to_display" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_classes_to_display" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:password_mismatch.Vitro
+uil-data:password_mismatch.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Passwords do not match."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "password_mismatch" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "password_mismatch" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:page_management.Vitro
+uil-data:page_management.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Page management"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "page_management" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "page_management" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:resource_uri.Vitro
+uil-data:resource_uri.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Resource URI"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "resource_uri" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "resource_uri" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:sparql_query_run_query.Vitro
+uil-data:sparql_query_run_query.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Run Query"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "sparql_query_run_query" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "sparql_query_run_query" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:enter_fixed_html_here.Vitro
+uil-data:enter_fixed_html_here.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Enter fixed HTML here"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "enter_fixed_html_here" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "enter_fixed_html_here" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:verify_this_match.Vitro
+uil-data:verify_this_match.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "verify this match"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "verify_this_match" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "verify_this_match" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:properties_capitalized.Vitro
+uil-data:properties_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Properties"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "properties_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "properties_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:raw_string_literals.Vitro
+uil-data:raw_string_literals.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Raw String Literals"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "raw_string_literals" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "raw_string_literals" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:no_content_create_groups_classes.Vitro
+uil-data:no_content_create_groups_classes.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "There is currently no content in the system, or you need to create class groups and assign your classes to them."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "no_content_create_groups_classes" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "no_content_create_groups_classes" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:home_page.Vitro
+uil-data:home_page.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "home page"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "home_page" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "home_page" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:restriction_on.Vitro
+uil-data:restriction_on.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "restriction on"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "restriction_on" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "restriction_on" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:processing_indicator.Vitro
+uil-data:processing_indicator.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "processing time indicator"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "processing_indicator" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "processing_indicator" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:selected_page_content_type.Vitro
+uil-data:selected_page_content_type.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Selected content type for the associated page"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "selected_page_content_type" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "selected_page_content_type" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:create_entry.Vitro
+uil-data:create_entry.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Create Entry"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "create_entry" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "create_entry" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:password_change_not_pending.Vitro
+uil-data:password_change_not_pending.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "The password for {0} has already been reset."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "password_change_not_pending" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "password_change_not_pending" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:javascript_instructions.Vitro
+uil-data:javascript_instructions.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "java script instructions"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "javascript_instructions" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "javascript_instructions" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_invalid_email.Vitro
+uil-data:error_invalid_email.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "''{0}'' is not a valid email address."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_invalid_email" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_invalid_email" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:new_pwd_matches_existing.Vitro
+uil-data:new_pwd_matches_existing.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Your new password must be different from your existing password."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "new_pwd_matches_existing" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "new_pwd_matches_existing" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:or.Vitro
+uil-data:or.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "or"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "or" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "or" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:search_form.Vitro
+uil-data:search_form.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Search form"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "search_form" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "search_form" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:menu_item_name.Vitro
+uil-data:menu_item_name.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Menu Item Name"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "menu_item_name" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "menu_item_name" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:june.Vitro
+uil-data:june.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "June"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "june" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "june" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:last_name.Vitro
+uil-data:last_name.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Last name"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "last_name" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "last_name" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:placeholder_image.Vitro
+uil-data:placeholder_image.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "placeholder image"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "placeholder_image" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "placeholder_image" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:requested_url.Vitro
+uil-data:requested_url.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Requested url"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "requested_url" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "requested_url" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:first_time_login_note.Vitro
+uil-data:first_time_login_note.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Note: An email will be sent to the address entered above notifying that an account has been created."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "first_time_login_note" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "first_time_login_note" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_external_auth_already_exists.Vitro
+uil-data:error_external_auth_already_exists.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "An account with that external authorization ID already exists."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_external_auth_already_exists" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_external_auth_already_exists" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:contains_no_pears.Vitro
+uil-data:contains_no_pears.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "contains no pears"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "contains_no_pears" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "contains_no_pears" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:index_page.Vitro
+uil-data:index_page.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "index page"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "index_page" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "index_page" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:search_tip_one.Vitro
+uil-data:search_tip_one.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Keep it simple! Use short, single terms unless your searches are returning too many results."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "search_tip_one" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "search_tip_one" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:sparql_query_construct_describe_results.Vitro
+uil-data:sparql_query_construct_describe_results.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Format for CONSTRUCT and DESCRIBE query results"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "sparql_query_construct_describe_results" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "sparql_query_construct_describe_results" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:password_capitalized.Vitro
+uil-data:password_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Password"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "password_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "password_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:file_upload_submit_label.Vitro
+uil-data:file_upload_submit_label.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Upload"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "file_upload_submit_label" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "file_upload_submit_label" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:please.Vitro
+uil-data:please.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Please"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "please" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "please" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:account_created.Vitro
+uil-data:account_created.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Your {0} account has been created."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "account_created" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "account_created" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:add.Vitro
+uil-data:add.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "add"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "add" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "add" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:limit.Vitro
+uil-data:limit.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Limit"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "limit" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "limit" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:november.Vitro
+uil-data:november.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "November"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "november" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "november" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:confirm_delete.Vitro
+uil-data:confirm_delete.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Are you sure you want to delete this photo?"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "confirm_delete" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "confirm_delete" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:login_welcome_message.Vitro
+uil-data:login_welcome_message.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Welcome{1, choice, 1# |1< back}, {0}"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "login_welcome_message" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "login_welcome_message" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:password_changed_subject.Vitro
+uil-data:password_changed_subject.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Password changed."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "password_changed_subject" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "password_changed_subject" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:incorrect_email_password.Vitro
+uil-data:incorrect_email_password.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Email or Password was incorrect."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "incorrect_email_password" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "incorrect_email_password" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:identifiers.Vitro
+uil-data:identifiers.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Identifiers"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "identifiers" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "identifiers" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:javascript_ie_alert_text.Vitro
+uil-data:javascript_ie_alert_text.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "This site uses HTML elements that are not recognized by Internet Explorer 8 and below in the absence of JavaScript. As a result, the site will not be rendered appropriately. To correct this, please either enable JavaScript, upgrade to Internet Explorer 9, or use another browser."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "javascript_ie_alert_text" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "javascript_ie_alert_text" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:zoo_two.Vitro
+uil-data:zoo_two.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Zoo 2"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "zoo_two" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "zoo_two" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:verbose_turn_on.Vitro
+uil-data:verbose_turn_on.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Turn on"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "verbose_turn_on" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "verbose_turn_on" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:selection_in_process.Vitro
+uil-data:selection_in_process.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Your selection is being processed."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "selection_in_process" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "selection_in_process" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:please_create.Vitro
+uil-data:please_create.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Please create"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "please_create" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "please_create" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:verbose_status_off.Vitro
+uil-data:verbose_status_off.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "off"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "verbose_status_off" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "verbose_status_off" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:page_not_configured.Vitro
+uil-data:page_not_configured.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "This page is not yet configured."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "page_not_configured" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "page_not_configured" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:new_account_notification.Vitro
+uil-data:new_account_notification.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "A notification email has been sent to {0} with instructions for activating the account and creating a password."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "new_account_notification" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "new_account_notification" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:full_list_startup.Vitro
+uil-data:full_list_startup.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "The full list of startup events and messages."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "full_list_startup" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "full_list_startup" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:user_role.Vitro
+uil-data:user_role.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Role"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "user_role" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "user_role" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:or_enter_valid_address.Vitro
+uil-data:or_enter_valid_address.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "or enter another complete and valid email address."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "or_enter_valid_address" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "or_enter_valid_address" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:all.Vitro
+uil-data:all.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "all"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "all" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "all" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:logged_in_but_no_profile.Vitro
+uil-data:logged_in_but_no_profile.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "You have logged in, but the system contains no profile for you."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "logged_in_but_no_profile" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "logged_in_but_no_profile" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:page_text.Vitro
+uil-data:page_text.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "page text"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "page_text" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "page_text" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:create_new_entry.Vitro
+uil-data:create_new_entry.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Please create a new entry."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "create_new_entry" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "create_new_entry" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:enter_in_security_field.Vitro
+uil-data:enter_in_security_field.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Please enter the letters displayed below into the security field"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "enter_in_security_field" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "enter_in_security_field" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_an_existing_or_create_a_new_one.Vitro
+uil-data:select_an_existing_or_create_a_new_one.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Select an existing or create a new one"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_an_existing_or_create_a_new_one" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_an_existing_or_create_a_new_one" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:not.Vitro
+uil-data:not.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "not"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "not" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "not" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:range_data_type.Vitro
+uil-data:range_data_type.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Range Data Type"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "range_data_type" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "range_data_type" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:august.Vitro
+uil-data:august.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "August"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "august" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "august" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:terms_of_use.Vitro
+uil-data:terms_of_use.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Terms of Use"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "terms_of_use" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "terms_of_use" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:dump_restore.Vitro
+uil-data:dump_restore.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Dump/Restore application"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "dump_restore" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "dump_restore" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:show_properties.Vitro
+uil-data:show_properties.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "show properties"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "show_properties" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "show_properties" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:associated_individuals.Vitro
+uil-data:associated_individuals.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Associated Individuals"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "associated_individuals" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "associated_individuals" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:name_capitalized.Vitro
+uil-data:name_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Name"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "name_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "name_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:manage_labels.Vitro
+uil-data:manage_labels.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "manage labels"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "manage_labels" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "manage_labels" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:current_user.Vitro
+uil-data:current_user.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Current user"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "current_user" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "current_user" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:minimum_ymd.Vitro
+uil-data:minimum_ymd.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Invalid entry. Please enter at least a Year, Month and Day."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "minimum_ymd" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "minimum_ymd" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:try_another_letter.Vitro
+uil-data:try_another_letter.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Please try another letter or browse all."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "try_another_letter" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "try_another_letter" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:alt_image_to_crop.Vitro
+uil-data:alt_image_to_crop.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Image to be cropped"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "alt_image_to_crop" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "alt_image_to_crop" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:current_task.Vitro
+uil-data:current_task.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "{0} the search index"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "current_task" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "current_task" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:imageUpload.errorNoImageForCropping.Vitro
+uil-data:imageUpload.errorNoImageForCropping.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "There is no image file to be cropped."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "imageUpload.errorNoImageForCropping" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "imageUpload.errorNoImageForCropping" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:we_have_an_error.Vitro
+uil-data:we_have_an_error.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "There was an error in the system."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "we_have_an_error" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "we_have_an_error" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_another_class.Vitro
+uil-data:select_another_class.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Please select another class from the list."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_another_class" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_another_class" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:manage_labels_for.Vitro
+uil-data:manage_labels_for.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Manage Labels for"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "manage_labels_for" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "manage_labels_for" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:revision_info.Vitro
+uil-data:revision_info.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Revision Information"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "revision_info" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "revision_info" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:rebuild_vis_cache.Vitro
+uil-data:rebuild_vis_cache.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Rebuild visualization cache"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "rebuild_vis_cache" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "rebuild_vis_cache" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:delete.Vitro
+uil-data:delete.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "delete"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "delete" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "delete" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:update_button.Vitro
+uil-data:update_button.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Update"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "update_button" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "update_button" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:imageUpload.errorNoPhotoSelected.Vitro
+uil-data:imageUpload.errorNoPhotoSelected.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Please browse and select a photo."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "imageUpload.errorNoPhotoSelected" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "imageUpload.errorNoPhotoSelected" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:imageUpload.errorUnrecognizedURI.Vitro
+uil-data:imageUpload.errorUnrecognizedURI.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "This URI is not recognized as belonging to anyone: ''{0}''"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "imageUpload.errorUnrecognizedURI" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "imageUpload.errorUnrecognizedURI" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:menu_item.Vitro
+uil-data:menu_item.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "menu item"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "menu_item" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "menu_item" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:auth_id_label.Vitro
+uil-data:auth_id_label.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "External Authentication ID"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "auth_id_label" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "auth_id_label" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:may.Vitro
+uil-data:may.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "May"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "may" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "may" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:what_is_vitro.Vitro
+uil-data:what_is_vitro.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "What is VITRO?"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "what_is_vitro" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "what_is_vitro" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_a_language.Vitro
+uil-data:select_a_language.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Select a language"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_a_language" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_a_language" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:ip_address.Vitro
+uil-data:ip_address.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "IP address"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "ip_address" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "ip_address" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:unrecognized_user.Vitro
+uil-data:unrecognized_user.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Unrecognized user"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "unrecognized_user" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "unrecognized_user" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:password_change_invalid_key.Vitro
+uil-data:password_change_invalid_key.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "The link you used for {0} is invalid. Please ask site administrator to resend the link."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "password_change_invalid_key" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "password_change_invalid_key" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:change_text_for.Vitro
+uil-data:change_text_for.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Change text for:"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "change_text_for" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "change_text_for" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:to_enable_javascript.Vitro
+uil-data:to_enable_javascript.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Here are the instructions for enabling JavaScript in your web browser"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "to_enable_javascript" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "to_enable_javascript" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:warning.Vitro
+uil-data:warning.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Warning"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "warning" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "warning" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:revision.Vitro
+uil-data:revision.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "revision"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "revision" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "revision" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:filter_by_roles.Vitro
+uil-data:filter_by_roles.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Filter by roles"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "filter_by_roles" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "filter_by_roles" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:page_uri_missing_msg.Vitro
+uil-data:page_uri_missing_msg.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Could not generate page beacause it was unclear what page was being requested.  A URL mapping may be missing."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "page_uri_missing_msg" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "page_uri_missing_msg" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:fatal_error.Vitro
+uil-data:fatal_error.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Fatal Error"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "fatal_error" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "fatal_error" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:page_select_permission_option.Vitro
+uil-data:page_select_permission_option.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Select permission"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "page_select_permission_option" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "page_select_permission_option" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:january.Vitro
+uil-data:january.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "January"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "january" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "january" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:property.Vitro
+uil-data:property.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "property"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "property" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "property" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:external_auth_id.Vitro
+uil-data:external_auth_id.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "External Auth ID"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "external_auth_id" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "external_auth_id" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:date_time_value_for.Vitro
+uil-data:date_time_value_for.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "date time value for"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "date_time_value_for" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "date_time_value_for" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:sparql_query_title.Vitro
+uil-data:sparql_query_title.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "SPARQL Query"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "sparql_query_title" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "sparql_query_title" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:previous.Vitro
+uil-data:previous.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Previous"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "previous" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "previous" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:upload_page_title_with_name.Vitro
+uil-data:upload_page_title_with_name.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Upload image for {0}"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "upload_page_title_with_name" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "upload_page_title_with_name" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:cant_change_password_while_logged_in.Vitro
+uil-data:cant_change_password_while_logged_in.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "You may not reset the password for {0} while you are logged in as {1}. Please log out and try again."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "cant_change_password_while_logged_in" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "cant_change_password_while_logged_in" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:rejected_spam.Vitro
+uil-data:rejected_spam.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "REJECTED - SPAM"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "rejected_spam" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "rejected_spam" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:logins_are_open.Vitro
+uil-data:logins_are_open.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Logins are open to all."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "logins_are_open" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "logins_are_open" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:confirm_delete_account_singular.Vitro
+uil-data:confirm_delete_account_singular.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Are you sure you want to delete this account?"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "confirm_delete_account_singular" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "confirm_delete_account_singular" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:all_capitalized.Vitro
+uil-data:all_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "All"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "all_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "all_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:of_the_results.Vitro
+uil-data:of_the_results.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "of the results"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "of_the_results" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "of_the_results" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_content_type.Vitro
+uil-data:select_content_type.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "You must select content to be included on the page"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_content_type" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_content_type" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:visit_project_website.Vitro
+uil-data:visit_project_website.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Visit the national project web site"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "visit_project_website" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "visit_project_website" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:view_labels_for.Vitro
+uil-data:view_labels_for.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "View Labels for"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "view_labels_for" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "view_labels_for" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:new_account_note.Vitro
+uil-data:new_account_note.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Note: An email will be sent to the address entered above notifying that an account has been created. It will include instructions for activating the account and creating a password."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "new_account_note" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "new_account_note" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_alert_icon.Vitro
+uil-data:error_alert_icon.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Error alert icon"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_alert_icon" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_alert_icon" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:imageUpload.errorImageTooSmall.Vitro
+uil-data:imageUpload.errorImageTooSmall.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "The uploaded image should be at least {0} pixels high and {1} pixels wide."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "imageUpload.errorImageTooSmall" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "imageUpload.errorImageTooSmall" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_account_to_delete.Vitro
+uil-data:select_account_to_delete.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "select this account to delete it"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_account_to_delete" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_account_to_delete" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:interest_thanks.Vitro
+uil-data:interest_thanks.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Thank you for your interest in {0}. Please submit this form with questions, comments, or feedback about the content of this site."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "interest_thanks" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "interest_thanks" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:year_numeric.Vitro
+uil-data:year_numeric.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Invalid entry. The Year must be numeric."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "year_numeric" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "year_numeric" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_an_existing_document.Vitro
+uil-data:select_an_existing_document.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Select an existing document"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_an_existing_document" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_an_existing_document" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:password_length.Vitro
+uil-data:password_length.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Password must be between {0} and {1} characters."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "password_length" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "password_length" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:monday.Vitro
+uil-data:monday.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Monday"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "monday" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "monday" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:account_created_subject.Vitro
+uil-data:account_created_subject.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Your {0} account has been created."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "account_created_subject" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "account_created_subject" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:vitro_bullet_three.Vitro
+uil-data:vitro_bullet_three.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Build a public web site to display your data"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "vitro_bullet_three" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "vitro_bullet_three" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:photo.Vitro
+uil-data:photo.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Photo"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "photo" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "photo" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:file_must_be_entered_msg.Vitro
+uil-data:file_must_be_entered_msg.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "a file must be entered for this field."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "file_must_be_entered_msg" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "file_must_be_entered_msg" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:entity_to_query_for.Vitro
+uil-data:entity_to_query_for.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "This id is the id of the entity to query for. netid also works."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "entity_to_query_for" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "entity_to_query_for" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:manage_grants_and_projects_link.Vitro
+uil-data:manage_grants_and_projects_link.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "manage grants & projects"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "manage_grants_and_projects_link" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "manage_grants_and_projects_link" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:manage_labels_intro.Vitro
+uil-data:manage_labels_intro.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "In the case where multiple labels exist in the same language, please use the remove link to delete the labels you do not want displayed on the profile page for a given language."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "manage_labels_intro" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "manage_labels_intro" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:hide_show_properties.Vitro
+uil-data:hide_show_properties.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "hide/show properties"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "hide_show_properties" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "hide_show_properties" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:untitled.Vitro
+uil-data:untitled.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "-untitled-"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "untitled" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "untitled" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:manage_publications_link.Vitro
+uil-data:manage_publications_link.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "manage publications"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "manage_publications_link" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "manage_publications_link" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_all.Vitro
+uil-data:select_all.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "select all"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_all" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_all" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:local_name.Vitro
+uil-data:local_name.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Local Name"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "local_name" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "local_name" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:end_interval_must_follow_start_interval.Vitro
+uil-data:end_interval_must_follow_start_interval.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "The End interval must be later than the Start interval."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "end_interval_must_follow_start_interval" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "end_interval_must_follow_start_interval" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:view_page.Vitro
+uil-data:view_page.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "View page"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "view_page" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "view_page" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:browse_page_javascript_one.Vitro
+uil-data:browse_page_javascript_one.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "This browse page requires javascript, but your browser is set to disable javascript. Either enable javascript or use the"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "browse_page_javascript_one" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "browse_page_javascript_one" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:sparql_query_builder.Vitro
+uil-data:sparql_query_builder.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "SPARQL query builder"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "sparql_query_builder" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "sparql_query_builder" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:sub_properties.Vitro
+uil-data:sub_properties.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Subproperties"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "sub_properties" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "sub_properties" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:add_label_for_language.Vitro
+uil-data:add_label_for_language.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Language"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "add_label_for_language" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "add_label_for_language" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:file_upload_error_file_not_found.Vitro
+uil-data:file_upload_error_file_not_found.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "File to upload not found"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "file_upload_error_file_not_found" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "file_upload_error_file_not_found" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:file_upload_predicate.Vitro
+uil-data:file_upload_predicate.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "predicate"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "file_upload_predicate" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "file_upload_predicate" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:start_with_leading_slash.Vitro
+uil-data:start_with_leading_slash.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Must begin with a leading forward slash: / (e.g., /people)"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "start_with_leading_slash" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "start_with_leading_slash" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:trace_available.Vitro
+uil-data:trace_available.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "full trace available in the vivo log"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "trace_available" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "trace_available" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:editing_prohibited.Vitro
+uil-data:editing_prohibited.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "This property is currently configured to prohibit editing."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "editing_prohibited" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "editing_prohibited" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:verbose_status_on.Vitro
+uil-data:verbose_status_on.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "on"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "verbose_status_on" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "verbose_status_on" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:use_capitalized.Vitro
+uil-data:use_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Use"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "use_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "use_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:search_index_status.Vitro
+uil-data:search_index_status.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Search Index Status"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "search_index_status" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "search_index_status" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:filter_search.Vitro
+uil-data:filter_search.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "filter search"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "filter_search" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "filter_search" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:with_vitro.Vitro
+uil-data:with_vitro.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "With Vitro, you can:"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "with_vitro" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "with_vitro" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:site_information.Vitro
+uil-data:site_information.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Site information"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "site_information" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "site_information" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:logins_temporarily_disabled.Vitro
+uil-data:logins_temporarily_disabled.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "User logins are temporarily disabled while the system is being maintained."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "logins_temporarily_disabled" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "logins_temporarily_disabled" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:leave_password_unchanged.Vitro
+uil-data:leave_password_unchanged.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Leaving this blank means that the password will not be changed."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "leave_password_unchanged" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "leave_password_unchanged" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:query_model.Vitro
+uil-data:query_model.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Query Model"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "query_model" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "query_model" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:restrict_logins_mixed_caps.Vitro
+uil-data:restrict_logins_mixed_caps.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Restrict logins"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "restrict_logins_mixed_caps" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "restrict_logins_mixed_caps" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:wednesday.Vitro
+uil-data:wednesday.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Wednesday"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "wednesday" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "wednesday" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:berries.Vitro
+uil-data:berries.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Berries:"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "berries" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "berries" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:full_name.Vitro
+uil-data:full_name.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Full name"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "full_name" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "full_name" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:no_email_supplied.Vitro
+uil-data:no_email_supplied.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "No email supplied."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "no_email_supplied" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "no_email_supplied" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_was_reported.Vitro
+uil-data:error_was_reported.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "This error has been reported to the site administrator."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_was_reported" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_was_reported" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:search_results_for.Vitro
+uil-data:search_results_for.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Search results for"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "search_results_for" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "search_results_for" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:search_tip_three.Vitro
+uil-data:search_tip_three.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Except for boolean operators, searches are <strong>not</strong> case-sensitive, so \"Geneva\" and \"geneva\" are equivalent."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "search_tip_three" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "search_tip_three" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:view_profile_for_page.Vitro
+uil-data:view_profile_for_page.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "view the individual profile for this page"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "view_profile_for_page" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "view_profile_for_page" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:reordering_menus_failed.Vitro
+uil-data:reordering_menus_failed.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Reordering of menu items failed."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "reordering_menus_failed" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "reordering_menus_failed" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:verbose_control.Vitro
+uil-data:verbose_control.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "verbose control"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "verbose_control" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "verbose_control" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:ontology_list.Vitro
+uil-data:ontology_list.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ontology list"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "ontology_list" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "ontology_list" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:edit_entry.Vitro
+uil-data:edit_entry.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "edit this entry"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "edit_entry" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "edit_entry" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:label.dateTimeWithPrecision.minutes_capitalized.Vitro
+uil-data:label.dateTimeWithPrecision.minutes_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Minutes"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "label.dateTimeWithPrecision.minutes_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "label.dateTimeWithPrecision.minutes_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:object.Vitro
+uil-data:object.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "object"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "object" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "object" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:confirm_email_changed_email_html_text.Vitro
+uil-data:confirm_email_changed_email_html_text.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "<p>\n Dear ${userAccount.firstName} ${userAccount.lastName}\n </p>\n\n <p>\n You recently changed the email address associated with\n ${userAccount.firstName} ${userAccount.lastName}\n </p>\n\n <p>\n Thank you.\n </p>"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "confirm_email_changed_email_html_text" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "confirm_email_changed_email_html_text" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_no_new_password.Vitro
+uil-data:error_no_new_password.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Please enter your new password."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_no_new_password" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_no_new_password" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:page_loggedin_permission_option.Vitro
+uil-data:page_loggedin_permission_option.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Logged in individuals can view this page"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "page_loggedin_permission_option" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "page_loggedin_permission_option" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:expecting_content.Vitro
+uil-data:expecting_content.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Expecting content?"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "expecting_content" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "expecting_content" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:required_fields.Vitro
+uil-data:required_fields.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "required fields"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "required_fields" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "required_fields" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:edit_page_title.Vitro
+uil-data:edit_page_title.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Edit"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "edit_page_title" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "edit_page_title" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_existing.Vitro
+uil-data:select_existing.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Select existing"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_existing" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_existing" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:invalid_url_msg.Vitro
+uil-data:invalid_url_msg.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "This URL must start with http:// or https://"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "invalid_url_msg" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "invalid_url_msg" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:search_button.Vitro
+uil-data:search_button.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Search"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "search_button" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "search_button" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:advanced_search_tips_header.Vitro
+uil-data:advanced_search_tips_header.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Advanced Tips"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "advanced_search_tips_header" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "advanced_search_tips_header" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:supply_url.Vitro
+uil-data:supply_url.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "You must supply a pretty URL"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "supply_url" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "supply_url" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_profiles.Vitro
+uil-data:select_profiles.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Select profiles"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_profiles" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_profiles" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_one.Vitro
+uil-data:select_one.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Select one"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_one" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_one" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:continue.Vitro
+uil-data:continue.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Continue"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "continue" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "continue" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:language_selection_failed.Vitro
+uil-data:language_selection_failed.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "There was a problem in the system. Your language choice was rejected."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "language_selection_failed" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "language_selection_failed" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:display_has_element_error.Vitro
+uil-data:display_has_element_error.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "There was an error in the system. The display:hasElement property could not be retrieved."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "display_has_element_error" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "display_has_element_error" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:file_upload_error_file_is_too_big.Vitro
+uil-data:file_upload_error_file_is_too_big.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Uploaded file is too big. Maximum file size is {0} bytes. Uploaded file is {1} bytes."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "file_upload_error_file_is_too_big" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "file_upload_error_file_is_too_big" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:template_capitalized.Vitro
+uil-data:template_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Template"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "template_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "template_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:file_upload_supported_media.Vitro
+uil-data:file_upload_supported_media.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Allowed media types:"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "file_upload_supported_media" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "file_upload_supported_media" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:user_accounts_title.Vitro
+uil-data:user_accounts_title.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "user accounts"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "user_accounts_title" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "user_accounts_title" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:create_your_password.Vitro
+uil-data:create_your_password.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Create your Password"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "create_your_password" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "create_your_password" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:create_account.Vitro
+uil-data:create_account.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Create account"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "create_account" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "create_account" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:remove_menu_item.Vitro
+uil-data:remove_menu_item.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Remove menu item"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "remove_menu_item" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "remove_menu_item" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:click_to_view_account.Vitro
+uil-data:click_to_view_account.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "click to view account details"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "click_to_view_account" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "click_to_view_account" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:add_new_entry_for.Vitro
+uil-data:add_new_entry_for.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Add new entry for:"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "add_new_entry_for" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "add_new_entry_for" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:menu_ordering.Vitro
+uil-data:menu_ordering.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Menu Ordering"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "menu_ordering" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "menu_ordering" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:map_processor_error.Vitro
+uil-data:map_processor_error.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "An error has occurred and the map of processors for this content is missing. Please contact the administrator"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "map_processor_error" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "map_processor_error" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:change_profile_title.Vitro
+uil-data:change_profile_title.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "change profile"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "change_profile_title" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "change_profile_title" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:domain_class.Vitro
+uil-data:domain_class.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Domain Class"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "domain_class" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "domain_class" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:manage_labels_capitalized.Vitro
+uil-data:manage_labels_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Manage Labels"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "manage_labels_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "manage_labels_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_passwords_dont_match.Vitro
+uil-data:error_passwords_dont_match.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "The passwords entered do not match."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_passwords_dont_match" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_passwords_dont_match" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:save_profile_changes.Vitro
+uil-data:save_profile_changes.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Save changes to profiles"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "save_profile_changes" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "save_profile_changes" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:site_administration.Vitro
+uil-data:site_administration.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Site Administration"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "site_administration" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "site_administration" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:vitro_bullet_one.Vitro
+uil-data:vitro_bullet_one.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Create or load ontologies in OWL format"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "vitro_bullet_one" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "vitro_bullet_one" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:pages.Vitro
+uil-data:pages.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "pages"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "pages" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "pages" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:inferred_class_hierarchy.Vitro
+uil-data:inferred_class_hierarchy.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Inferred Class Hierarchy"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "inferred_class_hierarchy" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "inferred_class_hierarchy" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:auth_id_in_use.Vitro
+uil-data:auth_id_in_use.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "This Identifier is already in use."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "auth_id_in_use" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "auth_id_in_use" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:data_input.Vitro
+uil-data:data_input.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Data Input"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "data_input" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "data_input" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:recompute_inferences_mixed_caps.Vitro
+uil-data:recompute_inferences_mixed_caps.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Recompute inferences"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "recompute_inferences_mixed_caps" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "recompute_inferences_mixed_caps" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:individual_name.Vitro
+uil-data:individual_name.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "individual name"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "individual_name" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "individual_name" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:thursday.Vitro
+uil-data:thursday.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Thursday"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "thursday" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "thursday" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:alert_icon.Vitro
+uil-data:alert_icon.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Alert Icon"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "alert_icon" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "alert_icon" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:if_blank_page_title_used.Vitro
+uil-data:if_blank_page_title_used.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "If left blank, the page title will be used."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "if_blank_page_title_used" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "if_blank_page_title_used" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:password_reset_pending_email_plain_text.Vitro
+uil-data:password_reset_pending_email_plain_text.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Dear ${userAccount.firstName} ${userAccount.lastName}:\n\nWe have received a request to reset the password for your ${siteName} account\n(${userAccount.emailAddress}).\n\nPlease follow the instructions below to proceed with your password reset.\n\nIf you did not request this new account you can safely ignore this email.\nThis request will expire if not acted upon within 30 days.\n\nPaste the link below into your browser's address bar to reset your password\nusing our secure server.\n\n${passwordLink}\n\nThank you!\n"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "password_reset_pending_email_plain_text" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "password_reset_pending_email_plain_text" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:hide_properties.Vitro
+uil-data:hide_properties.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "hide properties"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "hide_properties" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "hide_properties" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:file_upload_error_file_type_not_recognized.Vitro
+uil-data:file_upload_error_file_type_not_recognized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "File type not recognised"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "file_upload_error_file_type_not_recognized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "file_upload_error_file_type_not_recognized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_no_role.Vitro
+uil-data:error_no_role.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "You must select a role."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_no_role" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_no_role" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:new_account_title.Vitro
+uil-data:new_account_title.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "new account"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "new_account_title" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "new_account_title" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:file_upload_no_allowed_media.Vitro
+uil-data:file_upload_no_allowed_media.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "No allowed media types defined in runtime.properties"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "file_upload_no_allowed_media" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "file_upload_no_allowed_media" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:property_groups.Vitro
+uil-data:property_groups.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Property groups"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "property_groups" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "property_groups" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:startup_trace.Vitro
+uil-data:startup_trace.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Startup trace"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "startup_trace" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "startup_trace" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:search_accounts_button.Vitro
+uil-data:search_accounts_button.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Search accounts"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "search_accounts_button" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "search_accounts_button" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:operation_unsuccessful.Vitro
+uil-data:operation_unsuccessful.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "The operation was unsuccessful. Full details can be found in the system log."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "operation_unsuccessful" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "operation_unsuccessful" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:submit_button.Vitro
+uil-data:submit_button.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Submit"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "submit_button" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "submit_button" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:page_uri_missing.Vitro
+uil-data:page_uri_missing.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "No page URI specified"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "page_uri_missing" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "page_uri_missing" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_no_email_address.Vitro
+uil-data:error_no_email_address.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Please enter your email address."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_no_email_address" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_no_email_address" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:controls.Vitro
+uil-data:controls.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Controls"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "controls" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "controls" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:fruit.Vitro
+uil-data:fruit.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Fruit"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "fruit" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "fruit" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:admin_panel.Vitro
+uil-data:admin_panel.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Admin Panel"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "admin_panel" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "admin_panel" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:the_range_class_does_not_exist.Vitro
+uil-data:the_range_class_does_not_exist.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "The range class for this property does not exist in the system."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "the_range_class_does_not_exist" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "the_range_class_does_not_exist" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:reset_your_password.Vitro
+uil-data:reset_your_password.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Reset your Password"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "reset_your_password" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "reset_your_password" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:advanced_search_tip_two.Vitro
+uil-data:advanced_search_tip_two.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "\"NOT\" can help limit searches -- e.g., <i>climate</i> NOT <i>change</i>."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "advanced_search_tip_two" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "advanced_search_tip_two" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:save_new_page.Vitro
+uil-data:save_new_page.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Save new page"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "save_new_page" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "save_new_page" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:book_title.Vitro
+uil-data:book_title.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Book Title:"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "book_title" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "book_title" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:view_content_index.Vitro
+uil-data:view_content_index.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "View an outline of the content in this site"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "view_content_index" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "view_content_index" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:or_create_new_one.Vitro
+uil-data:or_create_new_one.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "or create a new one."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "or_create_new_one" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "or_create_new_one" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:remove_selection.Vitro
+uil-data:remove_selection.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Remove selection"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "remove_selection" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "remove_selection" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:cardinality.Vitro
+uil-data:cardinality.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "cardinality"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "cardinality" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "cardinality" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:apostrophe_not_allowed.Vitro
+uil-data:apostrophe_not_allowed.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "The variable name should not have an apostrophe."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "apostrophe_not_allowed" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "apostrophe_not_allowed" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:confirm_menu_item_delete.Vitro
+uil-data:confirm_menu_item_delete.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Are you sure you want to remove"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "confirm_menu_item_delete" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "confirm_menu_item_delete" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:work_level.Vitro
+uil-data:work_level.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Work level"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "work_level" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "work_level" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:acct_created_external_only_email_html_text.Vitro
+uil-data:acct_created_external_only_email_html_text.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "<p>\n ${userAccount.firstName} ${userAccount.lastName}\n </p>\n\n <p>\n <strong>Congratulations!</strong>\n </p>\n\n <p>\n We have created your new VIVO account associated with ${userAccount.emailAddress}.\n </p>\n\n <p>\n Thanks!\n </p>"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "acct_created_external_only_email_html_text" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "acct_created_external_only_email_html_text" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:friday.Vitro
+uil-data:friday.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Friday"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "friday" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "friday" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:return_to_the.Vitro
+uil-data:return_to_the.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Return to the"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "return_to_the" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "return_to_the" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:sparql_query.Vitro
+uil-data:sparql_query.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "SPARQL query"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "sparql_query" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "sparql_query" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:myAccount_confirm_changes.Vitro
+uil-data:myAccount_confirm_changes.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Your changes have been saved."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "myAccount_confirm_changes" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "myAccount_confirm_changes" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:to.Vitro
+uil-data:to.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "to"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "to" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "to" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:login_to_manage_site.Vitro
+uil-data:login_to_manage_site.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "log in to manage this site"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "login_to_manage_site" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "login_to_manage_site" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:a_classgroup.Vitro
+uil-data:a_classgroup.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "a class group"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "a_classgroup" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "a_classgroup" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:upload_page_title.Vitro
+uil-data:upload_page_title.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Upload image"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "upload_page_title" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "upload_page_title" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_existing_collaborator.Vitro
+uil-data:select_existing_collaborator.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Select an existing Collaborator for {0}"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_existing_collaborator" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_existing_collaborator" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:label.dateTimeWithPrecision.day_capitalized.Vitro
+uil-data:label.dateTimeWithPrecision.day_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Day"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "label.dateTimeWithPrecision.day_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "label.dateTimeWithPrecision.day_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:login_button.Vitro
+uil-data:login_button.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Log in"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "login_button" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "login_button" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:internal_login.Vitro
+uil-data:internal_login.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Internal Login"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "internal_login" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "internal_login" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_occurred.Vitro
+uil-data:error_occurred.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "An error occurred on the VIVO site"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_occurred" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_occurred" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:advanced_search_tip_four.Vitro
+uil-data:advanced_search_tip_four.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Close word variations will also be found -- e.g., <i>sequence</i> matches <i>sequences</i> and <i>sequencing</i>."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "advanced_search_tip_four" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "advanced_search_tip_four" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:updated_account_title.Vitro
+uil-data:updated_account_title.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "updated account"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "updated_account_title" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "updated_account_title" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:year_month_day.Vitro
+uil-data:year_month_day.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Invalid entry. Please enter a Year, Month and Day."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "year_month_day" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "year_month_day" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:log_out.Vitro
+uil-data:log_out.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Log out"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "log_out" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "log_out" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:application_error_email_plain_text.Vitro
+uil-data:application_error_email_plain_text.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "An error occurred on your ${siteName!} web site at ${datetime!}\n\nRequested url: ${requestedUrl!}\n\n<#if errorMessage?has_content>\n Error message: ${errorMessage!}\n</#if>\n\nStack trace (full trace available in the log):\n${stackTrace!}\n\n<#if cause?has_content>\nCaused by:\n${cause!}\n</#if>"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "application_error_email_plain_text" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "application_error_email_plain_text" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_vclass_uri.Vitro
+uil-data:select_vclass_uri.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Select VClass"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_vclass_uri" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_vclass_uri" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:custom_template_requiring_content.Vitro
+uil-data:custom_template_requiring_content.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Custom template requiring content"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "custom_template_requiring_content" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "custom_template_requiring_content" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:file_upload_error_uri_not_exists.Vitro
+uil-data:file_upload_error_uri_not_exists.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Uri {0} doesn't exist."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "file_upload_error_uri_not_exists" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "file_upload_error_uri_not_exists" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:external_id_not_provided.Vitro
+uil-data:external_id_not_provided.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Login failed - External ID is not found."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "external_id_not_provided" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "external_id_not_provided" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:imageUpload.errorBadMultipartRequest.Vitro
+uil-data:imageUpload.errorBadMultipartRequest.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Failed to parse the multi-part request for uploading an image."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "imageUpload.errorBadMultipartRequest" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "imageUpload.errorBadMultipartRequest" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:view_all_accounts.Vitro
+uil-data:view_all_accounts.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "View all accounts"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "view_all_accounts" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "view_all_accounts" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:file_upload_file.Vitro
+uil-data:file_upload_file.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "file"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "file_upload_file" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "file_upload_file" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:search_failed.Vitro
+uil-data:search_failed.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Search failed."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "search_failed" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "search_failed" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:minimum_hour.Vitro
+uil-data:minimum_hour.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Invalid entry. Please specify at least an Hour."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "minimum_hour" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "minimum_hour" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:faux_property_alpha.Vitro
+uil-data:faux_property_alpha.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "faux properties alphabetically"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "faux_property_alpha" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "faux_property_alpha" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:info_icon.Vitro
+uil-data:info_icon.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "info icon"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "info_icon" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "info_icon" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:save_button.Vitro
+uil-data:save_button.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Save"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "save_button" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "save_button" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:who_can_edit_profile.Vitro
+uil-data:who_can_edit_profile.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Who can edit my profile"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "who_can_edit_profile" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "who_can_edit_profile" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:add_an_entry_to.Vitro
+uil-data:add_an_entry_to.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Add an entry of type"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "add_an_entry_to" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "add_an_entry_to" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:page_not_found_msg.Vitro
+uil-data:page_not_found_msg.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "The page was not found in the system."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "page_not_found_msg" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "page_not_found_msg" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:no_content_in_system.Vitro
+uil-data:no_content_in_system.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "There is currently no {0} content in the system"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "no_content_in_system" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "no_content_in_system" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:rdf.Vitro
+uil-data:rdf.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "RDF"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "rdf" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "rdf" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:datetime_year_required.Vitro
+uil-data:datetime_year_required.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Date/time intervals must begin with a year. Enter either a Start Year, an End Year or both."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "datetime_year_required" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "datetime_year_required" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:external_auth_name.Vitro
+uil-data:external_auth_name.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "external authentication name"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "external_auth_name" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "external_auth_name" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:external_login_failed.Vitro
+uil-data:external_login_failed.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "External login failed"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "external_login_failed" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "external_login_failed" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:label.dateTimeWithPrecision.seconds_capitalized.Vitro
+uil-data:label.dateTimeWithPrecision.seconds_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Seconds"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "label.dateTimeWithPrecision.seconds_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "label.dateTimeWithPrecision.seconds_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:custom_template.Vitro
+uil-data:custom_template.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Custom Template"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "custom_template" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "custom_template" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:associated_profile_label.Vitro
+uil-data:associated_profile_label.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Associated profile:"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "associated_profile_label" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "associated_profile_label" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:page_not_found.Vitro
+uil-data:page_not_found.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Page Not Found"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "page_not_found" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "page_not_found" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_existing_last_name.Vitro
+uil-data:select_existing_last_name.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Select an existing last name"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_existing_last_name" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_existing_last_name" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:title_capitalized.Vitro
+uil-data:title_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Title"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "title_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "title_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:file_upload_error_no_action.Vitro
+uil-data:file_upload_error_no_action.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "No action specified"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "file_upload_error_no_action" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "file_upload_error_no_action" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:change_entry_for.Vitro
+uil-data:change_entry_for.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Change entry for:"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "change_entry_for" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "change_entry_for" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:cause.Vitro
+uil-data:cause.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Cause:"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "cause" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "cause" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:may_edit.Vitro
+uil-data:may_edit.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "May edit"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "may_edit" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "may_edit" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:properties.Vitro
+uil-data:properties.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "properties"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "properties" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "properties" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:add_new.Vitro
+uil-data:add_new.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Add new"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "add_new" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "add_new" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:apples.Vitro
+uil-data:apples.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Apples"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "apples" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "apples" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:tuesday.Vitro
+uil-data:tuesday.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Tuesday"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "tuesday" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "tuesday" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:email_changed_subject.Vitro
+uil-data:email_changed_subject.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Your {0} email account has been changed."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "email_changed_subject" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "email_changed_subject" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:site_admin.Vitro
+uil-data:site_admin.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Site Admin"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "site_admin" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "site_admin" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:code_processing_error.Vitro
+uil-data:code_processing_error.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "An error has occurred and the code for processing this content is missing a component. Please contact the administrator."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "code_processing_error" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "code_processing_error" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:base_property_capitalized.Vitro
+uil-data:base_property_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Base Property"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "base_property_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "base_property_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:username.Vitro
+uil-data:username.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Username"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "username" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "username" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:to_order_menu_items.Vitro
+uil-data:to_order_menu_items.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "to set the order of menu items."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "to_order_menu_items" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "to_order_menu_items" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:none.Vitro
+uil-data:none.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "none"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "none" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "none" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:classes_capitalized.Vitro
+uil-data:classes_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Classes"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "classes_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "classes_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:cancel_link.Vitro
+uil-data:cancel_link.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Cancel"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "cancel_link" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "cancel_link" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:send_feedback_questions.Vitro
+uil-data:send_feedback_questions.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Send us your feedback or ask a question"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "send_feedback_questions" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "send_feedback_questions" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:account_already_activated.Vitro
+uil-data:account_already_activated.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "The account for {0} has already been activated."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "account_already_activated" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "account_already_activated" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:page.Vitro
+uil-data:page.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "page"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "page" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "page" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:type_more_characters.Vitro
+uil-data:type_more_characters.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "type more characters"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "type_more_characters" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "type_more_characters" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:search_tips_header.Vitro
+uil-data:search_tips_header.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Search Tips"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "search_tips_header" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "search_tips_header" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:data_not_past_msg.Vitro
+uil-data:data_not_past_msg.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Please enter a future target date for publication (past dates are invalid)."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "data_not_past_msg" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "data_not_past_msg" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_associated_profile.Vitro
+uil-data:select_associated_profile.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Select the associated profile"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_associated_profile" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_associated_profile" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:edit_capitalized.Vitro
+uil-data:edit_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Edit"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "edit_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "edit_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:site_name.Vitro
+uil-data:site_name.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "site name"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "site_name" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "site_name" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:replace_photo.Vitro
+uil-data:replace_photo.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Replace Photo"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "replace_photo" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "replace_photo" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:rebuild_button.Vitro
+uil-data:rebuild_button.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Rebuild"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "rebuild_button" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "rebuild_button" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:numbers.Vitro
+uil-data:numbers.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Numbers"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "numbers" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "numbers" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:acct_created_external_only_email_plain_text.Vitro
+uil-data:acct_created_external_only_email_plain_text.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "${userAccount.firstName} ${userAccount.lastName}\n\nCongratulations!\n\nWe have created your new VIVO account associated with\n${userAccount.emailAddress}.\n\nThanks!\n"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "acct_created_external_only_email_plain_text" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "acct_created_external_only_email_plain_text" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:auth_id_explanation.Vitro
+uil-data:auth_id_explanation.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Can be used to associate the account with the user's profile via the matching property."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "auth_id_explanation" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "auth_id_explanation" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:support.Vitro
+uil-data:support.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Support"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "support" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "support" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:enter_search_term.Vitro
+uil-data:enter_search_term.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Please enter a search term."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "enter_search_term" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "enter_search_term" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:feedback_thanks_heading.Vitro
+uil-data:feedback_thanks_heading.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Thank you for your feedback"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "feedback_thanks_heading" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "feedback_thanks_heading" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:updated_account_notification.Vitro
+uil-data:updated_account_notification.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "A confirmation email has been sent to {0} with instructions for resetting a password. The password will not be reset until the user follows the link provided in this email."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "updated_account_notification" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "updated_account_notification" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:menu_ordering_mixed_caps.Vitro
+uil-data:menu_ordering_mixed_caps.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Menu ordering"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "menu_ordering_mixed_caps" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "menu_ordering_mixed_caps" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:expand_all.Vitro
+uil-data:expand_all.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "expand all"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "expand_all" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "expand_all" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:confirm_password_capitalized.Vitro
+uil-data:confirm_password_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Confirm Password"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "confirm_password_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "confirm_password_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:uri_not_defined.Vitro
+uil-data:uri_not_defined.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "URI for page not defined"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "uri_not_defined" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "uri_not_defined" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:a_link.Vitro
+uil-data:a_link.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "a link"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "a_link" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "a_link" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:view_list_of_labels.Vitro
+uil-data:view_list_of_labels.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "view list of labels"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "view_list_of_labels" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "view_list_of_labels" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:not_logged_in.Vitro
+uil-data:not_logged_in.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Not logged in"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "not_logged_in" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "not_logged_in" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:page_public_permission_option.Vitro
+uil-data:page_public_permission_option.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Anyone can view this page"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "page_public_permission_option" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "page_public_permission_option" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:file_upload_error_uri_not_given.Vitro
+uil-data:file_upload_error_uri_not_given.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "No {0} uri was given."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "file_upload_error_uri_not_given" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "file_upload_error_uri_not_given" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:file_upload_heading.Vitro
+uil-data:file_upload_heading.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "File uploading"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "file_upload_heading" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "file_upload_heading" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:save_this_content.Vitro
+uil-data:save_this_content.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Save this content"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "save_this_content" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "save_this_content" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:data.Vitro
+uil-data:data.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "data"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "data" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "data" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_incorrect_credentials.Vitro
+uil-data:error_incorrect_credentials.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "The email or password you entered is incorrect."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_incorrect_credentials" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_incorrect_credentials" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:start_url_with_slash.Vitro
+uil-data:start_url_with_slash.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "The pretty URL must begin with a leading forward slash"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "start_url_with_slash" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "start_url_with_slash" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:february.Vitro
+uil-data:february.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "February"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "february" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "february" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:delete_entry.Vitro
+uil-data:delete_entry.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "delete this entry"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "delete_entry" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "delete_entry" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:imageUpload.errorFormFieldMissing.Vitro
+uil-data:imageUpload.errorFormFieldMissing.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "The form did not contain a ''{0}'' field.\""@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "imageUpload.errorFormFieldMissing" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "imageUpload.errorFormFieldMissing" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:formatted_date_time.Vitro
+uil-data:formatted_date_time.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Formatted date-time"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "formatted_date_time" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "formatted_date_time" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:imageUpload.errorUnknown.Vitro
+uil-data:imageUpload.errorUnknown.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Sorry, we were unable to process the photo you provided. Please try another photo."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "imageUpload.errorUnknown" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "imageUpload.errorUnknown" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:password_reset_pending_email_html_text.Vitro
+uil-data:password_reset_pending_email_html_text.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "<p>\n Dear ${userAccount.firstName} ${userAccount.lastName}:\n </p>\n\n <p>\n We have received a request to reset the password for your ${siteName} account (${userAccount.emailAddress}).\n </p>\n\n <p>\n Please follow the instructions below to proceed with your password reset.\n </p>\n\n <p>\n If you did not request this new account you can safely ignore this email.\n This request will expire if not acted upon within 30 days.\n </p>\n\n <p>\n Click on the link below or paste it into your browser's address bar to reset your password\n using our secure server.\n </p>\n\n <p><a href=\"${passwordLink}\" title=\"password\">${passwordLink}</a> </p>\n\n <p>Thank you!</p>"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "password_reset_pending_email_html_text" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "password_reset_pending_email_html_text" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:ontology_editor.Vitro
+uil-data:ontology_editor.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ontology Editor"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "ontology_editor" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "ontology_editor" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:from_capitalized.Vitro
+uil-data:from_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "From"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "from_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "from_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:logged_out.Vitro
+uil-data:logged_out.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "You have logged out."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "logged_out" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "logged_out" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:search_for.Vitro
+uil-data:search_for.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Search for ''{0}''"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "search_for" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "search_for" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:other.Vitro
+uil-data:other.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "other"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "other" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "other" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:supply_variable_name.Vitro
+uil-data:supply_variable_name.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "You must supply a variable to save HTML content."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "supply_variable_name" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "supply_variable_name" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:remove_restrictions.Vitro
+uil-data:remove_restrictions.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Remove Restrictions"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "remove_restrictions" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "remove_restrictions" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:variable_name_all_caps.Vitro
+uil-data:variable_name_all_caps.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Variable Name"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "variable_name_all_caps" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "variable_name_all_caps" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:levels.Vitro
+uil-data:levels.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Levels"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "levels" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "levels" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:range_class.Vitro
+uil-data:range_class.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Range Class"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "range_class" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "range_class" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:type_more_chars.Vitro
+uil-data:type_more_chars.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "type more character"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "type_more_chars" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "type_more_chars" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:advanced_data_tools.Vitro
+uil-data:advanced_data_tools.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Advanced Data Tools"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "advanced_data_tools" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "advanced_data_tools" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:current_date.Vitro
+uil-data:current_date.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Current date:"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "current_date" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "current_date" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:since_elapsed_time_est_total.Vitro
+uil-data:since_elapsed_time_est_total.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "since {0}, elapsed time {1}, estimated total time {2}"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "since_elapsed_time_est_total" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "since_elapsed_time_est_total" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:close.Vitro
+uil-data:close.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "close"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "close" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "close" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:change_selection.Vitro
+uil-data:change_selection.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "change selection"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "change_selection" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "change_selection" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:copyright.Vitro
+uil-data:copyright.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "copyright"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "copyright" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "copyright" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_page_content_type.Vitro
+uil-data:select_page_content_type.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Select content type for the associated page"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_page_content_type" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_page_content_type" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:zoo_one.Vitro
+uil-data:zoo_one.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Zoo 1"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "zoo_one" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "zoo_one" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:cancel_title.Vitro
+uil-data:cancel_title.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "cancel"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "cancel_title" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "cancel_title" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:add_individual_of_class.Vitro
+uil-data:add_individual_of_class.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Add individual of this class"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "add_individual_of_class" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "add_individual_of_class" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:label.dateTimeWithPrecision.year_capitalized.Vitro
+uil-data:label.dateTimeWithPrecision.year_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Year"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "label.dateTimeWithPrecision.year_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "label.dateTimeWithPrecision.year_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:relate_editors_profiles.Vitro
+uil-data:relate_editors_profiles.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Relate profile editors and profiles"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "relate_editors_profiles" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "relate_editors_profiles" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:vitro_bullet_four.Vitro
+uil-data:vitro_bullet_four.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Search your data"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "vitro_bullet_four" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "vitro_bullet_four" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:save_changes.Vitro
+uil-data:save_changes.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Save changes"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "save_changes" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "save_changes" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:cant_activate_while_logged_in.Vitro
+uil-data:cant_activate_while_logged_in.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "You may not activate the account for {0} while you are logged in as {1}. Please log out and try again."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "cant_activate_while_logged_in" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "cant_activate_while_logged_in" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:next_capitalized.Vitro
+uil-data:next_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Next"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "next_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "next_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:end_capitalized.Vitro
+uil-data:end_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "End"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "end_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "end_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:custom_template_containing_content.Vitro
+uil-data:custom_template_containing_content.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Custom template containing all content"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "custom_template_containing_content" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "custom_template_containing_content" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:name_of.Vitro
+uil-data:name_of.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "name_of" ;
-        prop:hasPackage  "Vitro-languages" .
+        rdf:type         uil:UILabel ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "name_of" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:content_type.Vitro
+uil-data:content_type.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Content Type"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "content_type" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "content_type" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:add_label.Vitro
+uil-data:add_label.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Add Label"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "add_label" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "add_label" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:activate_developer_panel_mixed_caps.Vitro
+uil-data:activate_developer_panel_mixed_caps.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Activate developer panel"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "activate_developer_panel_mixed_caps" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "activate_developer_panel_mixed_caps" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:reset_search_index.Vitro
+uil-data:reset_search_index.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Reset the search index and re-populate it."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "reset_search_index" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "reset_search_index" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:please_provide_contact_information.Vitro
+uil-data:please_provide_contact_information.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Please provide your contact information to finish creating your account."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "please_provide_contact_information" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "please_provide_contact_information" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:continued.Vitro
+uil-data:continued.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "cont'd"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "continued" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "continued" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_no_email.Vitro
+uil-data:error_no_email.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "You must supply an email address."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_no_email" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_no_email" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_no_last_name.Vitro
+uil-data:error_no_last_name.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "You must supply a last name."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_no_last_name" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_no_last_name" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:december.Vitro
+uil-data:december.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "December"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "december" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "december" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:multiple_content_default_template_error.Vitro
+uil-data:multiple_content_default_template_error.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "With multiple content types, you must specify a custom template."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "multiple_content_default_template_error" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "multiple_content_default_template_error" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:all_classes.Vitro
+uil-data:all_classes.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "All Classes"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "all_classes" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "all_classes" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:viewing_page.Vitro
+uil-data:viewing_page.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Likely viewing page"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "viewing_page" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "viewing_page" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:individual_not_found_msg.Vitro
+uil-data:individual_not_found_msg.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "The individual was not found in the system."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "individual_not_found_msg" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "individual_not_found_msg" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:setup_navigation_menu.Vitro
+uil-data:setup_navigation_menu.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Setup the primary navigation menu for your website"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "setup_navigation_menu" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "setup_navigation_menu" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:external_id_already_in_use.Vitro
+uil-data:external_id_already_in_use.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "User account already exists for ''{0}''"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "external_id_already_in_use" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "external_id_already_in_use" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:ascending_order.Vitro
+uil-data:ascending_order.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "ascending order"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "ascending_order" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "ascending_order" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:browse_all_content.Vitro
+uil-data:browse_all_content.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "browse all content"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "browse_all_content" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "browse_all_content" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:begin_with_slash_no_example.Vitro
+uil-data:begin_with_slash_no_example.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Must begin with a leading forward slash: /"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "begin_with_slash_no_example" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "begin_with_slash_no_example" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_occurred_at.Vitro
+uil-data:error_occurred_at.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "An error occurred on your VIVO site at {0}."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_occurred_at" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_occurred_at" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_editors.Vitro
+uil-data:select_editors.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Select editors"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_editors" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_editors" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:supply_html.Vitro
+uil-data:supply_html.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "You must supply some HTML or text."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "supply_html" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "supply_html" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:slash_example.Vitro
+uil-data:slash_example.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "(e.g., /people)"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "slash_example" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "slash_example" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:property_hierarchy.Vitro
+uil-data:property_hierarchy.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Property Hierarchy"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "property_hierarchy" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "property_hierarchy" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:try_rebuilding_index.Vitro
+uil-data:try_rebuilding_index.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Try rebuilding the search index"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "try_rebuilding_index" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "try_rebuilding_index" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_in_search_request.Vitro
+uil-data:error_in_search_request.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "The search request contained errors."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_in_search_request" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_in_search_request" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:first_time_login.Vitro
+uil-data:first_time_login.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "First time log in"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "first_time_login" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "first_time_login" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:first_time_external_email_plain_text.Vitro
+uil-data:first_time_external_email_plain_text.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "${userAccount.firstName} ${userAccount.lastName}\n\nCongratulations!\n\nWe have created your new VIVO account associated with\n${userAccount.emailAddress}.\n\nThanks!"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "first_time_external_email_plain_text" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "first_time_external_email_plain_text" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:faux_property_by_base.Vitro
+uil-data:faux_property_by_base.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "faux properties by base property"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "faux_property_by_base" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "faux_property_by_base" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:alt_thumbnail_photo.Vitro
+uil-data:alt_thumbnail_photo.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Individual photo"@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "alt_thumbnail_photo" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "alt_thumbnail_photo" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:no_individual_associated_with_id.Vitro
+uil-data:no_individual_associated_with_id.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "For some reason, there is no individual in VIVO that is associated with your Net ID. Perhaps you should contact your VIVO administrator."@en-US ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "no_individual_associated_with_id" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "no_individual_associated_with_id" ;
+        uil:hasPackage  "Vitro-languages" .

--- a/home/src/main/resources/rdf/i18n/es/interface-i18n/firsttime/vitro_UiLabel.ttl
+++ b/home/src/main/resources/rdf/i18n/es/interface-i18n/firsttime/vitro_UiLabel.ttl
@@ -1,6266 +1,6266 @@
 @prefix owl:   <http://www.w3.org/2002/07/owl#> .
 @prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
-@prefix prop-data: <http://vivoweb.org/ontology/core/properties/individual#> .
-@prefix prop:  <http://vivoweb.org/ontology/core/properties/vocabulary#> .
+@prefix uil-data: <http://vivoweb.org/ontology/vitro/ui-label/individual#> .
+@prefix uil:  <http://vivoweb.org/ontology/vitro/ui-label/vocabulary#> .
 @prefix xsd:   <http://www.w3.org/2001/XMLSchema#> .
 @prefix skos:  <http://www.w3.org/2004/02/skos/core#> .
 @prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> .
 
-prop-data:collapse_all.Vitro
+uil-data:collapse_all.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Contraer todo"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "collapse_all" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "collapse_all" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:no_password_supplied.Vitro
+uil-data:no_password_supplied.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ninguna contraseña proporcionada."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "no_password_supplied" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "no_password_supplied" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:crop_page_title.Vitro
+uil-data:crop_page_title.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Cortar imagen"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "crop_page_title" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "crop_page_title" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:label.dateTimeWithPrecision.month_capitalized.Vitro
+uil-data:label.dateTimeWithPrecision.month_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Mes"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "label.dateTimeWithPrecision.month_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "label.dateTimeWithPrecision.month_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:advanced_search_tip_three.Vitro
+uil-data:advanced_search_tip_three.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Las búsquedas de frases se pueden combinar con operadores booleanos -- por ejemplo, \"<i>cambio climático</i>\" OR \"<i>calentamiento global</i>\"."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "advanced_search_tip_three" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "advanced_search_tip_three" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:file_upload_error_file_size_is_zero.Vitro
+uil-data:file_upload_error_file_size_is_zero.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "file_upload_error_file_size_is_zero" ;
-        prop:hasPackage  "Vitro-languages" .
+        rdf:type         uil:UILabel ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "file_upload_error_file_size_is_zero" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:delete_entry_capitalized.Vitro
+uil-data:delete_entry_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Borrar esta entrada?"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "delete_entry_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "delete_entry_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:remove_selection_title.Vitro
+uil-data:remove_selection_title.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "eliminar selección"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "remove_selection_title" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "remove_selection_title" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:powered_by.Vitro
+uil-data:powered_by.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Desarrollado por"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "powered_by" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "powered_by" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:accounts_search_results.Vitro
+uil-data:accounts_search_results.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Resultados de la búsqueda"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "accounts_search_results" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "accounts_search_results" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:search_individual_results.Vitro
+uil-data:search_individual_results.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Individuos de la clase de búsqueda"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "search_individual_results" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "search_individual_results" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:vclassAlpha_not_implemented.Vitro
+uil-data:vclassAlpha_not_implemented.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "vclassAlpha aún no está implementado."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "vclassAlpha_not_implemented" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "vclassAlpha_not_implemented" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_an_existing.Vitro
+uil-data:select_an_existing.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Seleccione un nombre existente de"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_an_existing" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_an_existing" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:no_appropriate_entry.Vitro
+uil-data:no_appropriate_entry.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Si no encuentra la entrada correspondiente en la lista de selección anterior"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "no_appropriate_entry" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "no_appropriate_entry" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:descending_order.Vitro
+uil-data:descending_order.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Orden descendente"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "descending_order" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "descending_order" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:label.dateTimeWithPrecision.hour_capitalized.Vitro
+uil-data:label.dateTimeWithPrecision.hour_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Hora"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "label.dateTimeWithPrecision.hour_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "label.dateTimeWithPrecision.hour_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:add_remove_rdf.Vitro
+uil-data:add_remove_rdf.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Añadir / Quitar datos RDF"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "add_remove_rdf" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "add_remove_rdf" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:account.Vitro
+uil-data:account.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "cuenta"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "account" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "account" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:label.Vitro
+uil-data:label.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "etiqueta"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "label" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "label" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:no_classes_to_select.Vitro
+uil-data:no_classes_to_select.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "No hay clases en el sistema del cual seleccionar."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "no_classes_to_select" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "no_classes_to_select" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:page_curator_permission_option.Vitro
+uil-data:page_curator_permission_option.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Curadores y superiores pueden ver esta página"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "page_curator_permission_option" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "page_curator_permission_option" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:individuals_in_system.Vitro
+uil-data:individuals_in_system.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "individuos en el sistema."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "individuals_in_system" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "individuals_in_system" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:search_help.Vitro
+uil-data:search_help.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "buscar ayuda"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "search_help" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "search_help" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:there_are_no_entries_starting_with.Vitro
+uil-data:there_are_no_entries_starting_with.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "No hay entradas que comiencen con"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "there_are_no_entries_starting_with" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "there_are_no_entries_starting_with" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:user_accounts_link.Vitro
+uil-data:user_accounts_link.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Cuentas de usuario"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "user_accounts_link" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "user_accounts_link" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:ontology_capitalized.Vitro
+uil-data:ontology_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ontología"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "ontology_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "ontology_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:change_password_to_login.Vitro
+uil-data:change_password_to_login.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Cambiar contraseña para iniciar sesión"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "change_password_to_login" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "change_password_to_login" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:a_menu_page.Vitro
+uil-data:a_menu_page.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Esta es una página del menú principal"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "a_menu_page" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "a_menu_page" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:comments.Vitro
+uil-data:comments.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Comentarios"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "comments" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "comments" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:add_new_of_type.Vitro
+uil-data:add_new_of_type.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Añadir un nuevo elemento de este tipo"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "add_new_of_type" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "add_new_of_type" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:reset_password_note.Vitro
+uil-data:reset_password_note.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Nota: Las instrucciones para restablecer la contraseña serán enviados por correo electrónico a la dirección indicada anteriormente. La contraseña no se restablecerá hasta que el usuario acceda al enlace que aparece en este correo electrónico."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "reset_password_note" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "reset_password_note" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:startup_status.Vitro
+uil-data:startup_status.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Estatus de inicio"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "startup_status" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "startup_status" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:no_results_returned.Vitro
+uil-data:no_results_returned.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "No se devolvieron resultados."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "no_results_returned" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "no_results_returned" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:submit_add_new_account.Vitro
+uil-data:submit_add_new_account.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Añadir nueva cuenta"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "submit_add_new_account" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "submit_add_new_account" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:password_reset_complete_subject.Vitro
+uil-data:password_reset_complete_subject.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Su {0} contraseña ha sido cambiada."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "password_reset_complete_subject" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "password_reset_complete_subject" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:file_upload_error_supported_actions.Vitro
+uil-data:file_upload_error_supported_actions.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "file_upload_error_supported_actions" ;
-        prop:hasPackage  "Vitro-languages" .
+        rdf:type         uil:UILabel ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "file_upload_error_supported_actions" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:create_classgroup.Vitro
+uil-data:create_classgroup.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Crear un grupo de clase"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "create_classgroup" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "create_classgroup" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:accounts.Vitro
+uil-data:accounts.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "cuentas"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "accounts" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "accounts" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:page_not_created_msg.Vitro
+uil-data:page_not_created_msg.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Hubo un error al crear la página, verifique los registros."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "page_not_created_msg" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "page_not_created_msg" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:login_count.Vitro
+uil-data:login_count.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Cuenta de acceso"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "login_count" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "login_count" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:not_expected_results.Vitro
+uil-data:not_expected_results.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "¿No son los resultados que esperaba?"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "not_expected_results" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "not_expected_results" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:paging_link_more.Vitro
+uil-data:paging_link_more.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Más ..."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "paging_link_more" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "paging_link_more" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:sparql_query_description_1.Vitro
+uil-data:sparql_query_description_1.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "# and (if available) their labels"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "sparql_query_description_1" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "sparql_query_description_1" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:acct_created_email_plain_text.Vitro
+uil-data:acct_created_email_plain_text.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "${userAccount.firstName} ${userAccount.lastName}\n\nEnhorabuena!\n\nHemos creado la nueva cuenta en ${siteName},\nasociada con ${userAccount.emailAddress}.\n\nSi no has solicitado esta nueva cuenta puedes ignorar este mensaje.\nEsta solicitud caducará si no se activa durante los próximos 30 días.\n\nPega el siguiente enlace en la barra de direcciones de tu navegador para\ncrear la contraseña de tu nueva cuenta usando nuestro servidor seguro.\n\n${passwordLink}\n\n¡Gracias!"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "acct_created_email_plain_text" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "acct_created_email_plain_text" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:all_rights_reserved.Vitro
+uil-data:all_rights_reserved.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Todos los derechos reservados."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "all_rights_reserved" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "all_rights_reserved" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:submit_save.Vitro
+uil-data:submit_save.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Guardar foto"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "submit_save" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "submit_save" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:associate_classes_with_group.Vitro
+uil-data:associate_classes_with_group.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "y las clases asociadas con el grupo creado."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "associate_classes_with_group" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "associate_classes_with_group" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:about.Vitro
+uil-data:about.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Acerca de"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "about" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "about" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:activate_developer_panel.Vitro
+uil-data:activate_developer_panel.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Activar el panel desarrollador"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "activate_developer_panel" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "activate_developer_panel" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:since.Vitro
+uil-data:since.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Desde"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "since" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "since" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:limit_to.Vitro
+uil-data:limit_to.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Limitar a"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "limit_to" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "limit_to" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:password_created_subject.Vitro
+uil-data:password_created_subject.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Su {0} contraseña ha sido creada con éxito."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "password_created_subject" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "password_created_subject" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:vitro_description.Vitro
+uil-data:vitro_description.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Vitro es una ontología basada en la web de propósito general y editor de instancia pública con la navegación personalizable. Vitro es una aplicación web Java que se ejecuta en un contenedor de servlets Tomcat."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "vitro_description" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "vitro_description" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:logins_disabled_for_maintenance.Vitro
+uil-data:logins_disabled_for_maintenance.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Los inicios de sesión de usuario están desactivados temporalmente mientras se le da mantenimiento al sistema."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "logins_disabled_for_maintenance" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "logins_disabled_for_maintenance" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:current_time.Vitro
+uil-data:current_time.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Hora actual:"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "current_time" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "current_time" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:release.Vitro
+uil-data:release.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "liberar"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "release" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "release" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:authenticator.Vitro
+uil-data:authenticator.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Autenticador"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "authenticator" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "authenticator" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:preparing_to_rebuild_index.Vitro
+uil-data:preparing_to_rebuild_index.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Preparación para reconstruir el índice de búsqueda."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "preparing_to_rebuild_index" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "preparing_to_rebuild_index" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:login_status.Vitro
+uil-data:login_status.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Estatus de conexión:"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "login_status" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "login_status" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:scroll_to_menus.Vitro
+uil-data:scroll_to_menus.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "desplazarse al menú grupo de propiedades"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "scroll_to_menus" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "scroll_to_menus" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:sparql_query_description_0.Vitro
+uil-data:sparql_query_description_0.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "# This example query gets 20 geographic locations"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "sparql_query_description_0" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "sparql_query_description_0" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:delete_button.Vitro
+uil-data:delete_button.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Borrar"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "delete_button" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "delete_button" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:fixed_html.Vitro
+uil-data:fixed_html.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "HTML fijo"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "fixed_html" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "fixed_html" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:you_can.Vitro
+uil-data:you_can.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Usted puede"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "you_can" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "you_can" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:supply_sparql_query.Vitro
+uil-data:supply_sparql_query.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Debe proporcionar una consulta SPARQL."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "supply_sparql_query" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "supply_sparql_query" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:enter_email_password.Vitro
+uil-data:enter_email_password.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Introduzca la dirección de correo electrónico y la contraseña de su cuenta interna de Vitro."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "enter_email_password" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "enter_email_password" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:selected_editors.Vitro
+uil-data:selected_editors.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Editores seleccionados"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "selected_editors" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "selected_editors" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:custom_template_mixed_caps.Vitro
+uil-data:custom_template_mixed_caps.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Plantilla personalizada"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "custom_template_mixed_caps" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "custom_template_mixed_caps" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:animal.Vitro
+uil-data:animal.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Animal:"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "animal" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "animal" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:enter_sparql_query_here.Vitro
+uil-data:enter_sparql_query_here.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Introduzca consulta SPARQL aquí"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "enter_sparql_query_here" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "enter_sparql_query_here" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:recompute_inferences.Vitro
+uil-data:recompute_inferences.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Recalcular inferencias"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "recompute_inferences" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "recompute_inferences" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:restrict_logins.Vitro
+uil-data:restrict_logins.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Restringir inicios de sesión"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "restrict_logins" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "restrict_logins" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:email_address.Vitro
+uil-data:email_address.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Dirección de correo electrónico"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "email_address" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "email_address" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:alt_confirmation.Vitro
+uil-data:alt_confirmation.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Icono de confirmación"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "alt_confirmation" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "alt_confirmation" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:drag_drop_to_reorder_menus.Vitro
+uil-data:drag_drop_to_reorder_menus.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Arrastrar y soltar para cambiar el orden de los elementos de menú"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "drag_drop_to_reorder_menus" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "drag_drop_to_reorder_menus" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:most_recent_update.Vitro
+uil-data:most_recent_update.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "La actualización más reciente fue en"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "most_recent_update" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "most_recent_update" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:delete_link.Vitro
+uil-data:delete_link.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Borrar foto"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "delete_link" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "delete_link" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:check_startup_status.Vitro
+uil-data:check_startup_status.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Compruebe el estatus de la página de inicio y/o registros de Tomcat para obtener más información."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "check_startup_status" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "check_startup_status" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:no_pages_defined.Vitro
+uil-data:no_pages_defined.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "No hay páginas aún definidos."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "no_pages_defined" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "no_pages_defined" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:advanced_search_tip_five.Vitro
+uil-data:advanced_search_tip_five.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Utilice el carácter comodín * para que coincida con una variación aún mayor -- por ejemplo, <i>nano*</i> encuentra también <i>nanotecnología</i> y <i>nanofabricación</i>."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "advanced_search_tip_five" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "advanced_search_tip_five" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_message.Vitro
+uil-data:error_message.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Mensaje de error"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_message" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_message" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:double_quote_note_allowed.Vitro
+uil-data:double_quote_note_allowed.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "El nombre de la variable no debería tener una comilla doble."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "double_quote_note_allowed" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "double_quote_note_allowed" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:crop_page_title_with_name.Vitro
+uil-data:crop_page_title_with_name.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Recortar imagen por {0}"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "crop_page_title_with_name" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "crop_page_title_with_name" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:logins_not_restricted.Vitro
+uil-data:logins_not_restricted.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "El inicio de sesión ya no se encuentra restringido."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "logins_not_restricted" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "logins_not_restricted" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:deleted_accounts.Vitro
+uil-data:deleted_accounts.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Borrado {0} {0, choice, 0#accounts |1#account |1<accounts}."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "deleted_accounts" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "deleted_accounts" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:whole_number.Vitro
+uil-data:whole_number.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Entrada invalida. Ingrese un número entero sin punto decimal o separadores de miles."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "whole_number" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "whole_number" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:edit_account.Vitro
+uil-data:edit_account.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Editar cuenta"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "edit_account" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "edit_account" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:search_tip_two.Vitro
+uil-data:search_tip_two.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Utilice comillas para buscar una frase entera -- por ejemplo, \"<i>el plegamiento de proteínas</i>\"."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "search_tip_two" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "search_tip_two" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:email_capitalized.Vitro
+uil-data:email_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Correo electrónico"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "email_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "email_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:policies.Vitro
+uil-data:policies.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Políticas"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "policies" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "policies" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:failed.Vitro
+uil-data:failed.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "fallo"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "failed" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "failed" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:containers_do_not_pick_up_changes.Vitro
+uil-data:containers_do_not_pick_up_changes.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Los contenedores no recogen cambios en el valor de sus elementos"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "containers_do_not_pick_up_changes" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "containers_do_not_pick_up_changes" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:file_upload_error_media_type_not_allowed.Vitro
+uil-data:file_upload_error_media_type_not_allowed.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "file_upload_error_media_type_not_allowed" ;
-        prop:hasPackage  "Vitro-languages" .
+        rdf:type         uil:UILabel ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "file_upload_error_media_type_not_allowed" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:add_new_classes.Vitro
+uil-data:add_new_classes.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Agregar nueva clase"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "add_new_classes" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "add_new_classes" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:identifier_factories.Vitro
+uil-data:identifier_factories.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Factores de identificación"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "identifier_factories" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "identifier_factories" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:show_subclasses.Vitro
+uil-data:show_subclasses.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "mostrar subclases"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "show_subclasses" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "show_subclasses" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:enter_id_to_login.Vitro
+uil-data:enter_id_to_login.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Introduzca el ID de usuario con el que desea iniciar sesión, o haga clic en Cancelar."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "enter_id_to_login" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "enter_id_to_login" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:upload_heading.Vitro
+uil-data:upload_heading.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Subir foto"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "upload_heading" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "upload_heading" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:warnings_issued.Vitro
+uil-data:warnings_issued.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "{0} surgieron advertencias durante el arranque."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "warnings_issued" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "warnings_issued" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:account_management.Vitro
+uil-data:account_management.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Administración de cuentas"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "account_management" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "account_management" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_content_display.Vitro
+uil-data:select_content_display.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Seleccione el contenido para mostrar"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_content_display" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_content_display" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:account_no_longer_exists.Vitro
+uil-data:account_no_longer_exists.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "La cuenta a la que está tratando de establecer una contraseña, ya no está disponible. Por favor, póngase en contacto con el administrador del sistema."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "account_no_longer_exists" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "account_no_longer_exists" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:page_select_permission.Vitro
+uil-data:page_select_permission.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Seleccione los permisos de página"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "page_select_permission" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "page_select_permission" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:test_for_logged_in_users.Vitro
+uil-data:test_for_logged_in_users.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Este es el widget de pruebas para usuarios registrados."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "test_for_logged_in_users" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "test_for_logged_in_users" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:edit_page.Vitro
+uil-data:edit_page.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Editar {0} Página"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "edit_page" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "edit_page" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:no_match.Vitro
+uil-data:no_match.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "No hay resultados"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "no_match" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "no_match" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:add_new_page.Vitro
+uil-data:add_new_page.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Añadir una nueva página"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "add_new_page" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "add_new_page" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:class_groups.Vitro
+uil-data:class_groups.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Grupo de clases"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "class_groups" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "class_groups" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:password_reset_pending_email_subject.Vitro
+uil-data:password_reset_pending_email_subject.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Solicitud para reestablecer contraseña en ${siteName}"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "password_reset_pending_email_subject" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "password_reset_pending_email_subject" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:manage.Vitro
+uil-data:manage.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Administrar"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "manage" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "manage" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_password_length.Vitro
+uil-data:error_password_length.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "La contraseña debe tener entre {0} y {1} caracteres."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_password_length" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_password_length" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:view_profile_editors.Vitro
+uil-data:view_profile_editors.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ver todos los editores de perfil"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "view_profile_editors" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "view_profile_editors" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:subclasses_capitalized.Vitro
+uil-data:subclasses_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Subclases"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "subclasses_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "subclasses_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:auth_matching_id_label.Vitro
+uil-data:auth_matching_id_label.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Identicador externo / Identificador compatible"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "auth_matching_id_label" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "auth_matching_id_label" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:page_editor_permission_option.Vitro
+uil-data:page_editor_permission_option.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Editores y roles superiores pueden ver esta página"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "page_editor_permission_option" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "page_editor_permission_option" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:delete_page.Vitro
+uil-data:delete_page.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "borrar esta página"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "delete_page" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "delete_page" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:for.Vitro
+uil-data:for.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "para"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "for" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "for" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:manage_list_of_labels.Vitro
+uil-data:manage_list_of_labels.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Administrar la lista de etiquetas"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "manage_list_of_labels" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "manage_list_of_labels" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:content.Vitro
+uil-data:content.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "contenido"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "content" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "content" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:match_by.Vitro
+uil-data:match_by.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "coincidir por {0}"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "match_by" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "match_by" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:alt_preview_crop.Vitro
+uil-data:alt_preview_crop.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Vista previa de la foto recortada"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "alt_preview_crop" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "alt_preview_crop" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:pretty_url.Vitro
+uil-data:pretty_url.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "URL confiable"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "pretty_url" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "pretty_url" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:operation_successful.Vitro
+uil-data:operation_successful.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "La operación se ha realizado correctamente."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "operation_successful" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "operation_successful" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:add_capitalized.Vitro
+uil-data:add_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Agregar"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "add_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "add_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:accounts_per_page.Vitro
+uil-data:accounts_per_page.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "cuentas por página"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "accounts_per_page" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "accounts_per_page" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_editor_and_profile.Vitro
+uil-data:select_editor_and_profile.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Usted debe seleccionar un mínimo de 1 editor y perfil."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_editor_and_profile" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_editor_and_profile" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:request_failed.Vitro
+uil-data:request_failed.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Error en la solicitud. Por favor, póngase en contacto con el administrador del sistema."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "request_failed" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "request_failed" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:from_site_admin_page.Vitro
+uil-data:from_site_admin_page.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "desde la página de administración del sitio."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "from_site_admin_page" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "from_site_admin_page" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:new_password_capitalized.Vitro
+uil-data:new_password_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Nueva contraseña"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "new_password_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "new_password_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:advanced_search_tip_one.Vitro
+uil-data:advanced_search_tip_one.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Cuando se introduce más de un término, la búsqueda devolverá resultados que contengan todas ellas a menos que agregue el operador booleano \"OR\" -- por ejemplo, <i>pollo</i> OR <i>huevos</i>."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "advanced_search_tip_one" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "advanced_search_tip_one" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:password_reset_complete_email_plain_text.Vitro
+uil-data:password_reset_complete_email_plain_text.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "${userAccount.firstName} ${userAccount.lastName}\n\nContraseña cambiada con éxito.\n\nSu nueva contraseña asociada con ${userAccount.emailAddress}\nha sido cambiada.\n\nGracias."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "password_reset_complete_email_plain_text" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "password_reset_complete_email_plain_text" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:application_error_email_subject.Vitro
+uil-data:application_error_email_subject.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Se ha producido un error en tu sitio ${siteName!} "@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "application_error_email_subject" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "application_error_email_subject" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:return_to.Vitro
+uil-data:return_to.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "volver a {0}"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "return_to" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "return_to" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:last_login.Vitro
+uil-data:last_login.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Última sesión"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "last_login" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "last_login" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:view_profile_in_rdf.Vitro
+uil-data:view_profile_in_rdf.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "ver perfil en formato RDF"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "view_profile_in_rdf" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "view_profile_in_rdf" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:minimum_password_length.Vitro
+uil-data:minimum_password_length.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Mínimo de {0} caracteres de longitud."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "minimum_password_length" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "minimum_password_length" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:contact_us.Vitro
+uil-data:contact_us.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Contáctenos"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "contact_us" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "contact_us" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:download_results.Vitro
+uil-data:download_results.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Descargar resultados"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "download_results" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "download_results" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:selected_profiles.Vitro
+uil-data:selected_profiles.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Perfiles seleccionados"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "selected_profiles" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "selected_profiles" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:has_value.Vitro
+uil-data:has_value.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "tiene valor"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "has_value" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "has_value" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:faux_property_listing.Vitro
+uil-data:faux_property_listing.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Lista de propiedades falsas"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "faux_property_listing" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "faux_property_listing" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:display_admin_header.Vitro
+uil-data:display_admin_header.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Visualizar administración y configuración"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "display_admin_header" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "display_admin_header" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_no_password.Vitro
+uil-data:error_no_password.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Introduzca su contraseña."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_no_password" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_no_password" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:remove_capitalized.Vitro
+uil-data:remove_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "eliminar"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "remove_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "remove_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:october.Vitro
+uil-data:october.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Octubre"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "october" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "october" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:file_upload_subject.Vitro
+uil-data:file_upload_subject.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "file_upload_subject" ;
-        prop:hasPackage  "Vitro-languages" .
+        rdf:type         uil:UILabel ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "file_upload_subject" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:manage_site.Vitro
+uil-data:manage_site.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Administrar este sitio"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "manage_site" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "manage_site" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:confirm_delete_account_plural.Vitro
+uil-data:confirm_delete_account_plural.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "¿Está seguro de que desea eliminar estas cuentas?"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "confirm_delete_account_plural" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "confirm_delete_account_plural" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:sunday.Vitro
+uil-data:sunday.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Domingo"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "sunday" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "sunday" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:password_system_has_changed.Vitro
+uil-data:password_system_has_changed.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "password_system_has_changed" ;
-        prop:hasPackage  "Vitro-languages" .
+        rdf:type         uil:UILabel ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "password_system_has_changed" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:rebuild_search_index.Vitro
+uil-data:rebuild_search_index.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Reconstruir índice de búsqueda"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "rebuild_search_index" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "rebuild_search_index" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:password_saved.Vitro
+uil-data:password_saved.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Su contraseña ha sido guardada."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "password_saved" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "password_saved" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:supply_query_variable.Vitro
+uil-data:supply_query_variable.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Debe suministrar una variable para guardar los resultados de la consulta."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "supply_query_variable" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "supply_query_variable" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:configure_page_if_permissable.Vitro
+uil-data:configure_page_if_permissable.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "configurar esta página si el usuario tiene permiso."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "configure_page_if_permissable" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "configure_page_if_permissable" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:invalid_date_form_msg.Vitro
+uil-data:invalid_date_form_msg.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "debe tener un formato de fecha válido mm / dd / aaaa."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "invalid_date_form_msg" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "invalid_date_form_msg" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:manage_list_of.Vitro
+uil-data:manage_list_of.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Administrar la lista de"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "manage_list_of" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "manage_list_of" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:verbose_property_status.Vitro
+uil-data:verbose_property_status.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Desplegar detalladamente las propiedades"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "verbose_property_status" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "verbose_property_status" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:sparql_query_select_ask_results.Vitro
+uil-data:sparql_query_select_ask_results.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Format for SELECT and ASK query results"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "sparql_query_select_ask_results" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "sparql_query_select_ask_results" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:individual_not_found.Vitro
+uil-data:individual_not_found.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Usuario no encontrado:"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "individual_not_found" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "individual_not_found" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:classes_by_classgroup.Vitro
+uil-data:classes_by_classgroup.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Clases por grupo de clase"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "classes_by_classgroup" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "classes_by_classgroup" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:confirm_email_changed_email_plain_text.Vitro
+uil-data:confirm_email_changed_email_plain_text.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Hola, ${userAccount.firstName} ${userAccount.lastName}\n\nHa cambiado recientemente la dirección de correo electrónico asociada a\n${userAccount.firstName} ${userAccount.lastName}\n\nGracias."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "confirm_email_changed_email_plain_text" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "confirm_email_changed_email_plain_text" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:close_capitalized.Vitro
+uil-data:close_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Cerrar"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "close_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "close_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:browse_class_group.Vitro
+uil-data:browse_class_group.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Examinar grupo de clase"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "browse_class_group" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "browse_class_group" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:statistics.Vitro
+uil-data:statistics.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Estadísticas"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "statistics" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "statistics" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:new_password.Vitro
+uil-data:new_password.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Nueva contraseña"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "new_password" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "new_password" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:hide_show_subclasses.Vitro
+uil-data:hide_show_subclasses.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "ocultar/mostrar subclases"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "hide_show_subclasses" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "hide_show_subclasses" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:class_hierarchy.Vitro
+uil-data:class_hierarchy.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Jerarquía de clases"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "class_hierarchy" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "class_hierarchy" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:add_content_manage_site.Vitro
+uil-data:add_content_manage_site.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "agregar contenido y administrar este sitio"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "add_content_manage_site" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "add_content_manage_site" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:background_threads.Vitro
+uil-data:background_threads.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Temas de fondo"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "background_threads" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "background_threads" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:create_capitalized.Vitro
+uil-data:create_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Crear"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "create_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "create_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_previous_password.Vitro
+uil-data:error_previous_password.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "La nueva contraseña no debe ser igual a la contraseña actual."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_previous_password" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_previous_password" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:change_password.Vitro
+uil-data:change_password.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Debe cambiar su contraseña para entrar"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "change_password" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "change_password" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:menu_management.Vitro
+uil-data:menu_management.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Administración de menú"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "menu_management" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "menu_management" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:email_change_will_be_confirmed.Vitro
+uil-data:email_change_will_be_confirmed.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Nota: si el correo electrónico cambia, un mensaje de confirmación será enviado a la nueva dirección de correo electrónico indicada anteriormente."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "email_change_will_be_confirmed" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "email_change_will_be_confirmed" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:fake_external_auth.Vitro
+uil-data:fake_external_auth.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Error de inicio de sesión"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "fake_external_auth" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "fake_external_auth" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:run_sdb_setup.Vitro
+uil-data:run_sdb_setup.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ejecutar la instalación SDB"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "run_sdb_setup" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "run_sdb_setup" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:property_management.Vitro
+uil-data:property_management.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Administración de propiedades"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "property_management" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "property_management" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:end_your_Session.Vitro
+uil-data:end_your_Session.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Finalizar su sesión"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "end_your_Session" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "end_your_Session" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:search_index_not_connected.Vitro
+uil-data:search_index_not_connected.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "El índice de búsqueda no está conectado."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "search_index_not_connected" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "search_index_not_connected" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:change_content_type.Vitro
+uil-data:change_content_type.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Cambiar el tipo de contenido"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "change_content_type" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "change_content_type" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:invalid_search_term.Vitro
+uil-data:invalid_search_term.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Criterio de búsqueda no válido"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "invalid_search_term" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "invalid_search_term" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:index_recs_completed.Vitro
+uil-data:index_recs_completed.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Completado {0} de {1} registros indexados."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "index_recs_completed" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "index_recs_completed" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:add_profile.Vitro
+uil-data:add_profile.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Añadir perfil"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "add_profile" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "add_profile" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:view_labels_capitalized.Vitro
+uil-data:view_labels_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ver etiquetas"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "view_labels_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "view_labels_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:maximum_cardinality.Vitro
+uil-data:maximum_cardinality.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "máxima cardinalidad"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "maximum_cardinality" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "maximum_cardinality" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:please_format_email.Vitro
+uil-data:please_format_email.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Actualizar su dirección de correo electrónico como:"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "please_format_email" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "please_format_email" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:external_auth_only.Vitro
+uil-data:external_auth_only.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Sólo usuarios autentificados"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "external_auth_only" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "external_auth_only" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:return_to_individual.Vitro
+uil-data:return_to_individual.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Volver a la página de usuarios"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "return_to_individual" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "return_to_individual" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:all_x_properties.Vitro
+uil-data:all_x_properties.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Todos los {0} propiedades"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "all_x_properties" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "all_x_properties" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:password_created_email_plain_text.Vitro
+uil-data:password_created_email_plain_text.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "${userAccount.firstName} ${userAccount.lastName}\n\nContraseña creado con éxito.\n\nSu nueva contraseña asociada con ${userAccount.emailAddress}\nse ha creado.\n\nGracias.\n"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "password_created_email_plain_text" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "password_created_email_plain_text" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:already_logged_in.Vitro
+uil-data:already_logged_in.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Usted ya está registrado"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "already_logged_in" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "already_logged_in" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:supply_class_group.Vitro
+uil-data:supply_class_group.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Debe proporcionar un grupo de clase"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "supply_class_group" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "supply_class_group" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:matching_prop_not_defined.Vitro
+uil-data:matching_prop_not_defined.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "La propiedad de coincidencia no está definida"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "matching_prop_not_defined" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "matching_prop_not_defined" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:display_rank.Vitro
+uil-data:display_rank.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Mostrar Rango"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "display_rank" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "display_rank" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:profile_editing_title.Vitro
+uil-data:profile_editing_title.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Los editores que se seleccionan a la izquierda tendrán la posibilidad de editar los perfiles VIVO que se selecciona en el lado derecho. Puede seleccionar varios editores y varios perfiles, pero debe seleccionar un mínimo de 1 cada uno."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "profile_editing_title" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "profile_editing_title" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:test_for_nonlogged_in_users.Vitro
+uil-data:test_for_nonlogged_in_users.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Este es el widget de pruebas para usuarios no registrados."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "test_for_nonlogged_in_users" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "test_for_nonlogged_in_users" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:insufficient_authorization.Vitro
+uil-data:insufficient_authorization.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Lo sentimos, pero no está autorizado para ver la página solicitada. Si cree que esto es un error, por favor póngase en contacto con nosotros para poder ayudarle."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "insufficient_authorization" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "insufficient_authorization" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:supply_content_type.Vitro
+uil-data:supply_content_type.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Debe proporcionar un tipo de contenido"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "supply_content_type" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "supply_content_type" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:back_to_results.Vitro
+uil-data:back_to_results.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "regresar a los resultados"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "back_to_results" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "back_to_results" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:may_not_edit.Vitro
+uil-data:may_not_edit.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "No puede editar"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "may_not_edit" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "may_not_edit" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:four_digit_year.Vitro
+uil-data:four_digit_year.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Entrada invalida. Ingrese un año de 4 dígitos."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "four_digit_year" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "four_digit_year" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:browse_page_javascript_two.Vitro
+uil-data:browse_page_javascript_two.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "para buscar información."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "browse_page_javascript_two" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "browse_page_javascript_two" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:password_created_email_html_text.Vitro
+uil-data:password_created_email_html_text.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "<p>\n ${userAccount.firstName} ${userAccount.lastName}\n </p>\n\n <p>\n <strong>Contraseña creado con éxito.</strong>\n </p>\n\n <p>\n Su nueva contraseña asociada con ${userAccount.emailAddress} se ha creado.\n </p>\n\n <p>\n Gracias.\n </p>"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "password_created_email_html_text" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "password_created_email_html_text" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:current_photo.Vitro
+uil-data:current_photo.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Foto actual"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "current_photo" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "current_photo" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_last_name.Vitro
+uil-data:select_last_name.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Seleccione un apellido existente"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_last_name" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_last_name" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:supply_template.Vitro
+uil-data:supply_template.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Debe proporcionar una plantilla"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "supply_template" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "supply_template" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:view_all_accounts_title.Vitro
+uil-data:view_all_accounts_title.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "ver todas las cuentas"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "view_all_accounts_title" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "view_all_accounts_title" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:cropping_note.Vitro
+uil-data:cropping_note.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Para realizar ajustes, puede arrastrar alrededor y cambiar el tamaño de la foto de la derecha. / Cuando haya terminado de editar la foto, haga clic en el botón \"Guardar foto\"."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "cropping_note" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "cropping_note" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:page_not_created.Vitro
+uil-data:page_not_created.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "La página no pudo ser creada"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "page_not_created" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "page_not_created" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_email_already_exists.Vitro
+uil-data:error_email_already_exists.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Una cuenta con esta dirección de correo electrónico ya existe."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_email_already_exists" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_email_already_exists" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:required_field_empty_msg.Vitro
+uil-data:required_field_empty_msg.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Este campo no debe estar vacío."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "required_field_empty_msg" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "required_field_empty_msg" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:site_maintenance.Vitro
+uil-data:site_maintenance.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Mantenimiento del sitio"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "site_maintenance" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "site_maintenance" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:current_date_time.Vitro
+uil-data:current_date_time.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Fecha y hora actual:"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "current_date_time" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "current_date_time" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:page_link.Vitro
+uil-data:page_link.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Enlace de página"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "page_link" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "page_link" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:object_property_hierarchy.Vitro
+uil-data:object_property_hierarchy.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Jerarquía de propiedades de objetos"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "object_property_hierarchy" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "object_property_hierarchy" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:user_accounts.Vitro
+uil-data:user_accounts.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Cuentas de usuario"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "user_accounts" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "user_accounts" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:maximum_file_size.Vitro
+uil-data:maximum_file_size.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Tamaño máximo de archivo: {0} megabytes"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "maximum_file_size" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "maximum_file_size" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:add_new_account.Vitro
+uil-data:add_new_account.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Añadir nueva cuenta"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "add_new_account" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "add_new_account" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:browse_all_starts_with.Vitro
+uil-data:browse_all_starts_with.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Visualizar todas las personas cuyo apellido empieza con {0}"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "browse_all_starts_with" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "browse_all_starts_with" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:status.Vitro
+uil-data:status.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Estatus"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "status" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "status" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:index.Vitro
+uil-data:index.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Inicio"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "index" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "index" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:verify_this_match_title.Vitro
+uil-data:verify_this_match_title.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Verificar esta operación"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "verify_this_match_title" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "verify_this_match_title" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:search_indexer_idle.Vitro
+uil-data:search_indexer_idle.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "El indexador de búsqueda está inactivo."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "search_indexer_idle" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "search_indexer_idle" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:start_capitalized.Vitro
+uil-data:start_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Iniciar"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "start_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "start_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:minimum_cardinality.Vitro
+uil-data:minimum_cardinality.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "cardinalidad mínima"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "minimum_cardinality" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "minimum_cardinality" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:manage_affiliated_people_link.Vitro
+uil-data:manage_affiliated_people_link.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "administrar personas afiliadas"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "manage_affiliated_people_link" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "manage_affiliated_people_link" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:initial_password.Vitro
+uil-data:initial_password.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Contraseña inicial"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "initial_password" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "initial_password" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:invalid_format.Vitro
+uil-data:invalid_format.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Formato inválido"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "invalid_format" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "invalid_format" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:menu_orering.Vitro
+uil-data:menu_orering.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Orden del menú"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "menu_orering" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "menu_orering" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:confirm_entry_deletion_from.Vitro
+uil-data:confirm_entry_deletion_from.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "¿Está seguro de que desea eliminar la siguiente entrada del"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "confirm_entry_deletion_from" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "confirm_entry_deletion_from" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:add_types.Vitro
+uil-data:add_types.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Agregar uno o más tipos"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "add_types" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "add_types" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:group_capitalized.Vitro
+uil-data:group_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Grupo"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "group_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "group_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:entry.Vitro
+uil-data:entry.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "entrada"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "entry" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "entry" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:search_vitro.Vitro
+uil-data:search_vitro.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Búsqueda en VITRO"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "search_vitro" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "search_vitro" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:version.Vitro
+uil-data:version.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Versión"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "version" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "version" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:hide_subclasses.Vitro
+uil-data:hide_subclasses.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "ocultar subclases"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "hide_subclasses" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "hide_subclasses" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:caused_by.Vitro
+uil-data:caused_by.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Causada por"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "caused_by" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "caused_by" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:show_more_content.Vitro
+uil-data:show_more_content.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "mostrar más contenido"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "show_more_content" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "show_more_content" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:advanced_search_tip_six.Vitro
+uil-data:advanced_search_tip_six.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Una búsqueda utiliza versiones acortadas de palabras -- por ejemplo, una búsqueda de <i>cogniti*</i> no encuentra nada, mientras que \"cogni*\" encuentra tanto <i>cognitivo</i> y <i>cognición</i>."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "advanced_search_tip_six" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "advanced_search_tip_six" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:myAccount_confirm_changes_plus_note.Vitro
+uil-data:myAccount_confirm_changes_plus_note.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Los cambios se han guardado. Un correo electrónico de confirmación ha sido enviado a {0}."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "myAccount_confirm_changes_plus_note" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "myAccount_confirm_changes_plus_note" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:class_management.Vitro
+uil-data:class_management.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Administración de clases"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "class_management" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "class_management" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:display_less.Vitro
+uil-data:display_less.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Menos"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "display_less" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "display_less" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:add_property_group.Vitro
+uil-data:add_property_group.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Agregar nuevo grupo de propiedades"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "add_property_group" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "add_property_group" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:browse_by.Vitro
+uil-data:browse_by.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Búsqueda por"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "browse_by" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "browse_by" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:class_group_link.Vitro
+uil-data:class_group_link.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "enlace de grupo de clases"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "class_group_link" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "class_group_link" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:confirm_password.Vitro
+uil-data:confirm_password.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Confirmar nueva contraseña"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "confirm_password" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "confirm_password" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:saturday.Vitro
+uil-data:saturday.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Sábado"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "saturday" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "saturday" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:_publications_link.Vitro
+uil-data:_publications_link.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "_publications_link" ;
-        prop:hasPackage  "Vitro-languages" .
+        rdf:type         uil:UILabel ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "_publications_link" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:javascript_require_to_edit.Vitro
+uil-data:javascript_require_to_edit.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Para editar el contenido, tendrá que activar JavaScript."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "javascript_require_to_edit" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "javascript_require_to_edit" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:fatal_error_detected.Vitro
+uil-data:fatal_error_detected.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "{0} detectado un error grave durante el inicio."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "fatal_error_detected" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "fatal_error_detected" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:menu_page.Vitro
+uil-data:menu_page.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Página de menú"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "menu_page" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "menu_page" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:create_new_individual_of_the_following_type.Vitro
+uil-data:create_new_individual_of_the_following_type.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Crear un objeto del siguiente tipo"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "create_new_individual_of_the_following_type" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "create_new_individual_of_the_following_type" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:logins_not_already_restricted.Vitro
+uil-data:logins_not_already_restricted.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "El inicio de sesión ya no se encuentra restringido."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "logins_not_already_restricted" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "logins_not_already_restricted" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:stack_trace.Vitro
+uil-data:stack_trace.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Traza de errores"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "stack_trace" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "stack_trace" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:confirm_page_deletion.Vitro
+uil-data:confirm_page_deletion.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "¿Está seguro de que desea eliminar esta página?:"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "confirm_page_deletion" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "confirm_page_deletion" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_locale.Vitro
+uil-data:select_locale.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "seleccionar la configuración regional"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_locale" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_locale" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:reset_password.Vitro
+uil-data:reset_password.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Restablecer contraseña"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "reset_password" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "reset_password" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:vitro_bullet_two.Vitro
+uil-data:vitro_bullet_two.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Editar instancias y relaciones"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "vitro_bullet_two" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "vitro_bullet_two" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:replace_page_title.Vitro
+uil-data:replace_page_title.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Reemplazar imagen"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "replace_page_title" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "replace_page_title" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:subproperty.Vitro
+uil-data:subproperty.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "subpropiedad"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "subproperty" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "subproperty" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:rdf_export.Vitro
+uil-data:rdf_export.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "exportar RDF"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "rdf_export" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "rdf_export" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:click_to_view_larger.Vitro
+uil-data:click_to_view_larger.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "clic para ampliar la imagen"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "click_to_view_larger" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "click_to_view_larger" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:build_date.Vitro
+uil-data:build_date.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Fecha de creación"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "build_date" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "build_date" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:flags.Vitro
+uil-data:flags.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Banderas"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "flags" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "flags" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:march.Vitro
+uil-data:march.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Marzo"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "march" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "march" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:display_only.Vitro
+uil-data:display_only.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Mostrar únicamente"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "display_only" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "display_only" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:to_manage_content.Vitro
+uil-data:to_manage_content.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "para administrar el contenido."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "to_manage_content" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "to_manage_content" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:acct_created_email_html_text.Vitro
+uil-data:acct_created_email_html_text.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "<p>\n ${userAccount.firstName} ${userAccount.lastName}\n </p>\n\n <p>\n <strong>Enhorabuena!</strong>\n </p>\n\n <p>\n Hemos creado la nueva cuenta en ${siteName}, asociada con ${userAccount.emailAddress}.\n </p>\n\n <p>\n Si no has solicitado esta nueva cuenta puedes ignorar este mensaje.\n Esta solicitud caducará si no se activa durante los próximos 30 días.\n </p>\n\n <p>\n Haga clic en el enlace de abajo para crear la contraseña de tu cuenta usando nuestro servidor seguro.\n </p>\n\n <p>\n <a href=\"${passwordLink}\" title=\"password\">${passwordLink}</a>\n </p>\n\n <p>\n Si el enlace no funciona, puedes copiar y pegar el enlace directamente en la barra de direcciones de tu navegador.\n </p>\n\n <p>\n ¡Gracias!\n </p>\n"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "acct_created_email_html_text" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "acct_created_email_html_text" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:file_upload_confirm_delete.Vitro
+uil-data:file_upload_confirm_delete.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "file_upload_confirm_delete" ;
-        prop:hasPackage  "Vitro-languages" .
+        rdf:type         uil:UILabel ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "file_upload_confirm_delete" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:cropping_caption.Vitro
+uil-data:cropping_caption.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "La foto de tu perfil se verá como la imagen de abajo."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "cropping_caption" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "cropping_caption" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:browse_capitalized.Vitro
+uil-data:browse_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "navegar"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "browse_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "browse_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:display_options.Vitro
+uil-data:display_options.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Opciones de visualización"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "display_options" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "display_options" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:site_config.Vitro
+uil-data:site_config.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Configuración de la plataforma"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "site_config" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "site_config" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:undo_camelcasing.Vitro
+uil-data:undo_camelcasing.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Deshacer el formato camelcase"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "undo_camelcasing" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "undo_camelcasing" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:view_all_capitalized.Vitro
+uil-data:view_all_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ver todos"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "view_all_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "view_all_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_processing_labels.Vitro
+uil-data:error_processing_labels.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Error al procesar la solicitud: las etiquetas no comprobadas no pueden ser eliminadas."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_processing_labels" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_processing_labels" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:dates.Vitro
+uil-data:dates.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Fechas"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "dates" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "dates" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:myAccount_heading.Vitro
+uil-data:myAccount_heading.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Mi cuenta"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "myAccount_heading" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "myAccount_heading" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:roles.Vitro
+uil-data:roles.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Roles"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "roles" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "roles" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:april.Vitro
+uil-data:april.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Abril"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "april" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "april" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:password_reset_pending_subject.Vitro
+uil-data:password_reset_pending_subject.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "{0} solicitud para restablecer la contraseña"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "password_reset_pending_subject" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "password_reset_pending_subject" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:some_values_from.Vitro
+uil-data:some_values_from.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "algunos valores de"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "some_values_from" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "some_values_from" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:browse_all_public_content.Vitro
+uil-data:browse_all_public_content.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Usted puede navegar por todo el contenido público con que cuenta actualmente en el sistema"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "browse_all_public_content" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "browse_all_public_content" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:all_values_from.Vitro
+uil-data:all_values_from.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "todos los valores de"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "all_values_from" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "all_values_from" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:updated_account_2.Vitro
+uil-data:updated_account_2.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "se ha actualizado."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "updated_account_2" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "updated_account_2" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:alt_error_alert.Vitro
+uil-data:alt_error_alert.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Icono de alerta de error"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "alt_error_alert" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "alt_error_alert" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:year_month.Vitro
+uil-data:year_month.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Entrada invalida. Por favor ingrese un año y mes."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "year_month" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "year_month" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:name.Vitro
+uil-data:name.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "nombre"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "name" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "name" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:no_image.Vitro
+uil-data:no_image.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "ninguna imagen"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "no_image" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "no_image" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:sparql_query_save_results.Vitro
+uil-data:sparql_query_save_results.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Save results to file"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "sparql_query_save_results" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "sparql_query_save_results" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:add_new_group.Vitro
+uil-data:add_new_group.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Agregar nuevo grupo"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "add_new_group" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "add_new_group" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:browse_all.Vitro
+uil-data:browse_all.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ver todos"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "browse_all" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "browse_all" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:processing_icon.Vitro
+uil-data:processing_icon.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "procesando"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "processing_icon" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "processing_icon" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:logins_restricted.Vitro
+uil-data:logins_restricted.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "El inicio de sesión se encuentra restringido."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "logins_restricted" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "logins_restricted" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:search_tip_four.Vitro
+uil-data:search_tip_four.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Si no está seguro de la ortografía correcta, ponga ~ al final de su término de búsqueda -- por ejemplo, <i>cabage~</i> encuentra <i>cabbage</i>, <i>steven~</i> encuentra <i>Stephen</i> y <i>Stefan</i> (así como otros nombres similares)."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "search_tip_four" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "search_tip_four" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:imageUpload.errorNoURI.Vitro
+uil-data:imageUpload.errorNoURI.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "No se proporcionó ninguna entidad URI"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "imageUpload.errorNoURI" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "imageUpload.errorNoURI" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:password_saved_please_login.Vitro
+uil-data:password_saved_please_login.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Su contraseña ha sido guardada. Por favor, inicie sesión"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "password_saved_please_login" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "password_saved_please_login" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:upload_photo.Vitro
+uil-data:upload_photo.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Subir una foto"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "upload_photo" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "upload_photo" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:sparql_query_results.Vitro
+uil-data:sparql_query_results.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Resultados de consulta SPARQL"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "sparql_query_results" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "sparql_query_results" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:enter_new_password.Vitro
+uil-data:enter_new_password.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Introduzca su nueva contraseña para {0}"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "enter_new_password" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "enter_new_password" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:display_more_ellipsis.Vitro
+uil-data:display_more_ellipsis.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "... Más"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "display_more_ellipsis" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "display_more_ellipsis" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:updated_account_1.Vitro
+uil-data:updated_account_1.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "La cuenta para el"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "updated_account_1" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "updated_account_1" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:add_page.Vitro
+uil-data:add_page.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Agregar página"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "add_page" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "add_page" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:list_elements_of.Vitro
+uil-data:list_elements_of.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Lista de los elementos de"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "list_elements_of" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "list_elements_of" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:class_group_all_caps.Vitro
+uil-data:class_group_all_caps.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Grupo de clase"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "class_group_all_caps" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "class_group_all_caps" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:no_class_restrictions.Vitro
+uil-data:no_class_restrictions.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "No hay clases con una restricción en esta propiedad."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "no_class_restrictions" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "no_class_restrictions" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:refresh_page_after_reordering.Vitro
+uil-data:refresh_page_after_reordering.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Actualice la página después de reordenar los elementos de menú"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "refresh_page_after_reordering" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "refresh_page_after_reordering" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:asserted_class_hierarchy.Vitro
+uil-data:asserted_class_hierarchy.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Jerarquía de clase afirmada"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "asserted_class_hierarchy" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "asserted_class_hierarchy" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:page_admin_permission_option.Vitro
+uil-data:page_admin_permission_option.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Sólo los administradores pueden ver esta página"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "page_admin_permission_option" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "page_admin_permission_option" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:create_associated_profile.Vitro
+uil-data:create_associated_profile.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Crear el perfil asociado"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "create_associated_profile" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "create_associated_profile" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:password_reset_complete_email_html_text.Vitro
+uil-data:password_reset_complete_email_html_text.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "<p>\n ${userAccount.firstName} ${userAccount.lastName}\n </p>\n\n <p>\n <strong>Contraseña cambiada con éxito.</strong>\n </p>\n\n <p>\n Su nueva contraseña asociada con ${userAccount.emailAddress} ha sido cambiada.\n </p>\n\n <p>\n Gracias.\n </p>"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "password_reset_complete_email_html_text" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "password_reset_complete_email_html_text" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:first_time_external_email_html_text.Vitro
+uil-data:first_time_external_email_html_text.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "<p>\n ${userAccount.firstName} ${userAccount.lastName}\n </p>\n\n <p>\n <strong>¡Enhorabuena!</strong>\n </p>\n\n <p>\n Hemos creado la nueva cuenta VIVO asociado con ${userAccount.emailAddress}.\n </p>\n\n <p>\n ¡Gracias!\n </p>"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "first_time_external_email_html_text" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "first_time_external_email_html_text" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:default.Vitro
+uil-data:default.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Perdeterminado"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "default" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "default" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_password_mismatch.Vitro
+uil-data:error_password_mismatch.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Las contraseñas no coinciden."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_password_mismatch" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_password_mismatch" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:and.Vitro
+uil-data:and.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "y"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "and" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "and" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:no_matching_results.Vitro
+uil-data:no_matching_results.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "No hay resultados que coincidan."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "no_matching_results" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "no_matching_results" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:internal_class_i_capped.Vitro
+uil-data:internal_class_i_capped.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Clase interna institucional"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "internal_class_i_capped" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "internal_class_i_capped" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:decimal_only.Vitro
+uil-data:decimal_only.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Entrada invalida. Se permite un punto decimal, pero los separadores de miles no lo son."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "decimal_only" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "decimal_only" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:new_account_2.Vitro
+uil-data:new_account_2.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "fue creado con éxito."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "new_account_2" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "new_account_2" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:listed_page_title.Vitro
+uil-data:listed_page_title.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "listado título de página"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "listed_page_title" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "listed_page_title" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:delete_profile_editor.Vitro
+uil-data:delete_profile_editor.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Eliminar editor de perfiles"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "delete_profile_editor" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "delete_profile_editor" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_no_first_name.Vitro
+uil-data:error_no_first_name.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Debe proporcionar su nombre."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_no_first_name" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_no_first_name" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:browse_all_in_class.Vitro
+uil-data:browse_all_in_class.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Examinar todos los usuarios de esta clase"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "browse_all_in_class" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "browse_all_in_class" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:save_entry.Vitro
+uil-data:save_entry.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Guardar entrada"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "save_entry" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "save_entry" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:confirm_initial_password.Vitro
+uil-data:confirm_initial_password.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Confirmar contraseña inicial"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "confirm_initial_password" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "confirm_initial_password" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:ingest_tools.Vitro
+uil-data:ingest_tools.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Herramientas de importación"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "ingest_tools" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "ingest_tools" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:application_error_email_html_text.Vitro
+uil-data:application_error_email_html_text.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "<p>Se ha producido un error en tu sitio ${siteName!} en ${datetime!}.</p>\n\n <p>\n <strong>URL solicitada:</strong> ${requestedUrl!}\n </p>\n\n <p>\n <#if errorMessage?has_content>\n <strong>Mensaje de error:</strong> ${errorMessage!}\n </#if>\n </p>\n\n <p>\n <strong>Traza de errores</strong> (Traza completa disponible en el registro):\n <pre>${stackTrace!}</pre>\n </p>\n\n <#if cause?has_content>\n <p><strong>Causada por:</strong>\n <pre>${cause!}</pre>\n </p>\n </#if>"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "application_error_email_html_text" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "application_error_email_html_text" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:log_in.Vitro
+uil-data:log_in.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "iniciar sesión"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "log_in" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "log_in" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:new_account_1.Vitro
+uil-data:new_account_1.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Una nueva cuenta para"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "new_account_1" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "new_account_1" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:imageUpload.errorUnrecognizedFileType.Vitro
+uil-data:imageUpload.errorUnrecognizedFileType.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "''{0}'' no es un tipo de archivo de imagen reconocida. Por favor, subir archivos JPEG, GIF o PNG solamente."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "imageUpload.errorUnrecognizedFileType" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "imageUpload.errorUnrecognizedFileType" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:replace_page_title_with_name.Vitro
+uil-data:replace_page_title_with_name.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Reemplazar imagen por {0}"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "replace_page_title_with_name" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "replace_page_title_with_name" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:unsupported_ie_version.Vitro
+uil-data:unsupported_ie_version.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Este formulario no es compatible con versiones de Internet Explorer menores a la versión 8. Actualice su navegador, o cambia a otro navegador, como Firefox."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "unsupported_ie_version" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "unsupported_ie_version" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:logins_are_restricted.Vitro
+uil-data:logins_are_restricted.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "El inicio de sesión se encuentra restringido."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "logins_are_restricted" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "logins_are_restricted" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:add_profile_editor.Vitro
+uil-data:add_profile_editor.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Añadir editor de perfiles"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "add_profile_editor" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "add_profile_editor" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:supply_name.Vitro
+uil-data:supply_name.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Debe proporcionar un título"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "supply_name" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "supply_name" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:feedback_thanks_text.Vitro
+uil-data:feedback_thanks_text.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Gracias por ponerse en contacto con nuestro equipo de conservación y desarrollo. Nosotros responderemos a su consulta lo antes posible."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "feedback_thanks_text" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "feedback_thanks_text" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_class_for_search.Vitro
+uil-data:select_class_for_search.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Debe seleccionar una clase para mostrar sus individuos."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_class_for_search" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_class_for_search" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:since_elapsed_time.Vitro
+uil-data:since_elapsed_time.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "desde {0}, tiempo transcurrido {1}"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "since_elapsed_time" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "since_elapsed_time" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:unknown_user_name.Vitro
+uil-data:unknown_user_name.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "amigo"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "unknown_user_name" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "unknown_user_name" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:faux_property_capitalized.Vitro
+uil-data:faux_property_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Faux Property"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "faux_property_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "faux_property_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:enter_value_name_field.Vitro
+uil-data:enter_value_name_field.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Por favor, introduzca un valor en el campo Nombre."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "enter_value_name_field" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "enter_value_name_field" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:group_name.Vitro
+uil-data:group_name.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Nombre del grupo"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "group_name" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "group_name" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:data_property_hierarchy.Vitro
+uil-data:data_property_hierarchy.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Jerarquía de propiedades de datos"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "data_property_hierarchy" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "data_property_hierarchy" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:external_login_text.Vitro
+uil-data:external_login_text.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Entrar usando Shibboleth"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "external_login_text" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "external_login_text" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:imageUpload.errorFileTooBig.Vitro
+uil-data:imageUpload.errorFileTooBig.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Favor de elegir una imagen más pequeña de {0} megabytes."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "imageUpload.errorFileTooBig" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "imageUpload.errorFileTooBig" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:profile_editors.Vitro
+uil-data:profile_editors.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Editores de perfil"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "profile_editors" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "profile_editors" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:implement_capitalized.Vitro
+uil-data:implement_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Implementar"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "implement_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "implement_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:sparql_query_header.Vitro
+uil-data:sparql_query_header.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Query"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "sparql_query_header" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "sparql_query_header" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:view.Vitro
+uil-data:view.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "ver"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "view" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "view" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:manage_profile_editing.Vitro
+uil-data:manage_profile_editing.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Administrar edición de perfiles"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "manage_profile_editing" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "manage_profile_editing" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:minimum_image_dimensions.Vitro
+uil-data:minimum_image_dimensions.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Dimensiones mínimas de imagen: {0} x {1} píxeles"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "minimum_image_dimensions" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "minimum_image_dimensions" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:view_list_in_rdf.Vitro
+uil-data:view_list_in_rdf.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ver la lista {0} en formato RDF"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "view_list_in_rdf" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "view_list_in_rdf" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:more_details_about_site.Vitro
+uil-data:more_details_about_site.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Más detalles sobre este sitio"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "more_details_about_site" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "more_details_about_site" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:new_entry_for.Vitro
+uil-data:new_entry_for.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "\"{0}\" para {1}"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "new_entry_for" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "new_entry_for" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:july.Vitro
+uil-data:july.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Julio"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "july" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "july" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:page_uri.Vitro
+uil-data:page_uri.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "URI de página"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "page_uri" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "page_uri" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:edit_date_time_value.Vitro
+uil-data:edit_date_time_value.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Editar valor fecha/hora"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "edit_date_time_value" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "edit_date_time_value" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:limited_to_type.Vitro
+uil-data:limited_to_type.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "limitado a tipo de registro"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "limited_to_type" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "limited_to_type" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:class_name.Vitro
+uil-data:class_name.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "nombre de la clase"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "class_name" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "class_name" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:create_date_time_value.Vitro
+uil-data:create_date_time_value.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Crear valor fecha/hora"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "create_date_time_value" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "create_date_time_value" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:there_are_no_entries_for_selection.Vitro
+uil-data:there_are_no_entries_for_selection.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "No hay entradas en el sistema desde el cual elegir."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "there_are_no_entries_for_selection" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "there_are_no_entries_for_selection" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:edit_this_individual.Vitro
+uil-data:edit_this_individual.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Editar este usuario"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "edit_this_individual" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "edit_this_individual" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:start_interval_must_precede_end_earlier.Vitro
+uil-data:start_interval_must_precede_end_earlier.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "El intervalo inicial debe ser anterior al intervalo final."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "start_interval_must_precede_end_earlier" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "start_interval_must_precede_end_earlier" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:type_capitalized.Vitro
+uil-data:type_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Tipo"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "type_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "type_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:selected.Vitro
+uil-data:selected.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Seleccionado"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "selected" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "selected" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:submit_upload.Vitro
+uil-data:submit_upload.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Subir foto"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "submit_upload" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "submit_upload" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:confirm_individual_deletion.Vitro
+uil-data:confirm_individual_deletion.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "confirm_individual_deletion" ;
-        prop:hasPackage  "Vitro-languages" .
+        rdf:type         uil:UILabel ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "confirm_individual_deletion" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:september.Vitro
+uil-data:september.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Septiembre"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "september" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "september" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:verbose_turn_off.Vitro
+uil-data:verbose_turn_off.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Apagar"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "verbose_turn_off" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "verbose_turn_off" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_type.Vitro
+uil-data:select_type.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Seleccione un tipo"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_type" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_type" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:comments_questions.Vitro
+uil-data:comments_questions.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Comentarios, preguntas o sugerencias"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "comments_questions" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "comments_questions" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:send_mail.Vitro
+uil-data:send_mail.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Enviar correo"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "send_mail" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "send_mail" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:change_profile.Vitro
+uil-data:change_profile.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "cambiar el perfil"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "change_profile" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "change_profile" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:logins_already_restricted.Vitro
+uil-data:logins_already_restricted.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "El inicio de sesión se encuentra restringido."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "logins_already_restricted" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "logins_already_restricted" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:photo_types.Vitro
+uil-data:photo_types.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "(JPEG, GIF, o PNG)"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "photo_types" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "photo_types" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:search_term_error_near.Vitro
+uil-data:search_term_error_near.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "El término de búsqueda tuvo un error"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "search_term_error_near" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "search_term_error_near" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:share_profile_uri.Vitro
+uil-data:share_profile_uri.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "compartir el URI de este perfil"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "share_profile_uri" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "share_profile_uri" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:no_html_specified.Vitro
+uil-data:no_html_specified.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "No se ha especificado el HTML ."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "no_html_specified" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "no_html_specified" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:first_name.Vitro
+uil-data:first_name.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Nombre"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "first_name" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "first_name" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:class_link.Vitro
+uil-data:class_link.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Enlace de clase"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "class_link" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "class_link" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:view_profile_page_for.Vitro
+uil-data:view_profile_page_for.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ver la página de perfil"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "view_profile_page_for" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "view_profile_page_for" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_classes_to_display.Vitro
+uil-data:select_classes_to_display.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Debe seleccionar las clases a mostrar"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_classes_to_display" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_classes_to_display" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:password_mismatch.Vitro
+uil-data:password_mismatch.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Las contraseñas no coinciden."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "password_mismatch" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "password_mismatch" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:page_management.Vitro
+uil-data:page_management.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Administración de la página"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "page_management" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "page_management" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:resource_uri.Vitro
+uil-data:resource_uri.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Recurso URI"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "resource_uri" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "resource_uri" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:sparql_query_run_query.Vitro
+uil-data:sparql_query_run_query.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Run Query"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "sparql_query_run_query" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "sparql_query_run_query" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:enter_fixed_html_here.Vitro
+uil-data:enter_fixed_html_here.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ingrese código HTML fijo"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "enter_fixed_html_here" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "enter_fixed_html_here" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:verify_this_match.Vitro
+uil-data:verify_this_match.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Verificar esta opración"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "verify_this_match" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "verify_this_match" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:properties_capitalized.Vitro
+uil-data:properties_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Propiedades"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "properties_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "properties_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:raw_string_literals.Vitro
+uil-data:raw_string_literals.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Literales de cadena en bruto"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "raw_string_literals" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "raw_string_literals" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:no_content_create_groups_classes.Vitro
+uil-data:no_content_create_groups_classes.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Actualmente no hay contenido en el sistema, se necesita crear grupos de clase y asignar sus clases a ellos."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "no_content_create_groups_classes" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "no_content_create_groups_classes" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:home_page.Vitro
+uil-data:home_page.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "tu página de inicio"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "home_page" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "home_page" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:restriction_on.Vitro
+uil-data:restriction_on.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "restricción en"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "restriction_on" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "restriction_on" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:processing_indicator.Vitro
+uil-data:processing_indicator.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Indicador de tiempo de procesamiento"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "processing_indicator" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "processing_indicator" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:selected_page_content_type.Vitro
+uil-data:selected_page_content_type.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Tipo de contenido seleccionado para la página asociada"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "selected_page_content_type" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "selected_page_content_type" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:create_entry.Vitro
+uil-data:create_entry.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Crear entrada"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "create_entry" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "create_entry" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:password_change_not_pending.Vitro
+uil-data:password_change_not_pending.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "La contraseña para {0} ya se ha restablecido."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "password_change_not_pending" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "password_change_not_pending" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:javascript_instructions.Vitro
+uil-data:javascript_instructions.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "instrucciones javascript"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "javascript_instructions" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "javascript_instructions" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_invalid_email.Vitro
+uil-data:error_invalid_email.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "''{0}'' no es una dirección de correo electrónico válida."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_invalid_email" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_invalid_email" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:new_pwd_matches_existing.Vitro
+uil-data:new_pwd_matches_existing.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Su nueva contraseña debe ser diferente de la contraseña existente."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "new_pwd_matches_existing" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "new_pwd_matches_existing" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:or.Vitro
+uil-data:or.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "o"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "or" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "or" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:search_form.Vitro
+uil-data:search_form.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Formulario de búsqueda"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "search_form" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "search_form" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:menu_item_name.Vitro
+uil-data:menu_item_name.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Nombre del elemento de Menú"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "menu_item_name" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "menu_item_name" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:june.Vitro
+uil-data:june.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Junio"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "june" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "june" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:last_name.Vitro
+uil-data:last_name.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Apellido"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "last_name" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "last_name" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:placeholder_image.Vitro
+uil-data:placeholder_image.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Marcador de posición de la imagen"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "placeholder_image" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "placeholder_image" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:requested_url.Vitro
+uil-data:requested_url.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "URL solicitada"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "requested_url" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "requested_url" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:first_time_login_note.Vitro
+uil-data:first_time_login_note.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Nota: Un correo electrónico será enviado a la dirección indicada anteriormente notificando que una cuenta ha sido creada."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "first_time_login_note" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "first_time_login_note" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_external_auth_already_exists.Vitro
+uil-data:error_external_auth_already_exists.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Una cuenta con dicho ID de autorización ya existe."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_external_auth_already_exists" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_external_auth_already_exists" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:contains_no_pears.Vitro
+uil-data:contains_no_pears.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "no contiene peras"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "contains_no_pears" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "contains_no_pears" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:index_page.Vitro
+uil-data:index_page.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "página de inicio"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "index_page" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "index_page" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:search_tip_one.Vitro
+uil-data:search_tip_one.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Mantenlo simple! Use términos cortos, a menos que sus búsquedas devuelvan demasiados resultados."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "search_tip_one" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "search_tip_one" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:sparql_query_construct_describe_results.Vitro
+uil-data:sparql_query_construct_describe_results.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Format for CONSTRUCT and DESCRIBE query results"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "sparql_query_construct_describe_results" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "sparql_query_construct_describe_results" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:password_capitalized.Vitro
+uil-data:password_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Contraseña"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "password_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "password_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:file_upload_submit_label.Vitro
+uil-data:file_upload_submit_label.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "file_upload_submit_label" ;
-        prop:hasPackage  "Vitro-languages" .
+        rdf:type         uil:UILabel ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "file_upload_submit_label" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:please.Vitro
+uil-data:please.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Por favor"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "please" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "please" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:account_created.Vitro
+uil-data:account_created.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Su {0} cuenta ha sido creada."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "account_created" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "account_created" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:add.Vitro
+uil-data:add.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Agregar"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "add" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "add" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:limit.Vitro
+uil-data:limit.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Limitar"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "limit" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "limit" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:november.Vitro
+uil-data:november.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Noviembre"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "november" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "november" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:confirm_delete.Vitro
+uil-data:confirm_delete.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "¿Esta usted seguro que quiere borrar esta foto?"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "confirm_delete" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "confirm_delete" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:login_welcome_message.Vitro
+uil-data:login_welcome_message.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Bienvenido {1, choice, 1# |1< back}, {0}"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "login_welcome_message" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "login_welcome_message" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:password_changed_subject.Vitro
+uil-data:password_changed_subject.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Contraseña cambiada."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "password_changed_subject" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "password_changed_subject" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:incorrect_email_password.Vitro
+uil-data:incorrect_email_password.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Correo o contraseña incorrectos."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "incorrect_email_password" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "incorrect_email_password" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:identifiers.Vitro
+uil-data:identifiers.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Identificadores"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "identifiers" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "identifiers" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:javascript_ie_alert_text.Vitro
+uil-data:javascript_ie_alert_text.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Este sitio utiliza elementos HTML que no son reconocidos por Internet Explorer 8 y menores, debido a que no cuentan con JavaScript. Como resultado, el sitio no se presentará apropiadamente. Para corregir esto, por favor habilite JavaScript, actualice a Internet Explorer 9, o utilizar otro navegador."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "javascript_ie_alert_text" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "javascript_ie_alert_text" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:zoo_two.Vitro
+uil-data:zoo_two.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Zoológico 2"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "zoo_two" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "zoo_two" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:verbose_turn_on.Vitro
+uil-data:verbose_turn_on.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Encender"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "verbose_turn_on" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "verbose_turn_on" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:selection_in_process.Vitro
+uil-data:selection_in_process.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Su solicitud se está procesando."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "selection_in_process" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "selection_in_process" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:please_create.Vitro
+uil-data:please_create.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Por favor crear"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "please_create" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "please_create" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:verbose_status_off.Vitro
+uil-data:verbose_status_off.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "apagado"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "verbose_status_off" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "verbose_status_off" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:page_not_configured.Vitro
+uil-data:page_not_configured.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Esta página aún no está configurada."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "page_not_configured" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "page_not_configured" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:new_account_notification.Vitro
+uil-data:new_account_notification.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Un correo electrónico de notificación ha sido enviada a {0} con las instrucciones para activar la cuenta y crear una contraseña."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "new_account_notification" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "new_account_notification" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:full_list_startup.Vitro
+uil-data:full_list_startup.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Lista completa de eventos y mensajes de inicio."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "full_list_startup" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "full_list_startup" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:user_role.Vitro
+uil-data:user_role.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Rol"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "user_role" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "user_role" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:or_enter_valid_address.Vitro
+uil-data:or_enter_valid_address.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "o introducir otra dirección de correo electrónico completa y válida."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "or_enter_valid_address" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "or_enter_valid_address" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:all.Vitro
+uil-data:all.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "todo"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "all" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "all" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:logged_in_but_no_profile.Vitro
+uil-data:logged_in_but_no_profile.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Usted ha ingresado, pero el sistema no contiene ningún perfil para usted."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "logged_in_but_no_profile" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "logged_in_but_no_profile" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:page_text.Vitro
+uil-data:page_text.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "texto de la página"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "page_text" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "page_text" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:create_new_entry.Vitro
+uil-data:create_new_entry.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Por favor, cree una nueva entrada."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "create_new_entry" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "create_new_entry" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:enter_in_security_field.Vitro
+uil-data:enter_in_security_field.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Por favor introduce las letras que se muestran a continuación en el campo de seguridad"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "enter_in_security_field" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "enter_in_security_field" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_an_existing_or_create_a_new_one.Vitro
+uil-data:select_an_existing_or_create_a_new_one.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Seleccione uno existente o cree uno nuevo"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_an_existing_or_create_a_new_one" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_an_existing_or_create_a_new_one" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:not.Vitro
+uil-data:not.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "no"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "not" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "not" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:range_data_type.Vitro
+uil-data:range_data_type.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Tipo de datos de rango"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "range_data_type" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "range_data_type" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:august.Vitro
+uil-data:august.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Agosto"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "august" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "august" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:terms_of_use.Vitro
+uil-data:terms_of_use.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Términos de uso"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "terms_of_use" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "terms_of_use" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:dump_restore.Vitro
+uil-data:dump_restore.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Aplicación de volcado / restauración"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "dump_restore" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "dump_restore" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:show_properties.Vitro
+uil-data:show_properties.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "mostrar las propiedades"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "show_properties" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "show_properties" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:associated_individuals.Vitro
+uil-data:associated_individuals.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Personas asociadas"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "associated_individuals" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "associated_individuals" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:name_capitalized.Vitro
+uil-data:name_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Nombre"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "name_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "name_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:manage_labels.Vitro
+uil-data:manage_labels.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Administrar etiquetas"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "manage_labels" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "manage_labels" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:current_user.Vitro
+uil-data:current_user.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Usuario actual"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "current_user" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "current_user" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:minimum_ymd.Vitro
+uil-data:minimum_ymd.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Entrada invalida. Por favor ingrese al menos un año, mes y día."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "minimum_ymd" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "minimum_ymd" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:try_another_letter.Vitro
+uil-data:try_another_letter.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Por favor, pruebe otra carta o navegue por todas."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "try_another_letter" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "try_another_letter" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:alt_image_to_crop.Vitro
+uil-data:alt_image_to_crop.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Imagen que desea recortar"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "alt_image_to_crop" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "alt_image_to_crop" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:current_task.Vitro
+uil-data:current_task.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "{0} el índice de búsqueda"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "current_task" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "current_task" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:imageUpload.errorNoImageForCropping.Vitro
+uil-data:imageUpload.errorNoImageForCropping.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "No existe una imagen para recortar."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "imageUpload.errorNoImageForCropping" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "imageUpload.errorNoImageForCropping" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:we_have_an_error.Vitro
+uil-data:we_have_an_error.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Se produjo un error en el sistema."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "we_have_an_error" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "we_have_an_error" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_another_class.Vitro
+uil-data:select_another_class.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Por favor, seleccione otra clase de la lista."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_another_class" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_another_class" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:manage_labels_for.Vitro
+uil-data:manage_labels_for.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Administrar etiquetas para"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "manage_labels_for" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "manage_labels_for" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:revision_info.Vitro
+uil-data:revision_info.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Información de revisiones"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "revision_info" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "revision_info" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:rebuild_vis_cache.Vitro
+uil-data:rebuild_vis_cache.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Reconstruir caché de visualización"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "rebuild_vis_cache" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "rebuild_vis_cache" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:delete.Vitro
+uil-data:delete.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "borrar"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "delete" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "delete" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:update_button.Vitro
+uil-data:update_button.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Actualizar"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "update_button" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "update_button" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:imageUpload.errorNoPhotoSelected.Vitro
+uil-data:imageUpload.errorNoPhotoSelected.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Por favor, busque y seleccione una fotografía."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "imageUpload.errorNoPhotoSelected" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "imageUpload.errorNoPhotoSelected" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:imageUpload.errorUnrecognizedURI.Vitro
+uil-data:imageUpload.errorUnrecognizedURI.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Este URI no perteneciente a nada:'' {0}''"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "imageUpload.errorUnrecognizedURI" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "imageUpload.errorUnrecognizedURI" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:menu_item.Vitro
+uil-data:menu_item.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "elemento de menú"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "menu_item" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "menu_item" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:auth_id_label.Vitro
+uil-data:auth_id_label.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "ID de autenticación externa"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "auth_id_label" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "auth_id_label" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:may.Vitro
+uil-data:may.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Mayo"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "may" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "may" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:what_is_vitro.Vitro
+uil-data:what_is_vitro.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "¿Qué es VITRO?"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "what_is_vitro" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "what_is_vitro" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_a_language.Vitro
+uil-data:select_a_language.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Selecciona un idioma"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_a_language" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_a_language" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:ip_address.Vitro
+uil-data:ip_address.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Dirección IP"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "ip_address" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "ip_address" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:unrecognized_user.Vitro
+uil-data:unrecognized_user.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Usuario no reconocido"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "unrecognized_user" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "unrecognized_user" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:password_change_invalid_key.Vitro
+uil-data:password_change_invalid_key.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "El vínculo que usó para {0} no es válido. Solicite al administrador del sitio que vuelva a enviar el enlace. "@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "password_change_invalid_key" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "password_change_invalid_key" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:change_text_for.Vitro
+uil-data:change_text_for.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Cambiar texto por:"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "change_text_for" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "change_text_for" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:to_enable_javascript.Vitro
+uil-data:to_enable_javascript.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Aquí están las instrucciones para habilitar JavaScript en su navegador web"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "to_enable_javascript" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "to_enable_javascript" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:warning.Vitro
+uil-data:warning.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Advertencia"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "warning" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "warning" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:revision.Vitro
+uil-data:revision.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "revisión"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "revision" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "revision" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:filter_by_roles.Vitro
+uil-data:filter_by_roles.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Filtrar por roles"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "filter_by_roles" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "filter_by_roles" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:page_uri_missing_msg.Vitro
+uil-data:page_uri_missing_msg.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "No se pudo generar la página porque no estaba claro qué página se estaba solicitando. Es posible que falte una asignación de URL."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "page_uri_missing_msg" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "page_uri_missing_msg" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:fatal_error.Vitro
+uil-data:fatal_error.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Error Fatal"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "fatal_error" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "fatal_error" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:page_select_permission_option.Vitro
+uil-data:page_select_permission_option.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Seleccione el permiso"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "page_select_permission_option" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "page_select_permission_option" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:january.Vitro
+uil-data:january.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Enero"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "january" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "january" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:property.Vitro
+uil-data:property.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "propiedad"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "property" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "property" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:external_auth_id.Vitro
+uil-data:external_auth_id.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "ID de autenticación externa"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "external_auth_id" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "external_auth_id" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:date_time_value_for.Vitro
+uil-data:date_time_value_for.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "valor de fecha y hora para"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "date_time_value_for" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "date_time_value_for" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:sparql_query_title.Vitro
+uil-data:sparql_query_title.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "SPARQL Query"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "sparql_query_title" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "sparql_query_title" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:previous.Vitro
+uil-data:previous.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Anterior"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "previous" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "previous" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:upload_page_title_with_name.Vitro
+uil-data:upload_page_title_with_name.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Subir imagen de {0}"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "upload_page_title_with_name" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "upload_page_title_with_name" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:cant_change_password_while_logged_in.Vitro
+uil-data:cant_change_password_while_logged_in.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "El usuario no puede cambiar la contraseña de {0} mientras está conectado como {1}. Por favor, cierre la sesión y vuelva a intentarlo."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "cant_change_password_while_logged_in" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "cant_change_password_while_logged_in" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:rejected_spam.Vitro
+uil-data:rejected_spam.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "RECHAZADO - SPAM"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "rejected_spam" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "rejected_spam" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:logins_are_open.Vitro
+uil-data:logins_are_open.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "El inicio de sesión está abierto a todos los usuarios."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "logins_are_open" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "logins_are_open" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:confirm_delete_account_singular.Vitro
+uil-data:confirm_delete_account_singular.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "¿Está seguro de que desea eliminar esta cuenta?"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "confirm_delete_account_singular" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "confirm_delete_account_singular" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:all_capitalized.Vitro
+uil-data:all_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Todo"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "all_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "all_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:of_the_results.Vitro
+uil-data:of_the_results.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "de los resultados"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "of_the_results" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "of_the_results" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_content_type.Vitro
+uil-data:select_content_type.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Usted debe seleccionar el contenido que se incluirán en la página"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_content_type" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_content_type" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:visit_project_website.Vitro
+uil-data:visit_project_website.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Visite el sitio web de la institución"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "visit_project_website" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "visit_project_website" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:view_labels_for.Vitro
+uil-data:view_labels_for.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ver etiquetas de"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "view_labels_for" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "view_labels_for" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:new_account_note.Vitro
+uil-data:new_account_note.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Nota: Un correo electrónico será enviado a la dirección indicada anteriormente notificando que una cuenta ha sido creada. Se incluyen instrucciones para la activación de la cuenta y la creación de una contraseña."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "new_account_note" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "new_account_note" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_alert_icon.Vitro
+uil-data:error_alert_icon.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "icono alerta de error"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_alert_icon" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_alert_icon" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:imageUpload.errorImageTooSmall.Vitro
+uil-data:imageUpload.errorImageTooSmall.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "La imagen cargada debe ser de al menos {0} píxeles de alto y {1} píxeles de ancho."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "imageUpload.errorImageTooSmall" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "imageUpload.errorImageTooSmall" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_account_to_delete.Vitro
+uil-data:select_account_to_delete.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "seleccione una cuenta para eliminarla"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_account_to_delete" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_account_to_delete" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:interest_thanks.Vitro
+uil-data:interest_thanks.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Gracias por su interés en {0}. Por favor, envíe este formulario con preguntas, comentarios o sugerencias sobre el contenido de este sitio."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "interest_thanks" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "interest_thanks" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:year_numeric.Vitro
+uil-data:year_numeric.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Entrada invalida. El año debe ser numérico."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "year_numeric" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "year_numeric" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_an_existing_document.Vitro
+uil-data:select_an_existing_document.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Seleccione un documento existente"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_an_existing_document" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_an_existing_document" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:password_length.Vitro
+uil-data:password_length.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "La contraseña debe tener entre {0} y {1} caracteres."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "password_length" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "password_length" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:monday.Vitro
+uil-data:monday.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Lunes"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "monday" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "monday" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:account_created_subject.Vitro
+uil-data:account_created_subject.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Su {0} cuenta ha sido creada."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "account_created_subject" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "account_created_subject" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:vitro_bullet_three.Vitro
+uil-data:vitro_bullet_three.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Construir un sitio web público para mostrar sus datos"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "vitro_bullet_three" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "vitro_bullet_three" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:photo.Vitro
+uil-data:photo.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Foto"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "photo" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "photo" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:file_must_be_entered_msg.Vitro
+uil-data:file_must_be_entered_msg.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "se debe ingresar un archivo para este campo."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "file_must_be_entered_msg" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "file_must_be_entered_msg" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:entity_to_query_for.Vitro
+uil-data:entity_to_query_for.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Este id es el identificador del usuario a consultar. netid también funciona."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "entity_to_query_for" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "entity_to_query_for" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:manage_grants_and_projects_link.Vitro
+uil-data:manage_grants_and_projects_link.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "administrar subvenciones y proyectos"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "manage_grants_and_projects_link" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "manage_grants_and_projects_link" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:manage_labels_intro.Vitro
+uil-data:manage_labels_intro.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "En el caso de que existan varias etiquetas en el mismo idioma, por favor, utilice el enlace remove para eliminar las etiquetas que no desea que aparezcan en la página de perfil para un determinado idioma."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "manage_labels_intro" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "manage_labels_intro" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:hide_show_properties.Vitro
+uil-data:hide_show_properties.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "ocultar/mostrar las propiedades"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "hide_show_properties" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "hide_show_properties" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:untitled.Vitro
+uil-data:untitled.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "-sin titulo-"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "untitled" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "untitled" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:manage_publications_link.Vitro
+uil-data:manage_publications_link.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "administrar publicaciones"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "manage_publications_link" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "manage_publications_link" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_all.Vitro
+uil-data:select_all.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "seleccionar todo"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_all" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_all" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:local_name.Vitro
+uil-data:local_name.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Nombre local"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "local_name" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "local_name" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:end_interval_must_follow_start_interval.Vitro
+uil-data:end_interval_must_follow_start_interval.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "El intervalo final debe ser posterior al intervalo inicial."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "end_interval_must_follow_start_interval" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "end_interval_must_follow_start_interval" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:view_page.Vitro
+uil-data:view_page.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ver página"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "view_page" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "view_page" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:browse_page_javascript_one.Vitro
+uil-data:browse_page_javascript_one.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Esta página de exploración requiere javascript, su navegador está configurado para deshabilitar javascript. Favor de habilitarlo para poder hacer uso de Javascript"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "browse_page_javascript_one" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "browse_page_javascript_one" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:sparql_query_builder.Vitro
+uil-data:sparql_query_builder.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Generador de consultas SPARQL"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "sparql_query_builder" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "sparql_query_builder" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:sub_properties.Vitro
+uil-data:sub_properties.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Subpropiedades"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "sub_properties" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "sub_properties" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:add_label_for_language.Vitro
+uil-data:add_label_for_language.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "idioma"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "add_label_for_language" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "add_label_for_language" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:file_upload_error_file_not_found.Vitro
+uil-data:file_upload_error_file_not_found.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "file_upload_error_file_not_found" ;
-        prop:hasPackage  "Vitro-languages" .
+        rdf:type         uil:UILabel ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "file_upload_error_file_not_found" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:file_upload_predicate.Vitro
+uil-data:file_upload_predicate.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "file_upload_predicate" ;
-        prop:hasPackage  "Vitro-languages" .
+        rdf:type         uil:UILabel ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "file_upload_predicate" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:start_with_leading_slash.Vitro
+uil-data:start_with_leading_slash.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Debe comenzar con una barra diagonal principal: / (por ejemplo, /people)"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "start_with_leading_slash" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "start_with_leading_slash" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:trace_available.Vitro
+uil-data:trace_available.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Traza completa disponible en el registro de VIVO"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "trace_available" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "trace_available" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:editing_prohibited.Vitro
+uil-data:editing_prohibited.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Esta propiedad está configurada para no permitir la edición."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "editing_prohibited" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "editing_prohibited" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:verbose_status_on.Vitro
+uil-data:verbose_status_on.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "encendido"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "verbose_status_on" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "verbose_status_on" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:use_capitalized.Vitro
+uil-data:use_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Usar"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "use_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "use_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:search_index_status.Vitro
+uil-data:search_index_status.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Estatus del índice de búsqueda"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "search_index_status" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "search_index_status" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:filter_search.Vitro
+uil-data:filter_search.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Filtrar búsqueda"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "filter_search" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "filter_search" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:with_vitro.Vitro
+uil-data:with_vitro.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Con Vitro, puede:"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "with_vitro" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "with_vitro" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:site_information.Vitro
+uil-data:site_information.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Información del sitio"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "site_information" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "site_information" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:logins_temporarily_disabled.Vitro
+uil-data:logins_temporarily_disabled.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Los inicios de sesión de usuario están desactivados temporalmente mientras se da mantenimiento al sistema."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "logins_temporarily_disabled" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "logins_temporarily_disabled" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:leave_password_unchanged.Vitro
+uil-data:leave_password_unchanged.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Si deja este campo en blanco no se cambiará la contraseña."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "leave_password_unchanged" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "leave_password_unchanged" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:query_model.Vitro
+uil-data:query_model.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Consulta de modelo"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "query_model" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "query_model" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:restrict_logins_mixed_caps.Vitro
+uil-data:restrict_logins_mixed_caps.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Restringir inicios de sesión"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "restrict_logins_mixed_caps" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "restrict_logins_mixed_caps" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:wednesday.Vitro
+uil-data:wednesday.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Miércoles"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "wednesday" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "wednesday" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:berries.Vitro
+uil-data:berries.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Bayas:"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "berries" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "berries" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:full_name.Vitro
+uil-data:full_name.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Nombre completo"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "full_name" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "full_name" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:no_email_supplied.Vitro
+uil-data:no_email_supplied.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Sin correo electrónico proporcionado."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "no_email_supplied" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "no_email_supplied" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_was_reported.Vitro
+uil-data:error_was_reported.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Este error se ha reportado al administrador del sitio."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_was_reported" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_was_reported" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:search_results_for.Vitro
+uil-data:search_results_for.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Resultados de la búsqueda"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "search_results_for" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "search_results_for" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:search_tip_three.Vitro
+uil-data:search_tip_three.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "A excepción de los operadores booleanos, las búsquedas <strong>no distinguen</strong> entre mayúsculas y minúsculas, por lo que \"Ginebra\" y \"ginebra\" son equivalentes."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "search_tip_three" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "search_tip_three" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:view_profile_for_page.Vitro
+uil-data:view_profile_for_page.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "ver el perfil individual de esta página"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "view_profile_for_page" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "view_profile_for_page" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:reordering_menus_failed.Vitro
+uil-data:reordering_menus_failed.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Error al reordenar los elementos de menú."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "reordering_menus_failed" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "reordering_menus_failed" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:verbose_control.Vitro
+uil-data:verbose_control.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "control detallado"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "verbose_control" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "verbose_control" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:ontology_list.Vitro
+uil-data:ontology_list.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Lista de ontologías"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "ontology_list" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "ontology_list" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:edit_entry.Vitro
+uil-data:edit_entry.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "modifique esta entrada"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "edit_entry" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "edit_entry" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:label.dateTimeWithPrecision.minutes_capitalized.Vitro
+uil-data:label.dateTimeWithPrecision.minutes_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Minutas"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "label.dateTimeWithPrecision.minutes_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "label.dateTimeWithPrecision.minutes_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:object.Vitro
+uil-data:object.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "objeto"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "object" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "object" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:confirm_email_changed_email_html_text.Vitro
+uil-data:confirm_email_changed_email_html_text.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "<p>\n Hola, ${userAccount.firstName} ${userAccount.lastName}\n </p>\n\n <p>\n Ha cambiado recientemente la dirección de correo electrónico asociada a\n ${userAccount.firstName} ${userAccount.lastName}\n </p>\n\n <p>\n Gracias.\n </p>"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "confirm_email_changed_email_html_text" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "confirm_email_changed_email_html_text" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_no_new_password.Vitro
+uil-data:error_no_new_password.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Introduzca su nueva contraseña."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_no_new_password" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_no_new_password" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:page_loggedin_permission_option.Vitro
+uil-data:page_loggedin_permission_option.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Usuarios conectados pueden ver esta página"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "page_loggedin_permission_option" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "page_loggedin_permission_option" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:expecting_content.Vitro
+uil-data:expecting_content.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "¿Esperando contenido?"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "expecting_content" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "expecting_content" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:required_fields.Vitro
+uil-data:required_fields.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Campos obligatorios"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "required_fields" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "required_fields" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:edit_page_title.Vitro
+uil-data:edit_page_title.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Edit"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "edit_page_title" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "edit_page_title" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_existing.Vitro
+uil-data:select_existing.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Seleccionar existente"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_existing" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_existing" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:invalid_url_msg.Vitro
+uil-data:invalid_url_msg.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Esta URL debe comenzar con http: // o https: //"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "invalid_url_msg" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "invalid_url_msg" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:search_button.Vitro
+uil-data:search_button.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Buscar"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "search_button" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "search_button" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:advanced_search_tips_header.Vitro
+uil-data:advanced_search_tips_header.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Consejos Avanzados"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "advanced_search_tips_header" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "advanced_search_tips_header" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:supply_url.Vitro
+uil-data:supply_url.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Debe proporcionar una URL completa"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "supply_url" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "supply_url" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_profiles.Vitro
+uil-data:select_profiles.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Seleccione perfiles"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_profiles" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_profiles" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_one.Vitro
+uil-data:select_one.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Seleccione uno"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_one" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_one" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:continue.Vitro
+uil-data:continue.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Continuar"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "continue" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "continue" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:language_selection_failed.Vitro
+uil-data:language_selection_failed.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Hubo un problema en el sistema. La selección del idioma fue rechazada."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "language_selection_failed" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "language_selection_failed" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:display_has_element_error.Vitro
+uil-data:display_has_element_error.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Se produjo un error en el sistema. La pantalla: propiedad hasElement no se pudo recuperar."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "display_has_element_error" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "display_has_element_error" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:file_upload_error_file_is_too_big.Vitro
+uil-data:file_upload_error_file_is_too_big.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "file_upload_error_file_is_too_big" ;
-        prop:hasPackage  "Vitro-languages" .
+        rdf:type         uil:UILabel ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "file_upload_error_file_is_too_big" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:template_capitalized.Vitro
+uil-data:template_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Plantilla"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "template_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "template_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:file_upload_supported_media.Vitro
+uil-data:file_upload_supported_media.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "file_upload_supported_media" ;
-        prop:hasPackage  "Vitro-languages" .
+        rdf:type         uil:UILabel ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "file_upload_supported_media" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:user_accounts_title.Vitro
+uil-data:user_accounts_title.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Cuentas de usuario"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "user_accounts_title" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "user_accounts_title" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:create_your_password.Vitro
+uil-data:create_your_password.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Crear contraseña"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "create_your_password" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "create_your_password" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:create_account.Vitro
+uil-data:create_account.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Crear una cuenta"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "create_account" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "create_account" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:remove_menu_item.Vitro
+uil-data:remove_menu_item.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Eliminar elemento de menú"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "remove_menu_item" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "remove_menu_item" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:click_to_view_account.Vitro
+uil-data:click_to_view_account.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "haga clic para ver detalles de la cuenta"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "click_to_view_account" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "click_to_view_account" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:add_new_entry_for.Vitro
+uil-data:add_new_entry_for.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Agregar nueva entrada para:"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "add_new_entry_for" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "add_new_entry_for" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:menu_ordering.Vitro
+uil-data:menu_ordering.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Orden del Menú"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "menu_ordering" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "menu_ordering" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:map_processor_error.Vitro
+uil-data:map_processor_error.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ha ocurrido un error y el mapa de los procesadores con este tipo de contenido está ausente. Por favor, póngase en contacto con el administrador"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "map_processor_error" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "map_processor_error" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:change_profile_title.Vitro
+uil-data:change_profile_title.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "cambiar el perfil"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "change_profile_title" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "change_profile_title" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:domain_class.Vitro
+uil-data:domain_class.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Dominio de clase"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "domain_class" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "domain_class" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:manage_labels_capitalized.Vitro
+uil-data:manage_labels_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Administrar etiquetas"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "manage_labels_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "manage_labels_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_passwords_dont_match.Vitro
+uil-data:error_passwords_dont_match.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Las contraseñas introducidas no coinciden."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_passwords_dont_match" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_passwords_dont_match" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:save_profile_changes.Vitro
+uil-data:save_profile_changes.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Guarde los cambios en los perfiles"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "save_profile_changes" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "save_profile_changes" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:site_administration.Vitro
+uil-data:site_administration.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Administración del sitio"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "site_administration" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "site_administration" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:vitro_bullet_one.Vitro
+uil-data:vitro_bullet_one.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Crear o cargar ontologías en formato OWL"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "vitro_bullet_one" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "vitro_bullet_one" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:pages.Vitro
+uil-data:pages.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "páginas"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "pages" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "pages" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:inferred_class_hierarchy.Vitro
+uil-data:inferred_class_hierarchy.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Jerarquía de clase deducida"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "inferred_class_hierarchy" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "inferred_class_hierarchy" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:auth_id_in_use.Vitro
+uil-data:auth_id_in_use.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Este identificador ya está en uso."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "auth_id_in_use" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "auth_id_in_use" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:data_input.Vitro
+uil-data:data_input.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Entrada de datos"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "data_input" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "data_input" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:recompute_inferences_mixed_caps.Vitro
+uil-data:recompute_inferences_mixed_caps.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Recalcular inferencias"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "recompute_inferences_mixed_caps" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "recompute_inferences_mixed_caps" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:individual_name.Vitro
+uil-data:individual_name.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "nombre individual"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "individual_name" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "individual_name" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:thursday.Vitro
+uil-data:thursday.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Jueves"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "thursday" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "thursday" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:alert_icon.Vitro
+uil-data:alert_icon.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Icono de alerta"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "alert_icon" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "alert_icon" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:if_blank_page_title_used.Vitro
+uil-data:if_blank_page_title_used.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Si se deja en blanco, se utilizará el título de la página."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "if_blank_page_title_used" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "if_blank_page_title_used" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:password_reset_pending_email_plain_text.Vitro
+uil-data:password_reset_pending_email_plain_text.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Estimado ${userAccount.firstName} ${userAccount.lastName}:\n\nHemos recibido una solicitud para restablecer la contraseña de tu cuenta ${siteName}\n(${userAccount.emailAddress}).\n\nPor favor, sigue las siguientes instrucciones para proceder con el restablecimiento de tu contraseña.\n\nSi no has solicitado esta nueva cuenta puedes ignorar este mensaje.\nEsta solicitud caducará si no se activa en un plazo de 30 días.\n\nPega el siguiente enlace en la barra de direcciones de tu navegador para\nrestablecer tu contraseña usando nuestro servidor seguro.\n\n${passwordLink}\n\n¡Gracias!\n"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "password_reset_pending_email_plain_text" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "password_reset_pending_email_plain_text" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:hide_properties.Vitro
+uil-data:hide_properties.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "ocultar las propiedades"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "hide_properties" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "hide_properties" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:file_upload_error_file_type_not_recognized.Vitro
+uil-data:file_upload_error_file_type_not_recognized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "file_upload_error_file_type_not_recognized" ;
-        prop:hasPackage  "Vitro-languages" .
+        rdf:type         uil:UILabel ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "file_upload_error_file_type_not_recognized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_no_role.Vitro
+uil-data:error_no_role.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Debe seleccionar un rol."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_no_role" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_no_role" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:new_account_title.Vitro
+uil-data:new_account_title.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "nueva cuenta"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "new_account_title" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "new_account_title" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:file_upload_no_allowed_media.Vitro
+uil-data:file_upload_no_allowed_media.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "file_upload_no_allowed_media" ;
-        prop:hasPackage  "Vitro-languages" .
+        rdf:type         uil:UILabel ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "file_upload_no_allowed_media" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:property_groups.Vitro
+uil-data:property_groups.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Grupos de propiedades"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "property_groups" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "property_groups" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:startup_trace.Vitro
+uil-data:startup_trace.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Rastro de inicio"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "startup_trace" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "startup_trace" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:search_accounts_button.Vitro
+uil-data:search_accounts_button.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Buscar cuentas"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "search_accounts_button" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "search_accounts_button" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:operation_unsuccessful.Vitro
+uil-data:operation_unsuccessful.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "La operación no tuvo éxito. Los detalles completos se pueden encontrar en el registro del sistema."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "operation_unsuccessful" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "operation_unsuccessful" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:submit_button.Vitro
+uil-data:submit_button.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Enviar"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "submit_button" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "submit_button" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:page_uri_missing.Vitro
+uil-data:page_uri_missing.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "No hay URI de página especificado"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "page_uri_missing" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "page_uri_missing" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_no_email_address.Vitro
+uil-data:error_no_email_address.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Introduzca su dirección de correo electrónico."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_no_email_address" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_no_email_address" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:controls.Vitro
+uil-data:controls.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Controles"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "controls" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "controls" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:fruit.Vitro
+uil-data:fruit.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Fruta"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "fruit" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "fruit" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:admin_panel.Vitro
+uil-data:admin_panel.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Panel de administración"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "admin_panel" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "admin_panel" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:the_range_class_does_not_exist.Vitro
+uil-data:the_range_class_does_not_exist.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "La clase de rango de esta propiedad no existe en el sistema."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "the_range_class_does_not_exist" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "the_range_class_does_not_exist" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:reset_your_password.Vitro
+uil-data:reset_your_password.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Renovar su contraseña"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "reset_your_password" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "reset_your_password" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:advanced_search_tip_two.Vitro
+uil-data:advanced_search_tip_two.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "\"NOT\" puede ayudar a limitar búsquedas -- por ejemplo, <i>clima</i> NOT <i>cambia</i>."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "advanced_search_tip_two" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "advanced_search_tip_two" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:save_new_page.Vitro
+uil-data:save_new_page.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Guardar página nueva"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "save_new_page" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "save_new_page" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:book_title.Vitro
+uil-data:book_title.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Título del libro:"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "book_title" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "book_title" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:view_content_index.Vitro
+uil-data:view_content_index.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ver un resumen de los contenidos de este sitio"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "view_content_index" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "view_content_index" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:or_create_new_one.Vitro
+uil-data:or_create_new_one.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "o cree uno nuevo."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "or_create_new_one" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "or_create_new_one" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:remove_selection.Vitro
+uil-data:remove_selection.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Eliminar selección"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "remove_selection" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "remove_selection" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:cardinality.Vitro
+uil-data:cardinality.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "cardinalidad"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "cardinality" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "cardinality" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:apostrophe_not_allowed.Vitro
+uil-data:apostrophe_not_allowed.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "El nombre de la variable no debe tener un apóstrofe."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "apostrophe_not_allowed" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "apostrophe_not_allowed" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:confirm_menu_item_delete.Vitro
+uil-data:confirm_menu_item_delete.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "¿Está seguro de que desea eliminar"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "confirm_menu_item_delete" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "confirm_menu_item_delete" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:work_level.Vitro
+uil-data:work_level.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Nivel de trabajo"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "work_level" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "work_level" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:acct_created_external_only_email_html_text.Vitro
+uil-data:acct_created_external_only_email_html_text.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "<p>\n ${userAccount.firstName} ${userAccount.lastName}\n </p>\n\n <p>\n <strong>¡Enhorabuena!</strong>\n </p>\n\n <p>\n Hemos creado la nueva cuenta VIVO asociado con ${userAccount.emailAddress}.\n </p>\n\n <p>\n ¡Gracias!\n </p>\n"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "acct_created_external_only_email_html_text" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "acct_created_external_only_email_html_text" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:friday.Vitro
+uil-data:friday.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Viernes"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "friday" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "friday" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:return_to_the.Vitro
+uil-data:return_to_the.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Vuelva a la"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "return_to_the" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "return_to_the" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:sparql_query.Vitro
+uil-data:sparql_query.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Consulta SPARQL"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "sparql_query" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "sparql_query" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:myAccount_confirm_changes.Vitro
+uil-data:myAccount_confirm_changes.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Los cambios se han guardado."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "myAccount_confirm_changes" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "myAccount_confirm_changes" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:to.Vitro
+uil-data:to.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "a"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "to" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "to" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:login_to_manage_site.Vitro
+uil-data:login_to_manage_site.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Iniciar sesión para administrar este sitio"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "login_to_manage_site" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "login_to_manage_site" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:a_classgroup.Vitro
+uil-data:a_classgroup.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "un grupo de clase"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "a_classgroup" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "a_classgroup" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:upload_page_title.Vitro
+uil-data:upload_page_title.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Subir imágen"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "upload_page_title" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "upload_page_title" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_existing_collaborator.Vitro
+uil-data:select_existing_collaborator.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Seleccione un colaborador existente para {0}"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_existing_collaborator" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_existing_collaborator" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:label.dateTimeWithPrecision.day_capitalized.Vitro
+uil-data:label.dateTimeWithPrecision.day_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Día"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "label.dateTimeWithPrecision.day_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "label.dateTimeWithPrecision.day_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:login_button.Vitro
+uil-data:login_button.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Iniciar sesión"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "login_button" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "login_button" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:internal_login.Vitro
+uil-data:internal_login.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Inicio de sesión interno"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "internal_login" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "internal_login" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_occurred.Vitro
+uil-data:error_occurred.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Se ha producido un error en el sitio VIVO"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_occurred" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_occurred" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:advanced_search_tip_four.Vitro
+uil-data:advanced_search_tip_four.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Asimismo, se encuentra variaciones de palabras -- por ejemplo, <i>secuencia</i> similar <i>secuencias</i> y <i>secuenciación</i>."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "advanced_search_tip_four" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "advanced_search_tip_four" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:updated_account_title.Vitro
+uil-data:updated_account_title.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "cuenta actualizada"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "updated_account_title" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "updated_account_title" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:year_month_day.Vitro
+uil-data:year_month_day.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Entrada invalida. Por favor ingrese un año, mes y día."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "year_month_day" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "year_month_day" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:log_out.Vitro
+uil-data:log_out.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Finalizar sesión"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "log_out" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "log_out" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:application_error_email_plain_text.Vitro
+uil-data:application_error_email_plain_text.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Se ha producido un error en tu sitio ${siteName!} en ${datetime!}.\nURL solicitada: ${requestedUrl!}\n\n<#if errorMessage?has_content>\n Mensaje de error: ${errorMessage!}\n</#if>\n\nTraza de errores (Traza completa disponible en el registro):\n${stackTrace!}\n\n<#if cause?has_content>\nCausada por:\n${cause!}\n</#if>"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "application_error_email_plain_text" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "application_error_email_plain_text" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_vclass_uri.Vitro
+uil-data:select_vclass_uri.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Seleccione VClass"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_vclass_uri" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_vclass_uri" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:custom_template_requiring_content.Vitro
+uil-data:custom_template_requiring_content.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Plantilla personalizada, requiere contenido"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "custom_template_requiring_content" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "custom_template_requiring_content" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:file_upload_error_uri_not_exists.Vitro
+uil-data:file_upload_error_uri_not_exists.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "file_upload_error_uri_not_exists" ;
-        prop:hasPackage  "Vitro-languages" .
+        rdf:type         uil:UILabel ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "file_upload_error_uri_not_exists" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:external_id_not_provided.Vitro
+uil-data:external_id_not_provided.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Error de acceso - no se encuentra el ID externo."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "external_id_not_provided" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "external_id_not_provided" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:imageUpload.errorBadMultipartRequest.Vitro
+uil-data:imageUpload.errorBadMultipartRequest.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Error al analizar la solicitud de varias partes para subir una imagen."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "imageUpload.errorBadMultipartRequest" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "imageUpload.errorBadMultipartRequest" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:view_all_accounts.Vitro
+uil-data:view_all_accounts.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ver todas las cuentas"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "view_all_accounts" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "view_all_accounts" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:file_upload_file.Vitro
+uil-data:file_upload_file.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "file_upload_file" ;
-        prop:hasPackage  "Vitro-languages" .
+        rdf:type         uil:UILabel ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "file_upload_file" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:search_failed.Vitro
+uil-data:search_failed.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "La búsqueda ha fallado."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "search_failed" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "search_failed" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:minimum_hour.Vitro
+uil-data:minimum_hour.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Entrada invalida. Por favor, especifique al menos una hora."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "minimum_hour" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "minimum_hour" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:faux_property_alpha.Vitro
+uil-data:faux_property_alpha.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "propiedades falsas alfabéticamente"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "faux_property_alpha" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "faux_property_alpha" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:info_icon.Vitro
+uil-data:info_icon.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "icono de información"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "info_icon" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "info_icon" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:save_button.Vitro
+uil-data:save_button.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Guardar"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "save_button" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "save_button" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:who_can_edit_profile.Vitro
+uil-data:who_can_edit_profile.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Quién puede modificar mi perfil"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "who_can_edit_profile" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "who_can_edit_profile" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:add_an_entry_to.Vitro
+uil-data:add_an_entry_to.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Agregue una entrada de tipo"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "add_an_entry_to" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "add_an_entry_to" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:page_not_found_msg.Vitro
+uil-data:page_not_found_msg.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "La página no se encontró en el sistema."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "page_not_found_msg" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "page_not_found_msg" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:no_content_in_system.Vitro
+uil-data:no_content_in_system.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Actualmente no existen {0} dentro del sistema"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "no_content_in_system" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "no_content_in_system" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:rdf.Vitro
+uil-data:rdf.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "RDF"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "rdf" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "rdf" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:datetime_year_required.Vitro
+uil-data:datetime_year_required.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Intervalos de fecha / hora deben empezar por el año. Ingrese una fecha de inicio, una fecha final, o ambas."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "datetime_year_required" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "datetime_year_required" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:external_auth_name.Vitro
+uil-data:external_auth_name.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Nombre de autenticación externo"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "external_auth_name" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "external_auth_name" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:external_login_failed.Vitro
+uil-data:external_login_failed.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Error de inicio"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "external_login_failed" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "external_login_failed" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:label.dateTimeWithPrecision.seconds_capitalized.Vitro
+uil-data:label.dateTimeWithPrecision.seconds_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Segundos"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "label.dateTimeWithPrecision.seconds_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "label.dateTimeWithPrecision.seconds_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:custom_template.Vitro
+uil-data:custom_template.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Plantilla personalizada"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "custom_template" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "custom_template" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:associated_profile_label.Vitro
+uil-data:associated_profile_label.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Perfil asociado:"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "associated_profile_label" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "associated_profile_label" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:page_not_found.Vitro
+uil-data:page_not_found.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Página no encontrada"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "page_not_found" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "page_not_found" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_existing_last_name.Vitro
+uil-data:select_existing_last_name.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Seleccione un apellido existente"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_existing_last_name" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_existing_last_name" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:title_capitalized.Vitro
+uil-data:title_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Título"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "title_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "title_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:file_upload_error_no_action.Vitro
+uil-data:file_upload_error_no_action.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "file_upload_error_no_action" ;
-        prop:hasPackage  "Vitro-languages" .
+        rdf:type         uil:UILabel ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "file_upload_error_no_action" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:change_entry_for.Vitro
+uil-data:change_entry_for.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Cambiar entrada para:"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "change_entry_for" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "change_entry_for" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:cause.Vitro
+uil-data:cause.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Causa:"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "cause" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "cause" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:may_edit.Vitro
+uil-data:may_edit.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Puede editar"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "may_edit" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "may_edit" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:properties.Vitro
+uil-data:properties.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "propiedades"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "properties" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "properties" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:add_new.Vitro
+uil-data:add_new.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Agregar nuevo"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "add_new" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "add_new" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:apples.Vitro
+uil-data:apples.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Manzanas"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "apples" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "apples" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:tuesday.Vitro
+uil-data:tuesday.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Martes"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "tuesday" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "tuesday" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:email_changed_subject.Vitro
+uil-data:email_changed_subject.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Su {0} cuenta de correo electrónico se ha cambiado."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "email_changed_subject" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "email_changed_subject" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:site_admin.Vitro
+uil-data:site_admin.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Administración del sitio"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "site_admin" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "site_admin" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:code_processing_error.Vitro
+uil-data:code_processing_error.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ha ocurrido un error y al código de procesamiento de este contenido le falta un componente. Por favor, póngase en contacto con el administrador."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "code_processing_error" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "code_processing_error" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:base_property_capitalized.Vitro
+uil-data:base_property_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Propiedad base"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "base_property_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "base_property_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:username.Vitro
+uil-data:username.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Nombre de usuario"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "username" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "username" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:to_order_menu_items.Vitro
+uil-data:to_order_menu_items.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "para establecer el orden de los elementos del menú."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "to_order_menu_items" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "to_order_menu_items" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:none.Vitro
+uil-data:none.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "ninguno"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "none" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "none" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:classes_capitalized.Vitro
+uil-data:classes_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Clases"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "classes_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "classes_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:cancel_link.Vitro
+uil-data:cancel_link.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Cancelar"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "cancel_link" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "cancel_link" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:send_feedback_questions.Vitro
+uil-data:send_feedback_questions.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Envíenos sus comentarios o haga una pregunta"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "send_feedback_questions" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "send_feedback_questions" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:account_already_activated.Vitro
+uil-data:account_already_activated.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "La cuenta para {0} ya se ha activado."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "account_already_activated" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "account_already_activated" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:page.Vitro
+uil-data:page.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "página"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "page" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "page" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:type_more_characters.Vitro
+uil-data:type_more_characters.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Escribir más caracteres"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "type_more_characters" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "type_more_characters" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:search_tips_header.Vitro
+uil-data:search_tips_header.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Consejos de Búsqueda"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "search_tips_header" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "search_tips_header" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:data_not_past_msg.Vitro
+uil-data:data_not_past_msg.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Introduzca una fecha objetivo futura para la publicación (las fechas anteriores no son válidas)."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "data_not_past_msg" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "data_not_past_msg" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_associated_profile.Vitro
+uil-data:select_associated_profile.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Seleccione el perfil asociado"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_associated_profile" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_associated_profile" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:edit_capitalized.Vitro
+uil-data:edit_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Editar"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "edit_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "edit_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:site_name.Vitro
+uil-data:site_name.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "nombre del sitio"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "site_name" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "site_name" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:replace_photo.Vitro
+uil-data:replace_photo.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Reemplazar foto"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "replace_photo" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "replace_photo" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:rebuild_button.Vitro
+uil-data:rebuild_button.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Reconstruir"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "rebuild_button" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "rebuild_button" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:numbers.Vitro
+uil-data:numbers.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Números"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "numbers" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "numbers" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:acct_created_external_only_email_plain_text.Vitro
+uil-data:acct_created_external_only_email_plain_text.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "${userAccount.firstName} ${userAccount.lastName}\n\n¡Enhorabuena!\n\nHemos creado la nueva cuenta VIVO asociado con\n${userAccount.emailAddress}.\n\n¡Gracias!"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "acct_created_external_only_email_plain_text" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "acct_created_external_only_email_plain_text" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:auth_id_explanation.Vitro
+uil-data:auth_id_explanation.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Puede ser usado para asociar la cuenta con el perfil del usuario a través de la propiedad correspondiente."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "auth_id_explanation" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "auth_id_explanation" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:support.Vitro
+uil-data:support.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Soporte"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "support" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "support" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:enter_search_term.Vitro
+uil-data:enter_search_term.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Por favor introduzca un término de búsqueda."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "enter_search_term" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "enter_search_term" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:feedback_thanks_heading.Vitro
+uil-data:feedback_thanks_heading.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Gracias por su colaboración"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "feedback_thanks_heading" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "feedback_thanks_heading" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:updated_account_notification.Vitro
+uil-data:updated_account_notification.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Un correo electrónico de confirmación ha sido enviado a {0} con instrucciones para restablecer la contraseña. La contraseña no se restablecerá hasta que el usuario acceda al enlace que aparece en este correo electrónico."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "updated_account_notification" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "updated_account_notification" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:menu_ordering_mixed_caps.Vitro
+uil-data:menu_ordering_mixed_caps.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Orden del Menú"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "menu_ordering_mixed_caps" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "menu_ordering_mixed_caps" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:expand_all.Vitro
+uil-data:expand_all.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "expandir todo"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "expand_all" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "expand_all" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:confirm_password_capitalized.Vitro
+uil-data:confirm_password_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Confirmar Contraseña"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "confirm_password_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "confirm_password_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:uri_not_defined.Vitro
+uil-data:uri_not_defined.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "URI de página no definido"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "uri_not_defined" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "uri_not_defined" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:a_link.Vitro
+uil-data:a_link.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "un enlace"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "a_link" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "a_link" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:view_list_of_labels.Vitro
+uil-data:view_list_of_labels.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Visualizarla la lista de etiquetas"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "view_list_of_labels" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "view_list_of_labels" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:not_logged_in.Vitro
+uil-data:not_logged_in.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "No logueado"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "not_logged_in" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "not_logged_in" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:page_public_permission_option.Vitro
+uil-data:page_public_permission_option.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Cualquier persona puede ver esta página"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "page_public_permission_option" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "page_public_permission_option" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:file_upload_error_uri_not_given.Vitro
+uil-data:file_upload_error_uri_not_given.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "file_upload_error_uri_not_given" ;
-        prop:hasPackage  "Vitro-languages" .
+        rdf:type         uil:UILabel ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "file_upload_error_uri_not_given" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:file_upload_heading.Vitro
+uil-data:file_upload_heading.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "file_upload_heading" ;
-        prop:hasPackage  "Vitro-languages" .
+        rdf:type         uil:UILabel ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "file_upload_heading" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:save_this_content.Vitro
+uil-data:save_this_content.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Guardar este contenido"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "save_this_content" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "save_this_content" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:data.Vitro
+uil-data:data.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "datos"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "data" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "data" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_incorrect_credentials.Vitro
+uil-data:error_incorrect_credentials.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "El correo o la contraseña son incorrectos."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_incorrect_credentials" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_incorrect_credentials" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:start_url_with_slash.Vitro
+uil-data:start_url_with_slash.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "La URL confiable debe comenzar con una barra diagonal principal"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "start_url_with_slash" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "start_url_with_slash" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:february.Vitro
+uil-data:february.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Febrero"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "february" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "february" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:delete_entry.Vitro
+uil-data:delete_entry.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "eliminar esta entrada"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "delete_entry" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "delete_entry" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:imageUpload.errorFormFieldMissing.Vitro
+uil-data:imageUpload.errorFormFieldMissing.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "El formulario no contiene un campo ''{0}''"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "imageUpload.errorFormFieldMissing" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "imageUpload.errorFormFieldMissing" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:formatted_date_time.Vitro
+uil-data:formatted_date_time.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Formato de fecha y hora"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "formatted_date_time" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "formatted_date_time" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:imageUpload.errorUnknown.Vitro
+uil-data:imageUpload.errorUnknown.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Lo sentimos, la fotografía no ha podido ser procesada. Por favor, intente con otra fotografía"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "imageUpload.errorUnknown" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "imageUpload.errorUnknown" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:password_reset_pending_email_html_text.Vitro
+uil-data:password_reset_pending_email_html_text.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "<p>\n Estimado ${userAccount.firstName} ${userAccount.lastName}:\n </p>\n\n <p>\n Hemos recibido una solicitud para restablecer la contraseña de tu cuenta ${siteName}\n (${userAccount.emailAddress}).\n </p>\n\n <p>\n Por favor, sigue las siguientes instrucciones para proceder con el restablecimiento de tu contraseña.\n </p>\n\n <p>\n Si no has solicitado esta nueva cuenta puedes ignorar este mensaje.\n Esta solicitud caducará si no se activa en un plazo de 30 días.\n </p>\n\n <p>\n Haga clic en el enlace de abajo o pegalo en la barra de direcciones de tu navegador para\n restablecer tu contraseña usando nuestro servidor seguro.\n </p>\n\n <p><a href=\"${passwordLink}\" title=\"password\">${passwordLink}</a> </p>\n\n <p>¡Gracias!</p>"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "password_reset_pending_email_html_text" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "password_reset_pending_email_html_text" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:ontology_editor.Vitro
+uil-data:ontology_editor.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Editor de ontología"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "ontology_editor" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "ontology_editor" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:from_capitalized.Vitro
+uil-data:from_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "De"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "from_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "from_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:logged_out.Vitro
+uil-data:logged_out.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ha cerrado la sesión."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "logged_out" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "logged_out" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:search_for.Vitro
+uil-data:search_for.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Buscar ''{0}''"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "search_for" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "search_for" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:other.Vitro
+uil-data:other.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "otro"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "other" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "other" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:supply_variable_name.Vitro
+uil-data:supply_variable_name.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Debe suministrar una variable para guardar el contenido HTML."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "supply_variable_name" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "supply_variable_name" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:remove_restrictions.Vitro
+uil-data:remove_restrictions.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Eliminar las restricciones"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "remove_restrictions" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "remove_restrictions" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:variable_name_all_caps.Vitro
+uil-data:variable_name_all_caps.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Nombre de la variable"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "variable_name_all_caps" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "variable_name_all_caps" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:levels.Vitro
+uil-data:levels.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Niveles"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "levels" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "levels" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:range_class.Vitro
+uil-data:range_class.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Rango de clase"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "range_class" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "range_class" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:type_more_chars.Vitro
+uil-data:type_more_chars.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "escribir más caracteres"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "type_more_chars" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "type_more_chars" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:advanced_data_tools.Vitro
+uil-data:advanced_data_tools.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Herramientas de datos avanzadas"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "advanced_data_tools" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "advanced_data_tools" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:current_date.Vitro
+uil-data:current_date.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Fecha actual:"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "current_date" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "current_date" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:since_elapsed_time_est_total.Vitro
+uil-data:since_elapsed_time_est_total.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "desde {0}, tiempo transcurrido {1}, tiempo total estimado {2}"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "since_elapsed_time_est_total" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "since_elapsed_time_est_total" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:close.Vitro
+uil-data:close.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "cerrar"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "close" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "close" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:change_selection.Vitro
+uil-data:change_selection.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "cambiar selección"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "change_selection" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "change_selection" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:copyright.Vitro
+uil-data:copyright.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "derechos de autor"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "copyright" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "copyright" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_page_content_type.Vitro
+uil-data:select_page_content_type.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Seleccione el tipo de contenido para la página asociada"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_page_content_type" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_page_content_type" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:zoo_one.Vitro
+uil-data:zoo_one.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Zoológico 1"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "zoo_one" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "zoo_one" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:cancel_title.Vitro
+uil-data:cancel_title.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Cancelar"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "cancel_title" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "cancel_title" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:add_individual_of_class.Vitro
+uil-data:add_individual_of_class.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Agregar usuario o actividad de esta clase"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "add_individual_of_class" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "add_individual_of_class" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:label.dateTimeWithPrecision.year_capitalized.Vitro
+uil-data:label.dateTimeWithPrecision.year_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Año"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "label.dateTimeWithPrecision.year_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "label.dateTimeWithPrecision.year_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:relate_editors_profiles.Vitro
+uil-data:relate_editors_profiles.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Relacionar editores de perfil y perfiles"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "relate_editors_profiles" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "relate_editors_profiles" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:vitro_bullet_four.Vitro
+uil-data:vitro_bullet_four.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Buscar sus datos"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "vitro_bullet_four" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "vitro_bullet_four" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:save_changes.Vitro
+uil-data:save_changes.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Guardar cambios"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "save_changes" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "save_changes" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:cant_activate_while_logged_in.Vitro
+uil-data:cant_activate_while_logged_in.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Usted no puede activar la cuenta para {0} mientras está conectado como {1}. Por favor, cierre la sesión y vuelva a intentarlo."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "cant_activate_while_logged_in" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "cant_activate_while_logged_in" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:next_capitalized.Vitro
+uil-data:next_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Siguiente"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "next_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "next_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:end_capitalized.Vitro
+uil-data:end_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Final"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "end_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "end_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:custom_template_containing_content.Vitro
+uil-data:custom_template_containing_content.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Plantilla personalizada, con todo el contenido"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "custom_template_containing_content" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "custom_template_containing_content" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:name_of.Vitro
+uil-data:name_of.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "name_of" ;
-        prop:hasPackage  "Vitro-languages" .
+        rdf:type         uil:UILabel ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "name_of" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:content_type.Vitro
+uil-data:content_type.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Tipo de contenido"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "content_type" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "content_type" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:add_label.Vitro
+uil-data:add_label.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Añadir etiqueta"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "add_label" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "add_label" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:activate_developer_panel_mixed_caps.Vitro
+uil-data:activate_developer_panel_mixed_caps.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Activar el panel desarrollador"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "activate_developer_panel_mixed_caps" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "activate_developer_panel_mixed_caps" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:reset_search_index.Vitro
+uil-data:reset_search_index.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Restablecer el índice de búsqueda y volver a llenarlo."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "reset_search_index" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "reset_search_index" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:please_provide_contact_information.Vitro
+uil-data:please_provide_contact_information.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Por favor proporcione su información de contacto para terminar de crear la cuenta."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "please_provide_contact_information" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "please_provide_contact_information" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:continued.Vitro
+uil-data:continued.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "continuación"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "continued" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "continued" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_no_email.Vitro
+uil-data:error_no_email.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Debe proporcionar una dirección de correo electrónico."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_no_email" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_no_email" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_no_last_name.Vitro
+uil-data:error_no_last_name.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Debe proporcionar su apellido."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_no_last_name" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_no_last_name" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:december.Vitro
+uil-data:december.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "diciembre"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "december" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "december" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:multiple_content_default_template_error.Vitro
+uil-data:multiple_content_default_template_error.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Con varios tipos de contenido , debe especificar una plantilla personalizada ."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "multiple_content_default_template_error" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "multiple_content_default_template_error" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:all_classes.Vitro
+uil-data:all_classes.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Todas las clases"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "all_classes" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "all_classes" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:viewing_page.Vitro
+uil-data:viewing_page.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Página de verificación"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "viewing_page" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "viewing_page" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:individual_not_found_msg.Vitro
+uil-data:individual_not_found_msg.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "El individuo no se encontró en el sistema."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "individual_not_found_msg" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "individual_not_found_msg" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:setup_navigation_menu.Vitro
+uil-data:setup_navigation_menu.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Configuración del menú principal de navegación de su sitio web"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "setup_navigation_menu" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "setup_navigation_menu" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:external_id_already_in_use.Vitro
+uil-data:external_id_already_in_use.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Cuenta de usuario ya existe para ''{0}''"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "external_id_already_in_use" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "external_id_already_in_use" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:ascending_order.Vitro
+uil-data:ascending_order.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Orden ascendente"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "ascending_order" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "ascending_order" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:browse_all_content.Vitro
+uil-data:browse_all_content.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "navegar por todo el contenido"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "browse_all_content" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "browse_all_content" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:begin_with_slash_no_example.Vitro
+uil-data:begin_with_slash_no_example.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Debe comenzar con una barra diagonal principal: /"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "begin_with_slash_no_example" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "begin_with_slash_no_example" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_occurred_at.Vitro
+uil-data:error_occurred_at.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Se ha producido un error en tu sitio VIVO en {0}."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_occurred_at" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_occurred_at" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_editors.Vitro
+uil-data:select_editors.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Seleccione editores"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_editors" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_editors" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:supply_html.Vitro
+uil-data:supply_html.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Debe proporcionar algo de HTML o de texto."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "supply_html" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "supply_html" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:slash_example.Vitro
+uil-data:slash_example.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "(Por ejemplo, /people)"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "slash_example" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "slash_example" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:property_hierarchy.Vitro
+uil-data:property_hierarchy.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Jerarquía de propiedades"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "property_hierarchy" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "property_hierarchy" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:try_rebuilding_index.Vitro
+uil-data:try_rebuilding_index.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Intenta reconstruir el índice de búsqueda"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "try_rebuilding_index" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "try_rebuilding_index" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_in_search_request.Vitro
+uil-data:error_in_search_request.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "La petición de búsqueda contenía errores."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_in_search_request" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_in_search_request" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:first_time_login.Vitro
+uil-data:first_time_login.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Primer inicio de sesión"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "first_time_login" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "first_time_login" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:first_time_external_email_plain_text.Vitro
+uil-data:first_time_external_email_plain_text.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "${userAccount.firstName} ${userAccount.lastName}\n\n¡Enhorabuena!\n\nHemos creado la nueva cuenta VIVO asociado con\n${userAccount.emailAddress}.\n\n¡Gracias!"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "first_time_external_email_plain_text" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "first_time_external_email_plain_text" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:faux_property_by_base.Vitro
+uil-data:faux_property_by_base.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "propiedades falsas por propiedad base"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "faux_property_by_base" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "faux_property_by_base" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:alt_thumbnail_photo.Vitro
+uil-data:alt_thumbnail_photo.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Foto del usuario"@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "alt_thumbnail_photo" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "alt_thumbnail_photo" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:no_individual_associated_with_id.Vitro
+uil-data:no_individual_associated_with_id.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Por alguna razón, no hay ninguna persona en VIVO que esté asociada con su Net ID. Favor de ponerse en contacto con el administrador de VIVO."@es ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "no_individual_associated_with_id" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "no_individual_associated_with_id" ;
+        uil:hasPackage  "Vitro-languages" .

--- a/home/src/main/resources/rdf/i18n/fr_CA/interface-i18n/firsttime/vitro_UiLabel.ttl
+++ b/home/src/main/resources/rdf/i18n/fr_CA/interface-i18n/firsttime/vitro_UiLabel.ttl
@@ -1,6268 +1,6268 @@
 @prefix owl:   <http://www.w3.org/2002/07/owl#> .
 @prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
-@prefix prop-data: <http://vivoweb.org/ontology/core/properties/individual#> .
-@prefix prop:  <http://vivoweb.org/ontology/core/properties/vocabulary#> .
+@prefix uil-data: <http://vivoweb.org/ontology/vitro/ui-label/individual#> .
+@prefix uil:  <http://vivoweb.org/ontology/vitro/ui-label/vocabulary#> .
 @prefix xsd:   <http://www.w3.org/2001/XMLSchema#> .
 @prefix skos:  <http://www.w3.org/2004/02/skos/core#> .
 @prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> .
 
-prop-data:collapse_all.Vitro
+uil-data:collapse_all.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "tout réduire"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "collapse_all" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "collapse_all" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:no_password_supplied.Vitro
+uil-data:no_password_supplied.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Mot de passe manquant."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "no_password_supplied" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "no_password_supplied" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:crop_page_title.Vitro
+uil-data:crop_page_title.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Rogner l'image"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "crop_page_title" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "crop_page_title" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:label.dateTimeWithPrecision.month_capitalized.Vitro
+uil-data:label.dateTimeWithPrecision.month_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Mois"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "label.dateTimeWithPrecision.month_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "label.dateTimeWithPrecision.month_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:advanced_search_tip_three.Vitro
+uil-data:advanced_search_tip_three.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Les recherches de phrases peuvent être combinées avec des opérateurs booléens -- par exemple \"<i>changemenst climatiques</i>\". OU \"<i>réchauffement global</i>\"."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "advanced_search_tip_three" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "advanced_search_tip_three" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:file_upload_error_file_size_is_zero.Vitro
+uil-data:file_upload_error_file_size_is_zero.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "file_upload_error_file_size_is_zero" ;
-        prop:hasPackage  "Vitro-languages" .
+        rdf:type         uil:UILabel ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "file_upload_error_file_size_is_zero" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:delete_entry_capitalized.Vitro
+uil-data:delete_entry_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Supprimer cet enregistrement?"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "delete_entry_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "delete_entry_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:remove_selection_title.Vitro
+uil-data:remove_selection_title.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "supprimer la sélection"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "remove_selection_title" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "remove_selection_title" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:powered_by.Vitro
+uil-data:powered_by.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Propulsé par"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "powered_by" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "powered_by" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:accounts_search_results.Vitro
+uil-data:accounts_search_results.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Comptes retrouvés"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "accounts_search_results" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "accounts_search_results" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:search_individual_results.Vitro
+uil-data:search_individual_results.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Recherche d'individus d'une classe"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "search_individual_results" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "search_individual_results" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:vclassAlpha_not_implemented.Vitro
+uil-data:vclassAlpha_not_implemented.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "vclassAlpha n'est pas encore supporté."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "vclassAlpha_not_implemented" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "vclassAlpha_not_implemented" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_an_existing.Vitro
+uil-data:select_an_existing.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Choisir un élément existant"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_an_existing" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_an_existing" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:no_appropriate_entry.Vitro
+uil-data:no_appropriate_entry.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Si vous ne trouvez pas l'enregistrement approprié dans la liste de sélection ci-dessus"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "no_appropriate_entry" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "no_appropriate_entry" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:descending_order.Vitro
+uil-data:descending_order.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "tri descendant"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "descending_order" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "descending_order" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:label.dateTimeWithPrecision.hour_capitalized.Vitro
+uil-data:label.dateTimeWithPrecision.hour_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Heure"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "label.dateTimeWithPrecision.hour_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "label.dateTimeWithPrecision.hour_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:add_remove_rdf.Vitro
+uil-data:add_remove_rdf.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ajouter/Retirer des données RDF"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "add_remove_rdf" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "add_remove_rdf" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:account.Vitro
+uil-data:account.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "compte"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "account" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "account" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:label.Vitro
+uil-data:label.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "étiquette"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "label" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "label" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:no_classes_to_select.Vitro
+uil-data:no_classes_to_select.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Il n'y a pas de classes parmi lesquelles vous pouvez choisir dans le système."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "no_classes_to_select" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "no_classes_to_select" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:page_curator_permission_option.Vitro
+uil-data:page_curator_permission_option.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "L'accès à cette page requiert au minimum des privilèges de curateur"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "page_curator_permission_option" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "page_curator_permission_option" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:individuals_in_system.Vitro
+uil-data:individuals_in_system.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "personnes dans le système."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "individuals_in_system" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "individuals_in_system" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:search_help.Vitro
+uil-data:search_help.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "aide sur la recherche"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "search_help" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "search_help" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:there_are_no_entries_starting_with.Vitro
+uil-data:there_are_no_entries_starting_with.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Il n'y a aucune entrée commençant par"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "there_are_no_entries_starting_with" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "there_are_no_entries_starting_with" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:user_accounts_link.Vitro
+uil-data:user_accounts_link.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Comptes d'usagers"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "user_accounts_link" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "user_accounts_link" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:ontology_capitalized.Vitro
+uil-data:ontology_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ontologies"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "ontology_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "ontology_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:change_password_to_login.Vitro
+uil-data:change_password_to_login.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Changez le mot de passe pour vous connecter"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "change_password_to_login" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "change_password_to_login" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:a_menu_page.Vitro
+uil-data:a_menu_page.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ceci est une page de menu"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "a_menu_page" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "a_menu_page" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:comments.Vitro
+uil-data:comments.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Commentaires"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "comments" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "comments" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:add_new_of_type.Vitro
+uil-data:add_new_of_type.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ajouter un nouvel enregistrement de ce type"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "add_new_of_type" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "add_new_of_type" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:reset_password_note.Vitro
+uil-data:reset_password_note.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Note: Les instructions pour la réinitialisation du mot de passe seront transmises à l'adresse ci-dessus. Le mot de passe ne sera pas réinitialisé tant que l'usager n'aura pas cliqué sur le lien inclus dans ce courriel."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "reset_password_note" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "reset_password_note" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:startup_status.Vitro
+uil-data:startup_status.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Statut de démarrage"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "startup_status" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "startup_status" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:no_results_returned.Vitro
+uil-data:no_results_returned.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Aucun résultat obtenu."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "no_results_returned" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "no_results_returned" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:submit_add_new_account.Vitro
+uil-data:submit_add_new_account.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ajouter un compte"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "submit_add_new_account" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "submit_add_new_account" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:password_reset_complete_subject.Vitro
+uil-data:password_reset_complete_subject.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Votre mot de passe {0} a été modifié avec succès."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "password_reset_complete_subject" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "password_reset_complete_subject" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:file_upload_error_supported_actions.Vitro
+uil-data:file_upload_error_supported_actions.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "file_upload_error_supported_actions" ;
-        prop:hasPackage  "Vitro-languages" .
+        rdf:type         uil:UILabel ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "file_upload_error_supported_actions" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:create_classgroup.Vitro
+uil-data:create_classgroup.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Créer un groupe de classes"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "create_classgroup" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "create_classgroup" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:accounts.Vitro
+uil-data:accounts.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "comptes"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "accounts" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "accounts" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:page_not_created_msg.Vitro
+uil-data:page_not_created_msg.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Il y a eu une erreur lors de la création de la page, veuillez vérifier les journaux."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "page_not_created_msg" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "page_not_created_msg" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:login_count.Vitro
+uil-data:login_count.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Nbre de connexions"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "login_count" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "login_count" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:not_expected_results.Vitro
+uil-data:not_expected_results.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ces résultats ne sont pas ceux attendus?"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "not_expected_results" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "not_expected_results" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:paging_link_more.Vitro
+uil-data:paging_link_more.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "plus..."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "paging_link_more" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "paging_link_more" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:sparql_query_description_1.Vitro
+uil-data:sparql_query_description_1.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "# and (if available) their labels"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "sparql_query_description_1" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "sparql_query_description_1" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:acct_created_email_plain_text.Vitro
+uil-data:acct_created_email_plain_text.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "${userAccount.firstName} ${userAccount.lastName}\n\nFélicitations!\n\nNous avons créé votre nouveau compte sur le site ${siteName},\nassociés à ${userAccount.emailAddress}.\n\nSi vous n'avez pas demandé ce nouveau compte, vous pouvez ignorer ce courriel..\nCette demande expirera si aucune action n'est entreprise avant 30 jours.\n\nCollez le lien ci-dessous dans la barre d'adresse de votre navigateur pour créer votre mot de passe\npour votre nouveau compte en utilisant notre serveur sécurisé.\n\n${passwordLink}\n\nMerci!"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "acct_created_email_plain_text" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "acct_created_email_plain_text" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:all_rights_reserved.Vitro
+uil-data:all_rights_reserved.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Tous droits réservés."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "all_rights_reserved" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "all_rights_reserved" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:submit_save.Vitro
+uil-data:submit_save.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Sauvegarder la photo"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "submit_save" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "submit_save" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:associate_classes_with_group.Vitro
+uil-data:associate_classes_with_group.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "et associez des classes au groupe créé."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "associate_classes_with_group" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "associate_classes_with_group" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:about.Vitro
+uil-data:about.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "À propos"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "about" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "about" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:activate_developer_panel.Vitro
+uil-data:activate_developer_panel.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Activer le panneau des développeurs"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "activate_developer_panel" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "activate_developer_panel" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:since.Vitro
+uil-data:since.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Depuis"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "since" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "since" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:limit_to.Vitro
+uil-data:limit_to.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Limiter à"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "limit_to" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "limit_to" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:password_created_subject.Vitro
+uil-data:password_created_subject.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Votre mot de passe {0} a été créé avec succès."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "password_created_subject" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "password_created_subject" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:vitro_description.Vitro
+uil-data:vitro_description.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Vitro est un éditeur d'ontologies et d'instances web à usage général avec une navigation publique personnalisable. Vitro est une application web Java qui s'exécute dans un conteneur de servlet Tomcat."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "vitro_description" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "vitro_description" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:logins_disabled_for_maintenance.Vitro
+uil-data:logins_disabled_for_maintenance.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Les accès sont temporairement désactivés durant la période de maintenance du système."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "logins_disabled_for_maintenance" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "logins_disabled_for_maintenance" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:current_time.Vitro
+uil-data:current_time.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Heure actuelle:"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "current_time" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "current_time" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:release.Vitro
+uil-data:release.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "version"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "release" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "release" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:authenticator.Vitro
+uil-data:authenticator.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Authentificateur"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "authenticator" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "authenticator" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:preparing_to_rebuild_index.Vitro
+uil-data:preparing_to_rebuild_index.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Préparation de la  reconstruction de l'index de recherche."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "preparing_to_rebuild_index" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "preparing_to_rebuild_index" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:login_status.Vitro
+uil-data:login_status.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Statut de connexion:"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "login_status" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "login_status" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:scroll_to_menus.Vitro
+uil-data:scroll_to_menus.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "faites défiler jusqu'aux menus de groupe de propriétés"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "scroll_to_menus" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "scroll_to_menus" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:sparql_query_description_0.Vitro
+uil-data:sparql_query_description_0.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "# This example query gets 20 geographic locations"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "sparql_query_description_0" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "sparql_query_description_0" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:delete_button.Vitro
+uil-data:delete_button.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Supprimer"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "delete_button" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "delete_button" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:fixed_html.Vitro
+uil-data:fixed_html.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "HTML fixe"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "fixed_html" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "fixed_html" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:you_can.Vitro
+uil-data:you_can.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Vous pouvez"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "you_can" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "you_can" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:supply_sparql_query.Vitro
+uil-data:supply_sparql_query.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Vous devez fournir une requête SPARQL."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "supply_sparql_query" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "supply_sparql_query" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:enter_email_password.Vitro
+uil-data:enter_email_password.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Inscrire l'identifiant / mot de passe de votre compte interne VITRO."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "enter_email_password" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "enter_email_password" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:selected_editors.Vitro
+uil-data:selected_editors.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Choisir des éditeurs"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "selected_editors" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "selected_editors" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:custom_template_mixed_caps.Vitro
+uil-data:custom_template_mixed_caps.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Gabarit personnalisé"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "custom_template_mixed_caps" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "custom_template_mixed_caps" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:animal.Vitro
+uil-data:animal.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Animal:"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "animal" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "animal" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:enter_sparql_query_here.Vitro
+uil-data:enter_sparql_query_here.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Saisir votre requête SPARQL ici"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "enter_sparql_query_here" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "enter_sparql_query_here" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:recompute_inferences.Vitro
+uil-data:recompute_inferences.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Recalculer l'inférence"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "recompute_inferences" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "recompute_inferences" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:restrict_logins.Vitro
+uil-data:restrict_logins.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Restreindre l'accès"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "restrict_logins" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "restrict_logins" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:email_address.Vitro
+uil-data:email_address.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Adresse courriel"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "email_address" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "email_address" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:alt_confirmation.Vitro
+uil-data:alt_confirmation.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Icône de confirmation"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "alt_confirmation" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "alt_confirmation" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:drag_drop_to_reorder_menus.Vitro
+uil-data:drag_drop_to_reorder_menus.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Glisser-déposer pour réorganiser les éléments du menu"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "drag_drop_to_reorder_menus" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "drag_drop_to_reorder_menus" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:most_recent_update.Vitro
+uil-data:most_recent_update.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "La plus récente mise à jour a été exécutée à "@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "most_recent_update" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "most_recent_update" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:delete_link.Vitro
+uil-data:delete_link.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Détruire la photo"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "delete_link" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "delete_link" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:check_startup_status.Vitro
+uil-data:check_startup_status.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Vérifier la page de statut du démarrage et/ou les journaux de Tomcat pour plus d'informations."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "check_startup_status" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "check_startup_status" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:no_pages_defined.Vitro
+uil-data:no_pages_defined.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Il n'y a pas encore de pages définies."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "no_pages_defined" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "no_pages_defined" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:advanced_search_tip_five.Vitro
+uil-data:advanced_search_tip_five.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Use the wildcard * character to match an even wider variation -- e.g., <i>nano*</i> will match both <i>nanotechnology</i> and <i>nanofabrication</i>."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "advanced_search_tip_five" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "advanced_search_tip_five" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_message.Vitro
+uil-data:error_message.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Message d'erreur"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_message" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_message" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:double_quote_note_allowed.Vitro
+uil-data:double_quote_note_allowed.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Le nom de la variable ne doit pas comporter de double guillemet."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "double_quote_note_allowed" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "double_quote_note_allowed" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:crop_page_title_with_name.Vitro
+uil-data:crop_page_title_with_name.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Rogner l'image de {0}"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "crop_page_title_with_name" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "crop_page_title_with_name" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:logins_not_restricted.Vitro
+uil-data:logins_not_restricted.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "L'accès maintenant permis."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "logins_not_restricted" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "logins_not_restricted" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:deleted_accounts.Vitro
+uil-data:deleted_accounts.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "{0} détruits {0, choice, 0#accounts|1#account|1<accounts}."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "deleted_accounts" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "deleted_accounts" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:whole_number.Vitro
+uil-data:whole_number.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Entrée invalide. Saisissez un nombre entier sans point décimal ou des séparateurs de milliers."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "whole_number" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "whole_number" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:edit_account.Vitro
+uil-data:edit_account.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Éditer le compte"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "edit_account" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "edit_account" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:search_tip_two.Vitro
+uil-data:search_tip_two.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Utilisez les guillemets pour rechercher une phrase entière -- par exemple, \"<i>écologie marine</i>."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "search_tip_two" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "search_tip_two" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:email_capitalized.Vitro
+uil-data:email_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Courriel"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "email_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "email_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:policies.Vitro
+uil-data:policies.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Politiques"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "policies" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "policies" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:failed.Vitro
+uil-data:failed.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "échoué"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "failed" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "failed" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:containers_do_not_pick_up_changes.Vitro
+uil-data:containers_do_not_pick_up_changes.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Les conteneurs ne prennent pas en compte les modifications de la valeur de leurs éléments"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "containers_do_not_pick_up_changes" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "containers_do_not_pick_up_changes" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:file_upload_error_media_type_not_allowed.Vitro
+uil-data:file_upload_error_media_type_not_allowed.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "file_upload_error_media_type_not_allowed" ;
-        prop:hasPackage  "Vitro-languages" .
+        rdf:type         uil:UILabel ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "file_upload_error_media_type_not_allowed" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:add_new_classes.Vitro
+uil-data:add_new_classes.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ajouter une classe"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "add_new_classes" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "add_new_classes" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:identifier_factories.Vitro
+uil-data:identifier_factories.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "facteurs d'identifiations "@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "identifier_factories" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "identifier_factories" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:show_subclasses.Vitro
+uil-data:show_subclasses.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "afficher les sous-classes"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "show_subclasses" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "show_subclasses" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:enter_id_to_login.Vitro
+uil-data:enter_id_to_login.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Entrer l'identifiant avec lequel vous voulez vous connecter, ou cliquer sur Annuler."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "enter_id_to_login" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "enter_id_to_login" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:upload_heading.Vitro
+uil-data:upload_heading.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Téléversement d'une image"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "upload_heading" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "upload_heading" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:warnings_issued.Vitro
+uil-data:warnings_issued.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "{0} avertissements au démarrage"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "warnings_issued" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "warnings_issued" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:account_management.Vitro
+uil-data:account_management.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Gestion des comptes d'usagers"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "account_management" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "account_management" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_content_display.Vitro
+uil-data:select_content_display.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Sélectionner le contenu à afficher"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_content_display" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_content_display" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:account_no_longer_exists.Vitro
+uil-data:account_no_longer_exists.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Le compte pour lequel vous tentez de modifier le mot de passe a été supprimé. Veuillez contacter votre administrateur système s'il s'agit d'une erreur."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "account_no_longer_exists" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "account_no_longer_exists" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:page_select_permission.Vitro
+uil-data:page_select_permission.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Sélectionner les permissions d'accès aux pages "@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "page_select_permission" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "page_select_permission" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:test_for_logged_in_users.Vitro
+uil-data:test_for_logged_in_users.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ceci est le widget de test pour les utilisateurs connectés."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "test_for_logged_in_users" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "test_for_logged_in_users" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:edit_page.Vitro
+uil-data:edit_page.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Éditer la page {0}"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "edit_page" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "edit_page" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:no_match.Vitro
+uil-data:no_match.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "aucune correspondance"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "no_match" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "no_match" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:add_new_page.Vitro
+uil-data:add_new_page.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ajouter une page"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "add_new_page" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "add_new_page" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:class_groups.Vitro
+uil-data:class_groups.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Groupes de classes"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "class_groups" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "class_groups" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:password_reset_pending_email_subject.Vitro
+uil-data:password_reset_pending_email_subject.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "${siteName} demande de réinitialisation du mot de passe"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "password_reset_pending_email_subject" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "password_reset_pending_email_subject" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:manage.Vitro
+uil-data:manage.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "gérer"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "manage" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "manage" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_password_length.Vitro
+uil-data:error_password_length.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Veuillez inscrire un mot de passe entre {0} et {1} caractères."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_password_length" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_password_length" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:view_profile_editors.Vitro
+uil-data:view_profile_editors.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Afficher tous les éditeurs de profils"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "view_profile_editors" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "view_profile_editors" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:subclasses_capitalized.Vitro
+uil-data:subclasses_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Sous-classes"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "subclasses_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "subclasses_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:auth_matching_id_label.Vitro
+uil-data:auth_matching_id_label.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "ID d'authentification externe / ID d'appariement"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "auth_matching_id_label" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "auth_matching_id_label" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:page_editor_permission_option.Vitro
+uil-data:page_editor_permission_option.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "L'accès à cette page requiert au minimum des privilèges d'éditeur"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "page_editor_permission_option" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "page_editor_permission_option" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:delete_page.Vitro
+uil-data:delete_page.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "supprimer cette page"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "delete_page" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "delete_page" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:for.Vitro
+uil-data:for.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "pour"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "for" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "for" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:manage_list_of_labels.Vitro
+uil-data:manage_list_of_labels.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "gérer la liste des étiquettes"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "manage_list_of_labels" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "manage_list_of_labels" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:content.Vitro
+uil-data:content.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "contenu"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "content" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "content" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:match_by.Vitro
+uil-data:match_by.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "apparié par {0}"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "match_by" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "match_by" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:alt_preview_crop.Vitro
+uil-data:alt_preview_crop.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Aperçu de l'image rognée"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "alt_preview_crop" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "alt_preview_crop" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:pretty_url.Vitro
+uil-data:pretty_url.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "URL conviviale"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "pretty_url" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "pretty_url" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:operation_successful.Vitro
+uil-data:operation_successful.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "L'opération a réussi."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "operation_successful" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "operation_successful" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:add_capitalized.Vitro
+uil-data:add_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ajouter"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "add_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "add_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:accounts_per_page.Vitro
+uil-data:accounts_per_page.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "comptes par page"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "accounts_per_page" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "accounts_per_page" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_editor_and_profile.Vitro
+uil-data:select_editor_and_profile.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Vous devez sélectionner au moins un éditeur et un profil."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_editor_and_profile" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_editor_and_profile" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:request_failed.Vitro
+uil-data:request_failed.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "La requête a échoué. Veuillez contacter l'administrateur(-trice) système."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "request_failed" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "request_failed" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:from_site_admin_page.Vitro
+uil-data:from_site_admin_page.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "depuis la page d'administration du site."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "from_site_admin_page" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "from_site_admin_page" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:new_password_capitalized.Vitro
+uil-data:new_password_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Nouveau mot de passe"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "new_password_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "new_password_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:advanced_search_tip_one.Vitro
+uil-data:advanced_search_tip_one.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Lorsque vous entrez plus d'un terme, la recherche donnera des résultats contenant tous ces termes à moins que vous n'ajoutiez le \" OU \" booléen -- par exemple, <i>poulet</i> OU <i>oeuf</i>."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "advanced_search_tip_one" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "advanced_search_tip_one" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:password_reset_complete_email_plain_text.Vitro
+uil-data:password_reset_complete_email_plain_text.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "${userAccount.firstName} ${userAccount.lastName}\n\nLe mot de passe a été changé avec succès.\n\nVotre nouveau mot de passe associé à ${userAccount.emailAddress}\na été modifié"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "password_reset_complete_email_plain_text" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "password_reset_complete_email_plain_text" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:application_error_email_subject.Vitro
+uil-data:application_error_email_subject.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Une erreur s'est produite sur votre site ${siteName!}"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "application_error_email_subject" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "application_error_email_subject" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:return_to.Vitro
+uil-data:return_to.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "revenir à {0}"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "return_to" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "return_to" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:last_login.Vitro
+uil-data:last_login.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Dernière connexion"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "last_login" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "last_login" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:view_profile_in_rdf.Vitro
+uil-data:view_profile_in_rdf.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "afficher le profil en format RDF"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "view_profile_in_rdf" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "view_profile_in_rdf" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:minimum_password_length.Vitro
+uil-data:minimum_password_length.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Longueur minimale de {0} caractères; maximum de {1}."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "minimum_password_length" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "minimum_password_length" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:contact_us.Vitro
+uil-data:contact_us.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Nous joindre"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "contact_us" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "contact_us" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:download_results.Vitro
+uil-data:download_results.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Télécharger les résultats"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "download_results" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "download_results" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:selected_profiles.Vitro
+uil-data:selected_profiles.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Profils sélectionnés"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "selected_profiles" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "selected_profiles" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:has_value.Vitro
+uil-data:has_value.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "a de la valeur"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "has_value" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "has_value" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:faux_property_listing.Vitro
+uil-data:faux_property_listing.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Liste des propriétés Faux"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "faux_property_listing" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "faux_property_listing" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:display_admin_header.Vitro
+uil-data:display_admin_header.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Administration et configuration de l'affichage"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "display_admin_header" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "display_admin_header" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_no_password.Vitro
+uil-data:error_no_password.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Veuillez inscrire votre mot de passe."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_no_password" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_no_password" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:remove_capitalized.Vitro
+uil-data:remove_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Supprimer"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "remove_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "remove_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:october.Vitro
+uil-data:october.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Octobre"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "october" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "october" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:file_upload_subject.Vitro
+uil-data:file_upload_subject.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "file_upload_subject" ;
-        prop:hasPackage  "Vitro-languages" .
+        rdf:type         uil:UILabel ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "file_upload_subject" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:manage_site.Vitro
+uil-data:manage_site.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Gérer ce site"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "manage_site" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "manage_site" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:confirm_delete_account_plural.Vitro
+uil-data:confirm_delete_account_plural.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Êtes-vous certain de vouloir supprimer ces comptes?"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "confirm_delete_account_plural" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "confirm_delete_account_plural" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:sunday.Vitro
+uil-data:sunday.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Dimanche"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "sunday" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "sunday" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:password_system_has_changed.Vitro
+uil-data:password_system_has_changed.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "password_system_has_changed" ;
-        prop:hasPackage  "Vitro-languages" .
+        rdf:type         uil:UILabel ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "password_system_has_changed" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:rebuild_search_index.Vitro
+uil-data:rebuild_search_index.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Reconstruire l'index du site"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "rebuild_search_index" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "rebuild_search_index" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:password_saved.Vitro
+uil-data:password_saved.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Votre mot de passe a été enregistré."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "password_saved" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "password_saved" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:supply_query_variable.Vitro
+uil-data:supply_query_variable.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Vous devez fournir une variable pour sauvegarder les résultats de la requête."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "supply_query_variable" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "supply_query_variable" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:configure_page_if_permissable.Vitro
+uil-data:configure_page_if_permissable.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "pour configurer cette page si l'utilisateur a les droits appropriés."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "configure_page_if_permissable" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "configure_page_if_permissable" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:invalid_date_form_msg.Vitro
+uil-data:invalid_date_form_msg.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "doit être au format mm/jj/aaaa."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "invalid_date_form_msg" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "invalid_date_form_msg" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:manage_list_of.Vitro
+uil-data:manage_list_of.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Gérer la liste de"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "manage_list_of" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "manage_list_of" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:verbose_property_status.Vitro
+uil-data:verbose_property_status.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "La propriété de verbosité est"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "verbose_property_status" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "verbose_property_status" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:sparql_query_select_ask_results.Vitro
+uil-data:sparql_query_select_ask_results.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Format for SELECT and ASK query results"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "sparql_query_select_ask_results" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "sparql_query_select_ask_results" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:individual_not_found.Vitro
+uil-data:individual_not_found.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "élément introuvable"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "individual_not_found" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "individual_not_found" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:classes_by_classgroup.Vitro
+uil-data:classes_by_classgroup.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Classes par groupe de classes"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "classes_by_classgroup" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "classes_by_classgroup" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:confirm_email_changed_email_plain_text.Vitro
+uil-data:confirm_email_changed_email_plain_text.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Bonjour, ${userAccount.firstName} ${userAccount.lastName}\n\nVous avez récemment changé l'adresse courriel associée à\n${userAccount.firstName} ${userAccount.lastName}\n\nMerci."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "confirm_email_changed_email_plain_text" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "confirm_email_changed_email_plain_text" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:close_capitalized.Vitro
+uil-data:close_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Fermer"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "close_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "close_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:browse_class_group.Vitro
+uil-data:browse_class_group.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Parcourir le groupe de classes"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "browse_class_group" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "browse_class_group" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:statistics.Vitro
+uil-data:statistics.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Statistiques"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "statistics" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "statistics" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:new_password.Vitro
+uil-data:new_password.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Nouveau mot de passe"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "new_password" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "new_password" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:hide_show_subclasses.Vitro
+uil-data:hide_show_subclasses.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "masquer/afficher les sous-classes"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "hide_show_subclasses" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "hide_show_subclasses" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:class_hierarchy.Vitro
+uil-data:class_hierarchy.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Hiérarchie des classes"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "class_hierarchy" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "class_hierarchy" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:add_content_manage_site.Vitro
+uil-data:add_content_manage_site.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "ajouter du contenu et gérer ce site"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "add_content_manage_site" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "add_content_manage_site" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:background_threads.Vitro
+uil-data:background_threads.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Tâches d'arrière-plan"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "background_threads" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "background_threads" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:create_capitalized.Vitro
+uil-data:create_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Créer"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "create_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "create_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_previous_password.Vitro
+uil-data:error_previous_password.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Le mot de passe fourni ne doit pas correspondre au mot de passe actuel"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_previous_password" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_previous_password" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:change_password.Vitro
+uil-data:change_password.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Vous devez modifier votre mot de passe pour vous connecter."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "change_password" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "change_password" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:menu_management.Vitro
+uil-data:menu_management.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Gestion de menus"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "menu_management" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "menu_management" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:email_change_will_be_confirmed.Vitro
+uil-data:email_change_will_be_confirmed.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Note: en cas de changement de courriel, une confirmation sera transmise à l'adresse ci-dessus."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "email_change_will_be_confirmed" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "email_change_will_be_confirmed" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:fake_external_auth.Vitro
+uil-data:fake_external_auth.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Autentification externe simulée"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "fake_external_auth" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "fake_external_auth" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:run_sdb_setup.Vitro
+uil-data:run_sdb_setup.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Exécuter la configuration SDB"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "run_sdb_setup" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "run_sdb_setup" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:property_management.Vitro
+uil-data:property_management.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Gestion des propriétés"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "property_management" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "property_management" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:end_your_Session.Vitro
+uil-data:end_your_Session.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Terminer votre session"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "end_your_Session" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "end_your_Session" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:search_index_not_connected.Vitro
+uil-data:search_index_not_connected.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "L'index de recherche n'est pas connecté."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "search_index_not_connected" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "search_index_not_connected" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:change_content_type.Vitro
+uil-data:change_content_type.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Changer le type de contenu"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "change_content_type" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "change_content_type" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:invalid_search_term.Vitro
+uil-data:invalid_search_term.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "expression de recherche invalide"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "invalid_search_term" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "invalid_search_term" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:index_recs_completed.Vitro
+uil-data:index_recs_completed.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Complété {0} de {1} enregistrement indexés."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "index_recs_completed" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "index_recs_completed" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:add_profile.Vitro
+uil-data:add_profile.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ajouter un profil"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "add_profile" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "add_profile" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:view_labels_capitalized.Vitro
+uil-data:view_labels_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Afficher les étiquettes"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "view_labels_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "view_labels_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:maximum_cardinality.Vitro
+uil-data:maximum_cardinality.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "cardinalité maximale"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "maximum_cardinality" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "maximum_cardinality" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:please_format_email.Vitro
+uil-data:please_format_email.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Veuillez formater votre adresse e-mail de la façon suivante :"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "please_format_email" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "please_format_email" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:external_auth_only.Vitro
+uil-data:external_auth_only.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Authentification externe seulement"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "external_auth_only" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "external_auth_only" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:return_to_individual.Vitro
+uil-data:return_to_individual.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Retournez à la page index des enregistrements "@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "return_to_individual" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "return_to_individual" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:all_x_properties.Vitro
+uil-data:all_x_properties.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Toutes les propriétés {0}"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "all_x_properties" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "all_x_properties" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:password_created_email_plain_text.Vitro
+uil-data:password_created_email_plain_text.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "${userAccount.firstName} ${userAccount.lastName}\n\nLe mot de passe a été créé avec succès.\n\nVotre nouveau mot de passe associé à ${userAccount.emailAddress}\na été créé.\n\nMerci.."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "password_created_email_plain_text" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "password_created_email_plain_text" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:already_logged_in.Vitro
+uil-data:already_logged_in.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Vous êtes déjà connecté."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "already_logged_in" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "already_logged_in" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:supply_class_group.Vitro
+uil-data:supply_class_group.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Vous devez spécifier un groupe de classes."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "supply_class_group" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "supply_class_group" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:matching_prop_not_defined.Vitro
+uil-data:matching_prop_not_defined.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "la propriété d'appariement n'est pas définie"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "matching_prop_not_defined" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "matching_prop_not_defined" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:display_rank.Vitro
+uil-data:display_rank.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Afficher le rang"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "display_rank" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "display_rank" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:profile_editing_title.Vitro
+uil-data:profile_editing_title.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Les éditeurs que vous sélectionnez à gauche ont la possibilité d'éditer les profils VIVO que vous sélectionnez à droite. Vous pouvez sélectionner plusieurs éditeurs et plusieurs profils, mais vous devez en sélectionner au moins un chacun."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "profile_editing_title" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "profile_editing_title" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:test_for_nonlogged_in_users.Vitro
+uil-data:test_for_nonlogged_in_users.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ceci est le widget de test pour les utilisateurs non connectés."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "test_for_nonlogged_in_users" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "test_for_nonlogged_in_users" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:insufficient_authorization.Vitro
+uil-data:insufficient_authorization.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Désolé, vous n'êtes pas autorisé à consulter la page demandée. Si vous considérez qu'il s'agit d'une erreur, veuillez contacter le support de VIVO."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "insufficient_authorization" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "insufficient_authorization" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:supply_content_type.Vitro
+uil-data:supply_content_type.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Vous devez spécifier un type de contenu"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "supply_content_type" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "supply_content_type" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:back_to_results.Vitro
+uil-data:back_to_results.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Retour aux résultats"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "back_to_results" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "back_to_results" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:may_not_edit.Vitro
+uil-data:may_not_edit.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ne peut éditer"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "may_not_edit" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "may_not_edit" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:four_digit_year.Vitro
+uil-data:four_digit_year.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Entrée invalide. Veuillez entrer une année à 4 chiffres."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "four_digit_year" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "four_digit_year" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:browse_page_javascript_two.Vitro
+uil-data:browse_page_javascript_two.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "pour rechercher des informations."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "browse_page_javascript_two" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "browse_page_javascript_two" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:password_created_email_html_text.Vitro
+uil-data:password_created_email_html_text.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "<p>\n ${userAccount.firstName} ${userAccount.lastName}\n </p>\n\n <p>\n <strong>Le mot de passe a été créé avec succès.</strong>\n </p>\n\n <p>\n Votre nouveau mot de passe associé à ${userAccount.emailAddress} a été créé.\n </p>\n\n <p>\n Merci.\n </p>"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "password_created_email_html_text" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "password_created_email_html_text" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:current_photo.Vitro
+uil-data:current_photo.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Photo active"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "current_photo" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "current_photo" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_last_name.Vitro
+uil-data:select_last_name.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Sélectionner un nom de famille existant"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_last_name" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_last_name" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:supply_template.Vitro
+uil-data:supply_template.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Vous devez spécifier un gabarit"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "supply_template" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "supply_template" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:view_all_accounts_title.Vitro
+uil-data:view_all_accounts_title.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "voir tous les comptes"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "view_all_accounts_title" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "view_all_accounts_title" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:cropping_note.Vitro
+uil-data:cropping_note.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Pour ajuster, vous pouvez bouger la photo dans le cadre ou la redimensionner vers la droite. Lorsque vous êtes satisfait, cliquez sur \"Sauvegarder la photo\"."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "cropping_note" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "cropping_note" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:page_not_created.Vitro
+uil-data:page_not_created.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "La page n'a pas pu être créée"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "page_not_created" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "page_not_created" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_email_already_exists.Vitro
+uil-data:error_email_already_exists.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Un compte d'usager est déjà associé à ce courriel."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_email_already_exists" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_email_already_exists" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:required_field_empty_msg.Vitro
+uil-data:required_field_empty_msg.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ce champ ne doit pas être vide."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "required_field_empty_msg" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "required_field_empty_msg" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:site_maintenance.Vitro
+uil-data:site_maintenance.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Maintenance du site"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "site_maintenance" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "site_maintenance" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:current_date_time.Vitro
+uil-data:current_date_time.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Date et heure actuelles:"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "current_date_time" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "current_date_time" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:page_link.Vitro
+uil-data:page_link.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "lien vers page"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "page_link" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "page_link" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:object_property_hierarchy.Vitro
+uil-data:object_property_hierarchy.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Hiérarchie des propriétés d'objets"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "object_property_hierarchy" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "object_property_hierarchy" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:user_accounts.Vitro
+uil-data:user_accounts.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Comptes d'utilisateurs"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "user_accounts" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "user_accounts" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:maximum_file_size.Vitro
+uil-data:maximum_file_size.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Taille maximale de l'image: {0} mégaoctets"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "maximum_file_size" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "maximum_file_size" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:add_new_account.Vitro
+uil-data:add_new_account.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ajouter un compte"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "add_new_account" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "add_new_account" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:browse_all_starts_with.Vitro
+uil-data:browse_all_starts_with.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Parcourir toutes fiches dont les noms commencent par {0}"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "browse_all_starts_with" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "browse_all_starts_with" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:status.Vitro
+uil-data:status.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Statut"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "status" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "status" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:index.Vitro
+uil-data:index.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Index"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "index" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "index" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:verify_this_match_title.Vitro
+uil-data:verify_this_match_title.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "vérifier cette correspondance"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "verify_this_match_title" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "verify_this_match_title" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:search_indexer_idle.Vitro
+uil-data:search_indexer_idle.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "L'indexeur de recherche est inactif."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "search_indexer_idle" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "search_indexer_idle" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:start_capitalized.Vitro
+uil-data:start_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Début"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "start_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "start_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:minimum_cardinality.Vitro
+uil-data:minimum_cardinality.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "cardinalité minimale"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "minimum_cardinality" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "minimum_cardinality" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:manage_affiliated_people_link.Vitro
+uil-data:manage_affiliated_people_link.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "gérer les personnes associées"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "manage_affiliated_people_link" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "manage_affiliated_people_link" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:initial_password.Vitro
+uil-data:initial_password.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Mot de passe initial"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "initial_password" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "initial_password" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:invalid_format.Vitro
+uil-data:invalid_format.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Format invalide"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "invalid_format" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "invalid_format" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:menu_orering.Vitro
+uil-data:menu_orering.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ordre des menus"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "menu_orering" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "menu_orering" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:confirm_entry_deletion_from.Vitro
+uil-data:confirm_entry_deletion_from.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Êtes-vous sûr de vouloir supprimer l'entrée suivante de"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "confirm_entry_deletion_from" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "confirm_entry_deletion_from" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:add_types.Vitro
+uil-data:add_types.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ajouter un ou plusieurs types"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "add_types" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "add_types" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:group_capitalized.Vitro
+uil-data:group_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Groupe"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "group_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "group_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:entry.Vitro
+uil-data:entry.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "entrée"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "entry" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "entry" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:search_vitro.Vitro
+uil-data:search_vitro.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Recherche VITRO"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "search_vitro" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "search_vitro" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:version.Vitro
+uil-data:version.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Version"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "version" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "version" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:hide_subclasses.Vitro
+uil-data:hide_subclasses.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "masquer les sous-classes"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "hide_subclasses" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "hide_subclasses" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:caused_by.Vitro
+uil-data:caused_by.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Causé par"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "caused_by" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "caused_by" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:show_more_content.Vitro
+uil-data:show_more_content.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "afficher plus"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "show_more_content" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "show_more_content" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:advanced_search_tip_six.Vitro
+uil-data:advanced_search_tip_six.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "La recherche utilise des versions abrégées des mots -- par exemple, une recherche pour <i>cogniti*</i> ne trouve rien, tandis que <i>cognit*</i> trouve à la fois <i>cognitive</i> et <i>cognition</i>."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "advanced_search_tip_six" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "advanced_search_tip_six" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:myAccount_confirm_changes_plus_note.Vitro
+uil-data:myAccount_confirm_changes_plus_note.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Vos modifications ont été enregistrées. Un courriel de confirmation a été transmis à {0}."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "myAccount_confirm_changes_plus_note" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "myAccount_confirm_changes_plus_note" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:class_management.Vitro
+uil-data:class_management.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Gestion des classes"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "class_management" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "class_management" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:display_less.Vitro
+uil-data:display_less.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "moins"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "display_less" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "display_less" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:add_property_group.Vitro
+uil-data:add_property_group.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ajouter un nouveau groupe de propriétés"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "add_property_group" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "add_property_group" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:browse_by.Vitro
+uil-data:browse_by.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Parcourir par"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "browse_by" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "browse_by" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:class_group_link.Vitro
+uil-data:class_group_link.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "lien de groupes de classes"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "class_group_link" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "class_group_link" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:confirm_password.Vitro
+uil-data:confirm_password.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Confirmer le nouveau mot de passe"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "confirm_password" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "confirm_password" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:saturday.Vitro
+uil-data:saturday.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Samedi"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "saturday" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "saturday" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:_publications_link.Vitro
+uil-data:_publications_link.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "gérer les publications"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "_publications_link" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "_publications_link" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:javascript_require_to_edit.Vitro
+uil-data:javascript_require_to_edit.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Pour pouvoir modifier le contenu, vous devez activer JavaScript."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "javascript_require_to_edit" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "javascript_require_to_edit" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:fatal_error_detected.Vitro
+uil-data:fatal_error_detected.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "{0} a détecté une erreur fatale au démarrage."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "fatal_error_detected" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "fatal_error_detected" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:menu_page.Vitro
+uil-data:menu_page.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Page de menu"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "menu_page" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "menu_page" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:create_new_individual_of_the_following_type.Vitro
+uil-data:create_new_individual_of_the_following_type.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Créer un objet du type suivant"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "create_new_individual_of_the_following_type" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "create_new_individual_of_the_following_type" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:logins_not_already_restricted.Vitro
+uil-data:logins_not_already_restricted.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "L'accès est déjà permis."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "logins_not_already_restricted" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "logins_not_already_restricted" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:stack_trace.Vitro
+uil-data:stack_trace.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Trace de la pile"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "stack_trace" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "stack_trace" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:confirm_page_deletion.Vitro
+uil-data:confirm_page_deletion.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Vous êtes certain de vouloir supprimer cette page :"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "confirm_page_deletion" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "confirm_page_deletion" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_locale.Vitro
+uil-data:select_locale.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Choisir une langue"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_locale" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_locale" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:reset_password.Vitro
+uil-data:reset_password.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Réinitialisation du mot de passe"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "reset_password" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "reset_password" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:vitro_bullet_two.Vitro
+uil-data:vitro_bullet_two.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Éditer des instances et des relations"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "vitro_bullet_two" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "vitro_bullet_two" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:replace_page_title.Vitro
+uil-data:replace_page_title.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Remplacer l'image"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "replace_page_title" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "replace_page_title" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:subproperty.Vitro
+uil-data:subproperty.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "sous-propriété"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "subproperty" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "subproperty" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:rdf_export.Vitro
+uil-data:rdf_export.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Exportation RDF"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "rdf_export" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "rdf_export" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:click_to_view_larger.Vitro
+uil-data:click_to_view_larger.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "cliquer pour afficher une plus grande image"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "click_to_view_larger" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "click_to_view_larger" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:build_date.Vitro
+uil-data:build_date.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Date de compilation"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "build_date" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "build_date" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:flags.Vitro
+uil-data:flags.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Fanions"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "flags" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "flags" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:march.Vitro
+uil-data:march.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Mars"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "march" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "march" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:display_only.Vitro
+uil-data:display_only.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Afficher seulement"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "display_only" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "display_only" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:to_manage_content.Vitro
+uil-data:to_manage_content.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "pour gérer le contenu."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "to_manage_content" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "to_manage_content" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:acct_created_email_html_text.Vitro
+uil-data:acct_created_email_html_text.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "<p>\n ${userAccount.firstName} ${userAccount.lastName}\n </p>\n\n <p>\n <strong>Félicitations!</strong>\n </p>\n\n <p>\n Nous avons créé votre nouveau compte sur le site ${siteName}, associés à ${userAccount.emailAddress}.\n </p>\n\n <p>\n Si vous n'avez pas demandé ce nouveau compte, vous pouvez ignorer ce courriel.\nCette demande expirera si aucune action n'est entreprise dans un délai de 30 jours.\n </p>\n\n <p>\n Cliquez sur le lien ci-dessous pour créer votre mot de passe pour votre nouveau compte en utilisant notre serveur sécurisé.\n </p>\n\n <p>\n <a href=\"${passwordLink}\" title=\"mot de passe\">${passwordLink}</a>\n </p>\n\n <p>\n Si le lien ci-dessus ne fonctionne pas, vous pouvez copier et coller le lien directement dans la barre d'adresse de votre navigateur..\n </p>\n\n <p>\n Merci!\n </p>"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "acct_created_email_html_text" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "acct_created_email_html_text" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:file_upload_confirm_delete.Vitro
+uil-data:file_upload_confirm_delete.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "file_upload_confirm_delete" ;
-        prop:hasPackage  "Vitro-languages" .
+        rdf:type         uil:UILabel ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "file_upload_confirm_delete" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:cropping_caption.Vitro
+uil-data:cropping_caption.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "La photo de votre profil ressemblera à l'image ci-dessous."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "cropping_caption" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "cropping_caption" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:browse_capitalized.Vitro
+uil-data:browse_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Parcourir"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "browse_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "browse_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:display_options.Vitro
+uil-data:display_options.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Options d'affichage"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "display_options" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "display_options" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:site_config.Vitro
+uil-data:site_config.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Configuration du site"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "site_config" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "site_config" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:undo_camelcasing.Vitro
+uil-data:undo_camelcasing.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Retirer la casse chameau "@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "undo_camelcasing" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "undo_camelcasing" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:view_all_capitalized.Vitro
+uil-data:view_all_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Tout afficher"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "view_all_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "view_all_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_processing_labels.Vitro
+uil-data:error_processing_labels.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Erreur au traitement de cette requête : les étiquettes non cochées n'ont pas pu être effacées."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_processing_labels" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_processing_labels" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:dates.Vitro
+uil-data:dates.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Dates"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "dates" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "dates" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:myAccount_heading.Vitro
+uil-data:myAccount_heading.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Mon dossier"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "myAccount_heading" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "myAccount_heading" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:roles.Vitro
+uil-data:roles.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Rôles"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "roles" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "roles" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:april.Vitro
+uil-data:april.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Avril"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "april" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "april" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:password_reset_pending_subject.Vitro
+uil-data:password_reset_pending_subject.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "demande de rénitialisation de mot de passe pour {0}"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "password_reset_pending_subject" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "password_reset_pending_subject" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:some_values_from.Vitro
+uil-data:some_values_from.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "quelques valeurs de"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "some_values_from" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "some_values_from" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:browse_all_public_content.Vitro
+uil-data:browse_all_public_content.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Vous pouvez consulter tout le contenu public actuellement dans le système à l'aide de la fonction"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "browse_all_public_content" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "browse_all_public_content" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:all_values_from.Vitro
+uil-data:all_values_from.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "toutes les valeurs de"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "all_values_from" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "all_values_from" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:updated_account_2.Vitro
+uil-data:updated_account_2.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "a été modifié."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "updated_account_2" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "updated_account_2" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:alt_error_alert.Vitro
+uil-data:alt_error_alert.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Icône d'alerte"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "alt_error_alert" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "alt_error_alert" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:year_month.Vitro
+uil-data:year_month.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Entrée invalide. Veuillez entrer une année et un mois."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "year_month" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "year_month" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:name.Vitro
+uil-data:name.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "nom"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "name" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "name" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:no_image.Vitro
+uil-data:no_image.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "pas d'image"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "no_image" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "no_image" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:sparql_query_save_results.Vitro
+uil-data:sparql_query_save_results.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Save results to file"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "sparql_query_save_results" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "sparql_query_save_results" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:add_new_group.Vitro
+uil-data:add_new_group.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ajouter un groupe"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "add_new_group" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "add_new_group" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:browse_all.Vitro
+uil-data:browse_all.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Tout parcourir"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "browse_all" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "browse_all" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:processing_icon.Vitro
+uil-data:processing_icon.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "processing"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "processing_icon" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "processing_icon" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:logins_restricted.Vitro
+uil-data:logins_restricted.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "L'accès est maintenant restreint."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "logins_restricted" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "logins_restricted" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:search_tip_four.Vitro
+uil-data:search_tip_four.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Si vous n'êtes pas sûr de la bonne orthographe, mettez ~ à la fin de votre terme de recherche -- par exemple, <i>cabage~</i> donne <i>cabbage</i>, <i>steven~</i> donne <i>Stephen</i> et <i>Stefan</i> (ainsi que d'autres noms similaires)."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "search_tip_four" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "search_tip_four" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:imageUpload.errorNoURI.Vitro
+uil-data:imageUpload.errorNoURI.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "URI non spécifiée"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "imageUpload.errorNoURI" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "imageUpload.errorNoURI" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:password_saved_please_login.Vitro
+uil-data:password_saved_please_login.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Votre mot de passe a été mis à jour. Veuillez vous reconnecter."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "password_saved_please_login" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "password_saved_please_login" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:upload_photo.Vitro
+uil-data:upload_photo.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Téléverser une photo"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "upload_photo" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "upload_photo" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:sparql_query_results.Vitro
+uil-data:sparql_query_results.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Résultats de la requête SPARQL"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "sparql_query_results" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "sparql_query_results" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:enter_new_password.Vitro
+uil-data:enter_new_password.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Inscrire un nouveau mot de passe pour {0}"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "enter_new_password" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "enter_new_password" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:display_more_ellipsis.Vitro
+uil-data:display_more_ellipsis.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "... plus"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "display_more_ellipsis" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "display_more_ellipsis" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:updated_account_1.Vitro
+uil-data:updated_account_1.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Le compte de"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "updated_account_1" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "updated_account_1" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:add_page.Vitro
+uil-data:add_page.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ajouter une page"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "add_page" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "add_page" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:list_elements_of.Vitro
+uil-data:list_elements_of.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Liste des éléments de"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "list_elements_of" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "list_elements_of" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:class_group_all_caps.Vitro
+uil-data:class_group_all_caps.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Groupe de classes"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "class_group_all_caps" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "class_group_all_caps" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:no_class_restrictions.Vitro
+uil-data:no_class_restrictions.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Il n'y a pas de classes ayant une restriction sur cette propriété."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "no_class_restrictions" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "no_class_restrictions" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:refresh_page_after_reordering.Vitro
+uil-data:refresh_page_after_reordering.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Rafraîchir la page une fois les éléments de menu réordonnés"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "refresh_page_after_reordering" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "refresh_page_after_reordering" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:asserted_class_hierarchy.Vitro
+uil-data:asserted_class_hierarchy.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Hiérarchie de classes assertées"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "asserted_class_hierarchy" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "asserted_class_hierarchy" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:page_admin_permission_option.Vitro
+uil-data:page_admin_permission_option.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Seul les administrateurs peuvent accéder à cette page"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "page_admin_permission_option" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "page_admin_permission_option" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:create_associated_profile.Vitro
+uil-data:create_associated_profile.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Créer le profil associé"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "create_associated_profile" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "create_associated_profile" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:password_reset_complete_email_html_text.Vitro
+uil-data:password_reset_complete_email_html_text.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "<p>\n ${userAccount.firstName} ${userAccount.lastName}\n </p>\n\n <p>\n <strong>Le mot de passe a été changé avec succès.</strong>\n </p>\n\n <p>\n Votre nouveau mot de passe associé à ${userAccount.emailAddress} a été modifié.\n </p>\n\n <p>\n Merci.\n </p>"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "password_reset_complete_email_html_text" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "password_reset_complete_email_html_text" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:first_time_external_email_html_text.Vitro
+uil-data:first_time_external_email_html_text.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "<p>\n ${userAccount.firstName} ${userAccount.lastName}\n </p>\n\n <p>\n <strong>Félicitations!</strong>\n </p>\n\n <p>\n Nous avons créé votre nouveau compte VIVO associé à ${userAccount.emailAddress}.\n </p>\n\n <p>\n Merci.\n </p>"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "first_time_external_email_html_text" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "first_time_external_email_html_text" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:default.Vitro
+uil-data:default.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Défaut"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "default" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "default" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_password_mismatch.Vitro
+uil-data:error_password_mismatch.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Les mots de passe ne correspondent pas."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_password_mismatch" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_password_mismatch" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:and.Vitro
+uil-data:and.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "et"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "and" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "and" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:no_matching_results.Vitro
+uil-data:no_matching_results.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Aucun résultat."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "no_matching_results" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "no_matching_results" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:internal_class_i_capped.Vitro
+uil-data:internal_class_i_capped.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Classes internes à l'institution"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "internal_class_i_capped" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "internal_class_i_capped" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:decimal_only.Vitro
+uil-data:decimal_only.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Entrée invalide.  Un point décimal est autorisé, mais les séparateurs de milliers ne le sont pas."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "decimal_only" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "decimal_only" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:new_account_2.Vitro
+uil-data:new_account_2.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "a été créé avec succès."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "new_account_2" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "new_account_2" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:listed_page_title.Vitro
+uil-data:listed_page_title.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "titre de la page affichée"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "listed_page_title" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "listed_page_title" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:delete_profile_editor.Vitro
+uil-data:delete_profile_editor.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Supprimer l'éditeur de profils"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "delete_profile_editor" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "delete_profile_editor" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_no_first_name.Vitro
+uil-data:error_no_first_name.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Vous devez inscrire un prénom."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_no_first_name" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_no_first_name" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:browse_all_in_class.Vitro
+uil-data:browse_all_in_class.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Parcourir les fiches de cette catégorie"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "browse_all_in_class" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "browse_all_in_class" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:save_entry.Vitro
+uil-data:save_entry.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Sauvegarder"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "save_entry" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "save_entry" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:confirm_initial_password.Vitro
+uil-data:confirm_initial_password.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Confirmer le mot de passe actuel"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "confirm_initial_password" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "confirm_initial_password" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:ingest_tools.Vitro
+uil-data:ingest_tools.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Outils d'ingestion"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "ingest_tools" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "ingest_tools" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:application_error_email_html_text.Vitro
+uil-data:application_error_email_html_text.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "<p>Une erreur s'est produite sur votre site ${siteName!} à ${datetime!}</p>\n\n <p>\n <strong>URL demandée:</strong> ${requestedUrl!}\n </p>\n\n <p>\n <#if errorMessage?has_content>\n <strong>Message d'erreur:</strong> ${errorMessage!}\n </#if>\n </p>\n\n <p>\n <strong>Trace de la pile</strong> (trace complète disponible dans le log):\n <pre>${stackTrace!}</pre>\n </p>\n\n <#if cause?has_content>\n <p><strong>Causé par:</strong>\n <pre>${cause!}</pre>\n </p>\n </#if>"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "application_error_email_html_text" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "application_error_email_html_text" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:log_in.Vitro
+uil-data:log_in.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "connectez-vous"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "log_in" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "log_in" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:new_account_1.Vitro
+uil-data:new_account_1.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Un nouveau compte pour"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "new_account_1" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "new_account_1" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:imageUpload.errorUnrecognizedFileType.Vitro
+uil-data:imageUpload.errorUnrecognizedFileType.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "''{0}''  n'est pas un format d'image reconnu. Veuillez choisir une image au format JPEG, GIF ou PNG."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "imageUpload.errorUnrecognizedFileType" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "imageUpload.errorUnrecognizedFileType" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:replace_page_title_with_name.Vitro
+uil-data:replace_page_title_with_name.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Remplacer l'image de {0}"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "replace_page_title_with_name" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "replace_page_title_with_name" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:unsupported_ie_version.Vitro
+uil-data:unsupported_ie_version.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ce formulaire n'est pas pris en charge dans les versions d'Internet Explorer inférieures à la version 8. Veuillez mettre à jour votre navigateur ou passer à un autre navigateur, tel que FireFox."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "unsupported_ie_version" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "unsupported_ie_version" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:logins_are_restricted.Vitro
+uil-data:logins_are_restricted.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "L'accès est restreint."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "logins_are_restricted" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "logins_are_restricted" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:add_profile_editor.Vitro
+uil-data:add_profile_editor.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ajouter un éditeur de profil"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "add_profile_editor" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "add_profile_editor" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:supply_name.Vitro
+uil-data:supply_name.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Vous devez inscrire un titre"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "supply_name" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "supply_name" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:feedback_thanks_text.Vitro
+uil-data:feedback_thanks_text.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Merci d'avoir contacté notre équipe. Nous vous répondrons dès que possible."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "feedback_thanks_text" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "feedback_thanks_text" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_class_for_search.Vitro
+uil-data:select_class_for_search.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Vous devez sélectionner une classe pour afficher ses éléments."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_class_for_search" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_class_for_search" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:since_elapsed_time.Vitro
+uil-data:since_elapsed_time.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Depuis {0}. Durée écoulée {1}"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "since_elapsed_time" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "since_elapsed_time" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:unknown_user_name.Vitro
+uil-data:unknown_user_name.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "ami"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "unknown_user_name" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "unknown_user_name" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:faux_property_capitalized.Vitro
+uil-data:faux_property_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Propriété Faux"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "faux_property_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "faux_property_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:enter_value_name_field.Vitro
+uil-data:enter_value_name_field.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Veuillez saisir une valeur dans le champs Nom"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "enter_value_name_field" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "enter_value_name_field" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:group_name.Vitro
+uil-data:group_name.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "nom du groupe"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "group_name" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "group_name" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:data_property_hierarchy.Vitro
+uil-data:data_property_hierarchy.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Hiérarchie des propriétés de données"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "data_property_hierarchy" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "data_property_hierarchy" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:external_login_text.Vitro
+uil-data:external_login_text.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Connexion utilisant BearCat Shibboleth"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "external_login_text" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "external_login_text" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:imageUpload.errorFileTooBig.Vitro
+uil-data:imageUpload.errorFileTooBig.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Veuillez téléverser une image de moins de {0} mégaoctets."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "imageUpload.errorFileTooBig" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "imageUpload.errorFileTooBig" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:profile_editors.Vitro
+uil-data:profile_editors.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Éditeurs de profils"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "profile_editors" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "profile_editors" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:implement_capitalized.Vitro
+uil-data:implement_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Créer "@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "implement_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "implement_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:sparql_query_header.Vitro
+uil-data:sparql_query_header.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Query"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "sparql_query_header" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "sparql_query_header" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:view.Vitro
+uil-data:view.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "afficher"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "view" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "view" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:manage_profile_editing.Vitro
+uil-data:manage_profile_editing.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Gestion de l'édition de profils"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "manage_profile_editing" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "manage_profile_editing" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:minimum_image_dimensions.Vitro
+uil-data:minimum_image_dimensions.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Taille minimale de l'image: {0} par {1} pixels"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "minimum_image_dimensions" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "minimum_image_dimensions" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:view_list_in_rdf.Vitro
+uil-data:view_list_in_rdf.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Voir la liste des {0} en format RDF"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "view_list_in_rdf" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "view_list_in_rdf" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:more_details_about_site.Vitro
+uil-data:more_details_about_site.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Informations supplémentaires concernant ce site"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "more_details_about_site" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "more_details_about_site" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:new_entry_for.Vitro
+uil-data:new_entry_for.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "un nouvel enregistrement \"{0}\" pour {1}"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "new_entry_for" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "new_entry_for" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:july.Vitro
+uil-data:july.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Juillet"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "july" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "july" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:page_uri.Vitro
+uil-data:page_uri.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "page URI"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "page_uri" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "page_uri" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:edit_date_time_value.Vitro
+uil-data:edit_date_time_value.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Éditer le paramètre de Date/Heure"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "edit_date_time_value" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "edit_date_time_value" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:limited_to_type.Vitro
+uil-data:limited_to_type.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "limité aux types "@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "limited_to_type" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "limited_to_type" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:class_name.Vitro
+uil-data:class_name.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "nom de la classe"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "class_name" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "class_name" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:create_date_time_value.Vitro
+uil-data:create_date_time_value.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Saisir le paramètre de Date/Heure"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "create_date_time_value" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "create_date_time_value" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:there_are_no_entries_for_selection.Vitro
+uil-data:there_are_no_entries_for_selection.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Il n'y a pas d'entrées dans le système à partir desquelles vous pouvez sélectionner."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "there_are_no_entries_for_selection" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "there_are_no_entries_for_selection" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:edit_this_individual.Vitro
+uil-data:edit_this_individual.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Éditer ce dossier"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "edit_this_individual" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "edit_this_individual" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:start_interval_must_precede_end_earlier.Vitro
+uil-data:start_interval_must_precede_end_earlier.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Le début de l'intervalle doit être antérieur à la fin de l'intervalle."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "start_interval_must_precede_end_earlier" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "start_interval_must_precede_end_earlier" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:type_capitalized.Vitro
+uil-data:type_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Type"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "type_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "type_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:selected.Vitro
+uil-data:selected.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Sélection"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "selected" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "selected" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:submit_upload.Vitro
+uil-data:submit_upload.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Téléverser une photo"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "submit_upload" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "submit_upload" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:confirm_individual_deletion.Vitro
+uil-data:confirm_individual_deletion.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "confirm_individual_deletion" ;
-        prop:hasPackage  "Vitro-languages" .
+        rdf:type         uil:UILabel ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "confirm_individual_deletion" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:september.Vitro
+uil-data:september.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Septembre"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "september" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "september" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:verbose_turn_off.Vitro
+uil-data:verbose_turn_off.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Turn off"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "verbose_turn_off" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "verbose_turn_off" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_type.Vitro
+uil-data:select_type.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Choisir un type"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_type" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_type" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:comments_questions.Vitro
+uil-data:comments_questions.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Questions, commentaires ou suggestions"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "comments_questions" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "comments_questions" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:send_mail.Vitro
+uil-data:send_mail.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Envoyer le courriel"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "send_mail" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "send_mail" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:change_profile.Vitro
+uil-data:change_profile.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "modifier le profil"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "change_profile" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "change_profile" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:logins_already_restricted.Vitro
+uil-data:logins_already_restricted.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "L'accès est déjà restreint."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "logins_already_restricted" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "logins_already_restricted" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:photo_types.Vitro
+uil-data:photo_types.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "(JPEG, GIF ou PNG)"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "photo_types" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "photo_types" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:search_term_error_near.Vitro
+uil-data:search_term_error_near.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "L'expression de recherche comporte une erreur"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "search_term_error_near" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "search_term_error_near" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:share_profile_uri.Vitro
+uil-data:share_profile_uri.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "partager ce profil avec son URI"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "share_profile_uri" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "share_profile_uri" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:no_html_specified.Vitro
+uil-data:no_html_specified.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "HTML non spécifié."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "no_html_specified" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "no_html_specified" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:first_name.Vitro
+uil-data:first_name.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Prénom"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "first_name" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "first_name" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:class_link.Vitro
+uil-data:class_link.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "lien de classe"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "class_link" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "class_link" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:view_profile_page_for.Vitro
+uil-data:view_profile_page_for.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Afficher la page de profil de"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "view_profile_page_for" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "view_profile_page_for" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_classes_to_display.Vitro
+uil-data:select_classes_to_display.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Vous devez sélectionner la classe à afficher."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_classes_to_display" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_classes_to_display" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:password_mismatch.Vitro
+uil-data:password_mismatch.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Les mots de passe ne concordent pas."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "password_mismatch" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "password_mismatch" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:page_management.Vitro
+uil-data:page_management.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Gestion des pages"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "page_management" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "page_management" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:resource_uri.Vitro
+uil-data:resource_uri.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Désactiver"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "resource_uri" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "resource_uri" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:sparql_query_run_query.Vitro
+uil-data:sparql_query_run_query.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Run Query"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "sparql_query_run_query" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "sparql_query_run_query" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:enter_fixed_html_here.Vitro
+uil-data:enter_fixed_html_here.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Saisir le HTML fixe ici"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "enter_fixed_html_here" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "enter_fixed_html_here" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:verify_this_match.Vitro
+uil-data:verify_this_match.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "vérifier cette correspondance"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "verify_this_match" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "verify_this_match" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:properties_capitalized.Vitro
+uil-data:properties_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Propriétés"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "properties_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "properties_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:raw_string_literals.Vitro
+uil-data:raw_string_literals.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Littéraux de chaînes brutes"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "raw_string_literals" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "raw_string_literals" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:no_content_create_groups_classes.Vitro
+uil-data:no_content_create_groups_classes.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Il n'y a actuellement aucun contenu dans le système, ou vous devez créer des groupes de classes et leur affecter vos classes."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "no_content_create_groups_classes" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "no_content_create_groups_classes" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:home_page.Vitro
+uil-data:home_page.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Page d'accueil"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "home_page" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "home_page" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:restriction_on.Vitro
+uil-data:restriction_on.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "restriction sur"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "restriction_on" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "restriction_on" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:processing_indicator.Vitro
+uil-data:processing_indicator.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "indicateur du temps de traitement"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "processing_indicator" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "processing_indicator" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:selected_page_content_type.Vitro
+uil-data:selected_page_content_type.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Type de contenu sélectionné pour la page associée"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "selected_page_content_type" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "selected_page_content_type" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:create_entry.Vitro
+uil-data:create_entry.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Créer une entrée"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "create_entry" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "create_entry" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:password_change_not_pending.Vitro
+uil-data:password_change_not_pending.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Le mot de passe de {0} a déjà été réinitialisé."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "password_change_not_pending" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "password_change_not_pending" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:javascript_instructions.Vitro
+uil-data:javascript_instructions.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "instructions JavaScript"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "javascript_instructions" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "javascript_instructions" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_invalid_email.Vitro
+uil-data:error_invalid_email.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "''{0}'' n'est pas une adresse courriel valide."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_invalid_email" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_invalid_email" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:new_pwd_matches_existing.Vitro
+uil-data:new_pwd_matches_existing.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Votre nouveau mot de passe doit être différent de l'ancien."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "new_pwd_matches_existing" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "new_pwd_matches_existing" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:or.Vitro
+uil-data:or.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "ou"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "or" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "or" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:search_form.Vitro
+uil-data:search_form.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Formulaire de recherche"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "search_form" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "search_form" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:menu_item_name.Vitro
+uil-data:menu_item_name.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Titre de l'élément de menu"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "menu_item_name" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "menu_item_name" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:june.Vitro
+uil-data:june.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Juin"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "june" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "june" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:last_name.Vitro
+uil-data:last_name.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Nom de famille"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "last_name" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "last_name" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:placeholder_image.Vitro
+uil-data:placeholder_image.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "espace réservé pour l'image"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "placeholder_image" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "placeholder_image" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:requested_url.Vitro
+uil-data:requested_url.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "URL demandée"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "requested_url" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "requested_url" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:first_time_login_note.Vitro
+uil-data:first_time_login_note.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Note: Un courriel sera envoyé à l'adresse ci-dessus afin de confirmer la création du compte."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "first_time_login_note" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "first_time_login_note" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_external_auth_already_exists.Vitro
+uil-data:error_external_auth_already_exists.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Un compte correspondant à cet identifiant externe est déjà présent."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_external_auth_already_exists" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_external_auth_already_exists" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:contains_no_pears.Vitro
+uil-data:contains_no_pears.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "ne contient pas de poires"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "contains_no_pears" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "contains_no_pears" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:index_page.Vitro
+uil-data:index_page.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "page index"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "index_page" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "index_page" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:search_tip_one.Vitro
+uil-data:search_tip_one.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Gardez les choses simples ! Utilisez des termes courts et simples, à moins que vos recherches ne donnent trop de résultats."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "search_tip_one" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "search_tip_one" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:sparql_query_construct_describe_results.Vitro
+uil-data:sparql_query_construct_describe_results.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Format for CONSTRUCT and DESCRIBE query results"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "sparql_query_construct_describe_results" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "sparql_query_construct_describe_results" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:password_capitalized.Vitro
+uil-data:password_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Mot de passe"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "password_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "password_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:file_upload_submit_label.Vitro
+uil-data:file_upload_submit_label.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "file_upload_submit_label" ;
-        prop:hasPackage  "Vitro-languages" .
+        rdf:type         uil:UILabel ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "file_upload_submit_label" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:please.Vitro
+uil-data:please.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "S'il-vous-plaît"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "please" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "please" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:account_created.Vitro
+uil-data:account_created.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Votre compte {0} a été créé."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "account_created" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "account_created" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:add.Vitro
+uil-data:add.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "ajouter"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "add" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "add" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:limit.Vitro
+uil-data:limit.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Limite"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "limit" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "limit" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:november.Vitro
+uil-data:november.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Novembre"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "november" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "november" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:confirm_delete.Vitro
+uil-data:confirm_delete.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Êtes-vous certain de vouloir supprimer cette photo?"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "confirm_delete" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "confirm_delete" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:login_welcome_message.Vitro
+uil-data:login_welcome_message.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Bienvenue {0}"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "login_welcome_message" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "login_welcome_message" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:password_changed_subject.Vitro
+uil-data:password_changed_subject.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Le mot de passe a été mis à jour."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "password_changed_subject" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "password_changed_subject" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:incorrect_email_password.Vitro
+uil-data:incorrect_email_password.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Courriel ou mot de passe erroné."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "incorrect_email_password" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "incorrect_email_password" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:identifiers.Vitro
+uil-data:identifiers.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Identifiants"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "identifiers" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "identifiers" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:javascript_ie_alert_text.Vitro
+uil-data:javascript_ie_alert_text.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ce site utilise des éléments HTML qui ne sont pas reconnus par les versions d'Internet Explorer 8 et antérieures en l'absence de JavaScript. Par conséquent, le site ne sera pas rendu de façon appropriée. Pour y remédier, veuillez activer JavaScript, passer à Internet Explorer 9 ou utiliser un autre navigateur."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "javascript_ie_alert_text" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "javascript_ie_alert_text" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:zoo_two.Vitro
+uil-data:zoo_two.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Zoo 2"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "zoo_two" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "zoo_two" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:verbose_turn_on.Vitro
+uil-data:verbose_turn_on.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Activer"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "verbose_turn_on" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "verbose_turn_on" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:selection_in_process.Vitro
+uil-data:selection_in_process.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Votre sélection est en cours de traitement."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "selection_in_process" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "selection_in_process" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:please_create.Vitro
+uil-data:please_create.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Veuillez créer"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "please_create" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "please_create" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:verbose_status_off.Vitro
+uil-data:verbose_status_off.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "inactif "@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "verbose_status_off" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "verbose_status_off" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:page_not_configured.Vitro
+uil-data:page_not_configured.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Cette page n'est pas encore configurée."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "page_not_configured" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "page_not_configured" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:new_account_notification.Vitro
+uil-data:new_account_notification.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Un courriel de confirmation a été envoyé à {0}. Il comporte des instructions pour activer le compte et créer un mot de passe."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "new_account_notification" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "new_account_notification" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:full_list_startup.Vitro
+uil-data:full_list_startup.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "La liste complète des événements et messages au démarrage."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "full_list_startup" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "full_list_startup" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:user_role.Vitro
+uil-data:user_role.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Rôle"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "user_role" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "user_role" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:or_enter_valid_address.Vitro
+uil-data:or_enter_valid_address.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "ou saisissez une autre adresse électronique complète et valide."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "or_enter_valid_address" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "or_enter_valid_address" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:all.Vitro
+uil-data:all.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "tous"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "all" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "all" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:logged_in_but_no_profile.Vitro
+uil-data:logged_in_but_no_profile.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Vous êtes connecté, mais aucun profil ne correspond à votre identifiant."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "logged_in_but_no_profile" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "logged_in_but_no_profile" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:page_text.Vitro
+uil-data:page_text.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "texte de la page "@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "page_text" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "page_text" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:create_new_entry.Vitro
+uil-data:create_new_entry.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Veuillez créer un nouvel enregistrement."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "create_new_entry" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "create_new_entry" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:enter_in_security_field.Vitro
+uil-data:enter_in_security_field.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Veuillez saisir les caractères apparaissant ci-dessous dans le champs sécurisé prévu à cet effet"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "enter_in_security_field" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "enter_in_security_field" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_an_existing_or_create_a_new_one.Vitro
+uil-data:select_an_existing_or_create_a_new_one.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Sélectionnez un existant ou créez-en un nouveau"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_an_existing_or_create_a_new_one" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_an_existing_or_create_a_new_one" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:not.Vitro
+uil-data:not.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "ne pas"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "not" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "not" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:range_data_type.Vitro
+uil-data:range_data_type.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Étendue du type de données "@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "range_data_type" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "range_data_type" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:august.Vitro
+uil-data:august.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Août"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "august" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "august" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:terms_of_use.Vitro
+uil-data:terms_of_use.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Conditions d'utilisation"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "terms_of_use" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "terms_of_use" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:dump_restore.Vitro
+uil-data:dump_restore.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Vider/Restaurer l'application"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "dump_restore" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "dump_restore" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:show_properties.Vitro
+uil-data:show_properties.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "afficher les propriétés"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "show_properties" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "show_properties" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:associated_individuals.Vitro
+uil-data:associated_individuals.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "éléments associés"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "associated_individuals" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "associated_individuals" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:name_capitalized.Vitro
+uil-data:name_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Nom"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "name_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "name_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:manage_labels.Vitro
+uil-data:manage_labels.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "gérer les étiquettes"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "manage_labels" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "manage_labels" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:current_user.Vitro
+uil-data:current_user.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Usager courant"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "current_user" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "current_user" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:minimum_ymd.Vitro
+uil-data:minimum_ymd.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Entrée invalide. Veuillez entrer au moins une année, un mois et un jour."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "minimum_ymd" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "minimum_ymd" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:try_another_letter.Vitro
+uil-data:try_another_letter.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Essayez une autre lettre ou parcourez toutes les lettres."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "try_another_letter" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "try_another_letter" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:alt_image_to_crop.Vitro
+uil-data:alt_image_to_crop.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Image à rogner"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "alt_image_to_crop" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "alt_image_to_crop" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:current_task.Vitro
+uil-data:current_task.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "{0} l'index de recherche"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "current_task" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "current_task" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:imageUpload.errorNoImageForCropping.Vitro
+uil-data:imageUpload.errorNoImageForCropping.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Aucune image à rogner."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "imageUpload.errorNoImageForCropping" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "imageUpload.errorNoImageForCropping" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:we_have_an_error.Vitro
+uil-data:we_have_an_error.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Une erreur système s'est produite."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "we_have_an_error" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "we_have_an_error" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_another_class.Vitro
+uil-data:select_another_class.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Veuillez sélectionner une autre classe dans la liste."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_another_class" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_another_class" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:manage_labels_for.Vitro
+uil-data:manage_labels_for.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Gérer les étiquettes de"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "manage_labels_for" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "manage_labels_for" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:revision_info.Vitro
+uil-data:revision_info.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Information sur la révision"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "revision_info" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "revision_info" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:rebuild_vis_cache.Vitro
+uil-data:rebuild_vis_cache.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Reconstruire la cache de visualisation"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "rebuild_vis_cache" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "rebuild_vis_cache" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:delete.Vitro
+uil-data:delete.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "supprimer"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "delete" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "delete" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:update_button.Vitro
+uil-data:update_button.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Mettre à jour"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "update_button" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "update_button" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:imageUpload.errorNoPhotoSelected.Vitro
+uil-data:imageUpload.errorNoPhotoSelected.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Parcourir et choisir une photo."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "imageUpload.errorNoPhotoSelected" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "imageUpload.errorNoPhotoSelected" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:imageUpload.errorUnrecognizedURI.Vitro
+uil-data:imageUpload.errorUnrecognizedURI.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Cette URI n'est reliée à aucun individu: ''{0}''"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "imageUpload.errorUnrecognizedURI" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "imageUpload.errorUnrecognizedURI" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:menu_item.Vitro
+uil-data:menu_item.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "élément de menu"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "menu_item" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "menu_item" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:auth_id_label.Vitro
+uil-data:auth_id_label.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "ID d'authentification externe"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "auth_id_label" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "auth_id_label" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:may.Vitro
+uil-data:may.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Mai"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "may" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "may" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:what_is_vitro.Vitro
+uil-data:what_is_vitro.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Qu'est-ce que VITRO?"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "what_is_vitro" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "what_is_vitro" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_a_language.Vitro
+uil-data:select_a_language.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Choisir une langue"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_a_language" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_a_language" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:ip_address.Vitro
+uil-data:ip_address.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "adresse IP"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "ip_address" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "ip_address" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:unrecognized_user.Vitro
+uil-data:unrecognized_user.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Utilisateur non identifié"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "unrecognized_user" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "unrecognized_user" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:password_change_invalid_key.Vitro
+uil-data:password_change_invalid_key.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Le lien que vous avez utilisé pour {0} n'est pas valide. Veuillez demander à l'administrateur du site de renvoyer le lien. "@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "password_change_invalid_key" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "password_change_invalid_key" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:change_text_for.Vitro
+uil-data:change_text_for.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Changement du texte pour: "@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "change_text_for" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "change_text_for" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:to_enable_javascript.Vitro
+uil-data:to_enable_javascript.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Voici les instructions pour activer JavaScript dans votre navigateur Web"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "to_enable_javascript" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "to_enable_javascript" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:warning.Vitro
+uil-data:warning.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Avertissement"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "warning" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "warning" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:revision.Vitro
+uil-data:revision.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "révision"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "revision" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "revision" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:filter_by_roles.Vitro
+uil-data:filter_by_roles.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Filtrer par rôles"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "filter_by_roles" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "filter_by_roles" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:page_uri_missing_msg.Vitro
+uil-data:page_uri_missing_msg.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Il n'a pas été possible de générer une page parce qu'il n'était pas clair quelle page était demandée.  Il se peut qu'il manque un mappage d'URL."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "page_uri_missing_msg" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "page_uri_missing_msg" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:fatal_error.Vitro
+uil-data:fatal_error.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Erreur fatale"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "fatal_error" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "fatal_error" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:page_select_permission_option.Vitro
+uil-data:page_select_permission_option.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Sélectionner les permissions"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "page_select_permission_option" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "page_select_permission_option" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:january.Vitro
+uil-data:january.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Janvier"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "january" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "january" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:property.Vitro
+uil-data:property.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "propriétés"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "property" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "property" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:external_auth_id.Vitro
+uil-data:external_auth_id.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "ID d'authentification externe"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "external_auth_id" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "external_auth_id" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:date_time_value_for.Vitro
+uil-data:date_time_value_for.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "paramètre de date et heure pour"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "date_time_value_for" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "date_time_value_for" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:sparql_query_title.Vitro
+uil-data:sparql_query_title.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "SPARQL Query"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "sparql_query_title" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "sparql_query_title" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:previous.Vitro
+uil-data:previous.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Précédent"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "previous" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "previous" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:upload_page_title_with_name.Vitro
+uil-data:upload_page_title_with_name.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Téléverser une image de {0}"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "upload_page_title_with_name" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "upload_page_title_with_name" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:cant_change_password_while_logged_in.Vitro
+uil-data:cant_change_password_while_logged_in.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Vous ne pouvez pas activer le compte {0} lorsque vous êtes connecté en tant que {1}. Veuillez essayer de vous reconnecter."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "cant_change_password_while_logged_in" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "cant_change_password_while_logged_in" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:rejected_spam.Vitro
+uil-data:rejected_spam.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "REJETÉ - POURRIEL"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "rejected_spam" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "rejected_spam" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:logins_are_open.Vitro
+uil-data:logins_are_open.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "L'accès est ouvert à tous."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "logins_are_open" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "logins_are_open" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:confirm_delete_account_singular.Vitro
+uil-data:confirm_delete_account_singular.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Êtes-vous certain de vouloir supprimer ce compte?"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "confirm_delete_account_singular" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "confirm_delete_account_singular" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:all_capitalized.Vitro
+uil-data:all_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Tous"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "all_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "all_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:of_the_results.Vitro
+uil-data:of_the_results.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "des résultats"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "of_the_results" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "of_the_results" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_content_type.Vitro
+uil-data:select_content_type.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Vous devez sélectionner le contenu à inclure dans la page"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_content_type" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_content_type" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:visit_project_website.Vitro
+uil-data:visit_project_website.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Visitez le site web du projet national"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "visit_project_website" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "visit_project_website" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:view_labels_for.Vitro
+uil-data:view_labels_for.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Afficher les étiquettes de"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "view_labels_for" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "view_labels_for" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:new_account_note.Vitro
+uil-data:new_account_note.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Note: Un courriel de confirmation a été envoyé à {0} .Il comporte des instructions pour réinitialiser le mot de passe. Le mot de passe ne sera pas réinitialisé tant que l'usager n'aura pas cliqué sur le lien inclus dans ce courriel."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "new_account_note" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "new_account_note" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_alert_icon.Vitro
+uil-data:error_alert_icon.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Icône d'alerte d'erreur"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_alert_icon" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_alert_icon" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:imageUpload.errorImageTooSmall.Vitro
+uil-data:imageUpload.errorImageTooSmall.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "L'image téléversée devrait avoir au moins {0} pixels de hauteur et {1} pixels de largeur."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "imageUpload.errorImageTooSmall" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "imageUpload.errorImageTooSmall" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_account_to_delete.Vitro
+uil-data:select_account_to_delete.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "sélectionner un compte à supprimer"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_account_to_delete" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_account_to_delete" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:interest_thanks.Vitro
+uil-data:interest_thanks.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Merci pour votre intérêt concernant {0}. Veuillez soumettre vos questions, commentaires et suggestions concernant ce site via ce formulaire."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "interest_thanks" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "interest_thanks" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:year_numeric.Vitro
+uil-data:year_numeric.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Entrée invalide. L année doit être numérique"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "year_numeric" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "year_numeric" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_an_existing_document.Vitro
+uil-data:select_an_existing_document.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Sélectionner un document existant"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_an_existing_document" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_an_existing_document" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:password_length.Vitro
+uil-data:password_length.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Le mot de passe doit être entre {0} et {1} caractères."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "password_length" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "password_length" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:monday.Vitro
+uil-data:monday.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Lundi"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "monday" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "monday" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:account_created_subject.Vitro
+uil-data:account_created_subject.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Votre compte {0} a été créé."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "account_created_subject" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "account_created_subject" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:vitro_bullet_three.Vitro
+uil-data:vitro_bullet_three.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Construire un site web public pour afficher vos données"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "vitro_bullet_three" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "vitro_bullet_three" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:photo.Vitro
+uil-data:photo.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Photo"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "photo" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "photo" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:file_must_be_entered_msg.Vitro
+uil-data:file_must_be_entered_msg.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "un fichier doit être spécifié pour ce champ."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "file_must_be_entered_msg" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "file_must_be_entered_msg" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:entity_to_query_for.Vitro
+uil-data:entity_to_query_for.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Cet identifiant est celui de l'élément sur lequel porte la requête. \"netid\" fonctionne également "@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "entity_to_query_for" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "entity_to_query_for" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:manage_grants_and_projects_link.Vitro
+uil-data:manage_grants_and_projects_link.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "gérer les subventions et les projets"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "manage_grants_and_projects_link" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "manage_grants_and_projects_link" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:manage_labels_intro.Vitro
+uil-data:manage_labels_intro.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Dans le cas où plusieurs étiquettes existent dans la même langue, veuillez utiliser le lien de suppression pour supprimer les étiquettes que vous ne voulez pas voir apparaître sur la page de profil pour une langue donnée."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "manage_labels_intro" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "manage_labels_intro" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:hide_show_properties.Vitro
+uil-data:hide_show_properties.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "masquer/afficher les propriétés"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "hide_show_properties" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "hide_show_properties" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:untitled.Vitro
+uil-data:untitled.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "-sans titre-"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "untitled" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "untitled" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:manage_publications_link.Vitro
+uil-data:manage_publications_link.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Gérer les publications"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "manage_publications_link" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "manage_publications_link" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_all.Vitro
+uil-data:select_all.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "tout sélectionner"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_all" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_all" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:local_name.Vitro
+uil-data:local_name.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Nom local "@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "local_name" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "local_name" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:end_interval_must_follow_start_interval.Vitro
+uil-data:end_interval_must_follow_start_interval.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "La fin de l'intervalle doit être postérieure au début de l'intervalle"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "end_interval_must_follow_start_interval" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "end_interval_must_follow_start_interval" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:view_page.Vitro
+uil-data:view_page.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Voir la page"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "view_page" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "view_page" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:browse_page_javascript_one.Vitro
+uil-data:browse_page_javascript_one.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Cette page de navigation nécessite JavaScript, mais votre navigateur est configuré pour désactiver JavaScript. Activez JavaScript ou utilisez la fonction"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "browse_page_javascript_one" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "browse_page_javascript_one" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:sparql_query_builder.Vitro
+uil-data:sparql_query_builder.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Créateur de requêtes SPARQL"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "sparql_query_builder" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "sparql_query_builder" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:sub_properties.Vitro
+uil-data:sub_properties.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Sous-propriétés"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "sub_properties" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "sub_properties" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:add_label_for_language.Vitro
+uil-data:add_label_for_language.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Langue"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "add_label_for_language" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "add_label_for_language" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:file_upload_error_file_not_found.Vitro
+uil-data:file_upload_error_file_not_found.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "file_upload_error_file_not_found" ;
-        prop:hasPackage  "Vitro-languages" .
+        rdf:type         uil:UILabel ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "file_upload_error_file_not_found" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:file_upload_predicate.Vitro
+uil-data:file_upload_predicate.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "file_upload_predicate" ;
-        prop:hasPackage  "Vitro-languages" .
+        rdf:type         uil:UILabel ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "file_upload_predicate" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:start_with_leading_slash.Vitro
+uil-data:start_with_leading_slash.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Doit commencer par une barre oblique vers l'avant : / (par ex.: /people)"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "start_with_leading_slash" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "start_with_leading_slash" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:trace_available.Vitro
+uil-data:trace_available.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "trace complète disponible dans le log de VIVO"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "trace_available" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "trace_available" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:editing_prohibited.Vitro
+uil-data:editing_prohibited.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Cette propriété est actuellement configurée pour interdire l'édition."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "editing_prohibited" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "editing_prohibited" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:verbose_status_on.Vitro
+uil-data:verbose_status_on.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "actif "@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "verbose_status_on" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "verbose_status_on" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:use_capitalized.Vitro
+uil-data:use_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Utiliser"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "use_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "use_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:search_index_status.Vitro
+uil-data:search_index_status.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Status de l'index de recherche"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "search_index_status" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "search_index_status" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:filter_search.Vitro
+uil-data:filter_search.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "filtrer la recherche"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "filter_search" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "filter_search" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:with_vitro.Vitro
+uil-data:with_vitro.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "À l'aide de Vitro, vous pouvez:"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "with_vitro" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "with_vitro" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:site_information.Vitro
+uil-data:site_information.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Informations de site"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "site_information" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "site_information" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:logins_temporarily_disabled.Vitro
+uil-data:logins_temporarily_disabled.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Les accès sont bloqués durant la maintenance du site."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "logins_temporarily_disabled" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "logins_temporarily_disabled" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:leave_password_unchanged.Vitro
+uil-data:leave_password_unchanged.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ne pas compléter ce champ implique que le mot de passe ne sera pas changé."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "leave_password_unchanged" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "leave_password_unchanged" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:query_model.Vitro
+uil-data:query_model.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Modèle de requête"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "query_model" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "query_model" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:restrict_logins_mixed_caps.Vitro
+uil-data:restrict_logins_mixed_caps.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Restriction des connexions"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "restrict_logins_mixed_caps" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "restrict_logins_mixed_caps" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:wednesday.Vitro
+uil-data:wednesday.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Mercredi"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "wednesday" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "wednesday" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:berries.Vitro
+uil-data:berries.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Baies:"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "berries" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "berries" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:full_name.Vitro
+uil-data:full_name.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Nom complet"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "full_name" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "full_name" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:no_email_supplied.Vitro
+uil-data:no_email_supplied.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Courriel manquant."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "no_email_supplied" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "no_email_supplied" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_was_reported.Vitro
+uil-data:error_was_reported.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Cette erreur a été signalée à l'administrateur du site."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_was_reported" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_was_reported" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:search_results_for.Vitro
+uil-data:search_results_for.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Résultats de recherche pour"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "search_results_for" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "search_results_for" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:search_tip_three.Vitro
+uil-data:search_tip_three.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Sauf pour les opérateurs booléens, les recherches ne sont <strong>pas</strong> sensibles à la casse, donc \"Genève\" et \"genève\" sont équivalents."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "search_tip_three" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "search_tip_three" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:view_profile_for_page.Vitro
+uil-data:view_profile_for_page.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "afficher le profil individuel pour cette page"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "view_profile_for_page" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "view_profile_for_page" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:reordering_menus_failed.Vitro
+uil-data:reordering_menus_failed.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "La réorganisation des éléments du menu a échoué."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "reordering_menus_failed" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "reordering_menus_failed" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:verbose_control.Vitro
+uil-data:verbose_control.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "contrôle de verbosité"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "verbose_control" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "verbose_control" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:ontology_list.Vitro
+uil-data:ontology_list.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Liste des ontologies"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "ontology_list" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "ontology_list" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:edit_entry.Vitro
+uil-data:edit_entry.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "éditer ce texte"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "edit_entry" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "edit_entry" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:label.dateTimeWithPrecision.minutes_capitalized.Vitro
+uil-data:label.dateTimeWithPrecision.minutes_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Minutes"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "label.dateTimeWithPrecision.minutes_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "label.dateTimeWithPrecision.minutes_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:object.Vitro
+uil-data:object.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "objet"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "object" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "object" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:confirm_email_changed_email_html_text.Vitro
+uil-data:confirm_email_changed_email_html_text.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "<p>\n Bonjour, ${userAccount.firstName} ${userAccount.lastName}\n </p>\n\n <p>\n Vous avez récemment changé l'adresse courriel associée à\n ${userAccount.firstName} ${userAccount.lastName}\n </p>\n\n <p>\n Merci.\n </p>"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "confirm_email_changed_email_html_text" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "confirm_email_changed_email_html_text" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_no_new_password.Vitro
+uil-data:error_no_new_password.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Veuillez inscrire un nouveau mot de passe."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_no_new_password" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_no_new_password" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:page_loggedin_permission_option.Vitro
+uil-data:page_loggedin_permission_option.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Les usagers connectés peuvent accéder à cette page"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "page_loggedin_permission_option" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "page_loggedin_permission_option" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:expecting_content.Vitro
+uil-data:expecting_content.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Contenu attendu?"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "expecting_content" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "expecting_content" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:required_fields.Vitro
+uil-data:required_fields.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "champs requis"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "required_fields" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "required_fields" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:edit_page_title.Vitro
+uil-data:edit_page_title.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Éditer"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "edit_page_title" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "edit_page_title" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_existing.Vitro
+uil-data:select_existing.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Choisir l'enregistrement existant"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_existing" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_existing" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:invalid_url_msg.Vitro
+uil-data:invalid_url_msg.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Cette URL doit commencer par http:// ou https://"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "invalid_url_msg" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "invalid_url_msg" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:search_button.Vitro
+uil-data:search_button.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Chercher"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "search_button" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "search_button" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:advanced_search_tips_header.Vitro
+uil-data:advanced_search_tips_header.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Conseils avancés"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "advanced_search_tips_header" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "advanced_search_tips_header" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:supply_url.Vitro
+uil-data:supply_url.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Vous devez inscrire une URL conviviale"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "supply_url" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "supply_url" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_profiles.Vitro
+uil-data:select_profiles.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Sélectionner des profils"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_profiles" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_profiles" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_one.Vitro
+uil-data:select_one.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Sélectionner une entrée"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_one" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_one" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:continue.Vitro
+uil-data:continue.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Continuer"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "continue" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "continue" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:language_selection_failed.Vitro
+uil-data:language_selection_failed.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Il y avait un problème dans le système. Votre choix de langue a été rejeté."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "language_selection_failed" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "language_selection_failed" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:display_has_element_error.Vitro
+uil-data:display_has_element_error.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Erreur système: la propriété \"display:hasElement\" n'a pu être retrouvée."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "display_has_element_error" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "display_has_element_error" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:file_upload_error_file_is_too_big.Vitro
+uil-data:file_upload_error_file_is_too_big.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "file_upload_error_file_is_too_big" ;
-        prop:hasPackage  "Vitro-languages" .
+        rdf:type         uil:UILabel ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "file_upload_error_file_is_too_big" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:template_capitalized.Vitro
+uil-data:template_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Gabarit"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "template_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "template_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:file_upload_supported_media.Vitro
+uil-data:file_upload_supported_media.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "file_upload_supported_media" ;
-        prop:hasPackage  "Vitro-languages" .
+        rdf:type         uil:UILabel ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "file_upload_supported_media" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:user_accounts_title.Vitro
+uil-data:user_accounts_title.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "comptes d'usagers"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "user_accounts_title" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "user_accounts_title" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:create_your_password.Vitro
+uil-data:create_your_password.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Créer votre mot de passe"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "create_your_password" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "create_your_password" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:create_account.Vitro
+uil-data:create_account.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Créer un compte"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "create_account" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "create_account" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:remove_menu_item.Vitro
+uil-data:remove_menu_item.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Supprimer l'élément de menu"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "remove_menu_item" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "remove_menu_item" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:click_to_view_account.Vitro
+uil-data:click_to_view_account.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Cliquer pour consulter les détails du compte"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "click_to_view_account" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "click_to_view_account" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:add_new_entry_for.Vitro
+uil-data:add_new_entry_for.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ajouter un enregistrement pour: "@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "add_new_entry_for" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "add_new_entry_for" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:menu_ordering.Vitro
+uil-data:menu_ordering.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ordre du menu"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "menu_ordering" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "menu_ordering" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:map_processor_error.Vitro
+uil-data:map_processor_error.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Une erreur s'est produite et la carte des processeurs pour ce contenu est manquante. Veuillez contacter l'administrateur. "@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "map_processor_error" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "map_processor_error" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:change_profile_title.Vitro
+uil-data:change_profile_title.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "modifier le profil"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "change_profile_title" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "change_profile_title" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:domain_class.Vitro
+uil-data:domain_class.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Domaine de classe"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "domain_class" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "domain_class" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:manage_labels_capitalized.Vitro
+uil-data:manage_labels_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Gérer les étiquettes"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "manage_labels_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "manage_labels_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_passwords_dont_match.Vitro
+uil-data:error_passwords_dont_match.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Les mots de passe ne concordent pas."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_passwords_dont_match" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_passwords_dont_match" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:save_profile_changes.Vitro
+uil-data:save_profile_changes.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Appliquer les changements aux profils"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "save_profile_changes" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "save_profile_changes" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:site_administration.Vitro
+uil-data:site_administration.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Administration du site"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "site_administration" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "site_administration" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:vitro_bullet_one.Vitro
+uil-data:vitro_bullet_one.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Créer ou charger des ontologies au format OWL"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "vitro_bullet_one" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "vitro_bullet_one" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:pages.Vitro
+uil-data:pages.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "pages"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "pages" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "pages" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:inferred_class_hierarchy.Vitro
+uil-data:inferred_class_hierarchy.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Hiérarchie de classes inférées"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "inferred_class_hierarchy" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "inferred_class_hierarchy" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:auth_id_in_use.Vitro
+uil-data:auth_id_in_use.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Cet identifiant est déjà utilisé."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "auth_id_in_use" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "auth_id_in_use" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:data_input.Vitro
+uil-data:data_input.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Entrée de données"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "data_input" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "data_input" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:recompute_inferences_mixed_caps.Vitro
+uil-data:recompute_inferences_mixed_caps.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Recalculer les inférences"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "recompute_inferences_mixed_caps" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "recompute_inferences_mixed_caps" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:individual_name.Vitro
+uil-data:individual_name.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "nom de l'individu"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "individual_name" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "individual_name" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:thursday.Vitro
+uil-data:thursday.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Jeudi"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "thursday" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "thursday" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:alert_icon.Vitro
+uil-data:alert_icon.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Icône d'alerte"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "alert_icon" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "alert_icon" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:if_blank_page_title_used.Vitro
+uil-data:if_blank_page_title_used.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "En l'absence de contenu, le titre de la page sera utilisé."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "if_blank_page_title_used" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "if_blank_page_title_used" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:password_reset_pending_email_plain_text.Vitro
+uil-data:password_reset_pending_email_plain_text.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Cher ${userAccount.firstName} ${userAccount.lastName}:\n\nNous avons reçu une demande de réinitialisation du mot de passe de votre site web pour le compte ${siteName} \n(${userAccount.emailAddress}).\n\nVeuillez suivre les instructions ci-dessous pour procéder à la réinitialisation de votre mot de passe.\n\nSi vous n'avez pas demandé ce nouveau compte, vous pouvez ignorer ce courriel.\nCette demande expirera si elle n'est pas traitée dans un délai de 30 jours.\n\nCollez le lien ci-dessous dans la barre d'adresse de votre navigateur pour réinitialiser votre mot de passe,\nen utilisant notre serveur sécurisé.\n\n${passwordLink}\n\nMerci.\n"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "password_reset_pending_email_plain_text" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "password_reset_pending_email_plain_text" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:hide_properties.Vitro
+uil-data:hide_properties.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "masquer les propriétés"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "hide_properties" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "hide_properties" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:file_upload_error_file_type_not_recognized.Vitro
+uil-data:file_upload_error_file_type_not_recognized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "file_upload_error_file_type_not_recognized" ;
-        prop:hasPackage  "Vitro-languages" .
+        rdf:type         uil:UILabel ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "file_upload_error_file_type_not_recognized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_no_role.Vitro
+uil-data:error_no_role.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Vous devez choisir un rôle."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_no_role" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_no_role" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:new_account_title.Vitro
+uil-data:new_account_title.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "nouveau compte"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "new_account_title" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "new_account_title" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:file_upload_no_allowed_media.Vitro
+uil-data:file_upload_no_allowed_media.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "file_upload_no_allowed_media" ;
-        prop:hasPackage  "Vitro-languages" .
+        rdf:type         uil:UILabel ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "file_upload_no_allowed_media" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:property_groups.Vitro
+uil-data:property_groups.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Groupes de propriétés"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "property_groups" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "property_groups" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:startup_trace.Vitro
+uil-data:startup_trace.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Trace de démarrage"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "startup_trace" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "startup_trace" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:search_accounts_button.Vitro
+uil-data:search_accounts_button.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Rechercher des comptes d'usagers"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "search_accounts_button" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "search_accounts_button" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:operation_unsuccessful.Vitro
+uil-data:operation_unsuccessful.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "L'opération a échoué. Vous trouverez tous les détails dans le journal du système."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "operation_unsuccessful" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "operation_unsuccessful" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:submit_button.Vitro
+uil-data:submit_button.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Soumettre"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "submit_button" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "submit_button" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:page_uri_missing.Vitro
+uil-data:page_uri_missing.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Page URI non spécifiée"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "page_uri_missing" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "page_uri_missing" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_no_email_address.Vitro
+uil-data:error_no_email_address.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Veuillez inscrire votre adresse courriel."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_no_email_address" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_no_email_address" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:controls.Vitro
+uil-data:controls.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Contrôles"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "controls" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "controls" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:fruit.Vitro
+uil-data:fruit.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Fruit"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "fruit" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "fruit" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:admin_panel.Vitro
+uil-data:admin_panel.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Panneau d'administration"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "admin_panel" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "admin_panel" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:the_range_class_does_not_exist.Vitro
+uil-data:the_range_class_does_not_exist.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "La classe de plage pour cette propriété n'existe pas dans le système."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "the_range_class_does_not_exist" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "the_range_class_does_not_exist" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:reset_your_password.Vitro
+uil-data:reset_your_password.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Réinitialiser votre mot de passe"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "reset_your_password" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "reset_your_password" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:advanced_search_tip_two.Vitro
+uil-data:advanced_search_tip_two.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "\"NOT\" peut aider à limiter les recherches -- par exemple, <i>climat</i> NOT <i>change</i>."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "advanced_search_tip_two" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "advanced_search_tip_two" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:save_new_page.Vitro
+uil-data:save_new_page.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Enregistrer la page"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "save_new_page" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "save_new_page" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:book_title.Vitro
+uil-data:book_title.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Titre du livre:"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "book_title" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "book_title" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:view_content_index.Vitro
+uil-data:view_content_index.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Voir un aperçu du contenu de ce site"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "view_content_index" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "view_content_index" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:or_create_new_one.Vitro
+uil-data:or_create_new_one.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "ou en créer un nouveau."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "or_create_new_one" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "or_create_new_one" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:remove_selection.Vitro
+uil-data:remove_selection.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Supprimer la sélection"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "remove_selection" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "remove_selection" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:cardinality.Vitro
+uil-data:cardinality.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "cardinalité"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "cardinality" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "cardinality" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:apostrophe_not_allowed.Vitro
+uil-data:apostrophe_not_allowed.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Le nom de la variable ne doit pas comporter d'apostrophe."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "apostrophe_not_allowed" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "apostrophe_not_allowed" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:confirm_menu_item_delete.Vitro
+uil-data:confirm_menu_item_delete.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Êtes-vous certain de vouloir supprimer?"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "confirm_menu_item_delete" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "confirm_menu_item_delete" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:work_level.Vitro
+uil-data:work_level.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Niveau de tâche"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "work_level" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "work_level" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:acct_created_external_only_email_html_text.Vitro
+uil-data:acct_created_external_only_email_html_text.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "<p>\n ${userAccount.firstName} ${userAccount.lastName}\n </p>\n\n <p>\n <strong>Félicitations!</strong>\n </p>\n\n <p>\n Nous avons créé votre nouveau compte VIVO associé à ${userAccount.emailAddress}.\n </p>\n\n <p>\n Merci!\n </p>"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "acct_created_external_only_email_html_text" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "acct_created_external_only_email_html_text" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:friday.Vitro
+uil-data:friday.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Vendredi"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "friday" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "friday" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:return_to_the.Vitro
+uil-data:return_to_the.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Revenir à la"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "return_to_the" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "return_to_the" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:sparql_query.Vitro
+uil-data:sparql_query.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Requête SPARQL"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "sparql_query" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "sparql_query" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:myAccount_confirm_changes.Vitro
+uil-data:myAccount_confirm_changes.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Vos modifications ont été enregistrées."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "myAccount_confirm_changes" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "myAccount_confirm_changes" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:to.Vitro
+uil-data:to.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "vers"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "to" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "to" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:login_to_manage_site.Vitro
+uil-data:login_to_manage_site.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Connectez-vous pour gérer ce site"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "login_to_manage_site" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "login_to_manage_site" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:a_classgroup.Vitro
+uil-data:a_classgroup.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "un groupe de classes"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "a_classgroup" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "a_classgroup" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:upload_page_title.Vitro
+uil-data:upload_page_title.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Téléverser une image"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "upload_page_title" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "upload_page_title" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_existing_collaborator.Vitro
+uil-data:select_existing_collaborator.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Sélectionner un collaborateur existant pour{0}"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_existing_collaborator" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_existing_collaborator" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:label.dateTimeWithPrecision.day_capitalized.Vitro
+uil-data:label.dateTimeWithPrecision.day_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Jour"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "label.dateTimeWithPrecision.day_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "label.dateTimeWithPrecision.day_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:login_button.Vitro
+uil-data:login_button.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Connexion"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "login_button" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "login_button" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:internal_login.Vitro
+uil-data:internal_login.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Connexion interne"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "internal_login" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "internal_login" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_occurred.Vitro
+uil-data:error_occurred.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Une erreur s'est produite sur le site VIVO"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_occurred" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_occurred" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:advanced_search_tip_four.Vitro
+uil-data:advanced_search_tip_four.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Des variations de mots proches seront également trouvées -- par exemple, <i>sequence</i> correspond à <i>sequences</i> et <i>sequencing</i>."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "advanced_search_tip_four" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "advanced_search_tip_four" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:updated_account_title.Vitro
+uil-data:updated_account_title.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "compte modifié"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "updated_account_title" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "updated_account_title" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:year_month_day.Vitro
+uil-data:year_month_day.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Entrée invalide. Veuillez entrer une année, un mois et un jour."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "year_month_day" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "year_month_day" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:log_out.Vitro
+uil-data:log_out.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Déconnexion"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "log_out" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "log_out" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:application_error_email_plain_text.Vitro
+uil-data:application_error_email_plain_text.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Une erreur s'est produite sur votre site ${siteName!} à ${datetime!}\n\nURL demandée: ${requestedUrl!}\n\n<#if errorMessage?has_content>\n Message d'erreur: ${errorMessage!}\n</#if>\n\nTrace de la pile (trace complète disponible dans le log):\n${stackTrace!}\n\n<#if cause?has_content>\nCausé par:\n${cause!}\n</#if>"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "application_error_email_plain_text" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "application_error_email_plain_text" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_vclass_uri.Vitro
+uil-data:select_vclass_uri.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "VClass sélectionné "@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_vclass_uri" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_vclass_uri" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:custom_template_requiring_content.Vitro
+uil-data:custom_template_requiring_content.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Gabarit personnalisé nécessitant du contenu"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "custom_template_requiring_content" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "custom_template_requiring_content" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:file_upload_error_uri_not_exists.Vitro
+uil-data:file_upload_error_uri_not_exists.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "file_upload_error_uri_not_exists" ;
-        prop:hasPackage  "Vitro-languages" .
+        rdf:type         uil:UILabel ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "file_upload_error_uri_not_exists" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:external_id_not_provided.Vitro
+uil-data:external_id_not_provided.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Connexion impossible - Identifiant externe introuvable."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "external_id_not_provided" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "external_id_not_provided" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:imageUpload.errorBadMultipartRequest.Vitro
+uil-data:imageUpload.errorBadMultipartRequest.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Échec de l'analyse de la demande en plusieurs parties pour le téléversement d'une image."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "imageUpload.errorBadMultipartRequest" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "imageUpload.errorBadMultipartRequest" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:view_all_accounts.Vitro
+uil-data:view_all_accounts.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Voir tous les comptes"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "view_all_accounts" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "view_all_accounts" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:file_upload_file.Vitro
+uil-data:file_upload_file.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "file_upload_file" ;
-        prop:hasPackage  "Vitro-languages" .
+        rdf:type         uil:UILabel ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "file_upload_file" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:search_failed.Vitro
+uil-data:search_failed.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "La recherche a échoué."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "search_failed" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "search_failed" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:minimum_hour.Vitro
+uil-data:minimum_hour.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Entrée invalide. Veuillez spécifier au moins une heure."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "minimum_hour" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "minimum_hour" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:faux_property_alpha.Vitro
+uil-data:faux_property_alpha.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Propriétés Faux triées alphabétiquement"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "faux_property_alpha" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "faux_property_alpha" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:info_icon.Vitro
+uil-data:info_icon.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "information d'icône"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "info_icon" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "info_icon" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:save_button.Vitro
+uil-data:save_button.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Sauvegarder"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "save_button" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "save_button" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:who_can_edit_profile.Vitro
+uil-data:who_can_edit_profile.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Qui peut éditer mon profil"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "who_can_edit_profile" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "who_can_edit_profile" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:add_an_entry_to.Vitro
+uil-data:add_an_entry_to.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ajouter un enregistrement de type "@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "add_an_entry_to" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "add_an_entry_to" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:page_not_found_msg.Vitro
+uil-data:page_not_found_msg.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "La page n'a pas été trouvée dans le système."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "page_not_found_msg" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "page_not_found_msg" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:no_content_in_system.Vitro
+uil-data:no_content_in_system.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Il n'y a actuellement aucun contenu {0} dans le système"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "no_content_in_system" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "no_content_in_system" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:rdf.Vitro
+uil-data:rdf.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "RDF"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "rdf" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "rdf" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:datetime_year_required.Vitro
+uil-data:datetime_year_required.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Les intervalles de date/heure doivent commencer par une année. Entrez une année de début, une année de fin ou les deux."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "datetime_year_required" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "datetime_year_required" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:external_auth_name.Vitro
+uil-data:external_auth_name.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "nom d'authentification externe"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "external_auth_name" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "external_auth_name" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:external_login_failed.Vitro
+uil-data:external_login_failed.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "La connexion externe a échoué."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "external_login_failed" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "external_login_failed" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:label.dateTimeWithPrecision.seconds_capitalized.Vitro
+uil-data:label.dateTimeWithPrecision.seconds_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Secondes"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "label.dateTimeWithPrecision.seconds_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "label.dateTimeWithPrecision.seconds_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:custom_template.Vitro
+uil-data:custom_template.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Gabarit personnalisé"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "custom_template" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "custom_template" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:associated_profile_label.Vitro
+uil-data:associated_profile_label.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Profil associé:"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "associated_profile_label" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "associated_profile_label" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:page_not_found.Vitro
+uil-data:page_not_found.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Page non trouvée"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "page_not_found" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "page_not_found" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_existing_last_name.Vitro
+uil-data:select_existing_last_name.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Choisir un nom de famille existant"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_existing_last_name" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_existing_last_name" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:title_capitalized.Vitro
+uil-data:title_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Titre"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "title_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "title_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:file_upload_error_no_action.Vitro
+uil-data:file_upload_error_no_action.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "file_upload_error_no_action" ;
-        prop:hasPackage  "Vitro-languages" .
+        rdf:type         uil:UILabel ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "file_upload_error_no_action" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:change_entry_for.Vitro
+uil-data:change_entry_for.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Modifier l'enregistrement pour: "@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "change_entry_for" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "change_entry_for" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:cause.Vitro
+uil-data:cause.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Cause:"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "cause" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "cause" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:may_edit.Vitro
+uil-data:may_edit.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Peut éditer"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "may_edit" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "may_edit" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:properties.Vitro
+uil-data:properties.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "propriétés"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "properties" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "properties" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:add_new.Vitro
+uil-data:add_new.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ajouter un(e)"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "add_new" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "add_new" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:apples.Vitro
+uil-data:apples.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Pommes"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "apples" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "apples" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:tuesday.Vitro
+uil-data:tuesday.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Mardi"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "tuesday" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "tuesday" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:email_changed_subject.Vitro
+uil-data:email_changed_subject.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Votre courriel {0} a été modifié."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "email_changed_subject" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "email_changed_subject" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:site_admin.Vitro
+uil-data:site_admin.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Administrer ce site"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "site_admin" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "site_admin" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:code_processing_error.Vitro
+uil-data:code_processing_error.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Une erreur s'est produite et il manque un composant au code de traitement de ce contenu. Veuillez contacter l'administrateur."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "code_processing_error" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "code_processing_error" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:base_property_capitalized.Vitro
+uil-data:base_property_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Propriété Base "@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "base_property_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "base_property_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:username.Vitro
+uil-data:username.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Identifiant"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "username" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "username" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:to_order_menu_items.Vitro
+uil-data:to_order_menu_items.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "pour définir l'ordre des éléments de menus."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "to_order_menu_items" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "to_order_menu_items" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:none.Vitro
+uil-data:none.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "aucun"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "none" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "none" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:classes_capitalized.Vitro
+uil-data:classes_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Classes"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "classes_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "classes_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:cancel_link.Vitro
+uil-data:cancel_link.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Annuler"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "cancel_link" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "cancel_link" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:send_feedback_questions.Vitro
+uil-data:send_feedback_questions.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Faites-nous part de vos commentaires ou de vos questions"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "send_feedback_questions" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "send_feedback_questions" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:account_already_activated.Vitro
+uil-data:account_already_activated.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Le compte de {0} a déjà été activé."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "account_already_activated" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "account_already_activated" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:page.Vitro
+uil-data:page.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "page"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "page" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "page" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:type_more_characters.Vitro
+uil-data:type_more_characters.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Entrer plus de caractères"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "type_more_characters" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "type_more_characters" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:search_tips_header.Vitro
+uil-data:search_tips_header.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Conseils pour la recherche"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "search_tips_header" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "search_tips_header" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:data_not_past_msg.Vitro
+uil-data:data_not_past_msg.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Veuillez saisir une date cible future pour la publication (les dates passées ne sont pas valides)."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "data_not_past_msg" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "data_not_past_msg" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_associated_profile.Vitro
+uil-data:select_associated_profile.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Sélectionnez le profil associé"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_associated_profile" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_associated_profile" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:edit_capitalized.Vitro
+uil-data:edit_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Éditer"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "edit_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "edit_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:site_name.Vitro
+uil-data:site_name.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "nom du site"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "site_name" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "site_name" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:replace_photo.Vitro
+uil-data:replace_photo.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Remplacer la Photo"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "replace_photo" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "replace_photo" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:rebuild_button.Vitro
+uil-data:rebuild_button.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Reconstruire"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "rebuild_button" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "rebuild_button" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:numbers.Vitro
+uil-data:numbers.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Nombres"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "numbers" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "numbers" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:acct_created_external_only_email_plain_text.Vitro
+uil-data:acct_created_external_only_email_plain_text.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "${userAccount.firstName} ${userAccount.lastName}\n\nFélicitations!\n\nNous avons créé votre nouveau compte VIVO associé à\n${userAccount.emailAddress}.\n\nMerci!\n"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "acct_created_external_only_email_plain_text" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "acct_created_external_only_email_plain_text" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:auth_id_explanation.Vitro
+uil-data:auth_id_explanation.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Peut être utilisé pour associer le compte avec le profil d'usager via la propriété d'appariement."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "auth_id_explanation" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "auth_id_explanation" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:support.Vitro
+uil-data:support.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Aide "@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "support" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "support" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:enter_search_term.Vitro
+uil-data:enter_search_term.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Veuillez entrer une expression de recherche."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "enter_search_term" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "enter_search_term" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:feedback_thanks_heading.Vitro
+uil-data:feedback_thanks_heading.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Merci pour vos commentaires"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "feedback_thanks_heading" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "feedback_thanks_heading" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:updated_account_notification.Vitro
+uil-data:updated_account_notification.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Un courriel de confirmation a été envoyé à {0} .Il comporte des instructions pour réinitialiser le mot de passe. Le mot de passe ne sera pas réinitialisé tant que l'usager n'aura pas cliqué sur le lien inclus dans ce courriel."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "updated_account_notification" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "updated_account_notification" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:menu_ordering_mixed_caps.Vitro
+uil-data:menu_ordering_mixed_caps.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ordre des menus"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "menu_ordering_mixed_caps" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "menu_ordering_mixed_caps" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:expand_all.Vitro
+uil-data:expand_all.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "tout développer"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "expand_all" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "expand_all" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:confirm_password_capitalized.Vitro
+uil-data:confirm_password_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Confirmer le nouveau mot de passe"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "confirm_password_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "confirm_password_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:uri_not_defined.Vitro
+uil-data:uri_not_defined.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "URI de la page non définie"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "uri_not_defined" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "uri_not_defined" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:a_link.Vitro
+uil-data:a_link.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "un lien"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "a_link" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "a_link" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:view_list_of_labels.Vitro
+uil-data:view_list_of_labels.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "afficher la liste des étiquettes"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "view_list_of_labels" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "view_list_of_labels" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:not_logged_in.Vitro
+uil-data:not_logged_in.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Non connecté"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "not_logged_in" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "not_logged_in" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:page_public_permission_option.Vitro
+uil-data:page_public_permission_option.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Cette page est visible à tous"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "page_public_permission_option" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "page_public_permission_option" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:file_upload_error_uri_not_given.Vitro
+uil-data:file_upload_error_uri_not_given.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "file_upload_error_uri_not_given" ;
-        prop:hasPackage  "Vitro-languages" .
+        rdf:type         uil:UILabel ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "file_upload_error_uri_not_given" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:file_upload_heading.Vitro
+uil-data:file_upload_heading.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "file_upload_heading" ;
-        prop:hasPackage  "Vitro-languages" .
+        rdf:type         uil:UILabel ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "file_upload_heading" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:save_this_content.Vitro
+uil-data:save_this_content.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Enregistrer ce contenu"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "save_this_content" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "save_this_content" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:data.Vitro
+uil-data:data.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "données"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "data" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "data" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_incorrect_credentials.Vitro
+uil-data:error_incorrect_credentials.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Le courriel saisi est invalide."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_incorrect_credentials" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_incorrect_credentials" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:start_url_with_slash.Vitro
+uil-data:start_url_with_slash.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "L'URL conviviale doit débuter par une barre oblique"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "start_url_with_slash" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "start_url_with_slash" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:february.Vitro
+uil-data:february.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Février"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "february" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "february" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:delete_entry.Vitro
+uil-data:delete_entry.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "supprimer ce texte"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "delete_entry" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "delete_entry" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:imageUpload.errorFormFieldMissing.Vitro
+uil-data:imageUpload.errorFormFieldMissing.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Le formulaire ne comportait pas de champs ''{0}''"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "imageUpload.errorFormFieldMissing" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "imageUpload.errorFormFieldMissing" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:formatted_date_time.Vitro
+uil-data:formatted_date_time.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Date et heure formattées"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "formatted_date_time" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "formatted_date_time" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:imageUpload.errorUnknown.Vitro
+uil-data:imageUpload.errorUnknown.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Désolé, impossible de traiter la photo fournie. Veuillez fournir une autre photo."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "imageUpload.errorUnknown" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "imageUpload.errorUnknown" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:password_reset_pending_email_html_text.Vitro
+uil-data:password_reset_pending_email_html_text.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "<p>\n Cher ${userAccount.firstName} ${userAccount.lastName}:\n </p>\n\n <p>\n Nous avons reçu une demande de réinitialisation du mot de passe de votre site web pour le compte ${siteName} (${userAccount.emailAddress}).\n </p>\n\n <p>\n Veuillez suivre les instructions ci-dessous pour procéder à la réinitialisation de votre mot de passe..\n </p>\n\n <p>\n Si vous n'avez pas demandé ce nouveau compte, vous pouvez ignorer ce courrier.\nCette demande expirera si elle n'est pas suivie d'effet dans un délai de 30 jours.\n </p>\n\n <p>\n Cliquez sur le lien ci-dessous ou collez-le dans la barre d'adresse de votre navigateur pour réinitialiser votre mot de passe,\n en utilisant notre serveur sécurisé.\n </p>\n\n <p><a href=\"${passwordLink}\" title=\"mot de passe\">${passwordLink}</a> </p>\n\n <p>Merci.</p>"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "password_reset_pending_email_html_text" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "password_reset_pending_email_html_text" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:ontology_editor.Vitro
+uil-data:ontology_editor.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Éditeur d'ontologies"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "ontology_editor" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "ontology_editor" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:from_capitalized.Vitro
+uil-data:from_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Depuis"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "from_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "from_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:logged_out.Vitro
+uil-data:logged_out.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Vous êtes déconnecté."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "logged_out" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "logged_out" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:search_for.Vitro
+uil-data:search_for.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Recherche de ''{0}''"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "search_for" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "search_for" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:other.Vitro
+uil-data:other.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "autre"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "other" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "other" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:supply_variable_name.Vitro
+uil-data:supply_variable_name.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Vous devez fournir une variable pour sauvegarder le contenu HTML."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "supply_variable_name" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "supply_variable_name" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:remove_restrictions.Vitro
+uil-data:remove_restrictions.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Annuler les restrictions d'accès"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "remove_restrictions" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "remove_restrictions" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:variable_name_all_caps.Vitro
+uil-data:variable_name_all_caps.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Nom de variable"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "variable_name_all_caps" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "variable_name_all_caps" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:levels.Vitro
+uil-data:levels.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Niveaux"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "levels" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "levels" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:range_class.Vitro
+uil-data:range_class.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Étendue de la classe "@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "range_class" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "range_class" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:type_more_chars.Vitro
+uil-data:type_more_chars.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "tapez plus de caractères"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "type_more_chars" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "type_more_chars" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:advanced_data_tools.Vitro
+uil-data:advanced_data_tools.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Outils de données avancés"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "advanced_data_tools" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "advanced_data_tools" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:current_date.Vitro
+uil-data:current_date.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Date actuelle:"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "current_date" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "current_date" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:since_elapsed_time_est_total.Vitro
+uil-data:since_elapsed_time_est_total.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "depuis {0}. Durée écoulée {1}, temps total estimé {2}"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "since_elapsed_time_est_total" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "since_elapsed_time_est_total" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:close.Vitro
+uil-data:close.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "fermer"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "close" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "close" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:change_selection.Vitro
+uil-data:change_selection.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "changer la sélection"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "change_selection" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "change_selection" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:copyright.Vitro
+uil-data:copyright.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "droits d'auteurs"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "copyright" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "copyright" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_page_content_type.Vitro
+uil-data:select_page_content_type.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Sélectionner le type de contenu pour la page associée"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_page_content_type" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_page_content_type" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:zoo_one.Vitro
+uil-data:zoo_one.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Zoo 1"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "zoo_one" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "zoo_one" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:cancel_title.Vitro
+uil-data:cancel_title.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "annuler"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "cancel_title" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "cancel_title" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:add_individual_of_class.Vitro
+uil-data:add_individual_of_class.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ajouter un individu de cette classe"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "add_individual_of_class" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "add_individual_of_class" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:label.dateTimeWithPrecision.year_capitalized.Vitro
+uil-data:label.dateTimeWithPrecision.year_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Année"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "label.dateTimeWithPrecision.year_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "label.dateTimeWithPrecision.year_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:relate_editors_profiles.Vitro
+uil-data:relate_editors_profiles.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Relier les éditeurs de profil et les profils"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "relate_editors_profiles" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "relate_editors_profiles" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:vitro_bullet_four.Vitro
+uil-data:vitro_bullet_four.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "questionner vos données"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "vitro_bullet_four" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "vitro_bullet_four" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:save_changes.Vitro
+uil-data:save_changes.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Sauvegarder"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "save_changes" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "save_changes" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:cant_activate_while_logged_in.Vitro
+uil-data:cant_activate_while_logged_in.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Vous ne pouvez pas activer le compte {0} lorsque vous êtes connecté en tant que {1}. Veuillez essayer de vous reconnecter."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "cant_activate_while_logged_in" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "cant_activate_while_logged_in" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:next_capitalized.Vitro
+uil-data:next_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Suivant"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "next_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "next_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:end_capitalized.Vitro
+uil-data:end_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Fin"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "end_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "end_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:custom_template_containing_content.Vitro
+uil-data:custom_template_containing_content.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Gabarit personnalisé contenant tout le contenu"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "custom_template_containing_content" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "custom_template_containing_content" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:name_of.Vitro
+uil-data:name_of.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "nom de"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "name_of" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "name_of" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:content_type.Vitro
+uil-data:content_type.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Type de contenu"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "content_type" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "content_type" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:add_label.Vitro
+uil-data:add_label.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ajouter une étiquette"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "add_label" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "add_label" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:activate_developer_panel_mixed_caps.Vitro
+uil-data:activate_developer_panel_mixed_caps.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Activer le panneau des développeurs"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "activate_developer_panel_mixed_caps" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "activate_developer_panel_mixed_caps" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:reset_search_index.Vitro
+uil-data:reset_search_index.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Reconstruire l'index de recherche."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "reset_search_index" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "reset_search_index" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:please_provide_contact_information.Vitro
+uil-data:please_provide_contact_information.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Veuillez inscrire une adresse courriel pour compléter la création de votre compte. "@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "please_provide_contact_information" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "please_provide_contact_information" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:continued.Vitro
+uil-data:continued.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "suite"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "continued" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "continued" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_no_email.Vitro
+uil-data:error_no_email.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Vous devez inscrire une adresse courriel."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_no_email" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_no_email" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_no_last_name.Vitro
+uil-data:error_no_last_name.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Vous devez inscrire un nom de famille."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_no_last_name" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_no_last_name" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:december.Vitro
+uil-data:december.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Decembre"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "december" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "december" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:multiple_content_default_template_error.Vitro
+uil-data:multiple_content_default_template_error.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Avec plusieurs types de contenu, vous devez spécifier un modèle personnalisé."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "multiple_content_default_template_error" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "multiple_content_default_template_error" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:all_classes.Vitro
+uil-data:all_classes.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Toutes les classes"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "all_classes" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "all_classes" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:viewing_page.Vitro
+uil-data:viewing_page.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Page d'aperçu probable "@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "viewing_page" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "viewing_page" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:individual_not_found_msg.Vitro
+uil-data:individual_not_found_msg.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Élément introuvable dans le système."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "individual_not_found_msg" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "individual_not_found_msg" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:setup_navigation_menu.Vitro
+uil-data:setup_navigation_menu.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Établir le menu de navigation principal de votre site"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "setup_navigation_menu" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "setup_navigation_menu" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:external_id_already_in_use.Vitro
+uil-data:external_id_already_in_use.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Un compte d'usager est déjà présent pour ''{0}''"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "external_id_already_in_use" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "external_id_already_in_use" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:ascending_order.Vitro
+uil-data:ascending_order.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "tri ascendant"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "ascending_order" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "ascending_order" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:browse_all_content.Vitro
+uil-data:browse_all_content.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "parcourir tout le contenu"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "browse_all_content" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "browse_all_content" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:begin_with_slash_no_example.Vitro
+uil-data:begin_with_slash_no_example.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Doit débuter avec une barre oblique: /"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "begin_with_slash_no_example" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "begin_with_slash_no_example" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_occurred_at.Vitro
+uil-data:error_occurred_at.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Une erreur s'est produite sur votre site VIVO à {0}."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_occurred_at" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_occurred_at" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_editors.Vitro
+uil-data:select_editors.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Sélection des éditeurs"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_editors" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_editors" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:supply_html.Vitro
+uil-data:supply_html.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Vous devez fournir du code HTML ou du texte."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "supply_html" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "supply_html" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:slash_example.Vitro
+uil-data:slash_example.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "(par ex.: /people)"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "slash_example" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "slash_example" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:property_hierarchy.Vitro
+uil-data:property_hierarchy.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Hiérarchie des propriétés"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "property_hierarchy" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "property_hierarchy" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:try_rebuilding_index.Vitro
+uil-data:try_rebuilding_index.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Essayez de construire l'index"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "try_rebuilding_index" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "try_rebuilding_index" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_in_search_request.Vitro
+uil-data:error_in_search_request.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "La requête comporte des erreurs"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_in_search_request" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_in_search_request" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:first_time_login.Vitro
+uil-data:first_time_login.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Première connexion"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "first_time_login" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "first_time_login" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:first_time_external_email_plain_text.Vitro
+uil-data:first_time_external_email_plain_text.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "${userAccount.firstName} ${userAccount.lastName}\n\nCongratulations!\n\nNous avons créé votre nouveau compte VIVO associé à\n${userAccount.emailAddress}.\n\nMerci!"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "first_time_external_email_plain_text" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "first_time_external_email_plain_text" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:faux_property_by_base.Vitro
+uil-data:faux_property_by_base.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "propriétés Faux par propriété Base "@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "faux_property_by_base" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "faux_property_by_base" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:alt_thumbnail_photo.Vitro
+uil-data:alt_thumbnail_photo.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Photo individuelle"@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "alt_thumbnail_photo" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "alt_thumbnail_photo" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:no_individual_associated_with_id.Vitro
+uil-data:no_individual_associated_with_id.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Pour une raison inconnue, aucun dossier dans VIVO n'est associé à votre Net ID. Contactez votre administrateur VIVO."@fr-CA ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "no_individual_associated_with_id" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "no_individual_associated_with_id" ;
+        uil:hasPackage  "Vitro-languages" .

--- a/home/src/main/resources/rdf/i18n/pt_BR/interface-i18n/firsttime/vitro_UiLabel.ttl
+++ b/home/src/main/resources/rdf/i18n/pt_BR/interface-i18n/firsttime/vitro_UiLabel.ttl
@@ -1,6266 +1,6266 @@
 @prefix owl:   <http://www.w3.org/2002/07/owl#> .
 @prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
-@prefix prop-data: <http://vivoweb.org/ontology/core/properties/individual#> .
-@prefix prop:  <http://vivoweb.org/ontology/core/properties/vocabulary#> .
+@prefix uil-data: <http://vivoweb.org/ontology/vitro/ui-label/individual#> .
+@prefix uil:  <http://vivoweb.org/ontology/vitro/ui-label/vocabulary#> .
 @prefix xsd:   <http://www.w3.org/2001/XMLSchema#> .
 @prefix skos:  <http://www.w3.org/2004/02/skos/core#> .
 @prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> .
 
-prop-data:collapse_all.Vitro
+uil-data:collapse_all.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "collapsar tudo"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "collapse_all" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "collapse_all" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:no_password_supplied.Vitro
+uil-data:no_password_supplied.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Nenhuma senha fornecida."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "no_password_supplied" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "no_password_supplied" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:crop_page_title.Vitro
+uil-data:crop_page_title.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Colheita"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "crop_page_title" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "crop_page_title" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:label.dateTimeWithPrecision.month_capitalized.Vitro
+uil-data:label.dateTimeWithPrecision.month_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Mês"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "label.dateTimeWithPrecision.month_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "label.dateTimeWithPrecision.month_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:advanced_search_tip_three.Vitro
+uil-data:advanced_search_tip_three.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Pesquisas de frases podem ser combinadas com operadores Booleanos - por exemplo, \"<i>climate change</i>\" OR \"<i>global warming</i>\"."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "advanced_search_tip_three" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "advanced_search_tip_three" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:file_upload_error_file_size_is_zero.Vitro
+uil-data:file_upload_error_file_size_is_zero.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "file_upload_error_file_size_is_zero" ;
-        prop:hasPackage  "Vitro-languages" .
+        rdf:type         uil:UILabel ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "file_upload_error_file_size_is_zero" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:delete_entry_capitalized.Vitro
+uil-data:delete_entry_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Apagar esta entrada?"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "delete_entry_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "delete_entry_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:remove_selection_title.Vitro
+uil-data:remove_selection_title.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "remover seleção"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "remove_selection_title" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "remove_selection_title" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:powered_by.Vitro
+uil-data:powered_by.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Desenvolvido por"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "powered_by" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "powered_by" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:accounts_search_results.Vitro
+uil-data:accounts_search_results.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Resultados da pesquisa para"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "accounts_search_results" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "accounts_search_results" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:search_individual_results.Vitro
+uil-data:search_individual_results.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Pesquisa indivíduos da Classe"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "search_individual_results" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "search_individual_results" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:vclassAlpha_not_implemented.Vitro
+uil-data:vclassAlpha_not_implemented.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "vclassAlpha ainda não está implementado."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "vclassAlpha_not_implemented" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "vclassAlpha_not_implemented" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_an_existing.Vitro
+uil-data:select_an_existing.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Selecione um já existente"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_an_existing" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_an_existing" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:no_appropriate_entry.Vitro
+uil-data:no_appropriate_entry.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Se você não encontrar a entrada apropriada na lista de seleção acima"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "no_appropriate_entry" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "no_appropriate_entry" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:descending_order.Vitro
+uil-data:descending_order.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "ordem decrescente"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "descending_order" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "descending_order" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:label.dateTimeWithPrecision.hour_capitalized.Vitro
+uil-data:label.dateTimeWithPrecision.hour_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Hora"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "label.dateTimeWithPrecision.hour_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "label.dateTimeWithPrecision.hour_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:add_remove_rdf.Vitro
+uil-data:add_remove_rdf.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Adicionar / Remover dados RDF"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "add_remove_rdf" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "add_remove_rdf" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:account.Vitro
+uil-data:account.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "conta"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "account" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "account" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:label.Vitro
+uil-data:label.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "rótulo"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "label" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "label" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:no_classes_to_select.Vitro
+uil-data:no_classes_to_select.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Não há aulas no sistema a partir do qual a escolha."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "no_classes_to_select" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "no_classes_to_select" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:page_curator_permission_option.Vitro
+uil-data:page_curator_permission_option.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Curadores e acima podem visualizar esta página"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "page_curator_permission_option" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "page_curator_permission_option" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:individuals_in_system.Vitro
+uil-data:individuals_in_system.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "indivíduos no sistema."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "individuals_in_system" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "individuals_in_system" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:search_help.Vitro
+uil-data:search_help.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "procura ajuda"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "search_help" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "search_help" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:there_are_no_entries_starting_with.Vitro
+uil-data:there_are_no_entries_starting_with.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Não há entradas começando com"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "there_are_no_entries_starting_with" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "there_are_no_entries_starting_with" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:user_accounts_link.Vitro
+uil-data:user_accounts_link.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Contas de usuário"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "user_accounts_link" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "user_accounts_link" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:ontology_capitalized.Vitro
+uil-data:ontology_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ontologia"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "ontology_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "ontology_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:change_password_to_login.Vitro
+uil-data:change_password_to_login.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Alterar senha para entrar"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "change_password_to_login" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "change_password_to_login" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:a_menu_page.Vitro
+uil-data:a_menu_page.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Esta é uma página de menu"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "a_menu_page" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "a_menu_page" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:comments.Vitro
+uil-data:comments.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Comentários"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "comments" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "comments" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:add_new_of_type.Vitro
+uil-data:add_new_of_type.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Adicionar um novo item deste tipo"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "add_new_of_type" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "add_new_of_type" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:reset_password_note.Vitro
+uil-data:reset_password_note.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Nota: As instruções para redefinir a senha, será enviada para o endereço digitado acima. A senha não será ser alterada até que o usuário clique mo link fornecido neste e-mail."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "reset_password_note" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "reset_password_note" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:startup_status.Vitro
+uil-data:startup_status.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "estatuto"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "startup_status" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "startup_status" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:no_results_returned.Vitro
+uil-data:no_results_returned.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Nenhum resultado foi retornado."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "no_results_returned" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "no_results_returned" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:submit_add_new_account.Vitro
+uil-data:submit_add_new_account.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Adicionar nova conta"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "submit_add_new_account" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "submit_add_new_account" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:password_reset_complete_subject.Vitro
+uil-data:password_reset_complete_subject.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "A {0} senha alterada."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "password_reset_complete_subject" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "password_reset_complete_subject" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:file_upload_error_supported_actions.Vitro
+uil-data:file_upload_error_supported_actions.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "file_upload_error_supported_actions" ;
-        prop:hasPackage  "Vitro-languages" .
+        rdf:type         uil:UILabel ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "file_upload_error_supported_actions" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:create_classgroup.Vitro
+uil-data:create_classgroup.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Criar um grupo de classe"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "create_classgroup" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "create_classgroup" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:accounts.Vitro
+uil-data:accounts.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "contas de usuário"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "accounts" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "accounts" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:page_not_created_msg.Vitro
+uil-data:page_not_created_msg.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ocorreu um erro ao criar a página, verifique os logs."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "page_not_created_msg" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "page_not_created_msg" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:login_count.Vitro
+uil-data:login_count.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Quantidade de Entrantes"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "login_count" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "login_count" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:not_expected_results.Vitro
+uil-data:not_expected_results.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Não foi o resultado esperado?"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "not_expected_results" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "not_expected_results" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:paging_link_more.Vitro
+uil-data:paging_link_more.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "mais ..."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "paging_link_more" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "paging_link_more" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:sparql_query_description_1.Vitro
+uil-data:sparql_query_description_1.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "# and (if available) their labels"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "sparql_query_description_1" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "sparql_query_description_1" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:acct_created_email_plain_text.Vitro
+uil-data:acct_created_email_plain_text.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "${userAccount.firstName} ${userAccount.lastName}\n\nParabéns!\n\nCriamos a sua nova conta no ${siteName},\nassociado com ${userAccount.emailAddress}.\n\nSe você não solicitou essa nova conta, você pode simplesmente ignorar este e-mail.\nEste pedido expirará se não for ultilizada nos proximos 30 dias.\n\nCole o link abaixo na barra de endereços do seu navegador para criar sua senha\npara a sua nova conta usando o nosso servidor seguro.\n\n${passwordLink}\n\nObrigado!\n"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "acct_created_email_plain_text" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "acct_created_email_plain_text" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:all_rights_reserved.Vitro
+uil-data:all_rights_reserved.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Todos os direitos reservados."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "all_rights_reserved" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "all_rights_reserved" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:submit_save.Vitro
+uil-data:submit_save.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Salvar foto"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "submit_save" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "submit_save" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:associate_classes_with_group.Vitro
+uil-data:associate_classes_with_group.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "associar as classes ao grupo criado."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "associate_classes_with_group" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "associate_classes_with_group" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:about.Vitro
+uil-data:about.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Sobre"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "about" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "about" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:activate_developer_panel.Vitro
+uil-data:activate_developer_panel.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ativar Painel Desenvolvedor"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "activate_developer_panel" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "activate_developer_panel" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:since.Vitro
+uil-data:since.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Desde"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "since" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "since" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:limit_to.Vitro
+uil-data:limit_to.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Limite para"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "limit_to" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "limit_to" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:password_created_subject.Vitro
+uil-data:password_created_subject.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "A {0} senha foi cruada com sucesso."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "password_created_subject" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "password_created_subject" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:vitro_description.Vitro
+uil-data:vitro_description.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Vitro é uma ontologia e exemplo de editor baseado na web para uso geral para uma navegação público e personalizável. Vitro é uma aplicação Java Web que roda em um contêiner servlet Tomcat."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "vitro_description" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "vitro_description" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:logins_disabled_for_maintenance.Vitro
+uil-data:logins_disabled_for_maintenance.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "login estão desativados temporariamente, enquanto o sistema está em Manutenção."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "logins_disabled_for_maintenance" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "logins_disabled_for_maintenance" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:current_time.Vitro
+uil-data:current_time.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Tempo atual:"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "current_time" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "current_time" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:release.Vitro
+uil-data:release.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "liberação"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "release" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "release" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:authenticator.Vitro
+uil-data:authenticator.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "autenticador"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "authenticator" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "authenticator" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:preparing_to_rebuild_index.Vitro
+uil-data:preparing_to_rebuild_index.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Preparando-se para reconstruir o índice de pesquisa."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "preparing_to_rebuild_index" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "preparing_to_rebuild_index" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:login_status.Vitro
+uil-data:login_status.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Login status:"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "login_status" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "login_status" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:scroll_to_menus.Vitro
+uil-data:scroll_to_menus.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "navegar pela propriedade do grupo menus"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "scroll_to_menus" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "scroll_to_menus" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:sparql_query_description_0.Vitro
+uil-data:sparql_query_description_0.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "# This example query gets 20 geographic locations"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "sparql_query_description_0" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "sparql_query_description_0" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:delete_button.Vitro
+uil-data:delete_button.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Excluir"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "delete_button" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "delete_button" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:fixed_html.Vitro
+uil-data:fixed_html.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Fixo HTML"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "fixed_html" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "fixed_html" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:you_can.Vitro
+uil-data:you_can.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Você pode"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "you_can" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "you_can" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:supply_sparql_query.Vitro
+uil-data:supply_sparql_query.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Você deve fornecer uma consulta SPARQL."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "supply_sparql_query" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "supply_sparql_query" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:enter_email_password.Vitro
+uil-data:enter_email_password.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Digite o endereço de e-mail e senha para sua conta Vitro interno."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "enter_email_password" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "enter_email_password" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:selected_editors.Vitro
+uil-data:selected_editors.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "editores Selecionadas"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "selected_editors" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "selected_editors" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:custom_template_mixed_caps.Vitro
+uil-data:custom_template_mixed_caps.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "template personalizado"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "custom_template_mixed_caps" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "custom_template_mixed_caps" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:animal.Vitro
+uil-data:animal.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Animal:"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "animal" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "animal" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:enter_sparql_query_here.Vitro
+uil-data:enter_sparql_query_here.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Digite consulta SPARQL aqui"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "enter_sparql_query_here" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "enter_sparql_query_here" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:recompute_inferences.Vitro
+uil-data:recompute_inferences.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Recomputar as Inferências"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "recompute_inferences" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "recompute_inferences" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:restrict_logins.Vitro
+uil-data:restrict_logins.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Restringir Logins"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "restrict_logins" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "restrict_logins" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:email_address.Vitro
+uil-data:email_address.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Endereço de e-mail"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "email_address" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "email_address" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:alt_confirmation.Vitro
+uil-data:alt_confirmation.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ícone Confirmação"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "alt_confirmation" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "alt_confirmation" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:drag_drop_to_reorder_menus.Vitro
+uil-data:drag_drop_to_reorder_menus.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Arrastar e soltar para reordenar os itens do menu"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "drag_drop_to_reorder_menus" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "drag_drop_to_reorder_menus" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:most_recent_update.Vitro
+uil-data:most_recent_update.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "A atualização mais recente foi em"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "most_recent_update" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "most_recent_update" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:delete_link.Vitro
+uil-data:delete_link.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Excluir foto"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "delete_link" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "delete_link" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:check_startup_status.Vitro
+uil-data:check_startup_status.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Verificar página de status de inicialização e / ou registros do Tomcat para obter mais informações."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "check_startup_status" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "check_startup_status" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:no_pages_defined.Vitro
+uil-data:no_pages_defined.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ainda não existem páginas definidas."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "no_pages_defined" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "no_pages_defined" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:advanced_search_tip_five.Vitro
+uil-data:advanced_search_tip_five.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Use o caracterer curinga * para corresponder a uma variação ainda maior - por exemplo,<i>nano*</i> irá corresponder tanto <i>nanotechnology</i> como <i>nanofabrication</i>."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "advanced_search_tip_five" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "advanced_search_tip_five" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_message.Vitro
+uil-data:error_message.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Mensagem de erro"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_message" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_message" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:double_quote_note_allowed.Vitro
+uil-data:double_quote_note_allowed.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "O nome da variável não deve ter uma dupla citação."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "double_quote_note_allowed" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "double_quote_note_allowed" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:crop_page_title_with_name.Vitro
+uil-data:crop_page_title_with_name.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "imagem = Cortar para {0}"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "crop_page_title_with_name" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "crop_page_title_with_name" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:logins_not_restricted.Vitro
+uil-data:logins_not_restricted.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Logins não estão mais restritos."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "logins_not_restricted" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "logins_not_restricted" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:deleted_accounts.Vitro
+uil-data:deleted_accounts.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Deletar {0} {0, choice, 0 # contas | 1 # conta | 1 <contas}."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "deleted_accounts" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "deleted_accounts" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:whole_number.Vitro
+uil-data:whole_number.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Entrada inválida. Digite um número inteiro sem ponto decimal ou milhares de separadores."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "whole_number" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "whole_number" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:edit_account.Vitro
+uil-data:edit_account.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Editar conta"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "edit_account" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "edit_account" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:search_tip_two.Vitro
+uil-data:search_tip_two.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Use aspas para procurar uma frase inteira - por exemplo, \"<i>protein folding</i>\"."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "search_tip_two" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "search_tip_two" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:email_capitalized.Vitro
+uil-data:email_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Email"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "email_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "email_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:policies.Vitro
+uil-data:policies.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Políticas"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "policies" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "policies" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:failed.Vitro
+uil-data:failed.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "falhou"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "failed" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "failed" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:containers_do_not_pick_up_changes.Vitro
+uil-data:containers_do_not_pick_up_changes.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Containers não identificou alterações no valor dos seus elementos"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "containers_do_not_pick_up_changes" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "containers_do_not_pick_up_changes" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:file_upload_error_media_type_not_allowed.Vitro
+uil-data:file_upload_error_media_type_not_allowed.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "file_upload_error_media_type_not_allowed" ;
-        prop:hasPackage  "Vitro-languages" .
+        rdf:type         uil:UILabel ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "file_upload_error_media_type_not_allowed" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:add_new_classes.Vitro
+uil-data:add_new_classes.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Adicionar Nova Classe"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "add_new_classes" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "add_new_classes" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:identifier_factories.Vitro
+uil-data:identifier_factories.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Identificador do factories"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "identifier_factories" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "identifier_factories" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:show_subclasses.Vitro
+uil-data:show_subclasses.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Mostar subclasses"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "show_subclasses" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "show_subclasses" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:enter_id_to_login.Vitro
+uil-data:enter_id_to_login.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Digite o ID do usuário que você deseja entrar ou clique em Cancelar."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "enter_id_to_login" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "enter_id_to_login" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:upload_heading.Vitro
+uil-data:upload_heading.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Photo Upload"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "upload_heading" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "upload_heading" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:warnings_issued.Vitro
+uil-data:warnings_issued.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "{0} emitiu algum avisos durante a inicialização."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "warnings_issued" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "warnings_issued" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:account_management.Vitro
+uil-data:account_management.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Gerenciamento de Conta"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "account_management" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "account_management" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_content_display.Vitro
+uil-data:select_content_display.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Selecione conteúdo a ser exibido"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_content_display" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_content_display" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:account_no_longer_exists.Vitro
+uil-data:account_no_longer_exists.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "A conta que você está tentando definir uma senha no não está mais disponível. Entre em contato com o administrador do sistema, se você acha que isso é um erro."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "account_no_longer_exists" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "account_no_longer_exists" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:page_select_permission.Vitro
+uil-data:page_select_permission.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Selecione as permissões de página"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "page_select_permission" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "page_select_permission" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:test_for_logged_in_users.Vitro
+uil-data:test_for_logged_in_users.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Este é o widget de teste para usuários registrados."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "test_for_logged_in_users" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "test_for_logged_in_users" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:edit_page.Vitro
+uil-data:edit_page.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Editar Página {0}"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "edit_page" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "edit_page" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:no_match.Vitro
+uil-data:no_match.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "não encontrado"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "no_match" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "no_match" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:add_new_page.Vitro
+uil-data:add_new_page.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Adicionar nova página"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "add_new_page" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "add_new_page" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:class_groups.Vitro
+uil-data:class_groups.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Grupo de Classes"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "class_groups" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "class_groups" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:password_reset_pending_email_subject.Vitro
+uil-data:password_reset_pending_email_subject.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "${siteName} solicitação de redefinição de senha"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "password_reset_pending_email_subject" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "password_reset_pending_email_subject" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:manage.Vitro
+uil-data:manage.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "gerenciar"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "manage" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "manage" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_password_length.Vitro
+uil-data:error_password_length.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Por favor insira uma senha entre {0} e {1} caracteres."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_password_length" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_password_length" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:view_profile_editors.Vitro
+uil-data:view_profile_editors.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Visualizar todos os perfis de editores"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "view_profile_editors" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "view_profile_editors" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:subclasses_capitalized.Vitro
+uil-data:subclasses_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Subclasses"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "subclasses_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "subclasses_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:auth_matching_id_label.Vitro
+uil-data:auth_matching_id_label.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Auth externo. ID / correspondência ID"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "auth_matching_id_label" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "auth_matching_id_label" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:page_editor_permission_option.Vitro
+uil-data:page_editor_permission_option.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Editores e Usúarios com permissão superior, podem visualizar esta página"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "page_editor_permission_option" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "page_editor_permission_option" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:delete_page.Vitro
+uil-data:delete_page.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "deletar esta página"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "delete_page" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "delete_page" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:for.Vitro
+uil-data:for.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "para"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "for" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "for" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:manage_list_of_labels.Vitro
+uil-data:manage_list_of_labels.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "lista de rótulos de gerir"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "manage_list_of_labels" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "manage_list_of_labels" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:content.Vitro
+uil-data:content.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "conteúdo"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "content" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "content" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:match_by.Vitro
+uil-data:match_by.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "partida por {0}"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "match_by" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "match_by" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:alt_preview_crop.Vitro
+uil-data:alt_preview_crop.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Pré-visualização de foto recortada"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "alt_preview_crop" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "alt_preview_crop" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:pretty_url.Vitro
+uil-data:pretty_url.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Bom URL"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "pretty_url" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "pretty_url" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:operation_successful.Vitro
+uil-data:operation_successful.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "A operação foi bem sucedida."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "operation_successful" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "operation_successful" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:add_capitalized.Vitro
+uil-data:add_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Adicionar"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "add_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "add_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:accounts_per_page.Vitro
+uil-data:accounts_per_page.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "contas de usuário por página"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "accounts_per_page" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "accounts_per_page" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_editor_and_profile.Vitro
+uil-data:select_editor_and_profile.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Você deve selecionar um mínimo de 1 editor e perfil."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_editor_and_profile" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_editor_and_profile" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:request_failed.Vitro
+uil-data:request_failed.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Solicitação falhou. Entre em contato com o administrador do sistema."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "request_failed" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "request_failed" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:from_site_admin_page.Vitro
+uil-data:from_site_admin_page.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "há partir da página de administração do site."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "from_site_admin_page" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "from_site_admin_page" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:new_password_capitalized.Vitro
+uil-data:new_password_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Nova senha"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "new_password_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "new_password_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:advanced_search_tip_one.Vitro
+uil-data:advanced_search_tip_one.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Quando você insere mais de um termo, a busca irá retornar resultados contendo todos eles a menos que você adicione o booleano \"OR\" - por exemplo, <i>chicken</i> OR <i>egg</i>."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "advanced_search_tip_one" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "advanced_search_tip_one" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:password_reset_complete_email_plain_text.Vitro
+uil-data:password_reset_complete_email_plain_text.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "${userAccount.firstName} ${userAccount.lastName}\n\nSenha alterada com sucesso.\n\nSua nova senha associada com ${userAccount.emailAddress} foi alterado.\n\nObrigado."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "password_reset_complete_email_plain_text" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "password_reset_complete_email_plain_text" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:application_error_email_subject.Vitro
+uil-data:application_error_email_subject.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ocorreu um erro em seu site ${siteName!}"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "application_error_email_subject" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "application_error_email_subject" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:return_to.Vitro
+uil-data:return_to.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "retorna ao {0}"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "return_to" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "return_to" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:last_login.Vitro
+uil-data:last_login.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Último login"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "last_login" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "last_login" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:view_profile_in_rdf.Vitro
+uil-data:view_profile_in_rdf.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "perfil vista em formato RDF"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "view_profile_in_rdf" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "view_profile_in_rdf" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:minimum_password_length.Vitro
+uil-data:minimum_password_length.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Mínimo de {0} caracteres de comprimento ; máximo de {1}."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "minimum_password_length" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "minimum_password_length" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:contact_us.Vitro
+uil-data:contact_us.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Fale Conosco"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "contact_us" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "contact_us" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:download_results.Vitro
+uil-data:download_results.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Baixe resultados"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "download_results" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "download_results" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:selected_profiles.Vitro
+uil-data:selected_profiles.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "perfis selecionados"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "selected_profiles" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "selected_profiles" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:has_value.Vitro
+uil-data:has_value.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "tem valor"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "has_value" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "has_value" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:faux_property_listing.Vitro
+uil-data:faux_property_listing.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Faux Property Listing"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "faux_property_listing" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "faux_property_listing" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:display_admin_header.Vitro
+uil-data:display_admin_header.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Exibir Administrador e configurações"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "display_admin_header" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "display_admin_header" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_no_password.Vitro
+uil-data:error_no_password.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Por favor insira sua senha."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_no_password" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_no_password" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:remove_capitalized.Vitro
+uil-data:remove_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Remove"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "remove_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "remove_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:october.Vitro
+uil-data:october.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Outubro"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "october" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "october" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:file_upload_subject.Vitro
+uil-data:file_upload_subject.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "file_upload_subject" ;
-        prop:hasPackage  "Vitro-languages" .
+        rdf:type         uil:UILabel ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "file_upload_subject" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:manage_site.Vitro
+uil-data:manage_site.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Gerenciar este site"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "manage_site" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "manage_site" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:confirm_delete_account_plural.Vitro
+uil-data:confirm_delete_account_plural.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Tem certeza de que deseja excluir essas contas?"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "confirm_delete_account_plural" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "confirm_delete_account_plural" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:sunday.Vitro
+uil-data:sunday.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Domingo"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "sunday" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "sunday" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:password_system_has_changed.Vitro
+uil-data:password_system_has_changed.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "password_system_has_changed" ;
-        prop:hasPackage  "Vitro-languages" .
+        rdf:type         uil:UILabel ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "password_system_has_changed" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:rebuild_search_index.Vitro
+uil-data:rebuild_search_index.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Reconstruir Índice de Pesquisa"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "rebuild_search_index" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "rebuild_search_index" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:password_saved.Vitro
+uil-data:password_saved.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Sua senha foi salva."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "password_saved" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "password_saved" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:supply_query_variable.Vitro
+uil-data:supply_query_variable.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Você deve fornecer uma variável para salvar os resultados da consulta."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "supply_query_variable" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "supply_query_variable" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:configure_page_if_permissable.Vitro
+uil-data:configure_page_if_permissable.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Para configurar esta página, o usuário necessita de permissão."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "configure_page_if_permissable" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "configure_page_if_permissable" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:invalid_date_form_msg.Vitro
+uil-data:invalid_date_form_msg.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "deve estar em formato de data válido mm / dd / aaaa."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "invalid_date_form_msg" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "invalid_date_form_msg" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:manage_list_of.Vitro
+uil-data:manage_list_of.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Gerenciar lista de"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "manage_list_of" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "manage_list_of" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:verbose_property_status.Vitro
+uil-data:verbose_property_status.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "detalhado exibição da propriedade é"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "verbose_property_status" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "verbose_property_status" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:sparql_query_select_ask_results.Vitro
+uil-data:sparql_query_select_ask_results.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Format for SELECT and ASK query results"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "sparql_query_select_ask_results" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "sparql_query_select_ask_results" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:individual_not_found.Vitro
+uil-data:individual_not_found.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Individual não encontrado:"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "individual_not_found" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "individual_not_found" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:classes_by_classgroup.Vitro
+uil-data:classes_by_classgroup.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Classes pelo Grupo Classes"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "classes_by_classgroup" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "classes_by_classgroup" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:confirm_email_changed_email_plain_text.Vitro
+uil-data:confirm_email_changed_email_plain_text.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Olá, ${userAccount.firstName} ${userAccount.lastName}\n\nVocê recentemente mudou o endereço de email associado\n${userAccount.firstName} ${userAccount.lastName}\n\nObrigado."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "confirm_email_changed_email_plain_text" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "confirm_email_changed_email_plain_text" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:close_capitalized.Vitro
+uil-data:close_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Perto"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "close_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "close_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:browse_class_group.Vitro
+uil-data:browse_class_group.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Navegar Grupo Classe"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "browse_class_group" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "browse_class_group" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:statistics.Vitro
+uil-data:statistics.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Estatísticas"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "statistics" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "statistics" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:new_password.Vitro
+uil-data:new_password.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Nova senha"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "new_password" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "new_password" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:hide_show_subclasses.Vitro
+uil-data:hide_show_subclasses.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Esconder/Visualizar subclasses"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "hide_show_subclasses" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "hide_show_subclasses" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:class_hierarchy.Vitro
+uil-data:class_hierarchy.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Hierarquia de Classe"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "class_hierarchy" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "class_hierarchy" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:add_content_manage_site.Vitro
+uil-data:add_content_manage_site.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "adicionar conteúdo e gerenciar este site"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "add_content_manage_site" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "add_content_manage_site" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:background_threads.Vitro
+uil-data:background_threads.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Background Threads"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "background_threads" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "background_threads" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:create_capitalized.Vitro
+uil-data:create_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Criar"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "create_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "create_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_previous_password.Vitro
+uil-data:error_previous_password.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Sua nova senha não pode  ser iqual a sua atual."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_previous_password" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_previous_password" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:change_password.Vitro
+uil-data:change_password.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Você deve alterar sua senha para entrar."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "change_password" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "change_password" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:menu_management.Vitro
+uil-data:menu_management.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Menu de Gerenciamento"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "menu_management" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "menu_management" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:email_change_will_be_confirmed.Vitro
+uil-data:email_change_will_be_confirmed.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Nota: se modificar o seu e-mail, um e-mail de confirmação será enviado para o novo endereço de e-mail digitado acima."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "email_change_will_be_confirmed" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "email_change_will_be_confirmed" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:fake_external_auth.Vitro
+uil-data:fake_external_auth.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Falha Autenticação Externa"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "fake_external_auth" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "fake_external_auth" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:run_sdb_setup.Vitro
+uil-data:run_sdb_setup.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Executar Configuração do SDB"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "run_sdb_setup" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "run_sdb_setup" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:property_management.Vitro
+uil-data:property_management.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Gerenciamento das Propriedades"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "property_management" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "property_management" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:end_your_Session.Vitro
+uil-data:end_your_Session.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Termine a sua sessão"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "end_your_Session" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "end_your_Session" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:search_index_not_connected.Vitro
+uil-data:search_index_not_connected.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "O índice de pesquisa não está conectado."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "search_index_not_connected" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "search_index_not_connected" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:change_content_type.Vitro
+uil-data:change_content_type.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Mudança tipo de conteúdo"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "change_content_type" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "change_content_type" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:invalid_search_term.Vitro
+uil-data:invalid_search_term.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Termo de pesquisa era inválido"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "invalid_search_term" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "invalid_search_term" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:index_recs_completed.Vitro
+uil-data:index_recs_completed.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Concluído {0} de {1} registros de índice."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "index_recs_completed" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "index_recs_completed" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:add_profile.Vitro
+uil-data:add_profile.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Adicionar perfil"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "add_profile" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "add_profile" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:view_labels_capitalized.Vitro
+uil-data:view_labels_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Visualizar Labels"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "view_labels_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "view_labels_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:maximum_cardinality.Vitro
+uil-data:maximum_cardinality.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "cardinalidade máxima"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "maximum_cardinality" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "maximum_cardinality" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:please_format_email.Vitro
+uil-data:please_format_email.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Por favor, formatar o seu endereço de e-mail como:"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "please_format_email" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "please_format_email" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:external_auth_only.Vitro
+uil-data:external_auth_only.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Externamente autenticados"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "external_auth_only" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "external_auth_only" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:return_to_individual.Vitro
+uil-data:return_to_individual.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Retornar para Página Individual"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "return_to_individual" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "return_to_individual" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:all_x_properties.Vitro
+uil-data:all_x_properties.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Todos  {0} das Propriedades"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "all_x_properties" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "all_x_properties" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:password_created_email_plain_text.Vitro
+uil-data:password_created_email_plain_text.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "${userAccount.firstName} ${userAccount.lastName}\n\nSenha criado com sucesso.\n\nSua nova senha foi criada e associada ${userAccount.emailAddress} .\n\nObrigado.\n"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "password_created_email_plain_text" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "password_created_email_plain_text" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:already_logged_in.Vitro
+uil-data:already_logged_in.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Você já está logado."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "already_logged_in" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "already_logged_in" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:supply_class_group.Vitro
+uil-data:supply_class_group.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Você deve fornecer um grupo de classe."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "supply_class_group" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "supply_class_group" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:matching_prop_not_defined.Vitro
+uil-data:matching_prop_not_defined.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "propriedade correspondente não está definido"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "matching_prop_not_defined" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "matching_prop_not_defined" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:display_rank.Vitro
+uil-data:display_rank.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Mostar Rank"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "display_rank" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "display_rank" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:profile_editing_title.Vitro
+uil-data:profile_editing_title.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Os editores que você selecionar no lado esquerdo terá a possibilidade de editar o perfis VIVO selecionado no lado direito. Você pode selecionar vários editores e vários perfis, mas você deve selecionar um mínimo de 1 cada."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "profile_editing_title" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "profile_editing_title" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:test_for_nonlogged_in_users.Vitro
+uil-data:test_for_nonlogged_in_users.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Este é o widget de teste para não-usuários registrados."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "test_for_nonlogged_in_users" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "test_for_nonlogged_in_users" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:insufficient_authorization.Vitro
+uil-data:insufficient_authorization.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Lamentamos, mas você não está autorizado a ver a página solicitada. Se você acha que isso é um erro, por favor, entre em contato conosco e teremos o maior prazer em ajudar."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "insufficient_authorization" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "insufficient_authorization" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:supply_content_type.Vitro
+uil-data:supply_content_type.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Você deve fornecer um tipo de conteúdo"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "supply_content_type" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "supply_content_type" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:back_to_results.Vitro
+uil-data:back_to_results.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Voltar aos resultados"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "back_to_results" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "back_to_results" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:may_not_edit.Vitro
+uil-data:may_not_edit.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "não pode editar"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "may_not_edit" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "may_not_edit" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:four_digit_year.Vitro
+uil-data:four_digit_year.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Entrada inválida. Digite um ano de 4 dígitos."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "four_digit_year" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "four_digit_year" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:browse_page_javascript_two.Vitro
+uil-data:browse_page_javascript_two.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "para procurar informações."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "browse_page_javascript_two" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "browse_page_javascript_two" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:password_created_email_html_text.Vitro
+uil-data:password_created_email_html_text.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "<p>\n ${userAccount.firstName} ${userAccount.lastName}\n </p>\n\n <p>\n <strong>Senha criado com sucesso.</strong>\n </p>\n\n <p>\n Sua nova senha foi criada e associada ${userAccount.emailAddress} .\n </p>\n\n <p>\n Obrigado.\n </p>"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "password_created_email_html_text" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "password_created_email_html_text" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:current_photo.Vitro
+uil-data:current_photo.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Foto Atual"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "current_photo" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "current_photo" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_last_name.Vitro
+uil-data:select_last_name.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Selecione último nome"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_last_name" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_last_name" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:supply_template.Vitro
+uil-data:supply_template.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Você deve fornecer um modelo"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "supply_template" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "supply_template" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:view_all_accounts_title.Vitro
+uil-data:view_all_accounts_title.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "visualizar todas as contas"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "view_all_accounts_title" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "view_all_accounts_title" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:cropping_note.Vitro
+uil-data:cropping_note.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Para fazer ajustes, você pode arrastar e redimensionar a foto para a direita. Quando você estiver satisfeito com sua foto, clique no botão \"Salvar fotos\"."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "cropping_note" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "cropping_note" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:page_not_created.Vitro
+uil-data:page_not_created.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Página não pôde ser criada"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "page_not_created" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "page_not_created" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_email_already_exists.Vitro
+uil-data:error_email_already_exists.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Uma conta com esse endereço de e-mail já existe."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_email_already_exists" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_email_already_exists" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:required_field_empty_msg.Vitro
+uil-data:required_field_empty_msg.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Este campo não deve estar vazio."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "required_field_empty_msg" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "required_field_empty_msg" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:site_maintenance.Vitro
+uil-data:site_maintenance.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Site em Manutenção"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "site_maintenance" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "site_maintenance" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:current_date_time.Vitro
+uil-data:current_date_time.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Data & Hora atual:"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "current_date_time" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "current_date_time" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:page_link.Vitro
+uil-data:page_link.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "link da página"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "page_link" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "page_link" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:object_property_hierarchy.Vitro
+uil-data:object_property_hierarchy.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Hierarquia da Propriedade do Objeto"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "object_property_hierarchy" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "object_property_hierarchy" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:user_accounts.Vitro
+uil-data:user_accounts.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Contas de Usuários"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "user_accounts" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "user_accounts" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:maximum_file_size.Vitro
+uil-data:maximum_file_size.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "tamanho máximo do arquivo: {0} megabytes"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "maximum_file_size" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "maximum_file_size" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:add_new_account.Vitro
+uil-data:add_new_account.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Adicionar nova conta"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "add_new_account" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "add_new_account" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:browse_all_starts_with.Vitro
+uil-data:browse_all_starts_with.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Busque todos os indivíduos cujo nome começa com {0}"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "browse_all_starts_with" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "browse_all_starts_with" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:status.Vitro
+uil-data:status.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Status"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "status" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "status" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:index.Vitro
+uil-data:index.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Índice"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "index" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "index" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:verify_this_match_title.Vitro
+uil-data:verify_this_match_title.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "verificar esta combinação"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "verify_this_match_title" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "verify_this_match_title" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:search_indexer_idle.Vitro
+uil-data:search_indexer_idle.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "O indexador de pesquisa está ocioso."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "search_indexer_idle" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "search_indexer_idle" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:start_capitalized.Vitro
+uil-data:start_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Início"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "start_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "start_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:minimum_cardinality.Vitro
+uil-data:minimum_cardinality.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "cardinalidade mínima"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "minimum_cardinality" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "minimum_cardinality" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:manage_affiliated_people_link.Vitro
+uil-data:manage_affiliated_people_link.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "gerenciar pessoas filiadas"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "manage_affiliated_people_link" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "manage_affiliated_people_link" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:initial_password.Vitro
+uil-data:initial_password.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Senha inicial"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "initial_password" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "initial_password" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:invalid_format.Vitro
+uil-data:invalid_format.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Formato Inválido"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "invalid_format" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "invalid_format" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:menu_orering.Vitro
+uil-data:menu_orering.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Menu Ordenado"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "menu_orering" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "menu_orering" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:confirm_entry_deletion_from.Vitro
+uil-data:confirm_entry_deletion_from.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Tem certeza de que deseja excluir a seguinte entrada"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "confirm_entry_deletion_from" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "confirm_entry_deletion_from" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:add_types.Vitro
+uil-data:add_types.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Adicionar um ou mais tipos"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "add_types" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "add_types" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:group_capitalized.Vitro
+uil-data:group_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Grupo"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "group_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "group_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:entry.Vitro
+uil-data:entry.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "entrada"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "entry" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "entry" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:search_vitro.Vitro
+uil-data:search_vitro.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Pesquisa no VITRO"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "search_vitro" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "search_vitro" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:version.Vitro
+uil-data:version.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Versão"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "version" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "version" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:hide_subclasses.Vitro
+uil-data:hide_subclasses.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ocultar subclasses"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "hide_subclasses" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "hide_subclasses" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:caused_by.Vitro
+uil-data:caused_by.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Causada por"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "caused_by" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "caused_by" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:show_more_content.Vitro
+uil-data:show_more_content.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "mostre mais conteúdo"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "show_more_content" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "show_more_content" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:advanced_search_tip_six.Vitro
+uil-data:advanced_search_tip_six.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Pesquisar usando versões abreviadas de palavras - por exemplo, uma pesquisa por <i>cogniti*</i> não encontra nada, enquanto <i>cognit*</i> encontra ambas <i>cognitive</i> e <i>cognition</i>."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "advanced_search_tip_six" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "advanced_search_tip_six" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:myAccount_confirm_changes_plus_note.Vitro
+uil-data:myAccount_confirm_changes_plus_note.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Suas alterações foram salvas. Um email de confirmação foi enviado para {0}."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "myAccount_confirm_changes_plus_note" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "myAccount_confirm_changes_plus_note" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:class_management.Vitro
+uil-data:class_management.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Gerenciador de Classe"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "class_management" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "class_management" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:display_less.Vitro
+uil-data:display_less.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Menos"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "display_less" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "display_less" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:add_property_group.Vitro
+uil-data:add_property_group.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Adicionar um novo grupo de propriedade"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "add_property_group" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "add_property_group" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:browse_by.Vitro
+uil-data:browse_by.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Procurar por"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "browse_by" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "browse_by" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:class_group_link.Vitro
+uil-data:class_group_link.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Link grupo de classe"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "class_group_link" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "class_group_link" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:confirm_password.Vitro
+uil-data:confirm_password.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Confirmar nova senha"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "confirm_password" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "confirm_password" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:saturday.Vitro
+uil-data:saturday.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Sábado"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "saturday" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "saturday" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:_publications_link.Vitro
+uil-data:_publications_link.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "_publications_link" ;
-        prop:hasPackage  "Vitro-languages" .
+        rdf:type         uil:UILabel ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "_publications_link" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:javascript_require_to_edit.Vitro
+uil-data:javascript_require_to_edit.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Para editar o conteúdo, você precisa ativar o JavaScript."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "javascript_require_to_edit" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "javascript_require_to_edit" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:fatal_error_detected.Vitro
+uil-data:fatal_error_detected.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "{0} detectou algum erro fatal durante a inicialização."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "fatal_error_detected" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "fatal_error_detected" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:menu_page.Vitro
+uil-data:menu_page.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Menu da Página"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "menu_page" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "menu_page" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:create_new_individual_of_the_following_type.Vitro
+uil-data:create_new_individual_of_the_following_type.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Criando o seguinte tipo de objeto"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "create_new_individual_of_the_following_type" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "create_new_individual_of_the_following_type" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:logins_not_already_restricted.Vitro
+uil-data:logins_not_already_restricted.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Logins já não são restritos."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "logins_not_already_restricted" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "logins_not_already_restricted" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:stack_trace.Vitro
+uil-data:stack_trace.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Rastreando"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "stack_trace" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "stack_trace" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:confirm_page_deletion.Vitro
+uil-data:confirm_page_deletion.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Tem certeza de que deseja apagar esta página:"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "confirm_page_deletion" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "confirm_page_deletion" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_locale.Vitro
+uil-data:select_locale.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "selecione a localização"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_locale" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_locale" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:reset_password.Vitro
+uil-data:reset_password.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "password reset"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "reset_password" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "reset_password" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:vitro_bullet_two.Vitro
+uil-data:vitro_bullet_two.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Editar instâncias e relacionamentos"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "vitro_bullet_two" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "vitro_bullet_two" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:replace_page_title.Vitro
+uil-data:replace_page_title.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Substituir imagem"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "replace_page_title" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "replace_page_title" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:subproperty.Vitro
+uil-data:subproperty.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Subpropriedade"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "subproperty" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "subproperty" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:rdf_export.Vitro
+uil-data:rdf_export.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Exportar RDF"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "rdf_export" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "rdf_export" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:click_to_view_larger.Vitro
+uil-data:click_to_view_larger.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "clique para ver a imagem ampliada"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "click_to_view_larger" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "click_to_view_larger" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:build_date.Vitro
+uil-data:build_date.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Data de construção"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "build_date" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "build_date" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:flags.Vitro
+uil-data:flags.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Flags"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "flags" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "flags" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:march.Vitro
+uil-data:march.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Março"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "march" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "march" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:display_only.Vitro
+uil-data:display_only.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Apenas visualização"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "display_only" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "display_only" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:to_manage_content.Vitro
+uil-data:to_manage_content.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "para gerenciar o conteúdo."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "to_manage_content" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "to_manage_content" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:acct_created_email_html_text.Vitro
+uil-data:acct_created_email_html_text.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "<p>\n ${userAccount.firstName} ${userAccount.lastName}\n </p>\n\n <p>\n <strong>Parabéns!</strong>\n </p>\n\n <p>\n Criamos a sua nova conta ${siteName}, associado com o email ${userAccount.emailAddress}.\n </p>\n\n <p>\n Se você não solicitou essa nova conta, você pode simplesmente ignorar este e-mail.\n Este pedido expirará se não for ultilizada nos proximos 30 dias.\n </p>\n\n <p>\n Clique no link abaixo para criar sua senha para sua nova conta usando o nosso servidor seguro.\n </p>\n\n <p>\n <a href=\"${passwordLink}\" title=\"password\">${passwordLink}</a>\n </p>\n\n <p>\n Se o link acima não funcionar, você pode copiar e colar o link diretamente na barra de endereços do seu navegador.\n </p>\n\n <p>\n Obrigado!\n </p>"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "acct_created_email_html_text" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "acct_created_email_html_text" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:file_upload_confirm_delete.Vitro
+uil-data:file_upload_confirm_delete.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "file_upload_confirm_delete" ;
-        prop:hasPackage  "Vitro-languages" .
+        rdf:type         uil:UILabel ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "file_upload_confirm_delete" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:cropping_caption.Vitro
+uil-data:cropping_caption.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Sua foto de perfil será visualizada com a imagem abaixo."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "cropping_caption" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "cropping_caption" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:browse_capitalized.Vitro
+uil-data:browse_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Procurar"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "browse_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "browse_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:display_options.Vitro
+uil-data:display_options.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Visualizar"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "display_options" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "display_options" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:site_config.Vitro
+uil-data:site_config.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Configuração do Site"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "site_config" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "site_config" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:undo_camelcasing.Vitro
+uil-data:undo_camelcasing.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Uncamelcasing"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "undo_camelcasing" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "undo_camelcasing" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:view_all_capitalized.Vitro
+uil-data:view_all_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ver Todos"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "view_all_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "view_all_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_processing_labels.Vitro
+uil-data:error_processing_labels.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "solicitação de processamento de erro: os rótulos não verificadas não pôde ser excluído."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_processing_labels" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_processing_labels" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:dates.Vitro
+uil-data:dates.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Datas"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "dates" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "dates" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:myAccount_heading.Vitro
+uil-data:myAccount_heading.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Minha conta"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "myAccount_heading" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "myAccount_heading" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:roles.Vitro
+uil-data:roles.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Papéis"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "roles" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "roles" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:april.Vitro
+uil-data:april.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Abril"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "april" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "april" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:password_reset_pending_subject.Vitro
+uil-data:password_reset_pending_subject.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "{0} solicitação de redefinição da senha"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "password_reset_pending_subject" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "password_reset_pending_subject" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:some_values_from.Vitro
+uil-data:some_values_from.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "alguns valores de"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "some_values_from" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "some_values_from" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:browse_all_public_content.Vitro
+uil-data:browse_all_public_content.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Atualmente, você pode ver todo o conteúdo público do sistema usando a"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "browse_all_public_content" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "browse_all_public_content" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:all_values_from.Vitro
+uil-data:all_values_from.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "todos os valores de"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "all_values_from" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "all_values_from" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:updated_account_2.Vitro
+uil-data:updated_account_2.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "foi atualizado."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "updated_account_2" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "updated_account_2" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:alt_error_alert.Vitro
+uil-data:alt_error_alert.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ícone de alerta de Erro"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "alt_error_alert" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "alt_error_alert" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:year_month.Vitro
+uil-data:year_month.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Entrada inválida. Digite um ano e um mês."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "year_month" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "year_month" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:name.Vitro
+uil-data:name.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "nome"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "name" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "name" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:no_image.Vitro
+uil-data:no_image.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "sem imagem"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "no_image" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "no_image" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:sparql_query_save_results.Vitro
+uil-data:sparql_query_save_results.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Save results to file"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "sparql_query_save_results" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "sparql_query_save_results" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:add_new_group.Vitro
+uil-data:add_new_group.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Adicionar novo grupo"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "add_new_group" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "add_new_group" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:browse_all.Vitro
+uil-data:browse_all.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Navegar tudo"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "browse_all" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "browse_all" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:processing_icon.Vitro
+uil-data:processing_icon.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Processando"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "processing_icon" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "processing_icon" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:logins_restricted.Vitro
+uil-data:logins_restricted.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Logins estão agora restrito."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "logins_restricted" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "logins_restricted" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:search_tip_four.Vitro
+uil-data:search_tip_four.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Se você não tiver certeza da grafia correta, colocar ~ no final do seu termo de busca - por exemplo,<i>cabage~</i> encontra <i>cabbage</i>, <i>steven~</i> encontra <i>Stephen</i> e <i>Stefan</i> (bem como outros nomes similares)."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "search_tip_four" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "search_tip_four" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:imageUpload.errorNoURI.Vitro
+uil-data:imageUpload.errorNoURI.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Nenhuma entidade URI foi fornecida"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "imageUpload.errorNoURI" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "imageUpload.errorNoURI" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:password_saved_please_login.Vitro
+uil-data:password_saved_please_login.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Sua senha foi salva. Por favor faça login."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "password_saved_please_login" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "password_saved_please_login" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:upload_photo.Vitro
+uil-data:upload_photo.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Carregue uma foto"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "upload_photo" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "upload_photo" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:sparql_query_results.Vitro
+uil-data:sparql_query_results.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Resultados da consulta SPARQL"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "sparql_query_results" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "sparql_query_results" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:enter_new_password.Vitro
+uil-data:enter_new_password.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Por favor digite sua nova senha para {0}"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "enter_new_password" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "enter_new_password" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:display_more_ellipsis.Vitro
+uil-data:display_more_ellipsis.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "... Más"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "display_more_ellipsis" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "display_more_ellipsis" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:updated_account_1.Vitro
+uil-data:updated_account_1.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "A conta para"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "updated_account_1" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "updated_account_1" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:add_page.Vitro
+uil-data:add_page.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Adicionar Página"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "add_page" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "add_page" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:list_elements_of.Vitro
+uil-data:list_elements_of.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "lista de elementos"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "list_elements_of" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "list_elements_of" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:class_group_all_caps.Vitro
+uil-data:class_group_all_caps.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Grupo Classe"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "class_group_all_caps" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "class_group_all_caps" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:no_class_restrictions.Vitro
+uil-data:no_class_restrictions.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Não há classes com restrição sobre esta propriedade."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "no_class_restrictions" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "no_class_restrictions" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:refresh_page_after_reordering.Vitro
+uil-data:refresh_page_after_reordering.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "A atualização da página ocorrre após a reordenação dos itens do menu"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "refresh_page_after_reordering" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "refresh_page_after_reordering" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:asserted_class_hierarchy.Vitro
+uil-data:asserted_class_hierarchy.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Hierarquia da Classe gerado Manualmente"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "asserted_class_hierarchy" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "asserted_class_hierarchy" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:page_admin_permission_option.Vitro
+uil-data:page_admin_permission_option.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Somente os administradores podem visualizar esta página"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "page_admin_permission_option" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "page_admin_permission_option" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:create_associated_profile.Vitro
+uil-data:create_associated_profile.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Criar o perfil associado"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "create_associated_profile" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "create_associated_profile" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:password_reset_complete_email_html_text.Vitro
+uil-data:password_reset_complete_email_html_text.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "<p>\n ${userAccount.firstName} ${userAccount.lastName}\n </p>\n\n <p>\n <strong>Senha alterada com sucesso.</strong>\n </p>\n\n <p>\n Sua nova senha associada com ${userAccount.emailAddress} foi alterado.\n </p>\n\n <p>\n Obrigado.\n </p>"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "password_reset_complete_email_html_text" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "password_reset_complete_email_html_text" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:first_time_external_email_html_text.Vitro
+uil-data:first_time_external_email_html_text.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "<p>\n ${userAccount.firstName} ${userAccount.lastName}\n </p>\n\n <p>\n <strong>Parabéns!</strong>\n </p>\n\n <p>\n Nós criamos sua conta nova VIVO associado com ${userAccount.emailAddress}.\n </p>\n\n <p>\n Obrigado!\n </p>"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "first_time_external_email_html_text" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "first_time_external_email_html_text" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:default.Vitro
+uil-data:default.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Padrão"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "default" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "default" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_password_mismatch.Vitro
+uil-data:error_password_mismatch.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "As senhas não são iguais."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_password_mismatch" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_password_mismatch" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:and.Vitro
+uil-data:and.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "e"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "and" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "and" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:no_matching_results.Vitro
+uil-data:no_matching_results.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Nenhum resultado de acordo."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "no_matching_results" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "no_matching_results" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:internal_class_i_capped.Vitro
+uil-data:internal_class_i_capped.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Classe Institutional Interna"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "internal_class_i_capped" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "internal_class_i_capped" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:decimal_only.Vitro
+uil-data:decimal_only.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Entrada inválida. Um ponto decimal é permitido, mas milhares de separadores não são."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "decimal_only" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "decimal_only" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:new_account_2.Vitro
+uil-data:new_account_2.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "foi criada com sucesso."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "new_account_2" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "new_account_2" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:listed_page_title.Vitro
+uil-data:listed_page_title.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "título da página listado"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "listed_page_title" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "listed_page_title" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:delete_profile_editor.Vitro
+uil-data:delete_profile_editor.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Apagar editor de perfis"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "delete_profile_editor" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "delete_profile_editor" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_no_first_name.Vitro
+uil-data:error_no_first_name.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Você deve fornecer um nome."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_no_first_name" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_no_first_name" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:browse_all_in_class.Vitro
+uil-data:browse_all_in_class.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Busque todos os indivíduos nesta classe"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "browse_all_in_class" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "browse_all_in_class" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:save_entry.Vitro
+uil-data:save_entry.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Salvar entrada"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "save_entry" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "save_entry" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:confirm_initial_password.Vitro
+uil-data:confirm_initial_password.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Confirmar senha inicial"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "confirm_initial_password" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "confirm_initial_password" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:ingest_tools.Vitro
+uil-data:ingest_tools.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ferramentas de Inserção"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "ingest_tools" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "ingest_tools" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:application_error_email_html_text.Vitro
+uil-data:application_error_email_html_text.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "<p>Ocorreu um erro em seu site ${siteName!} no ${datetime!}.</p>\n\n <p>\n <strong>url solicitada:</strong> ${requestedUrl!}\n </p>\n\n <p>\n <#if errorMessage?has_content>\n <strong>Mensagem de erro:</strong> ${errorMessage!}\n </#if>\n </p>\n\n <p>\n <strong>Rastreando</strong> (rastreamento disponível no log):\n <pre>${stackTrace!}</pre>\n </p>\n\n <#if cause?has_content>\n <p><strong>Causada por:</strong>\n <pre>${cause!}</pre>\n </p>\n </#if>"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "application_error_email_html_text" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "application_error_email_html_text" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:log_in.Vitro
+uil-data:log_in.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "entrar"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "log_in" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "log_in" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:new_account_1.Vitro
+uil-data:new_account_1.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Uma nova conta"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "new_account_1" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "new_account_1" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:imageUpload.errorUnrecognizedFileType.Vitro
+uil-data:imageUpload.errorUnrecognizedFileType.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "'' {0} '' não é um tipo de arquivo de imagem reconhecida. Por favor envie apenas arquivos JPEG, GIF ou PNG."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "imageUpload.errorUnrecognizedFileType" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "imageUpload.errorUnrecognizedFileType" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:replace_page_title_with_name.Vitro
+uil-data:replace_page_title_with_name.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Substituir imagem para {0}"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "replace_page_title_with_name" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "replace_page_title_with_name" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:unsupported_ie_version.Vitro
+uil-data:unsupported_ie_version.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Esta formulário não suporta versões do Internet Explorer inferiores a versão 8. Por favor, atualize seu navegador, ou mudar para outro navegador, como o Firefox."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "unsupported_ie_version" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "unsupported_ie_version" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:logins_are_restricted.Vitro
+uil-data:logins_are_restricted.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Logins são restritos."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "logins_are_restricted" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "logins_are_restricted" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:add_profile_editor.Vitro
+uil-data:add_profile_editor.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Adicionar editor de perfis"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "add_profile_editor" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "add_profile_editor" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:supply_name.Vitro
+uil-data:supply_name.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Você deve fornecer um título"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "supply_name" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "supply_name" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:feedback_thanks_text.Vitro
+uil-data:feedback_thanks_text.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Obrigado por entrar em contato com nossa equipe de desenvolvimento. Vamos responder a sua pergunta o mais rápido possível."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "feedback_thanks_text" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "feedback_thanks_text" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_class_for_search.Vitro
+uil-data:select_class_for_search.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Você deve selecionar uma classe para exibir seus indivíduos."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_class_for_search" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_class_for_search" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:since_elapsed_time.Vitro
+uil-data:since_elapsed_time.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "desde {0}, tempo decorrido {1}"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "since_elapsed_time" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "since_elapsed_time" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:unknown_user_name.Vitro
+uil-data:unknown_user_name.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "amigo"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "unknown_user_name" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "unknown_user_name" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:faux_property_capitalized.Vitro
+uil-data:faux_property_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Faux Property"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "faux_property_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "faux_property_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:enter_value_name_field.Vitro
+uil-data:enter_value_name_field.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Por favor insira um valor no campo de nome."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "enter_value_name_field" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "enter_value_name_field" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:group_name.Vitro
+uil-data:group_name.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "nome do grupo"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "group_name" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "group_name" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:data_property_hierarchy.Vitro
+uil-data:data_property_hierarchy.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Hierarquia da Propriedade do Dado"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "data_property_hierarchy" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "data_property_hierarchy" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:external_login_text.Vitro
+uil-data:external_login_text.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Login com BearCat Shibboleth"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "external_login_text" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "external_login_text" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:imageUpload.errorFileTooBig.Vitro
+uil-data:imageUpload.errorFileTooBig.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Faça upload de uma imagem menor do que {0} megabytes."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "imageUpload.errorFileTooBig" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "imageUpload.errorFileTooBig" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:profile_editors.Vitro
+uil-data:profile_editors.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Editores de Perfil"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "profile_editors" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "profile_editors" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:implement_capitalized.Vitro
+uil-data:implement_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Implementar"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "implement_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "implement_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:sparql_query_header.Vitro
+uil-data:sparql_query_header.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Query"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "sparql_query_header" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "sparql_query_header" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:view.Vitro
+uil-data:view.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "visualizar"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "view" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "view" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:manage_profile_editing.Vitro
+uil-data:manage_profile_editing.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Gerenciador dos Perfis Editado"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "manage_profile_editing" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "manage_profile_editing" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:minimum_image_dimensions.Vitro
+uil-data:minimum_image_dimensions.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Dimensões mínima da imagem: {0} {1} x pixels"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "minimum_image_dimensions" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "minimum_image_dimensions" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:view_list_in_rdf.Vitro
+uil-data:view_list_in_rdf.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ver a {0} lista em formato RDF"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "view_list_in_rdf" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "view_list_in_rdf" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:more_details_about_site.Vitro
+uil-data:more_details_about_site.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Mais detalhes sobre este site"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "more_details_about_site" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "more_details_about_site" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:new_entry_for.Vitro
+uil-data:new_entry_for.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "\"{0}\" para {1}"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "new_entry_for" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "new_entry_for" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:july.Vitro
+uil-data:july.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Julho"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "july" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "july" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:page_uri.Vitro
+uil-data:page_uri.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "página URI"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "page_uri" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "page_uri" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:edit_date_time_value.Vitro
+uil-data:edit_date_time_value.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Edit Date / Time Value"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "edit_date_time_value" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "edit_date_time_value" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:limited_to_type.Vitro
+uil-data:limited_to_type.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "limite do tipo"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "limited_to_type" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "limited_to_type" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:class_name.Vitro
+uil-data:class_name.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "nome da classe"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "class_name" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "class_name" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:create_date_time_value.Vitro
+uil-data:create_date_time_value.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Criar Data / Hora Valor"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "create_date_time_value" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "create_date_time_value" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:there_are_no_entries_for_selection.Vitro
+uil-data:there_are_no_entries_for_selection.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Não existem entradas no sistema a partir do qual escolher."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "there_are_no_entries_for_selection" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "there_are_no_entries_for_selection" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:edit_this_individual.Vitro
+uil-data:edit_this_individual.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Editar este indivíduo"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "edit_this_individual" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "edit_this_individual" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:start_interval_must_precede_end_earlier.Vitro
+uil-data:start_interval_must_precede_end_earlier.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "O intervalo de partida deve ser mais cedo do que o intervalo termino."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "start_interval_must_precede_end_earlier" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "start_interval_must_precede_end_earlier" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:type_capitalized.Vitro
+uil-data:type_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Tipo"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "type_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "type_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:selected.Vitro
+uil-data:selected.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Selecionado"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "selected" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "selected" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:submit_upload.Vitro
+uil-data:submit_upload.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Enviar foto"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "submit_upload" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "submit_upload" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:confirm_individual_deletion.Vitro
+uil-data:confirm_individual_deletion.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "confirm_individual_deletion" ;
-        prop:hasPackage  "Vitro-languages" .
+        rdf:type         uil:UILabel ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "confirm_individual_deletion" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:september.Vitro
+uil-data:september.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Setembro"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "september" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "september" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:verbose_turn_off.Vitro
+uil-data:verbose_turn_off.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Desliguar"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "verbose_turn_off" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "verbose_turn_off" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_type.Vitro
+uil-data:select_type.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Selecione um tipo de"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_type" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_type" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:comments_questions.Vitro
+uil-data:comments_questions.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Comentários, perguntas ou sugestões"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "comments_questions" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "comments_questions" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:send_mail.Vitro
+uil-data:send_mail.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Enviar e-mail"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "send_mail" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "send_mail" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:change_profile.Vitro
+uil-data:change_profile.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "mudança no perfil"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "change_profile" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "change_profile" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:logins_already_restricted.Vitro
+uil-data:logins_already_restricted.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Logins já são restritos."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "logins_already_restricted" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "logins_already_restricted" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:photo_types.Vitro
+uil-data:photo_types.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "(JPEG, GIF ou PNG)"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "photo_types" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "photo_types" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:search_term_error_near.Vitro
+uil-data:search_term_error_near.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "O termo de pesquisa teve um erro perto"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "search_term_error_near" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "search_term_error_near" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:share_profile_uri.Vitro
+uil-data:share_profile_uri.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "compartilhar a URI para este perfil"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "share_profile_uri" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "share_profile_uri" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:no_html_specified.Vitro
+uil-data:no_html_specified.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "HTML não especificado."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "no_html_specified" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "no_html_specified" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:first_name.Vitro
+uil-data:first_name.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Primeiro nome"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "first_name" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "first_name" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:class_link.Vitro
+uil-data:class_link.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "link da classe"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "class_link" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "class_link" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:view_profile_page_for.Vitro
+uil-data:view_profile_page_for.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ver a página do perfil para"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "view_profile_page_for" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "view_profile_page_for" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_classes_to_display.Vitro
+uil-data:select_classes_to_display.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Você deve selecionar as classes para exibir."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_classes_to_display" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_classes_to_display" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:password_mismatch.Vitro
+uil-data:password_mismatch.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "As senhas não são iguais."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "password_mismatch" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "password_mismatch" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:page_management.Vitro
+uil-data:page_management.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Gerenciador das Páginas"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "page_management" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "page_management" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:resource_uri.Vitro
+uil-data:resource_uri.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Fonte URI"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "resource_uri" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "resource_uri" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:sparql_query_run_query.Vitro
+uil-data:sparql_query_run_query.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Run Query"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "sparql_query_run_query" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "sparql_query_run_query" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:enter_fixed_html_here.Vitro
+uil-data:enter_fixed_html_here.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Entre fixo HTML aqui"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "enter_fixed_html_here" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "enter_fixed_html_here" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:verify_this_match.Vitro
+uil-data:verify_this_match.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "verificar esta combinação"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "verify_this_match" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "verify_this_match" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:properties_capitalized.Vitro
+uil-data:properties_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Propriedades"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "properties_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "properties_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:raw_string_literals.Vitro
+uil-data:raw_string_literals.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "corda cru literais"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "raw_string_literals" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "raw_string_literals" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:no_content_create_groups_classes.Vitro
+uil-data:no_content_create_groups_classes.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Atualmente não existe nenhum conteúdo no sistema, logo você precisa criar alguns grupos de classe e atribuir suas classes para elas."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "no_content_create_groups_classes" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "no_content_create_groups_classes" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:home_page.Vitro
+uil-data:home_page.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "home page"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "home_page" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "home_page" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:restriction_on.Vitro
+uil-data:restriction_on.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "restrição em"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "restriction_on" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "restriction_on" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:processing_indicator.Vitro
+uil-data:processing_indicator.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "indicador de tempo de processamento"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "processing_indicator" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "processing_indicator" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:selected_page_content_type.Vitro
+uil-data:selected_page_content_type.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "tipo de conteúdo selecionado para a página associada"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "selected_page_content_type" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "selected_page_content_type" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:create_entry.Vitro
+uil-data:create_entry.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Criar Entrada"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "create_entry" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "create_entry" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:password_change_not_pending.Vitro
+uil-data:password_change_not_pending.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "A senha para {0} já foi redefinida."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "password_change_not_pending" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "password_change_not_pending" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:javascript_instructions.Vitro
+uil-data:javascript_instructions.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "instruções javascript"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "javascript_instructions" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "javascript_instructions" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_invalid_email.Vitro
+uil-data:error_invalid_email.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "'' {0} '' não é um endereço de email válido."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_invalid_email" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_invalid_email" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:new_pwd_matches_existing.Vitro
+uil-data:new_pwd_matches_existing.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Sua nova senha deve ser diferente da sua senha já existente."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "new_pwd_matches_existing" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "new_pwd_matches_existing" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:or.Vitro
+uil-data:or.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "ou"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "or" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "or" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:search_form.Vitro
+uil-data:search_form.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Formulário de pesquisa"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "search_form" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "search_form" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:menu_item_name.Vitro
+uil-data:menu_item_name.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Nome do item de menu"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "menu_item_name" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "menu_item_name" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:june.Vitro
+uil-data:june.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Junho"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "june" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "june" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:last_name.Vitro
+uil-data:last_name.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Sobrenome"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "last_name" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "last_name" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:placeholder_image.Vitro
+uil-data:placeholder_image.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "imagem espaço reservado"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "placeholder_image" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "placeholder_image" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:requested_url.Vitro
+uil-data:requested_url.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "url solicitada"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "requested_url" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "requested_url" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:first_time_login_note.Vitro
+uil-data:first_time_login_note.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Nota: Um e-mail será enviado para o endereço digitado acima ,a qual a sua conta foi criada."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "first_time_login_note" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "first_time_login_note" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_external_auth_already_exists.Vitro
+uil-data:error_external_auth_already_exists.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "uma conta com esse ID de autorização externa já existe."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_external_auth_already_exists" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_external_auth_already_exists" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:contains_no_pears.Vitro
+uil-data:contains_no_pears.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "não contém pears"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "contains_no_pears" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "contains_no_pears" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:index_page.Vitro
+uil-data:index_page.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "página de índice"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "index_page" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "index_page" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:search_tip_one.Vitro
+uil-data:search_tip_one.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Mantenha simples! Use, termos curtas, a menos que suas busca estaja retornando muitos resultados."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "search_tip_one" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "search_tip_one" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:sparql_query_construct_describe_results.Vitro
+uil-data:sparql_query_construct_describe_results.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Format for CONSTRUCT and DESCRIBE query results"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "sparql_query_construct_describe_results" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "sparql_query_construct_describe_results" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:password_capitalized.Vitro
+uil-data:password_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Senha"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "password_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "password_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:file_upload_submit_label.Vitro
+uil-data:file_upload_submit_label.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "file_upload_submit_label" ;
-        prop:hasPackage  "Vitro-languages" .
+        rdf:type         uil:UILabel ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "file_upload_submit_label" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:please.Vitro
+uil-data:please.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Por favor"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "please" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "please" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:account_created.Vitro
+uil-data:account_created.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "O {0} conta foi criada."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "account_created" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "account_created" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:add.Vitro
+uil-data:add.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "adicionar"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "add" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "add" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:limit.Vitro
+uil-data:limit.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Limite"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "limit" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "limit" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:november.Vitro
+uil-data:november.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Novembro"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "november" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "november" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:confirm_delete.Vitro
+uil-data:confirm_delete.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Tem certeza que você deseja deletar essa foto?"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "confirm_delete" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "confirm_delete" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:login_welcome_message.Vitro
+uil-data:login_welcome_message.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Bem-vindo{1, choice, 1# |1< novamente}, {0}"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "login_welcome_message" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "login_welcome_message" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:password_changed_subject.Vitro
+uil-data:password_changed_subject.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Senha alterada."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "password_changed_subject" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "password_changed_subject" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:incorrect_email_password.Vitro
+uil-data:incorrect_email_password.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "E-mail ou senha estava incorreta."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "incorrect_email_password" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "incorrect_email_password" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:identifiers.Vitro
+uil-data:identifiers.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Identificadores"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "identifiers" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "identifiers" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:javascript_ie_alert_text.Vitro
+uil-data:javascript_ie_alert_text.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Este site usa elementos HTML que não são reconhecidos pelo Internet Explorer 8 e abaixo, na ausência de JavaScript. Como resultado, o local não será processado apropriadamente. Para corrigir isso, por favor, habilite o JavaScript, atualize para o Internet Explorer 9, ou use outro navegador."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "javascript_ie_alert_text" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "javascript_ie_alert_text" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:zoo_two.Vitro
+uil-data:zoo_two.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Zoo 2"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "zoo_two" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "zoo_two" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:verbose_turn_on.Vitro
+uil-data:verbose_turn_on.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Liguar"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "verbose_turn_on" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "verbose_turn_on" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:selection_in_process.Vitro
+uil-data:selection_in_process.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Sua seleção começou a ser processado."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "selection_in_process" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "selection_in_process" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:please_create.Vitro
+uil-data:please_create.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Crie Por favor"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "please_create" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "please_create" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:verbose_status_off.Vitro
+uil-data:verbose_status_off.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "desligado"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "verbose_status_off" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "verbose_status_off" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:page_not_configured.Vitro
+uil-data:page_not_configured.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Esta página ainda não está configurada."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "page_not_configured" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "page_not_configured" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:new_account_notification.Vitro
+uil-data:new_account_notification.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Um e-mail de notificação foi enviado para {0} com instruções para ativar a conta e criar uma senha."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "new_account_notification" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "new_account_notification" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:full_list_startup.Vitro
+uil-data:full_list_startup.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "A Lista Completa dos Eventos de Inicialização e suas Mensagens."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "full_list_startup" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "full_list_startup" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:user_role.Vitro
+uil-data:user_role.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Regra"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "user_role" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "user_role" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:or_enter_valid_address.Vitro
+uil-data:or_enter_valid_address.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "ou entrar em outro endereço de e-mail completo e válido."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "or_enter_valid_address" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "or_enter_valid_address" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:all.Vitro
+uil-data:all.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "tudo"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "all" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "all" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:logged_in_but_no_profile.Vitro
+uil-data:logged_in_but_no_profile.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Você se identificou, mas o sistema não encontrou um perfil para você."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "logged_in_but_no_profile" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "logged_in_but_no_profile" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:page_text.Vitro
+uil-data:page_text.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "text página"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "page_text" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "page_text" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:create_new_entry.Vitro
+uil-data:create_new_entry.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Por favor, crie uma nova entrada."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "create_new_entry" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "create_new_entry" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:enter_in_security_field.Vitro
+uil-data:enter_in_security_field.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Por favor insira as letras que aparecerem abaixo em matéria de segurança"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "enter_in_security_field" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "enter_in_security_field" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_an_existing_or_create_a_new_one.Vitro
+uil-data:select_an_existing_or_create_a_new_one.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Selecione um existente ou crie um novo"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_an_existing_or_create_a_new_one" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_an_existing_or_create_a_new_one" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:not.Vitro
+uil-data:not.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "não"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "not" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "not" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:range_data_type.Vitro
+uil-data:range_data_type.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Tipo de dados de intervalo"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "range_data_type" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "range_data_type" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:august.Vitro
+uil-data:august.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Agosto"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "august" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "august" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:terms_of_use.Vitro
+uil-data:terms_of_use.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Termos de Uso"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "terms_of_use" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "terms_of_use" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:dump_restore.Vitro
+uil-data:dump_restore.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Dump/Restore da Aplicação"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "dump_restore" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "dump_restore" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:show_properties.Vitro
+uil-data:show_properties.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Mostar propriedades"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "show_properties" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "show_properties" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:associated_individuals.Vitro
+uil-data:associated_individuals.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Pessoas Vinculadas"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "associated_individuals" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "associated_individuals" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:name_capitalized.Vitro
+uil-data:name_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Nome"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "name_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "name_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:manage_labels.Vitro
+uil-data:manage_labels.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "gerenciar rótulos"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "manage_labels" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "manage_labels" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:current_user.Vitro
+uil-data:current_user.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Usuário atual"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "current_user" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "current_user" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:minimum_ymd.Vitro
+uil-data:minimum_ymd.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Entrada inválida. Insira pelo menos um ano, mês e dia."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "minimum_ymd" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "minimum_ymd" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:try_another_letter.Vitro
+uil-data:try_another_letter.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Por favor, tente outra letra ou navegar."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "try_another_letter" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "try_another_letter" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:alt_image_to_crop.Vitro
+uil-data:alt_image_to_crop.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "imagem a ser cortada"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "alt_image_to_crop" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "alt_image_to_crop" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:current_task.Vitro
+uil-data:current_task.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "{0} o índice de pesquisa"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "current_task" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "current_task" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:imageUpload.errorNoImageForCropping.Vitro
+uil-data:imageUpload.errorNoImageForCropping.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Não há nenhum arquivo de imagem a ser cortada."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "imageUpload.errorNoImageForCropping" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "imageUpload.errorNoImageForCropping" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:we_have_an_error.Vitro
+uil-data:we_have_an_error.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Houve um erro no sistema."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "we_have_an_error" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "we_have_an_error" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_another_class.Vitro
+uil-data:select_another_class.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Por favor, selecione uma outra classe da lista."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_another_class" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_another_class" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:manage_labels_for.Vitro
+uil-data:manage_labels_for.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Gerenciar Labels para"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "manage_labels_for" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "manage_labels_for" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:revision_info.Vitro
+uil-data:revision_info.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Revisando Informações"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "revision_info" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "revision_info" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:rebuild_vis_cache.Vitro
+uil-data:rebuild_vis_cache.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Reconstruir cache de Visualização"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "rebuild_vis_cache" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "rebuild_vis_cache" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:delete.Vitro
+uil-data:delete.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "excluir"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "delete" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "delete" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:update_button.Vitro
+uil-data:update_button.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Atualizar"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "update_button" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "update_button" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:imageUpload.errorNoPhotoSelected.Vitro
+uil-data:imageUpload.errorNoPhotoSelected.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Por favor, procure e selecione uma foto."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "imageUpload.errorNoPhotoSelected" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "imageUpload.errorNoPhotoSelected" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:imageUpload.errorUnrecognizedURI.Vitro
+uil-data:imageUpload.errorUnrecognizedURI.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Este URI não é reconhecido como pertencente a alguém: '' {0} ''"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "imageUpload.errorUnrecognizedURI" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "imageUpload.errorUnrecognizedURI" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:menu_item.Vitro
+uil-data:menu_item.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "item do menu"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "menu_item" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "menu_item" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:auth_id_label.Vitro
+uil-data:auth_id_label.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Autentificação Externa de ID"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "auth_id_label" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "auth_id_label" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:may.Vitro
+uil-data:may.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Maio"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "may" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "may" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:what_is_vitro.Vitro
+uil-data:what_is_vitro.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "O que é VITRO?"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "what_is_vitro" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "what_is_vitro" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_a_language.Vitro
+uil-data:select_a_language.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Selecione um idioma"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_a_language" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_a_language" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:ip_address.Vitro
+uil-data:ip_address.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Endereço IP"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "ip_address" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "ip_address" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:unrecognized_user.Vitro
+uil-data:unrecognized_user.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Usuário não reconhecido"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "unrecognized_user" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "unrecognized_user" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:password_change_invalid_key.Vitro
+uil-data:password_change_invalid_key.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "O link que você usou para {0} é inválido. Peça ao administrador do site para reenviar o link. "@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "password_change_invalid_key" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "password_change_invalid_key" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:change_text_for.Vitro
+uil-data:change_text_for.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Alterar texto para:"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "change_text_for" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "change_text_for" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:to_enable_javascript.Vitro
+uil-data:to_enable_javascript.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Aqui estão as instruções para ativar o JavaScript no seu navegador"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "to_enable_javascript" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "to_enable_javascript" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:warning.Vitro
+uil-data:warning.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Aviso"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "warning" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "warning" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:revision.Vitro
+uil-data:revision.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "revisão"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "revision" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "revision" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:filter_by_roles.Vitro
+uil-data:filter_by_roles.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Filtrar por papéis"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "filter_by_roles" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "filter_by_roles" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:page_uri_missing_msg.Vitro
+uil-data:page_uri_missing_msg.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Não foi possível gerar página porque não estava claro qual a página que estava sendo solicitada. Um mapeamento de URL pode estar faltando."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "page_uri_missing_msg" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "page_uri_missing_msg" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:fatal_error.Vitro
+uil-data:fatal_error.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Erro Fatal"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "fatal_error" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "fatal_error" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:page_select_permission_option.Vitro
+uil-data:page_select_permission_option.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Selecione permissão"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "page_select_permission_option" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "page_select_permission_option" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:january.Vitro
+uil-data:january.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Janeiro"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "january" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "january" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:property.Vitro
+uil-data:property.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "propriedade"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "property" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "property" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:external_auth_id.Vitro
+uil-data:external_auth_id.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Autor Externo ID"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "external_auth_id" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "external_auth_id" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:date_time_value_for.Vitro
+uil-data:date_time_value_for.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "data valor de tempo para"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "date_time_value_for" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "date_time_value_for" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:sparql_query_title.Vitro
+uil-data:sparql_query_title.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "SPARQL Query"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "sparql_query_title" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "sparql_query_title" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:previous.Vitro
+uil-data:previous.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Anterior"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "previous" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "previous" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:upload_page_title_with_name.Vitro
+uil-data:upload_page_title_with_name.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Enviar imagem para {0}"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "upload_page_title_with_name" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "upload_page_title_with_name" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:cant_change_password_while_logged_in.Vitro
+uil-data:cant_change_password_while_logged_in.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Você não pode redefinir a senha para {0} enquanto você está logado como {1}. Por favor, saia e tente novamente."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "cant_change_password_while_logged_in" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "cant_change_password_while_logged_in" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:rejected_spam.Vitro
+uil-data:rejected_spam.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "REJEITADO - SPAM"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "rejected_spam" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "rejected_spam" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:logins_are_open.Vitro
+uil-data:logins_are_open.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Logins estão abertos a todos."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "logins_are_open" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "logins_are_open" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:confirm_delete_account_singular.Vitro
+uil-data:confirm_delete_account_singular.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Tem certeza de que deseja excluir esta conta?"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "confirm_delete_account_singular" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "confirm_delete_account_singular" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:all_capitalized.Vitro
+uil-data:all_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Tudo"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "all_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "all_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:of_the_results.Vitro
+uil-data:of_the_results.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "dos resultados"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "of_the_results" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "of_the_results" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_content_type.Vitro
+uil-data:select_content_type.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Você deve selecionar o conteúdo a ser incluído na página"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_content_type" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_content_type" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:visit_project_website.Vitro
+uil-data:visit_project_website.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Visite o web site do projeto nacional"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "visit_project_website" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "visit_project_website" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:view_labels_for.Vitro
+uil-data:view_labels_for.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Visualizar Labels para"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "view_labels_for" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "view_labels_for" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:new_account_note.Vitro
+uil-data:new_account_note.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Nota: Um e-mail será enviado para o endereço digitado acima notificando que uma conta foi criada. Ele irá incluir instruções para ativar a conta e criar uma senha."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "new_account_note" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "new_account_note" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_alert_icon.Vitro
+uil-data:error_alert_icon.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Erro ícone de alerta"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_alert_icon" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_alert_icon" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:imageUpload.errorImageTooSmall.Vitro
+uil-data:imageUpload.errorImageTooSmall.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "A imagem enviada deve ser pelo menos {0} pixels de altura e {1} pixels de largura."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "imageUpload.errorImageTooSmall" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "imageUpload.errorImageTooSmall" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_account_to_delete.Vitro
+uil-data:select_account_to_delete.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "seleccionar esta conta para excluír"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_account_to_delete" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_account_to_delete" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:interest_thanks.Vitro
+uil-data:interest_thanks.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Obrigado pelo seu interesse em {0}. Envie este formulário com perguntas, comentários ou feedback sobre o conteúdo deste site."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "interest_thanks" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "interest_thanks" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:year_numeric.Vitro
+uil-data:year_numeric.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Entrada inválida. O Ano deve ser numérico."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "year_numeric" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "year_numeric" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_an_existing_document.Vitro
+uil-data:select_an_existing_document.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Selecione um documento existem"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_an_existing_document" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_an_existing_document" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:password_length.Vitro
+uil-data:password_length.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "A senha deve ter entre {0} e {1} caracteres."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "password_length" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "password_length" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:monday.Vitro
+uil-data:monday.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Segunda-feira"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "monday" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "monday" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:account_created_subject.Vitro
+uil-data:account_created_subject.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "O {0} conta foi criada."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "account_created_subject" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "account_created_subject" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:vitro_bullet_three.Vitro
+uil-data:vitro_bullet_three.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Construir um site público para exibir seus dados"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "vitro_bullet_three" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "vitro_bullet_three" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:photo.Vitro
+uil-data:photo.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Foto"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "photo" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "photo" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:file_must_be_entered_msg.Vitro
+uil-data:file_must_be_entered_msg.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "um arquivo deve ser inserido para este campo."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "file_must_be_entered_msg" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "file_must_be_entered_msg" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:entity_to_query_for.Vitro
+uil-data:entity_to_query_for.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Este id é o ID da entidade para consultar. netid também funciona."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "entity_to_query_for" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "entity_to_query_for" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:manage_grants_and_projects_link.Vitro
+uil-data:manage_grants_and_projects_link.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "gerenciar projectos"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "manage_grants_and_projects_link" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "manage_grants_and_projects_link" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:manage_labels_intro.Vitro
+uil-data:manage_labels_intro.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "No caso de multiplos labels existirem com mesma linguagem, por favor remova um link labels que voce nao deseja exiber na sua pagina do perfil."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "manage_labels_intro" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "manage_labels_intro" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:hide_show_properties.Vitro
+uil-data:hide_show_properties.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ocultar / Mostrar Propriedades"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "hide_show_properties" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "hide_show_properties" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:untitled.Vitro
+uil-data:untitled.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "-sem titulo-"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "untitled" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "untitled" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:manage_publications_link.Vitro
+uil-data:manage_publications_link.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "gerenciar publicações"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "manage_publications_link" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "manage_publications_link" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_all.Vitro
+uil-data:select_all.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "selecionar todos"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_all" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_all" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:local_name.Vitro
+uil-data:local_name.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Nome Local"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "local_name" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "local_name" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:end_interval_must_follow_start_interval.Vitro
+uil-data:end_interval_must_follow_start_interval.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "O intervalo de término deve ser mais tarde do que o intervalo de partida."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "end_interval_must_follow_start_interval" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "end_interval_must_follow_start_interval" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:view_page.Vitro
+uil-data:view_page.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ver página"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "view_page" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "view_page" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:browse_page_javascript_one.Vitro
+uil-data:browse_page_javascript_one.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Esta página browse requer javascript, mas o seu navegador está configurado para desativar javascript. Habilite o Javascript ou utilizar o"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "browse_page_javascript_one" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "browse_page_javascript_one" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:sparql_query_builder.Vitro
+uil-data:sparql_query_builder.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Construtor de Consulta SPARQL"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "sparql_query_builder" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "sparql_query_builder" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:sub_properties.Vitro
+uil-data:sub_properties.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Subpropriedades"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "sub_properties" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "sub_properties" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:add_label_for_language.Vitro
+uil-data:add_label_for_language.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Idioma"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "add_label_for_language" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "add_label_for_language" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:file_upload_error_file_not_found.Vitro
+uil-data:file_upload_error_file_not_found.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "file_upload_error_file_not_found" ;
-        prop:hasPackage  "Vitro-languages" .
+        rdf:type         uil:UILabel ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "file_upload_error_file_not_found" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:file_upload_predicate.Vitro
+uil-data:file_upload_predicate.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "file_upload_predicate" ;
-        prop:hasPackage  "Vitro-languages" .
+        rdf:type         uil:UILabel ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "file_upload_predicate" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:start_with_leading_slash.Vitro
+uil-data:start_with_leading_slash.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Deve começar com um líder de barra: / (por exemplo, / de pessoas)"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "start_with_leading_slash" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "start_with_leading_slash" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:trace_available.Vitro
+uil-data:trace_available.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "rastreamento disponível no log do vivo"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "trace_available" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "trace_available" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:editing_prohibited.Vitro
+uil-data:editing_prohibited.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Esta propriedade está atualmente configurado para proibir a edição."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "editing_prohibited" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "editing_prohibited" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:verbose_status_on.Vitro
+uil-data:verbose_status_on.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "ligado"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "verbose_status_on" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "verbose_status_on" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:use_capitalized.Vitro
+uil-data:use_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Use"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "use_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "use_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:search_index_status.Vitro
+uil-data:search_index_status.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Status do Índice de Pesquisa"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "search_index_status" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "search_index_status" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:filter_search.Vitro
+uil-data:filter_search.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "busca filtro"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "filter_search" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "filter_search" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:with_vitro.Vitro
+uil-data:with_vitro.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Com o Vitro, você pode:"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "with_vitro" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "with_vitro" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:site_information.Vitro
+uil-data:site_information.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Informações do Site"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "site_information" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "site_information" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:logins_temporarily_disabled.Vitro
+uil-data:logins_temporarily_disabled.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Usuário estão desativados temporariamente enquanto o sistema está em manutenção."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "logins_temporarily_disabled" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "logins_temporarily_disabled" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:leave_password_unchanged.Vitro
+uil-data:leave_password_unchanged.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Deixando este campo em branco significa que a senha não será alterada."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "leave_password_unchanged" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "leave_password_unchanged" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:query_model.Vitro
+uil-data:query_model.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Consulta Modelo"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "query_model" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "query_model" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:restrict_logins_mixed_caps.Vitro
+uil-data:restrict_logins_mixed_caps.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Restringir Logins"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "restrict_logins_mixed_caps" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "restrict_logins_mixed_caps" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:wednesday.Vitro
+uil-data:wednesday.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Quarta-feira"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "wednesday" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "wednesday" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:berries.Vitro
+uil-data:berries.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Bagas:"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "berries" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "berries" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:full_name.Vitro
+uil-data:full_name.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Nome completo"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "full_name" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "full_name" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:no_email_supplied.Vitro
+uil-data:no_email_supplied.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "nenhum email fornecido."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "no_email_supplied" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "no_email_supplied" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_was_reported.Vitro
+uil-data:error_was_reported.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Este erro foi relatado para o administrador do site."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_was_reported" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_was_reported" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:search_results_for.Vitro
+uil-data:search_results_for.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Resultado da busca para"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "search_results_for" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "search_results_for" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:search_tip_three.Vitro
+uil-data:search_tip_three.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Exceto para as operadores booleanas, pesquisas <strong>not</strong> são maiúsculas e minúsculas, por isso \"Genebra\" e \"genebra\" são equivalentes."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "search_tip_three" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "search_tip_three" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:view_profile_for_page.Vitro
+uil-data:view_profile_for_page.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "visualizar o perfil individual para esta página"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "view_profile_for_page" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "view_profile_for_page" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:reordering_menus_failed.Vitro
+uil-data:reordering_menus_failed.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "reordenação de itens de menu falhou."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "reordering_menus_failed" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "reordering_menus_failed" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:verbose_control.Vitro
+uil-data:verbose_control.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "controle de detalhes"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "verbose_control" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "verbose_control" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:ontology_list.Vitro
+uil-data:ontology_list.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Lista de Ontologias"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "ontology_list" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "ontology_list" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:edit_entry.Vitro
+uil-data:edit_entry.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "editar esta entrada"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "edit_entry" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "edit_entry" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:label.dateTimeWithPrecision.minutes_capitalized.Vitro
+uil-data:label.dateTimeWithPrecision.minutes_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Minutos"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "label.dateTimeWithPrecision.minutes_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "label.dateTimeWithPrecision.minutes_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:object.Vitro
+uil-data:object.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "objeto"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "object" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "object" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:confirm_email_changed_email_html_text.Vitro
+uil-data:confirm_email_changed_email_html_text.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "<p>\n Olá, ${userAccount.firstName} ${userAccount.lastName}\n </p>\n\n <p>\n Você recentemente mudou o endereço de email associado\n ${userAccount.firstName} ${userAccount.lastName}\n </p>\n\n <p>\n Obrigado.\n </p>"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "confirm_email_changed_email_html_text" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "confirm_email_changed_email_html_text" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_no_new_password.Vitro
+uil-data:error_no_new_password.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Digite sua nova senha."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_no_new_password" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_no_new_password" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:page_loggedin_permission_option.Vitro
+uil-data:page_loggedin_permission_option.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Somente indivíduos logados podem visualizar esta página"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "page_loggedin_permission_option" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "page_loggedin_permission_option" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:expecting_content.Vitro
+uil-data:expecting_content.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Esperando conteúdo?"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "expecting_content" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "expecting_content" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:required_fields.Vitro
+uil-data:required_fields.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "campos obrigatórios"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "required_fields" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "required_fields" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:edit_page_title.Vitro
+uil-data:edit_page_title.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Edit"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "edit_page_title" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "edit_page_title" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_existing.Vitro
+uil-data:select_existing.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Selecione existente"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_existing" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_existing" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:invalid_url_msg.Vitro
+uil-data:invalid_url_msg.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Este URL deve começar com http: // ou https: //"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "invalid_url_msg" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "invalid_url_msg" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:search_button.Vitro
+uil-data:search_button.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Buscar"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "search_button" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "search_button" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:advanced_search_tips_header.Vitro
+uil-data:advanced_search_tips_header.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Dicas Avançadas"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "advanced_search_tips_header" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "advanced_search_tips_header" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:supply_url.Vitro
+uil-data:supply_url.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Você deve fornecer uma URL muito"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "supply_url" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "supply_url" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_profiles.Vitro
+uil-data:select_profiles.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Selecione os perfis"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_profiles" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_profiles" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_one.Vitro
+uil-data:select_one.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Selecionar um"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_one" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_one" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:continue.Vitro
+uil-data:continue.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Continuar"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "continue" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "continue" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:language_selection_failed.Vitro
+uil-data:language_selection_failed.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Houve um problema no sistema. Sua escolha idioma foi rejeitada."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "language_selection_failed" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "language_selection_failed" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:display_has_element_error.Vitro
+uil-data:display_has_element_error.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Houve um erro no sistema. O display: propriedade hasElement não pôde ser recuperado."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "display_has_element_error" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "display_has_element_error" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:file_upload_error_file_is_too_big.Vitro
+uil-data:file_upload_error_file_is_too_big.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "file_upload_error_file_is_too_big" ;
-        prop:hasPackage  "Vitro-languages" .
+        rdf:type         uil:UILabel ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "file_upload_error_file_is_too_big" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:template_capitalized.Vitro
+uil-data:template_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Template"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "template_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "template_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:file_upload_supported_media.Vitro
+uil-data:file_upload_supported_media.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "file_upload_supported_media" ;
-        prop:hasPackage  "Vitro-languages" .
+        rdf:type         uil:UILabel ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "file_upload_supported_media" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:user_accounts_title.Vitro
+uil-data:user_accounts_title.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "contas de Usuário"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "user_accounts_title" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "user_accounts_title" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:create_your_password.Vitro
+uil-data:create_your_password.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Crie uma senha"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "create_your_password" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "create_your_password" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:create_account.Vitro
+uil-data:create_account.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Criar uma conta"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "create_account" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "create_account" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:remove_menu_item.Vitro
+uil-data:remove_menu_item.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Remover item de menu"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "remove_menu_item" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "remove_menu_item" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:click_to_view_account.Vitro
+uil-data:click_to_view_account.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "clique para visualizar detalhes da conta"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "click_to_view_account" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "click_to_view_account" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:add_new_entry_for.Vitro
+uil-data:add_new_entry_for.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Adicionar nova entrada para:"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "add_new_entry_for" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "add_new_entry_for" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:menu_ordering.Vitro
+uil-data:menu_ordering.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Menu Ordenado"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "menu_ordering" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "menu_ordering" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:map_processor_error.Vitro
+uil-data:map_processor_error.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ocorreu um erro e o mapa de processadores para este conteúdo está faltando. Entre em contato com o administrador"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "map_processor_error" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "map_processor_error" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:change_profile_title.Vitro
+uil-data:change_profile_title.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "mudança no perfil"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "change_profile_title" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "change_profile_title" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:domain_class.Vitro
+uil-data:domain_class.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Classe de Dominio"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "domain_class" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "domain_class" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:manage_labels_capitalized.Vitro
+uil-data:manage_labels_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Gerenciar Labels"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "manage_labels_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "manage_labels_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_passwords_dont_match.Vitro
+uil-data:error_passwords_dont_match.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "As senhas digitadas não iquais."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_passwords_dont_match" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_passwords_dont_match" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:save_profile_changes.Vitro
+uil-data:save_profile_changes.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Salvar alterações em perfis"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "save_profile_changes" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "save_profile_changes" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:site_administration.Vitro
+uil-data:site_administration.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Administração do Site"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "site_administration" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "site_administration" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:vitro_bullet_one.Vitro
+uil-data:vitro_bullet_one.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Criar ou carregar ontologias no formato OWL"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "vitro_bullet_one" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "vitro_bullet_one" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:pages.Vitro
+uil-data:pages.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "páginas"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "pages" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "pages" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:inferred_class_hierarchy.Vitro
+uil-data:inferred_class_hierarchy.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Hierarquia da Classe gerado pela Inferência"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "inferred_class_hierarchy" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "inferred_class_hierarchy" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:auth_id_in_use.Vitro
+uil-data:auth_id_in_use.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Este identificador já está em uso."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "auth_id_in_use" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "auth_id_in_use" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:data_input.Vitro
+uil-data:data_input.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Entrada de Dados"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "data_input" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "data_input" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:recompute_inferences_mixed_caps.Vitro
+uil-data:recompute_inferences_mixed_caps.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Recalcular Inferências"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "recompute_inferences_mixed_caps" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "recompute_inferences_mixed_caps" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:individual_name.Vitro
+uil-data:individual_name.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "nome individual"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "individual_name" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "individual_name" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:thursday.Vitro
+uil-data:thursday.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "quinta-feira"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "thursday" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "thursday" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:alert_icon.Vitro
+uil-data:alert_icon.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ícone de Alerta"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "alert_icon" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "alert_icon" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:if_blank_page_title_used.Vitro
+uil-data:if_blank_page_title_used.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Se for deixado em branco, o título da página será usado."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "if_blank_page_title_used" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "if_blank_page_title_used" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:password_reset_pending_email_plain_text.Vitro
+uil-data:password_reset_pending_email_plain_text.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Caro ${userAccount.firstName} ${userAccount.lastName}:\n\nRecebemos um pedido para redefinir a senha para o seu ${siteName} conta\n(${userAccount.emailAddress}).\n\nPlease follow the instructions below to proceed with your password reset.\n\nSe você não solicitou essa nova conta, você pode simplesmente ignorar este e-mail.\nEste pedido expirará se não for executado no prazo de 30 dias.\n\nClique no link abaixo ou cole-o na barra de endereço do seu navegador para\nredefinir sua senha usando o nosso servidor seguro.\n\n${passwordLink}\n\nObrigado!\n"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "password_reset_pending_email_plain_text" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "password_reset_pending_email_plain_text" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:hide_properties.Vitro
+uil-data:hide_properties.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ocultar Propriedades"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "hide_properties" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "hide_properties" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:file_upload_error_file_type_not_recognized.Vitro
+uil-data:file_upload_error_file_type_not_recognized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "file_upload_error_file_type_not_recognized" ;
-        prop:hasPackage  "Vitro-languages" .
+        rdf:type         uil:UILabel ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "file_upload_error_file_type_not_recognized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_no_role.Vitro
+uil-data:error_no_role.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Você deve selecionar um."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_no_role" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_no_role" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:new_account_title.Vitro
+uil-data:new_account_title.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "nova conta"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "new_account_title" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "new_account_title" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:file_upload_no_allowed_media.Vitro
+uil-data:file_upload_no_allowed_media.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "file_upload_no_allowed_media" ;
-        prop:hasPackage  "Vitro-languages" .
+        rdf:type         uil:UILabel ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "file_upload_no_allowed_media" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:property_groups.Vitro
+uil-data:property_groups.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Grupos de Propriedades"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "property_groups" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "property_groups" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:startup_trace.Vitro
+uil-data:startup_trace.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Relatório da Inicialização do Sistema"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "startup_trace" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "startup_trace" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:search_accounts_button.Vitro
+uil-data:search_accounts_button.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "pesquisa"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "search_accounts_button" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "search_accounts_button" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:operation_unsuccessful.Vitro
+uil-data:operation_unsuccessful.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "A operação não foi bem sucedida. Todos os detalhes podem ser encontrados no log do sistema."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "operation_unsuccessful" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "operation_unsuccessful" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:submit_button.Vitro
+uil-data:submit_button.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Enviar"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "submit_button" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "submit_button" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:page_uri_missing.Vitro
+uil-data:page_uri_missing.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Nenhuma URI da página especificada"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "page_uri_missing" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "page_uri_missing" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_no_email_address.Vitro
+uil-data:error_no_email_address.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Por favor, insira o seu endereço de e-mail."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_no_email_address" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_no_email_address" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:controls.Vitro
+uil-data:controls.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Controles"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "controls" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "controls" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:fruit.Vitro
+uil-data:fruit.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Frutas"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "fruit" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "fruit" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:admin_panel.Vitro
+uil-data:admin_panel.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Painel Administrador"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "admin_panel" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "admin_panel" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:the_range_class_does_not_exist.Vitro
+uil-data:the_range_class_does_not_exist.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "A classe intervalo para essa propriedade não existe no sistema."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "the_range_class_does_not_exist" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "the_range_class_does_not_exist" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:reset_your_password.Vitro
+uil-data:reset_your_password.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Redefinir a sua senha"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "reset_your_password" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "reset_your_password" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:advanced_search_tip_two.Vitro
+uil-data:advanced_search_tip_two.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "\"NOT\" pode ajudar em limitar as pesquisas - por exemplo,<i>climate</i> NOT <i>change</i>."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "advanced_search_tip_two" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "advanced_search_tip_two" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:save_new_page.Vitro
+uil-data:save_new_page.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Salve nova página"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "save_new_page" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "save_new_page" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:book_title.Vitro
+uil-data:book_title.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Título do livro:"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "book_title" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "book_title" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:view_content_index.Vitro
+uil-data:view_content_index.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ver um esboço do conteúdo deste site"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "view_content_index" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "view_content_index" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:or_create_new_one.Vitro
+uil-data:or_create_new_one.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "ou criar um novo."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "or_create_new_one" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "or_create_new_one" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:remove_selection.Vitro
+uil-data:remove_selection.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Remover seleção"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "remove_selection" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "remove_selection" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:cardinality.Vitro
+uil-data:cardinality.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "cardinalidade"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "cardinality" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "cardinality" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:apostrophe_not_allowed.Vitro
+uil-data:apostrophe_not_allowed.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "O nome da variável não deve ter um apóstrofo."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "apostrophe_not_allowed" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "apostrophe_not_allowed" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:confirm_menu_item_delete.Vitro
+uil-data:confirm_menu_item_delete.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Tem certeza de que deseja remover"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "confirm_menu_item_delete" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "confirm_menu_item_delete" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:work_level.Vitro
+uil-data:work_level.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "nível de Trabalho"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "work_level" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "work_level" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:acct_created_external_only_email_html_text.Vitro
+uil-data:acct_created_external_only_email_html_text.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "<p>\n ${userAccount.firstName} ${userAccount.lastName}\n </p>\n\n <p>\n <strong>Parabéns!</strong>\n </p>\n\n <p>\n Nós criamos sua conta nova VIVO associado com ${userAccount.emailAddress}.\n </p>\n\n <p>\n Obrigado!\n </p>"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "acct_created_external_only_email_html_text" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "acct_created_external_only_email_html_text" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:friday.Vitro
+uil-data:friday.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "sexta-feira"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "friday" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "friday" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:return_to_the.Vitro
+uil-data:return_to_the.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Retornar para a"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "return_to_the" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "return_to_the" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:sparql_query.Vitro
+uil-data:sparql_query.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Consulta SPARQL"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "sparql_query" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "sparql_query" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:myAccount_confirm_changes.Vitro
+uil-data:myAccount_confirm_changes.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Suas alterações foram salvas."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "myAccount_confirm_changes" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "myAccount_confirm_changes" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:to.Vitro
+uil-data:to.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "para"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "to" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "to" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:login_to_manage_site.Vitro
+uil-data:login_to_manage_site.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "log in para gerenciar este site"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "login_to_manage_site" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "login_to_manage_site" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:a_classgroup.Vitro
+uil-data:a_classgroup.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "um grupo de classe"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "a_classgroup" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "a_classgroup" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:upload_page_title.Vitro
+uil-data:upload_page_title.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Enviar imagem"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "upload_page_title" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "upload_page_title" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_existing_collaborator.Vitro
+uil-data:select_existing_collaborator.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Selecione um colaborador existente para {0}"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_existing_collaborator" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_existing_collaborator" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:label.dateTimeWithPrecision.day_capitalized.Vitro
+uil-data:label.dateTimeWithPrecision.day_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Dia"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "label.dateTimeWithPrecision.day_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "label.dateTimeWithPrecision.day_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:login_button.Vitro
+uil-data:login_button.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Entrar"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "login_button" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "login_button" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:internal_login.Vitro
+uil-data:internal_login.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Internal Login"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "internal_login" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "internal_login" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_occurred.Vitro
+uil-data:error_occurred.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ocorreu um erro no site VIVO"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_occurred" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_occurred" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:advanced_search_tip_four.Vitro
+uil-data:advanced_search_tip_four.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Palavras de variações proximas também serão encontradas - por exemplo, <i>sequence</i> matches <i>sequences</i> and <i>sequencing</i>."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "advanced_search_tip_four" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "advanced_search_tip_four" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:updated_account_title.Vitro
+uil-data:updated_account_title.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "conta atualizada"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "updated_account_title" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "updated_account_title" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:year_month_day.Vitro
+uil-data:year_month_day.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Entrada inválida. Por favor, insira um ano, mês e dia."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "year_month_day" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "year_month_day" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:log_out.Vitro
+uil-data:log_out.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Sair"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "log_out" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "log_out" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:application_error_email_plain_text.Vitro
+uil-data:application_error_email_plain_text.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ocorreu um erro em seu site ${siteName!} no ${datetime!}.\nurl solicitada: ${requestedUrl!}\n\n<#if errorMessage?has_content>\n Mensagem de erro: ${errorMessage!}\n</#if>\n\nRastreando (rastreamento disponível no log):\n${stackTrace!}\n\n<#if cause?has_content>\nCausada por:\n${cause!}\n</#if>"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "application_error_email_plain_text" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "application_error_email_plain_text" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_vclass_uri.Vitro
+uil-data:select_vclass_uri.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Select Vclass"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_vclass_uri" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_vclass_uri" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:custom_template_requiring_content.Vitro
+uil-data:custom_template_requiring_content.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "template personalizado conteúdo requerendo"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "custom_template_requiring_content" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "custom_template_requiring_content" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:file_upload_error_uri_not_exists.Vitro
+uil-data:file_upload_error_uri_not_exists.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "file_upload_error_uri_not_exists" ;
-        prop:hasPackage  "Vitro-languages" .
+        rdf:type         uil:UILabel ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "file_upload_error_uri_not_exists" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:external_id_not_provided.Vitro
+uil-data:external_id_not_provided.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Login falhou - External ID não foi encontrado."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "external_id_not_provided" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "external_id_not_provided" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:imageUpload.errorBadMultipartRequest.Vitro
+uil-data:imageUpload.errorBadMultipartRequest.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Falha ao analisar a solicitação de multi-parte para fazer upload de uma imagem."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "imageUpload.errorBadMultipartRequest" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "imageUpload.errorBadMultipartRequest" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:view_all_accounts.Vitro
+uil-data:view_all_accounts.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ver todas as contas"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "view_all_accounts" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "view_all_accounts" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:file_upload_file.Vitro
+uil-data:file_upload_file.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "file_upload_file" ;
-        prop:hasPackage  "Vitro-languages" .
+        rdf:type         uil:UILabel ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "file_upload_file" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:search_failed.Vitro
+uil-data:search_failed.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Busca falhou."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "search_failed" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "search_failed" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:minimum_hour.Vitro
+uil-data:minimum_hour.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Entrada inválida. Por favor, especifique pelo menos uma hora."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "minimum_hour" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "minimum_hour" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:faux_property_alpha.Vitro
+uil-data:faux_property_alpha.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "propriedades falsas em ordem alfabética"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "faux_property_alpha" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "faux_property_alpha" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:info_icon.Vitro
+uil-data:info_icon.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "ícone info"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "info_icon" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "info_icon" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:save_button.Vitro
+uil-data:save_button.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Salvar"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "save_button" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "save_button" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:who_can_edit_profile.Vitro
+uil-data:who_can_edit_profile.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Quem pode editar meu perfil"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "who_can_edit_profile" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "who_can_edit_profile" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:add_an_entry_to.Vitro
+uil-data:add_an_entry_to.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Adicione uma entrada de tipo"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "add_an_entry_to" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "add_an_entry_to" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:page_not_found_msg.Vitro
+uil-data:page_not_found_msg.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "A página não foi encontrada no sistema."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "page_not_found_msg" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "page_not_found_msg" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:no_content_in_system.Vitro
+uil-data:no_content_in_system.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Atualmente, não há conteúdos de {0} no sistema"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "no_content_in_system" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "no_content_in_system" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:rdf.Vitro
+uil-data:rdf.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "RDF"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "rdf" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "rdf" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:datetime_year_required.Vitro
+uil-data:datetime_year_required.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Data / hora do intervalo deve ser iniciado com o ano. Entre com o ano inicial e final ou com ambos."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "datetime_year_required" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "datetime_year_required" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:external_auth_name.Vitro
+uil-data:external_auth_name.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "nome de autenticação externa"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "external_auth_name" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "external_auth_name" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:external_login_failed.Vitro
+uil-data:external_login_failed.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "login externo falhou"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "external_login_failed" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "external_login_failed" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:label.dateTimeWithPrecision.seconds_capitalized.Vitro
+uil-data:label.dateTimeWithPrecision.seconds_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Segundos"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "label.dateTimeWithPrecision.seconds_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "label.dateTimeWithPrecision.seconds_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:custom_template.Vitro
+uil-data:custom_template.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Modelo Personalizado"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "custom_template" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "custom_template" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:associated_profile_label.Vitro
+uil-data:associated_profile_label.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Perfil associado:"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "associated_profile_label" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "associated_profile_label" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:page_not_found.Vitro
+uil-data:page_not_found.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Página não encontrada"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "page_not_found" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "page_not_found" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_existing_last_name.Vitro
+uil-data:select_existing_last_name.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Selecione um último nome existente"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_existing_last_name" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_existing_last_name" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:title_capitalized.Vitro
+uil-data:title_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Título"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "title_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "title_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:file_upload_error_no_action.Vitro
+uil-data:file_upload_error_no_action.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "file_upload_error_no_action" ;
-        prop:hasPackage  "Vitro-languages" .
+        rdf:type         uil:UILabel ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "file_upload_error_no_action" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:change_entry_for.Vitro
+uil-data:change_entry_for.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Altere a entrada para:"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "change_entry_for" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "change_entry_for" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:cause.Vitro
+uil-data:cause.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Causa:"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "cause" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "cause" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:may_edit.Vitro
+uil-data:may_edit.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Pode editar"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "may_edit" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "may_edit" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:properties.Vitro
+uil-data:properties.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Propriedades"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "properties" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "properties" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:add_new.Vitro
+uil-data:add_new.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Adicionar Novo"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "add_new" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "add_new" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:apples.Vitro
+uil-data:apples.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Maçã"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "apples" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "apples" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:tuesday.Vitro
+uil-data:tuesday.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Terça-feira"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "tuesday" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "tuesday" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:email_changed_subject.Vitro
+uil-data:email_changed_subject.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "A conta {0} de e-mail foi alterada."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "email_changed_subject" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "email_changed_subject" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:site_admin.Vitro
+uil-data:site_admin.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Site Admin"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "site_admin" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "site_admin" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:code_processing_error.Vitro
+uil-data:code_processing_error.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ocorreu um erro e o código para processar este conteúdo está faltando um componente. Entre em contato com o administrador."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "code_processing_error" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "code_processing_error" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:base_property_capitalized.Vitro
+uil-data:base_property_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Propriedade da base"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "base_property_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "base_property_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:username.Vitro
+uil-data:username.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Nome de Usuário"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "username" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "username" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:to_order_menu_items.Vitro
+uil-data:to_order_menu_items.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "para definir a ordem dos itens de menu."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "to_order_menu_items" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "to_order_menu_items" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:none.Vitro
+uil-data:none.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "nenhum"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "none" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "none" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:classes_capitalized.Vitro
+uil-data:classes_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Classes"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "classes_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "classes_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:cancel_link.Vitro
+uil-data:cancel_link.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Cancelar"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "cancel_link" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "cancel_link" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:send_feedback_questions.Vitro
+uil-data:send_feedback_questions.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Envie-nos o seu feedback ou faça perguntas"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "send_feedback_questions" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "send_feedback_questions" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:account_already_activated.Vitro
+uil-data:account_already_activated.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "A conta para {0} já foi ativado."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "account_already_activated" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "account_already_activated" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:page.Vitro
+uil-data:page.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "página"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "page" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "page" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:type_more_characters.Vitro
+uil-data:type_more_characters.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Entre com mais caracteres"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "type_more_characters" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "type_more_characters" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:search_tips_header.Vitro
+uil-data:search_tips_header.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Dicas de busca"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "search_tips_header" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "search_tips_header" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:data_not_past_msg.Vitro
+uil-data:data_not_past_msg.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Insira uma data alvo futura para publicação (datas anteriores são inválidas)."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "data_not_past_msg" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "data_not_past_msg" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_associated_profile.Vitro
+uil-data:select_associated_profile.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Selecione o perfil associado"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_associated_profile" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_associated_profile" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:edit_capitalized.Vitro
+uil-data:edit_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Editar"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "edit_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "edit_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:site_name.Vitro
+uil-data:site_name.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "nome do site"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "site_name" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "site_name" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:replace_photo.Vitro
+uil-data:replace_photo.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Substituir Photo"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "replace_photo" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "replace_photo" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:rebuild_button.Vitro
+uil-data:rebuild_button.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Reconstruir"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "rebuild_button" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "rebuild_button" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:numbers.Vitro
+uil-data:numbers.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Números"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "numbers" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "numbers" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:acct_created_external_only_email_plain_text.Vitro
+uil-data:acct_created_external_only_email_plain_text.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "${userAccount.firstName} ${userAccount.lastName}\n\nParabéns!\n\nNós criamos sua conta nova VIVO associado com\n${userAccount.emailAddress}.\n\nObrigado!"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "acct_created_external_only_email_plain_text" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "acct_created_external_only_email_plain_text" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:auth_id_explanation.Vitro
+uil-data:auth_id_explanation.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Pode ser usado para associar a conta com o perfil do usuário por meio da propriedade correspondente."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "auth_id_explanation" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "auth_id_explanation" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:support.Vitro
+uil-data:support.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Suporte"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "support" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "support" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:enter_search_term.Vitro
+uil-data:enter_search_term.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Digite um termo de pesquisa."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "enter_search_term" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "enter_search_term" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:feedback_thanks_heading.Vitro
+uil-data:feedback_thanks_heading.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Obrigado pelo seu feedback"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "feedback_thanks_heading" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "feedback_thanks_heading" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:updated_account_notification.Vitro
+uil-data:updated_account_notification.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Um e-mail de confirmação foi enviado para {0} com instruções para redefinir uma senha. A senha não serão reiniciadas até que o usuário clicar no link fornecido neste e-mail."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "updated_account_notification" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "updated_account_notification" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:menu_ordering_mixed_caps.Vitro
+uil-data:menu_ordering_mixed_caps.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Menu Ordenado"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "menu_ordering_mixed_caps" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "menu_ordering_mixed_caps" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:expand_all.Vitro
+uil-data:expand_all.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Expandir todos"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "expand_all" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "expand_all" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:confirm_password_capitalized.Vitro
+uil-data:confirm_password_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Confirmar senha"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "confirm_password_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "confirm_password_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:uri_not_defined.Vitro
+uil-data:uri_not_defined.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "URI para página não está definida"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "uri_not_defined" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "uri_not_defined" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:a_link.Vitro
+uil-data:a_link.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "um link"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "a_link" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "a_link" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:view_list_of_labels.Vitro
+uil-data:view_list_of_labels.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "visualizar lista de rótulos"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "view_list_of_labels" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "view_list_of_labels" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:not_logged_in.Vitro
+uil-data:not_logged_in.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Não está logado"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "not_logged_in" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "not_logged_in" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:page_public_permission_option.Vitro
+uil-data:page_public_permission_option.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Qualquer um pode visualizar esta página"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "page_public_permission_option" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "page_public_permission_option" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:file_upload_error_uri_not_given.Vitro
+uil-data:file_upload_error_uri_not_given.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "file_upload_error_uri_not_given" ;
-        prop:hasPackage  "Vitro-languages" .
+        rdf:type         uil:UILabel ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "file_upload_error_uri_not_given" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:file_upload_heading.Vitro
+uil-data:file_upload_heading.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "file_upload_heading" ;
-        prop:hasPackage  "Vitro-languages" .
+        rdf:type         uil:UILabel ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "file_upload_heading" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:save_this_content.Vitro
+uil-data:save_this_content.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Salve este conteúdo"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "save_this_content" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "save_this_content" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:data.Vitro
+uil-data:data.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "dado"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "data" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "data" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_incorrect_credentials.Vitro
+uil-data:error_incorrect_credentials.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "O e-mail ou a senha digitada está incorreta."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_incorrect_credentials" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_incorrect_credentials" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:start_url_with_slash.Vitro
+uil-data:start_url_with_slash.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "A URL muito deve começar com uma líder de barra"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "start_url_with_slash" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "start_url_with_slash" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:february.Vitro
+uil-data:february.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "fevereiro"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "february" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "february" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:delete_entry.Vitro
+uil-data:delete_entry.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "excluir esta entrada"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "delete_entry" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "delete_entry" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:imageUpload.errorFormFieldMissing.Vitro
+uil-data:imageUpload.errorFormFieldMissing.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "O formulário não contém um '{0}' 'campo'. \""@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "imageUpload.errorFormFieldMissing" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "imageUpload.errorFormFieldMissing" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:formatted_date_time.Vitro
+uil-data:formatted_date_time.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Formato data-tempo"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "formatted_date_time" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "formatted_date_time" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:imageUpload.errorUnknown.Vitro
+uil-data:imageUpload.errorUnknown.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Desculpe, não fomos capazes de processar a foto que você forneceu. Por favor, tente outra foto."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "imageUpload.errorUnknown" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "imageUpload.errorUnknown" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:password_reset_pending_email_html_text.Vitro
+uil-data:password_reset_pending_email_html_text.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "<p>\n Caro ${userAccount.firstName} ${userAccount.lastName}:\n </p>\n\n <p>\n Recebemos um pedido para redefinir a senha para o seu ${siteName} conta\n (${userAccount.emailAddress}).\n </p>\n\n <p>\n Por favor, siga as instruções abaixo para prosseguir com a sua redefinição de senha.\n </p>\n\n <p>\n Se você não solicitou essa nova conta, você pode simplesmente ignorar este e-mail.\n            Este pedido expirará se não for executado no prazo de 30 dias.\n </p>\n\n <p>\n Clique no link abaixo ou cole-o na barra de endereço do seu navegador para\n redefinir sua senha usando o nosso servidor seguro.\n </p>\n\n <p><a href=\"${passwordLink}\" title=\"password\">${passwordLink}</a> </p>\n\n <p>Obrigado!</p>\n"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "password_reset_pending_email_html_text" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "password_reset_pending_email_html_text" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:ontology_editor.Vitro
+uil-data:ontology_editor.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Editor de Ontologia"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "ontology_editor" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "ontology_editor" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:from_capitalized.Vitro
+uil-data:from_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "De"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "from_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "from_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:logged_out.Vitro
+uil-data:logged_out.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Você se desconectou."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "logged_out" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "logged_out" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:search_for.Vitro
+uil-data:search_for.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Buscar por '' {0} ''"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "search_for" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "search_for" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:other.Vitro
+uil-data:other.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "outro"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "other" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "other" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:supply_variable_name.Vitro
+uil-data:supply_variable_name.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Você deve fornecer uma variável para salvar o conteúdo HTML."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "supply_variable_name" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "supply_variable_name" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:remove_restrictions.Vitro
+uil-data:remove_restrictions.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Remover restrições"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "remove_restrictions" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "remove_restrictions" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:variable_name_all_caps.Vitro
+uil-data:variable_name_all_caps.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Nome da variável"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "variable_name_all_caps" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "variable_name_all_caps" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:levels.Vitro
+uil-data:levels.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Níveis"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "levels" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "levels" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:range_class.Vitro
+uil-data:range_class.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "intervalo da Classe"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "range_class" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "range_class" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:type_more_chars.Vitro
+uil-data:type_more_chars.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "digite mais caracteres"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "type_more_chars" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "type_more_chars" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:advanced_data_tools.Vitro
+uil-data:advanced_data_tools.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ferramentas de Dados Avançados"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "advanced_data_tools" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "advanced_data_tools" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:current_date.Vitro
+uil-data:current_date.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Data atual:"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "current_date" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "current_date" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:since_elapsed_time_est_total.Vitro
+uil-data:since_elapsed_time_est_total.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "{0}, tempo decorrido {1}, o tempo total estimado {2}"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "since_elapsed_time_est_total" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "since_elapsed_time_est_total" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:close.Vitro
+uil-data:close.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "perto"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "close" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "close" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:change_selection.Vitro
+uil-data:change_selection.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "mudança seleçionada"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "change_selection" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "change_selection" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:copyright.Vitro
+uil-data:copyright.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "direitos autoras"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "copyright" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "copyright" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_page_content_type.Vitro
+uil-data:select_page_content_type.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Selecione o tipo de conteúdo para a página associada"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_page_content_type" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_page_content_type" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:zoo_one.Vitro
+uil-data:zoo_one.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Zoo 1"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "zoo_one" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "zoo_one" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:cancel_title.Vitro
+uil-data:cancel_title.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Cancelar"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "cancel_title" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "cancel_title" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:add_individual_of_class.Vitro
+uil-data:add_individual_of_class.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Adicionar indivíduo dessa classe"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "add_individual_of_class" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "add_individual_of_class" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:label.dateTimeWithPrecision.year_capitalized.Vitro
+uil-data:label.dateTimeWithPrecision.year_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ano"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "label.dateTimeWithPrecision.year_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "label.dateTimeWithPrecision.year_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:relate_editors_profiles.Vitro
+uil-data:relate_editors_profiles.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Referir editores de perfil e perfis"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "relate_editors_profiles" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "relate_editors_profiles" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:vitro_bullet_four.Vitro
+uil-data:vitro_bullet_four.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Pesquisar os seus dados"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "vitro_bullet_four" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "vitro_bullet_four" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:save_changes.Vitro
+uil-data:save_changes.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Salvar alterações"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "save_changes" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "save_changes" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:cant_activate_while_logged_in.Vitro
+uil-data:cant_activate_while_logged_in.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Você não pode ativar a conta para {0} enquanto você está logado como {1}. Por favor, saia e tente novamente."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "cant_activate_while_logged_in" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "cant_activate_while_logged_in" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:next_capitalized.Vitro
+uil-data:next_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Próxima"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "next_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "next_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:end_capitalized.Vitro
+uil-data:end_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Termino"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "end_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "end_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:custom_template_containing_content.Vitro
+uil-data:custom_template_containing_content.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "template personalizado que contém todo o conteúdo"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "custom_template_containing_content" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "custom_template_containing_content" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:name_of.Vitro
+uil-data:name_of.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "name_of" ;
-        prop:hasPackage  "Vitro-languages" .
+        rdf:type         uil:UILabel ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "name_of" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:content_type.Vitro
+uil-data:content_type.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Tipo de Conteúdo"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "content_type" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "content_type" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:add_label.Vitro
+uil-data:add_label.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Adicionar etiqueta"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "add_label" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "add_label" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:activate_developer_panel_mixed_caps.Vitro
+uil-data:activate_developer_panel_mixed_caps.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ativar Painel de Desenvolvedor"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "activate_developer_panel_mixed_caps" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "activate_developer_panel_mixed_caps" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:reset_search_index.Vitro
+uil-data:reset_search_index.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Reiniciar o índice de pesquisa e o reconstroi."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "reset_search_index" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "reset_search_index" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:please_provide_contact_information.Vitro
+uil-data:please_provide_contact_information.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Por favor, forneça suas informações de contato para terminar de criar a sua conta."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "please_provide_contact_information" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "please_provide_contact_information" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:continued.Vitro
+uil-data:continued.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "continuação"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "continued" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "continued" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_no_email.Vitro
+uil-data:error_no_email.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Você deve fornecer um endereço de e-mail."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_no_email" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_no_email" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_no_last_name.Vitro
+uil-data:error_no_last_name.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Você deve fornecer um sobrenome."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_no_last_name" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_no_last_name" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:december.Vitro
+uil-data:december.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "dezembro"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "december" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "december" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:multiple_content_default_template_error.Vitro
+uil-data:multiple_content_default_template_error.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Com vários tipos de conteúdo, você deve especificar um modelo personalizado."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "multiple_content_default_template_error" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "multiple_content_default_template_error" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:all_classes.Vitro
+uil-data:all_classes.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Todas as Classes"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "all_classes" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "all_classes" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:viewing_page.Vitro
+uil-data:viewing_page.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "página de visualização Likely"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "viewing_page" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "viewing_page" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:individual_not_found_msg.Vitro
+uil-data:individual_not_found_msg.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "O indivíduo não foi encontrado no sistema."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "individual_not_found_msg" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "individual_not_found_msg" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:setup_navigation_menu.Vitro
+uil-data:setup_navigation_menu.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Configurar o menu de navegação principal do seu website"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "setup_navigation_menu" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "setup_navigation_menu" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:external_id_already_in_use.Vitro
+uil-data:external_id_already_in_use.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Usuário já existe para '' {0} ''"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "external_id_already_in_use" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "external_id_already_in_use" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:ascending_order.Vitro
+uil-data:ascending_order.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "ordem crescente"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "ascending_order" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "ascending_order" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:browse_all_content.Vitro
+uil-data:browse_all_content.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "busque por todo o conteúdo"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "browse_all_content" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "browse_all_content" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:begin_with_slash_no_example.Vitro
+uil-data:begin_with_slash_no_example.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Deve começar com um líder de barra: /"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "begin_with_slash_no_example" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "begin_with_slash_no_example" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_occurred_at.Vitro
+uil-data:error_occurred_at.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ocorreu um erro em seu site VIVO no {0}."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_occurred_at" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_occurred_at" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_editors.Vitro
+uil-data:select_editors.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Selecione os editores"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_editors" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_editors" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:supply_html.Vitro
+uil-data:supply_html.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Você deve fornecer algum HTML ou texto."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "supply_html" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "supply_html" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:slash_example.Vitro
+uil-data:slash_example.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "(por exemplo, / pessoas)"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "slash_example" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "slash_example" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:property_hierarchy.Vitro
+uil-data:property_hierarchy.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Hierarquia da Propriedade"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "property_hierarchy" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "property_hierarchy" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:try_rebuilding_index.Vitro
+uil-data:try_rebuilding_index.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Tente reconstruir o índice de pesquisa"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "try_rebuilding_index" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "try_rebuilding_index" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_in_search_request.Vitro
+uil-data:error_in_search_request.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "O pedido de pesquisa contém erros."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_in_search_request" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_in_search_request" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:first_time_login.Vitro
+uil-data:first_time_login.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Primeira vez do login"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "first_time_login" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "first_time_login" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:first_time_external_email_plain_text.Vitro
+uil-data:first_time_external_email_plain_text.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "${userAccount.firstName} ${userAccount.lastName}\n\nParabéns!\n\nNós criamos sua conta nova VIVO associado com\n${userAccount.emailAddress}.\n\nObrigado!"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "first_time_external_email_plain_text" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "first_time_external_email_plain_text" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:faux_property_by_base.Vitro
+uil-data:faux_property_by_base.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "propriedades faux por propriedade base"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "faux_property_by_base" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "faux_property_by_base" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:alt_thumbnail_photo.Vitro
+uil-data:alt_thumbnail_photo.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "foto Individual"@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "alt_thumbnail_photo" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "alt_thumbnail_photo" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:no_individual_associated_with_id.Vitro
+uil-data:no_individual_associated_with_id.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Por alguma razão, não há nenhum indivíduo no VIVO que esteja associado ao seu ID Net. Talvez você deve entrar em contato com o administrador do VIVO."@pt-BR ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "no_individual_associated_with_id" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "no_individual_associated_with_id" ;
+        uil:hasPackage  "Vitro-languages" .

--- a/home/src/main/resources/rdf/i18n/ru_RU/interface-i18n/firsttime/vitro_UiLabel.ttl
+++ b/home/src/main/resources/rdf/i18n/ru_RU/interface-i18n/firsttime/vitro_UiLabel.ttl
@@ -1,6266 +1,6266 @@
 @prefix owl:   <http://www.w3.org/2002/07/owl#> .
 @prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
-@prefix prop-data: <http://vivoweb.org/ontology/core/properties/individual#> .
-@prefix prop:  <http://vivoweb.org/ontology/core/properties/vocabulary#> .
+@prefix uil-data: <http://vivoweb.org/ontology/vitro/ui-label/individual#> .
+@prefix uil:  <http://vivoweb.org/ontology/vitro/ui-label/vocabulary#> .
 @prefix xsd:   <http://www.w3.org/2001/XMLSchema#> .
 @prefix skos:  <http://www.w3.org/2004/02/skos/core#> .
 @prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> .
 
-prop-data:collapse_all.Vitro
+uil-data:collapse_all.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "всё свернуть"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "collapse_all" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "collapse_all" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:no_password_supplied.Vitro
+uil-data:no_password_supplied.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Пароль не задан."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "no_password_supplied" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "no_password_supplied" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:crop_page_title.Vitro
+uil-data:crop_page_title.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Обрезать фотографию"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "crop_page_title" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "crop_page_title" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:label.dateTimeWithPrecision.month_capitalized.Vitro
+uil-data:label.dateTimeWithPrecision.month_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Месяц"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "label.dateTimeWithPrecision.month_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "label.dateTimeWithPrecision.month_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:advanced_search_tip_three.Vitro
+uil-data:advanced_search_tip_three.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Поиск по словосочетанию может комбинироваться с булевыми операторами, например \"<i>изменение климата</i>\" OR \"<i>глобальное потупление</i>\"."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "advanced_search_tip_three" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "advanced_search_tip_three" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:file_upload_error_file_size_is_zero.Vitro
+uil-data:file_upload_error_file_size_is_zero.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "file_upload_error_file_size_is_zero" ;
-        prop:hasPackage  "Vitro-languages" .
+        rdf:type         uil:UILabel ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "file_upload_error_file_size_is_zero" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:delete_entry_capitalized.Vitro
+uil-data:delete_entry_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Удалить данную запись?"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "delete_entry_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "delete_entry_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:remove_selection_title.Vitro
+uil-data:remove_selection_title.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "снять выделение"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "remove_selection_title" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "remove_selection_title" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:powered_by.Vitro
+uil-data:powered_by.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Работает под управлением"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "powered_by" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "powered_by" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:accounts_search_results.Vitro
+uil-data:accounts_search_results.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Результаты поиска по запросу"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "accounts_search_results" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "accounts_search_results" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:search_individual_results.Vitro
+uil-data:search_individual_results.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Поиск экземпляров класса"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "search_individual_results" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "search_individual_results" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:vclassAlpha_not_implemented.Vitro
+uil-data:vclassAlpha_not_implemented.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "vclassAlpha еще не внедрён."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "vclassAlpha_not_implemented" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "vclassAlpha_not_implemented" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_an_existing.Vitro
+uil-data:select_an_existing.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Выберите название существующующего"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_an_existing" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_an_existing" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:no_appropriate_entry.Vitro
+uil-data:no_appropriate_entry.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Если вы не найдете подходящую запись в списке выбора выше"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "no_appropriate_entry" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "no_appropriate_entry" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:descending_order.Vitro
+uil-data:descending_order.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "в порядке убывания"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "descending_order" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "descending_order" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:label.dateTimeWithPrecision.hour_capitalized.Vitro
+uil-data:label.dateTimeWithPrecision.hour_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Часы"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "label.dateTimeWithPrecision.hour_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "label.dateTimeWithPrecision.hour_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:add_remove_rdf.Vitro
+uil-data:add_remove_rdf.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Добавить/Удалить данные в формате RDF"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "add_remove_rdf" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "add_remove_rdf" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:account.Vitro
+uil-data:account.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "учётная запись"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "account" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "account" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:label.Vitro
+uil-data:label.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "метка"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "label" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "label" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:no_classes_to_select.Vitro
+uil-data:no_classes_to_select.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "В системе нет классов, из которых можно было бы выбирать."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "no_classes_to_select" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "no_classes_to_select" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:page_curator_permission_option.Vitro
+uil-data:page_curator_permission_option.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Эту страницу могут просматривать пользователи со статусом не ниже куратора"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "page_curator_permission_option" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "page_curator_permission_option" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:individuals_in_system.Vitro
+uil-data:individuals_in_system.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "лиц в системе."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "individuals_in_system" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "individuals_in_system" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:search_help.Vitro
+uil-data:search_help.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Помощь по поиску"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "search_help" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "search_help" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:there_are_no_entries_starting_with.Vitro
+uil-data:there_are_no_entries_starting_with.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Нет записей, начинающихся с"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "there_are_no_entries_starting_with" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "there_are_no_entries_starting_with" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:user_accounts_link.Vitro
+uil-data:user_accounts_link.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Учётные записи пользователей"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "user_accounts_link" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "user_accounts_link" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:ontology_capitalized.Vitro
+uil-data:ontology_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Онтология"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "ontology_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "ontology_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:change_password_to_login.Vitro
+uil-data:change_password_to_login.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Смените пароль для входа"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "change_password_to_login" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "change_password_to_login" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:a_menu_page.Vitro
+uil-data:a_menu_page.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Это страница меню"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "a_menu_page" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "a_menu_page" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:comments.Vitro
+uil-data:comments.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Комментарии"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "comments" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "comments" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:add_new_of_type.Vitro
+uil-data:add_new_of_type.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Добавить новый элемент данного типа"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "add_new_of_type" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "add_new_of_type" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:reset_password_note.Vitro
+uil-data:reset_password_note.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Примечание: Инструкции по восстановлению пароля будут отправлены по электронной почте на указанный выше адрес. Пароль не будет сброшен до тех пор, пока пользователь не перейдет по ссылке, указанной в этом письме."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "reset_password_note" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "reset_password_note" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:startup_status.Vitro
+uil-data:startup_status.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Состояние при запуске"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "startup_status" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "startup_status" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:no_results_returned.Vitro
+uil-data:no_results_returned.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Запрос не вернул никаких результатов."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "no_results_returned" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "no_results_returned" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:submit_add_new_account.Vitro
+uil-data:submit_add_new_account.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Добавить новую учётную запись"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "submit_add_new_account" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "submit_add_new_account" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:password_reset_complete_subject.Vitro
+uil-data:password_reset_complete_subject.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ваш пароль {0} изменен."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "password_reset_complete_subject" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "password_reset_complete_subject" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:file_upload_error_supported_actions.Vitro
+uil-data:file_upload_error_supported_actions.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "file_upload_error_supported_actions" ;
-        prop:hasPackage  "Vitro-languages" .
+        rdf:type         uil:UILabel ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "file_upload_error_supported_actions" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:create_classgroup.Vitro
+uil-data:create_classgroup.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Создать группу классов"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "create_classgroup" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "create_classgroup" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:accounts.Vitro
+uil-data:accounts.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "учётные записи"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "accounts" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "accounts" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:page_not_created_msg.Vitro
+uil-data:page_not_created_msg.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "При создании страницы произошла ошибка, пожалуйста, проверьте журналы."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "page_not_created_msg" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "page_not_created_msg" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:login_count.Vitro
+uil-data:login_count.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Количество входов в систему"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "login_count" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "login_count" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:not_expected_results.Vitro
+uil-data:not_expected_results.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Не те результаты, которые вы ожидали?"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "not_expected_results" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "not_expected_results" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:paging_link_more.Vitro
+uil-data:paging_link_more.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "ещё..."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "paging_link_more" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "paging_link_more" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:sparql_query_description_1.Vitro
+uil-data:sparql_query_description_1.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "# и их метки (если они имеются)"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "sparql_query_description_1" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "sparql_query_description_1" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:acct_created_email_plain_text.Vitro
+uil-data:acct_created_email_plain_text.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "${userAccount.firstName} ${userAccount.lastName}\n\nПоздравляем!\n\nМы создали новую учётную запись на ${siteName}, связанную с адресом\n${userAccount.emailAddress}.\n\n Если Вы не запрашивали новую учётную запись, то можете смело игнорировать это письмо. \n Срок действия этого запроса истечет, если не предпринять никаких действий в течение 30 дней.\n Вставьте ссылку ниже в адресную строку браузера для создания пароля к учётной записи.\n\n ${passwordLink}\n\nСпасибо!"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "acct_created_email_plain_text" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "acct_created_email_plain_text" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:all_rights_reserved.Vitro
+uil-data:all_rights_reserved.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Все права защищены."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "all_rights_reserved" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "all_rights_reserved" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:submit_save.Vitro
+uil-data:submit_save.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Сохранить фото."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "submit_save" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "submit_save" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:associate_classes_with_group.Vitro
+uil-data:associate_classes_with_group.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "и связать классы с созданной группой."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "associate_classes_with_group" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "associate_classes_with_group" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:about.Vitro
+uil-data:about.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "О системе"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "about" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "about" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:activate_developer_panel.Vitro
+uil-data:activate_developer_panel.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Включить панель разработчика"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "activate_developer_panel" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "activate_developer_panel" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:since.Vitro
+uil-data:since.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "С"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "since" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "since" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:limit_to.Vitro
+uil-data:limit_to.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ограничить до "@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "limit_to" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "limit_to" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:password_created_subject.Vitro
+uil-data:password_created_subject.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ваш пароль {0} успешно создан."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "password_created_subject" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "password_created_subject" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:vitro_description.Vitro
+uil-data:vitro_description.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Vitro - это универсальный веб-редактор онтологий и экземпляров с настраиваемым общедоступным доступом. Также Vitro - это веб-приложение Java, работающее в контейнере сервлетов Tomcat. "@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "vitro_description" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "vitro_description" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:logins_disabled_for_maintenance.Vitro
+uil-data:logins_disabled_for_maintenance.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Вход в систему временно отключен на время обслуживания системы."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "logins_disabled_for_maintenance" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "logins_disabled_for_maintenance" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:current_time.Vitro
+uil-data:current_time.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Текущее время:"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "current_time" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "current_time" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:release.Vitro
+uil-data:release.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "выпуск "@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "release" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "release" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:authenticator.Vitro
+uil-data:authenticator.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Проверщик подлинности"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "authenticator" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "authenticator" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:preparing_to_rebuild_index.Vitro
+uil-data:preparing_to_rebuild_index.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Подготовка к перестройке поискового индекса."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "preparing_to_rebuild_index" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "preparing_to_rebuild_index" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:login_status.Vitro
+uil-data:login_status.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Состояние авторизации:"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "login_status" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "login_status" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:scroll_to_menus.Vitro
+uil-data:scroll_to_menus.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "перейдите к меню групп свойств"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "scroll_to_menus" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "scroll_to_menus" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:sparql_query_description_0.Vitro
+uil-data:sparql_query_description_0.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "# Этот пример запроса позволяет получить 20 географических местоположений"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "sparql_query_description_0" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "sparql_query_description_0" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:delete_button.Vitro
+uil-data:delete_button.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Удалить"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "delete_button" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "delete_button" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:fixed_html.Vitro
+uil-data:fixed_html.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Статический HTML-код"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "fixed_html" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "fixed_html" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:you_can.Vitro
+uil-data:you_can.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Вы можете"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "you_can" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "you_can" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:supply_sparql_query.Vitro
+uil-data:supply_sparql_query.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Следует задать запрос Sparql."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "supply_sparql_query" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "supply_sparql_query" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:enter_email_password.Vitro
+uil-data:enter_email_password.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Введите адрес электронной почты и пароль для вашей внутренней учетной записи Vitro."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "enter_email_password" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "enter_email_password" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:selected_editors.Vitro
+uil-data:selected_editors.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Выбранные редакторы"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "selected_editors" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "selected_editors" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:custom_template_mixed_caps.Vitro
+uil-data:custom_template_mixed_caps.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Собственный шаблон"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "custom_template_mixed_caps" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "custom_template_mixed_caps" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:animal.Vitro
+uil-data:animal.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Животное:"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "animal" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "animal" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:enter_sparql_query_here.Vitro
+uil-data:enter_sparql_query_here.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Введите сюда запрос SPARQL"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "enter_sparql_query_here" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "enter_sparql_query_here" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:recompute_inferences.Vitro
+uil-data:recompute_inferences.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Перестроить интерфейс"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "recompute_inferences" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "recompute_inferences" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:restrict_logins.Vitro
+uil-data:restrict_logins.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ограничить вход в систему"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "restrict_logins" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "restrict_logins" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:email_address.Vitro
+uil-data:email_address.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Адрес электронной почты"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "email_address" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "email_address" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:alt_confirmation.Vitro
+uil-data:alt_confirmation.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Значок подтверждения"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "alt_confirmation" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "alt_confirmation" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:drag_drop_to_reorder_menus.Vitro
+uil-data:drag_drop_to_reorder_menus.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Перетащите пункты меню для изменения порядка их следования"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "drag_drop_to_reorder_menus" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "drag_drop_to_reorder_menus" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:most_recent_update.Vitro
+uil-data:most_recent_update.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Последнее обновление датировано"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "most_recent_update" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "most_recent_update" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:delete_link.Vitro
+uil-data:delete_link.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Удалить фото"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "delete_link" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "delete_link" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:check_startup_status.Vitro
+uil-data:check_startup_status.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Проверьте страницу состояния запуска и/или журналы Tomcat для получения дополнительной информации."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "check_startup_status" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "check_startup_status" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:no_pages_defined.Vitro
+uil-data:no_pages_defined.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Никаких страниц еще не задано."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "no_pages_defined" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "no_pages_defined" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:advanced_search_tip_five.Vitro
+uil-data:advanced_search_tip_five.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Используйте символ * для поиска еще более разнообразных вариантов, например <i>нано*</i> подойдёт как для <i>нанотехнологии</i>, так и для <i>нанопроизводства</i>."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "advanced_search_tip_five" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "advanced_search_tip_five" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_message.Vitro
+uil-data:error_message.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Сообщение об ошибке"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_message" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_message" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:double_quote_note_allowed.Vitro
+uil-data:double_quote_note_allowed.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "В имени переменной не должно быть двойных кавычек."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "double_quote_note_allowed" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "double_quote_note_allowed" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:crop_page_title_with_name.Vitro
+uil-data:crop_page_title_with_name.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Обрезка фотографии для {0}"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "crop_page_title_with_name" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "crop_page_title_with_name" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:logins_not_restricted.Vitro
+uil-data:logins_not_restricted.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Вход в систему больше не ограничен."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "logins_not_restricted" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "logins_not_restricted" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:deleted_accounts.Vitro
+uil-data:deleted_accounts.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Удалено: {0} {0, choice, 0#учётных записей|1#учётная запись|2#учётные записи|1<учётных записей}."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "deleted_accounts" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "deleted_accounts" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:whole_number.Vitro
+uil-data:whole_number.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Неверный ввод. Введите целое число без десятичной точки или разделителя тысяч."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "whole_number" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "whole_number" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:edit_account.Vitro
+uil-data:edit_account.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Редактировать учётную запись"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "edit_account" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "edit_account" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:search_tip_two.Vitro
+uil-data:search_tip_two.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Используйте кавычки для поиска целого словосочетания, например, \"<i>свёртывание белка</i>\"."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "search_tip_two" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "search_tip_two" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:email_capitalized.Vitro
+uil-data:email_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Адрес электронной почты"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "email_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "email_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:policies.Vitro
+uil-data:policies.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Политики"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "policies" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "policies" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:failed.Vitro
+uil-data:failed.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "не удалось"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "failed" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "failed" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:containers_do_not_pick_up_changes.Vitro
+uil-data:containers_do_not_pick_up_changes.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Контейнеры не получают изменений значений своих элементов"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "containers_do_not_pick_up_changes" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "containers_do_not_pick_up_changes" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:file_upload_error_media_type_not_allowed.Vitro
+uil-data:file_upload_error_media_type_not_allowed.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "file_upload_error_media_type_not_allowed" ;
-        prop:hasPackage  "Vitro-languages" .
+        rdf:type         uil:UILabel ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "file_upload_error_media_type_not_allowed" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:add_new_classes.Vitro
+uil-data:add_new_classes.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Задать новый класс"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "add_new_classes" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "add_new_classes" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:identifier_factories.Vitro
+uil-data:identifier_factories.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Идентификационные центры"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "identifier_factories" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "identifier_factories" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:show_subclasses.Vitro
+uil-data:show_subclasses.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "отобразить подклассы"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "show_subclasses" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "show_subclasses" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:enter_id_to_login.Vitro
+uil-data:enter_id_to_login.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Введите идентификатор пользователя, под которым вы хотите войти в систему, или нажмите Отмена."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "enter_id_to_login" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "enter_id_to_login" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:upload_heading.Vitro
+uil-data:upload_heading.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Загрузка фото"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "upload_heading" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "upload_heading" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:warnings_issued.Vitro
+uil-data:warnings_issued.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "{0} выдал предупреждения во время запуска."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "warnings_issued" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "warnings_issued" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:account_management.Vitro
+uil-data:account_management.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Управление учётными записями"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "account_management" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "account_management" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_content_display.Vitro
+uil-data:select_content_display.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Выберите содержимое для отображения"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_content_display" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_content_display" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:account_no_longer_exists.Vitro
+uil-data:account_no_longer_exists.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Учетная запись, для которой вы пытаетесь установить пароль, больше не доступна. Обратитесь к системному администратору, если вы считаете, что произошла ошибка."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "account_no_longer_exists" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "account_no_longer_exists" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:page_select_permission.Vitro
+uil-data:page_select_permission.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Выберите разрешения для страницы"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "page_select_permission" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "page_select_permission" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:test_for_logged_in_users.Vitro
+uil-data:test_for_logged_in_users.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Это пробный виджет для авторизованных пользователей."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "test_for_logged_in_users" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "test_for_logged_in_users" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:edit_page.Vitro
+uil-data:edit_page.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Редактировать страницу {0}"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "edit_page" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "edit_page" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:no_match.Vitro
+uil-data:no_match.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "нет совпадений"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "no_match" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "no_match" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:add_new_page.Vitro
+uil-data:add_new_page.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Добавить новую страницу"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "add_new_page" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "add_new_page" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:class_groups.Vitro
+uil-data:class_groups.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Группы классов"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "class_groups" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "class_groups" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:password_reset_pending_email_subject.Vitro
+uil-data:password_reset_pending_email_subject.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Запрос на изменение пароля для сайта ${siteName}"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "password_reset_pending_email_subject" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "password_reset_pending_email_subject" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:manage.Vitro
+uil-data:manage.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "управлять"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "manage" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "manage" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_password_length.Vitro
+uil-data:error_password_length.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Пожалуйста, введите пароль длиной от {0} до {1} символов."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_password_length" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_password_length" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:view_profile_editors.Vitro
+uil-data:view_profile_editors.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Просмотреть всех редакторов профилей"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "view_profile_editors" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "view_profile_editors" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:subclasses_capitalized.Vitro
+uil-data:subclasses_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Подклассы"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "subclasses_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "subclasses_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:auth_matching_id_label.Vitro
+uil-data:auth_matching_id_label.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Внешний идентификатор / Совпадающий идентификатор"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "auth_matching_id_label" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "auth_matching_id_label" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:page_editor_permission_option.Vitro
+uil-data:page_editor_permission_option.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Эту страницу могут просматривать пользователи со статусом не ниже редактора"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "page_editor_permission_option" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "page_editor_permission_option" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:delete_page.Vitro
+uil-data:delete_page.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "удалить эту страницу"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "delete_page" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "delete_page" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:for.Vitro
+uil-data:for.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "о"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "for" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "for" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:manage_list_of_labels.Vitro
+uil-data:manage_list_of_labels.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "управлять списками меток"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "manage_list_of_labels" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "manage_list_of_labels" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:content.Vitro
+uil-data:content.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "содержимое"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "content" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "content" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:match_by.Vitro
+uil-data:match_by.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "совпадает с {0}"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "match_by" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "match_by" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:alt_preview_crop.Vitro
+uil-data:alt_preview_crop.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Предварительный просмотр обрезанной фотографии"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "alt_preview_crop" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "alt_preview_crop" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:pretty_url.Vitro
+uil-data:pretty_url.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Понятный URL"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "pretty_url" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "pretty_url" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:operation_successful.Vitro
+uil-data:operation_successful.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Операция успешно выполнена"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "operation_successful" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "operation_successful" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:add_capitalized.Vitro
+uil-data:add_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Добавить"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "add_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "add_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:accounts_per_page.Vitro
+uil-data:accounts_per_page.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "учётных записей на страницу"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "accounts_per_page" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "accounts_per_page" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_editor_and_profile.Vitro
+uil-data:select_editor_and_profile.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Вы должны выбрать по крайней мере одного редактора и один профиль."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_editor_and_profile" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_editor_and_profile" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:request_failed.Vitro
+uil-data:request_failed.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Запрос не прошел. Пожалуйста, свяжитесь с вашим системным администратором."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "request_failed" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "request_failed" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:from_site_admin_page.Vitro
+uil-data:from_site_admin_page.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "со страницы Администратора сайта."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "from_site_admin_page" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "from_site_admin_page" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:new_password_capitalized.Vitro
+uil-data:new_password_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Новый пароль"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "new_password_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "new_password_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:advanced_search_tip_one.Vitro
+uil-data:advanced_search_tip_one.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Если вы введете более одного термина, поиск вернет результаты, содержащие все из них, если только вы не добавите логическое \"OR\" - например, <i>курица</i> OR <i>яйцо</i>."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "advanced_search_tip_one" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "advanced_search_tip_one" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:password_reset_complete_email_plain_text.Vitro
+uil-data:password_reset_complete_email_plain_text.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "${userAccount.firstName} ${userAccount.lastName}\n\nПароль успешно изменён.\n\nВаш пароль, связанный с адресом ${userAccount.emailAddress}\nизменён.\n\nСпасибо.\n"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "password_reset_complete_email_plain_text" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "password_reset_complete_email_plain_text" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:application_error_email_subject.Vitro
+uil-data:application_error_email_subject.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "На сайте ${siteName!} произошла ошибка"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "application_error_email_subject" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "application_error_email_subject" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:return_to.Vitro
+uil-data:return_to.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "вернуться к {0}"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "return_to" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "return_to" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:last_login.Vitro
+uil-data:last_login.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Последний вход в систему"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "last_login" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "last_login" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:view_profile_in_rdf.Vitro
+uil-data:view_profile_in_rdf.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "показать схему в формате RDF"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "view_profile_in_rdf" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "view_profile_in_rdf" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:minimum_password_length.Vitro
+uil-data:minimum_password_length.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Минимальная длина {0} символов; максимальная {1}."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "minimum_password_length" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "minimum_password_length" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:contact_us.Vitro
+uil-data:contact_us.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Связаться с нами"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "contact_us" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "contact_us" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:download_results.Vitro
+uil-data:download_results.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Скачать результаты"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "download_results" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "download_results" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:selected_profiles.Vitro
+uil-data:selected_profiles.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Выбранные профили"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "selected_profiles" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "selected_profiles" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:has_value.Vitro
+uil-data:has_value.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "имеет значение"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "has_value" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "has_value" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:faux_property_listing.Vitro
+uil-data:faux_property_listing.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Список номинальных свойств"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "faux_property_listing" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "faux_property_listing" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:display_admin_header.Vitro
+uil-data:display_admin_header.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Администрирование и конфигурация отображения"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "display_admin_header" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "display_admin_header" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_no_password.Vitro
+uil-data:error_no_password.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Пожалуйста, введите свой пароль."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_no_password" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_no_password" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:remove_capitalized.Vitro
+uil-data:remove_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Удалить"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "remove_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "remove_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:october.Vitro
+uil-data:october.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "октябрь"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "october" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "october" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:file_upload_subject.Vitro
+uil-data:file_upload_subject.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "file_upload_subject" ;
-        prop:hasPackage  "Vitro-languages" .
+        rdf:type         uil:UILabel ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "file_upload_subject" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:manage_site.Vitro
+uil-data:manage_site.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Управлять сайтом"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "manage_site" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "manage_site" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:confirm_delete_account_plural.Vitro
+uil-data:confirm_delete_account_plural.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Вы уверены, что хотите удалить эти учётные записи?"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "confirm_delete_account_plural" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "confirm_delete_account_plural" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:sunday.Vitro
+uil-data:sunday.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "воскресенье"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "sunday" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "sunday" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:password_system_has_changed.Vitro
+uil-data:password_system_has_changed.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "password_system_has_changed" ;
-        prop:hasPackage  "Vitro-languages" .
+        rdf:type         uil:UILabel ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "password_system_has_changed" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:rebuild_search_index.Vitro
+uil-data:rebuild_search_index.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Перестроить поисковый индекс"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "rebuild_search_index" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "rebuild_search_index" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:password_saved.Vitro
+uil-data:password_saved.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ваш пароль был сохранен."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "password_saved" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "password_saved" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:supply_query_variable.Vitro
+uil-data:supply_query_variable.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Для сохранения результатов запроса необходимо задать переменную."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "supply_query_variable" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "supply_query_variable" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:configure_page_if_permissable.Vitro
+uil-data:configure_page_if_permissable.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "для настройки данной страницы, если у пользователя есть соответствующие права."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "configure_page_if_permissable" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "configure_page_if_permissable" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:invalid_date_form_msg.Vitro
+uil-data:invalid_date_form_msg.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "должна быть в допустимом формате даты ММ/ДД/ГГГГ."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "invalid_date_form_msg" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "invalid_date_form_msg" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:manage_list_of.Vitro
+uil-data:manage_list_of.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Управление списком"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "manage_list_of" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "manage_list_of" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:verbose_property_status.Vitro
+uil-data:verbose_property_status.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Развернутое отображение свойств"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "verbose_property_status" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "verbose_property_status" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:sparql_query_select_ask_results.Vitro
+uil-data:sparql_query_select_ask_results.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Формат результатов запросов SELECT и ASK"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "sparql_query_select_ask_results" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "sparql_query_select_ask_results" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:individual_not_found.Vitro
+uil-data:individual_not_found.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Лицо не найдено"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "individual_not_found" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "individual_not_found" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:classes_by_classgroup.Vitro
+uil-data:classes_by_classgroup.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Классы по группам классов"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "classes_by_classgroup" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "classes_by_classgroup" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:confirm_email_changed_email_plain_text.Vitro
+uil-data:confirm_email_changed_email_plain_text.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Здравствуйте, ${userAccount.firstName} ${userAccount.lastName}\n\nВы недавно изменили адрес электронной почты, связанный с\n${userAccount.firstName} ${userAccount.lastName}\n\nСпасибо."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "confirm_email_changed_email_plain_text" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "confirm_email_changed_email_plain_text" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:close_capitalized.Vitro
+uil-data:close_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Закрыть"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "close_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "close_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:browse_class_group.Vitro
+uil-data:browse_class_group.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Просмотр группы классов"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "browse_class_group" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "browse_class_group" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:statistics.Vitro
+uil-data:statistics.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Статистика"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "statistics" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "statistics" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:new_password.Vitro
+uil-data:new_password.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Новый пароль"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "new_password" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "new_password" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:hide_show_subclasses.Vitro
+uil-data:hide_show_subclasses.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "скрывать/показывать подклассы"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "hide_show_subclasses" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "hide_show_subclasses" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:class_hierarchy.Vitro
+uil-data:class_hierarchy.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Иерархия классов"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "class_hierarchy" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "class_hierarchy" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:add_content_manage_site.Vitro
+uil-data:add_content_manage_site.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "добавлять информацию и управлять сайтом"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "add_content_manage_site" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "add_content_manage_site" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:background_threads.Vitro
+uil-data:background_threads.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Фоновые потоки"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "background_threads" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "background_threads" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:create_capitalized.Vitro
+uil-data:create_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Создать новый объект"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "create_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "create_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_previous_password.Vitro
+uil-data:error_previous_password.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ваш новый пароль не может совпадать с текущим."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_previous_password" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_previous_password" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:change_password.Vitro
+uil-data:change_password.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Для входа в систему необходимо поменять пароль."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "change_password" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "change_password" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:menu_management.Vitro
+uil-data:menu_management.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Управление меню"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "menu_management" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "menu_management" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:email_change_will_be_confirmed.Vitro
+uil-data:email_change_will_be_confirmed.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Примечание: при изменении адреса электронной почты будет отправлено письмо с подтверждением на указанный выше новый адрес электронной почты."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "email_change_will_be_confirmed" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "email_change_will_be_confirmed" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:fake_external_auth.Vitro
+uil-data:fake_external_auth.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Имитация внешней аутентификации"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "fake_external_auth" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "fake_external_auth" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:run_sdb_setup.Vitro
+uil-data:run_sdb_setup.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Запустить установку SDB"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "run_sdb_setup" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "run_sdb_setup" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:property_management.Vitro
+uil-data:property_management.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Управление свойствами"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "property_management" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "property_management" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:end_your_Session.Vitro
+uil-data:end_your_Session.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Завершить ваш сеанс"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "end_your_Session" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "end_your_Session" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:search_index_not_connected.Vitro
+uil-data:search_index_not_connected.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Поисковый индекс не подключен."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "search_index_not_connected" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "search_index_not_connected" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:change_content_type.Vitro
+uil-data:change_content_type.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Изменить тип содержимого"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "change_content_type" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "change_content_type" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:invalid_search_term.Vitro
+uil-data:invalid_search_term.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Поисковый запросы был некорректен."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "invalid_search_term" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "invalid_search_term" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:index_recs_completed.Vitro
+uil-data:index_recs_completed.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Завершено {0} из {1} записей индекса."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "index_recs_completed" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "index_recs_completed" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:add_profile.Vitro
+uil-data:add_profile.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Добавить профиль"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "add_profile" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "add_profile" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:view_labels_capitalized.Vitro
+uil-data:view_labels_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Просмотр меток"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "view_labels_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "view_labels_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:maximum_cardinality.Vitro
+uil-data:maximum_cardinality.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "наибольшая значимость"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "maximum_cardinality" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "maximum_cardinality" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:please_format_email.Vitro
+uil-data:please_format_email.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Пожалуйста введите свой адрес электронной почты в формате:"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "please_format_email" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "please_format_email" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:external_auth_only.Vitro
+uil-data:external_auth_only.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Только внешняя аутентификация"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "external_auth_only" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "external_auth_only" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:return_to_individual.Vitro
+uil-data:return_to_individual.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Вернуться к личной странице"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "return_to_individual" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "return_to_individual" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:all_x_properties.Vitro
+uil-data:all_x_properties.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Все {0} свойств"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "all_x_properties" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "all_x_properties" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:password_created_email_plain_text.Vitro
+uil-data:password_created_email_plain_text.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "${userAccount.firstName} ${userAccount.lastName}\n\nПароль успешно создан.\n\nВаш пароль, связанный с адресом ${userAccount.emailAddress}\nсоздан.\n\nСпасибо."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "password_created_email_plain_text" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "password_created_email_plain_text" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:already_logged_in.Vitro
+uil-data:already_logged_in.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Вы уже вошли."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "already_logged_in" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "already_logged_in" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:supply_class_group.Vitro
+uil-data:supply_class_group.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Следует задать группу классов."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "supply_class_group" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "supply_class_group" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:matching_prop_not_defined.Vitro
+uil-data:matching_prop_not_defined.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "соответствующее свойство не определено"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "matching_prop_not_defined" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "matching_prop_not_defined" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:display_rank.Vitro
+uil-data:display_rank.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ранг отображения"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "display_rank" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "display_rank" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:profile_editing_title.Vitro
+uil-data:profile_editing_title.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Редакторы, выбранные вами в левом окошке, будут иметь возможность редактировать профили VIVO, выбранные вами в правом окошке. Вы можете выбрать несколько редакторов и несколько профилей, но по крайней мере по одному в каждом окне выбрать необходимо."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "profile_editing_title" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "profile_editing_title" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:test_for_nonlogged_in_users.Vitro
+uil-data:test_for_nonlogged_in_users.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Это пробный виджет для неавторизованных пользователей."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "test_for_nonlogged_in_users" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "test_for_nonlogged_in_users" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:insufficient_authorization.Vitro
+uil-data:insufficient_authorization.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Извините, но Вам не разрешено просматривать запрашиваемую страницу. Если Вы считаете, что это ошибка, пожалуйста, свяжитесь с нами, и мы будем рады помочь."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "insufficient_authorization" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "insufficient_authorization" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:supply_content_type.Vitro
+uil-data:supply_content_type.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Вам необходимо указать тип содержимого"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "supply_content_type" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "supply_content_type" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:back_to_results.Vitro
+uil-data:back_to_results.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Назад к результатам поиска"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "back_to_results" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "back_to_results" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:may_not_edit.Vitro
+uil-data:may_not_edit.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Не разрешается редактировать"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "may_not_edit" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "may_not_edit" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:four_digit_year.Vitro
+uil-data:four_digit_year.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Неверный ввод. Пожалуйста, введите год как четырёхзначное число."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "four_digit_year" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "four_digit_year" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:browse_page_javascript_two.Vitro
+uil-data:browse_page_javascript_two.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "для просмотра информации."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "browse_page_javascript_two" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "browse_page_javascript_two" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:password_created_email_html_text.Vitro
+uil-data:password_created_email_html_text.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "<p> ${userAccount.firstName} ${userAccount.lastName}</p>\n\n <p> <strong>Пароль успешно создан.</strong></p>\n\n <p>Ваш пароль, связанный с адресом ${userAccount.emailAddress} создан.</p>\n\n <p>Спасибо.</p>"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "password_created_email_html_text" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "password_created_email_html_text" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:current_photo.Vitro
+uil-data:current_photo.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Актуальное фото"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "current_photo" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "current_photo" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_last_name.Vitro
+uil-data:select_last_name.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Выберите существующую фамилию"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_last_name" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_last_name" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:supply_template.Vitro
+uil-data:supply_template.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Следует задать шаблон"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "supply_template" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "supply_template" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:view_all_accounts_title.Vitro
+uil-data:view_all_accounts_title.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "просмотреть все учетные записи"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "view_all_accounts_title" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "view_all_accounts_title" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:cropping_note.Vitro
+uil-data:cropping_note.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Фотографию справа можно двигать и корректировать её размер. Когда вы будете удовлетворены результатом, нажмите кнопку \"Сохранить фото\"."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "cropping_note" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "cropping_note" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:page_not_created.Vitro
+uil-data:page_not_created.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Не удалось создать страницу"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "page_not_created" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "page_not_created" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_email_already_exists.Vitro
+uil-data:error_email_already_exists.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Учетная запись с таким адресом электронной почты уже существует."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_email_already_exists" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_email_already_exists" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:required_field_empty_msg.Vitro
+uil-data:required_field_empty_msg.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Это поле не может быть оставлено пустым."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "required_field_empty_msg" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "required_field_empty_msg" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:site_maintenance.Vitro
+uil-data:site_maintenance.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Техническое обслуживание сайта"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "site_maintenance" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "site_maintenance" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:current_date_time.Vitro
+uil-data:current_date_time.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Текущая дата и время:"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "current_date_time" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "current_date_time" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:page_link.Vitro
+uil-data:page_link.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ссылка на страницу"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "page_link" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "page_link" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:object_property_hierarchy.Vitro
+uil-data:object_property_hierarchy.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Иерархия свойств объектов"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "object_property_hierarchy" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "object_property_hierarchy" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:user_accounts.Vitro
+uil-data:user_accounts.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Учётные записи пользователей"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "user_accounts" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "user_accounts" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:maximum_file_size.Vitro
+uil-data:maximum_file_size.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Максимальный размер файла: {0} мегабайт"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "maximum_file_size" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "maximum_file_size" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:add_new_account.Vitro
+uil-data:add_new_account.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Добавить учетную запись"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "add_new_account" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "add_new_account" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:browse_all_starts_with.Vitro
+uil-data:browse_all_starts_with.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Просмотреть всех людей, чье имя начинается с {0}"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "browse_all_starts_with" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "browse_all_starts_with" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:status.Vitro
+uil-data:status.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Статус"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "status" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "status" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:index.Vitro
+uil-data:index.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Каталог"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "index" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "index" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:verify_this_match_title.Vitro
+uil-data:verify_this_match_title.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "проверить это соответствие"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "verify_this_match_title" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "verify_this_match_title" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:search_indexer_idle.Vitro
+uil-data:search_indexer_idle.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Индексатор поиска простаивает."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "search_indexer_idle" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "search_indexer_idle" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:start_capitalized.Vitro
+uil-data:start_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Начало, "@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "start_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "start_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:minimum_cardinality.Vitro
+uil-data:minimum_cardinality.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "наименьшая значимость"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "minimum_cardinality" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "minimum_cardinality" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:manage_affiliated_people_link.Vitro
+uil-data:manage_affiliated_people_link.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "управление аффилированными лицами"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "manage_affiliated_people_link" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "manage_affiliated_people_link" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:initial_password.Vitro
+uil-data:initial_password.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Начальный пароль"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "initial_password" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "initial_password" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:invalid_format.Vitro
+uil-data:invalid_format.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Недопустимый формат"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "invalid_format" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "invalid_format" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:menu_orering.Vitro
+uil-data:menu_orering.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "„Упорядочивание меню“"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "menu_orering" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "menu_orering" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:confirm_entry_deletion_from.Vitro
+uil-data:confirm_entry_deletion_from.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Вы уверены, что хотите удалить следующую запись из"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "confirm_entry_deletion_from" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "confirm_entry_deletion_from" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:add_types.Vitro
+uil-data:add_types.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Добавьте один или несколько типов"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "add_types" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "add_types" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:group_capitalized.Vitro
+uil-data:group_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Группа"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "group_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "group_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:entry.Vitro
+uil-data:entry.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "запись"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "entry" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "entry" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:search_vitro.Vitro
+uil-data:search_vitro.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Поиск в VITRO"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "search_vitro" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "search_vitro" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:version.Vitro
+uil-data:version.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Версия"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "version" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "version" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:hide_subclasses.Vitro
+uil-data:hide_subclasses.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "скрыть подклассы"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "hide_subclasses" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "hide_subclasses" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:caused_by.Vitro
+uil-data:caused_by.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Вызвана"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "caused_by" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "caused_by" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:show_more_content.Vitro
+uil-data:show_more_content.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "показать больше содержимого"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "show_more_content" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "show_more_content" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:advanced_search_tip_six.Vitro
+uil-data:advanced_search_tip_six.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Поиск использует сокращенные версии слов, например, поиск по поиск по запросу <i>когнити*</i> не даст ничего, в то время, как запрос <i>когнит*</i> найдёт и <i>когнитивный</i> and <i>когнитариат</i>."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "advanced_search_tip_six" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "advanced_search_tip_six" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:myAccount_confirm_changes_plus_note.Vitro
+uil-data:myAccount_confirm_changes_plus_note.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ваши изменения были сохранены. На адрес {0} было отправлено письмо с подтверждением."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "myAccount_confirm_changes_plus_note" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "myAccount_confirm_changes_plus_note" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:class_management.Vitro
+uil-data:class_management.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Управение классами"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "class_management" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "class_management" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:display_less.Vitro
+uil-data:display_less.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "показать меньше"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "display_less" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "display_less" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:add_property_group.Vitro
+uil-data:add_property_group.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Добавить новую группу свойств"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "add_property_group" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "add_property_group" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:browse_by.Vitro
+uil-data:browse_by.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Просматривать "@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "browse_by" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "browse_by" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:class_group_link.Vitro
+uil-data:class_group_link.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "ссылка на группу классов"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "class_group_link" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "class_group_link" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:confirm_password.Vitro
+uil-data:confirm_password.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Подтвердите новый пароль"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "confirm_password" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "confirm_password" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:saturday.Vitro
+uil-data:saturday.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "суббота"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "saturday" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "saturday" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:_publications_link.Vitro
+uil-data:_publications_link.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "_publications_link" ;
-        prop:hasPackage  "Vitro-languages" .
+        rdf:type         uil:UILabel ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "_publications_link" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:javascript_require_to_edit.Vitro
+uil-data:javascript_require_to_edit.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Для редактирования необходимо разрешить JavaScript."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "javascript_require_to_edit" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "javascript_require_to_edit" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:fatal_error_detected.Vitro
+uil-data:fatal_error_detected.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "{0} обнаружена фатальная ошибка во время запуска."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "fatal_error_detected" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "fatal_error_detected" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:menu_page.Vitro
+uil-data:menu_page.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Страница меню"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "menu_page" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "menu_page" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:create_new_individual_of_the_following_type.Vitro
+uil-data:create_new_individual_of_the_following_type.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Создание объекта следующего типа"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "create_new_individual_of_the_following_type" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "create_new_individual_of_the_following_type" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:logins_not_already_restricted.Vitro
+uil-data:logins_not_already_restricted.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Вход в систему уже не ограничен."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "logins_not_already_restricted" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "logins_not_already_restricted" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:stack_trace.Vitro
+uil-data:stack_trace.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Трассировка стека"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "stack_trace" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "stack_trace" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:confirm_page_deletion.Vitro
+uil-data:confirm_page_deletion.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Вы уверены, что хотите удалить эту страницу:"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "confirm_page_deletion" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "confirm_page_deletion" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_locale.Vitro
+uil-data:select_locale.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "выбраррррегиональные настройки"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_locale" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_locale" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:reset_password.Vitro
+uil-data:reset_password.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Сбросить пароль"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "reset_password" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "reset_password" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:vitro_bullet_two.Vitro
+uil-data:vitro_bullet_two.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Редактировать экземпляры и отношения"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "vitro_bullet_two" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "vitro_bullet_two" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:replace_page_title.Vitro
+uil-data:replace_page_title.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Заменить изображение"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "replace_page_title" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "replace_page_title" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:subproperty.Vitro
+uil-data:subproperty.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "подсвойство"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "subproperty" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "subproperty" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:rdf_export.Vitro
+uil-data:rdf_export.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Экспортировать данные в формате RDF"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "rdf_export" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "rdf_export" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:click_to_view_larger.Vitro
+uil-data:click_to_view_larger.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "нажмите для просмотра увеличенного изображения"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "click_to_view_larger" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "click_to_view_larger" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:build_date.Vitro
+uil-data:build_date.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Дата сборки"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "build_date" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "build_date" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:flags.Vitro
+uil-data:flags.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Флаги"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "flags" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "flags" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:march.Vitro
+uil-data:march.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "март"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "march" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "march" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:display_only.Vitro
+uil-data:display_only.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Показывать только"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "display_only" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "display_only" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:to_manage_content.Vitro
+uil-data:to_manage_content.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "чтобы менять информацию."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "to_manage_content" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "to_manage_content" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:acct_created_email_html_text.Vitro
+uil-data:acct_created_email_html_text.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "<p>${userAccount.firstName} ${userAccount.lastName}</p>\n\n <p><strong>Поздравляем!</strong></p>\n\n <p>Мы создали новую учётную запись на сайте ${siteName}, связанную с адресом ${userAccount.emailAddress}.</p>\n\n <p>\n Если Вы не запрашивали новую учётную запись, то можете смело игнорировать это письмо. \n Срок действия этого запроса истечет, если не предпринять никаких действий в течение 30 дней.\n </p>\n\n <p>\n Нажмите на ссылку ниже, чтобы создать пароль для новой учетной записи.\n </p>\n\n <p>\n <a href=\"${passwordLink}\" title=\"создание пароля для учётной записи\">${passwordLink}</a>\n </p>\n\n <p>\n Если ссылка выше не работает, Вы можете скопировать и вставить ссылку прямо в адресную строку браузера.\n </p>\n\n <p>Спасибо!</p>"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "acct_created_email_html_text" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "acct_created_email_html_text" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:file_upload_confirm_delete.Vitro
+uil-data:file_upload_confirm_delete.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "file_upload_confirm_delete" ;
-        prop:hasPackage  "Vitro-languages" .
+        rdf:type         uil:UILabel ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "file_upload_confirm_delete" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:cropping_caption.Vitro
+uil-data:cropping_caption.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Фотография в Вашем профиле будет выглядеть так, как показано ниже."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "cropping_caption" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "cropping_caption" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:browse_capitalized.Vitro
+uil-data:browse_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Просматривать"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "browse_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "browse_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:display_options.Vitro
+uil-data:display_options.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Варианты отображения"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "display_options" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "display_options" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:site_config.Vitro
+uil-data:site_config.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Настройка сайта"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "site_config" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "site_config" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:undo_camelcasing.Vitro
+uil-data:undo_camelcasing.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Убрать ВерблюжийРегистр"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "undo_camelcasing" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "undo_camelcasing" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:view_all_capitalized.Vitro
+uil-data:view_all_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Посмотреть все"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "view_all_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "view_all_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_processing_labels.Vitro
+uil-data:error_processing_labels.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ошибка при обработке запроса: не отмеченные метки не могут быть удалены."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_processing_labels" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_processing_labels" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:dates.Vitro
+uil-data:dates.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Даты"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "dates" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "dates" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:myAccount_heading.Vitro
+uil-data:myAccount_heading.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Моя учетная запись"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "myAccount_heading" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "myAccount_heading" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:roles.Vitro
+uil-data:roles.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Роли"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "roles" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "roles" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:april.Vitro
+uil-data:april.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "апрель"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "april" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "april" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:password_reset_pending_subject.Vitro
+uil-data:password_reset_pending_subject.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "{0} запрос на сброс пароля"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "password_reset_pending_subject" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "password_reset_pending_subject" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:some_values_from.Vitro
+uil-data:some_values_from.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "некоторые значения из"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "some_values_from" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "some_values_from" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:browse_all_public_content.Vitro
+uil-data:browse_all_public_content.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Вы можете просматривать всю общедоступную информацию в данной системе при помощи"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "browse_all_public_content" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "browse_all_public_content" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:all_values_from.Vitro
+uil-data:all_values_from.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "все значения из"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "all_values_from" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "all_values_from" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:updated_account_2.Vitro
+uil-data:updated_account_2.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       " обновлена."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "updated_account_2" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "updated_account_2" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:alt_error_alert.Vitro
+uil-data:alt_error_alert.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Значок оповещения об ошибке"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "alt_error_alert" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "alt_error_alert" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:year_month.Vitro
+uil-data:year_month.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Неверный ввод. Пожалуйста, введите год и месяц."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "year_month" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "year_month" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:name.Vitro
+uil-data:name.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "имя"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "name" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "name" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:no_image.Vitro
+uil-data:no_image.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "изображение отсутствует"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "no_image" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "no_image" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:sparql_query_save_results.Vitro
+uil-data:sparql_query_save_results.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Сохранить результаты в файл"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "sparql_query_save_results" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "sparql_query_save_results" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:add_new_group.Vitro
+uil-data:add_new_group.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Добавить новую группу"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "add_new_group" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "add_new_group" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:browse_all.Vitro
+uil-data:browse_all.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Просмотреть все"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "browse_all" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "browse_all" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:processing_icon.Vitro
+uil-data:processing_icon.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "в обработке"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "processing_icon" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "processing_icon" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:logins_restricted.Vitro
+uil-data:logins_restricted.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Вход в систему теперь ограничен."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "logins_restricted" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "logins_restricted" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:search_tip_four.Vitro
+uil-data:search_tip_four.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Если вы не уверены в правильности написания, добавьте знак ~ в конце поискового запроса, например запрос <i>морков~</i> отыщет <i>морковь</i>, а по запросу <i>степан~</i> будет найдено и <i>Степун</i>, и <i>Стефан</i> (а также и другие похожие имена)."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "search_tip_four" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "search_tip_four" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:imageUpload.errorNoURI.Vitro
+uil-data:imageUpload.errorNoURI.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Не задан URI объекта"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "imageUpload.errorNoURI" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "imageUpload.errorNoURI" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:password_saved_please_login.Vitro
+uil-data:password_saved_please_login.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ваш пароль был сохранен. Пожалуйста, войдите в систему."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "password_saved_please_login" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "password_saved_please_login" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:upload_photo.Vitro
+uil-data:upload_photo.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Загрузить фото"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "upload_photo" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "upload_photo" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:sparql_query_results.Vitro
+uil-data:sparql_query_results.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Результаты запроса Sparql"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "sparql_query_results" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "sparql_query_results" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:enter_new_password.Vitro
+uil-data:enter_new_password.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Пожалуйста, введите новый пароль для {0}"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "enter_new_password" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "enter_new_password" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:display_more_ellipsis.Vitro
+uil-data:display_more_ellipsis.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "... ещё"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "display_more_ellipsis" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "display_more_ellipsis" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:updated_account_1.Vitro
+uil-data:updated_account_1.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Учётная запись "@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "updated_account_1" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "updated_account_1" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:add_page.Vitro
+uil-data:add_page.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Добавить страницу"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "add_page" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "add_page" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:list_elements_of.Vitro
+uil-data:list_elements_of.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Перечислить элементы списка"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "list_elements_of" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "list_elements_of" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:class_group_all_caps.Vitro
+uil-data:class_group_all_caps.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Группа классов"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "class_group_all_caps" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "class_group_all_caps" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:no_class_restrictions.Vitro
+uil-data:no_class_restrictions.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Не найдено классов с ограничением на задание данного отношения."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "no_class_restrictions" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "no_class_restrictions" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:refresh_page_after_reordering.Vitro
+uil-data:refresh_page_after_reordering.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Обновите страницу после изменения порядка следования пунктов меню"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "refresh_page_after_reordering" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "refresh_page_after_reordering" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:asserted_class_hierarchy.Vitro
+uil-data:asserted_class_hierarchy.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Иерархия утверждаемых классов"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "asserted_class_hierarchy" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "asserted_class_hierarchy" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:page_admin_permission_option.Vitro
+uil-data:page_admin_permission_option.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Эту страницу могут просматривать только администраторы"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "page_admin_permission_option" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "page_admin_permission_option" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:create_associated_profile.Vitro
+uil-data:create_associated_profile.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Создать связанный профиль"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "create_associated_profile" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "create_associated_profile" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:password_reset_complete_email_html_text.Vitro
+uil-data:password_reset_complete_email_html_text.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "<p> ${userAccount.firstName} ${userAccount.lastName}</p>\n\n <p><strong>Пароль успешно изменён.</strong></p>\n\n <p>Ваш пароль, связанный с адресом ${userAccount.emailAddress} изменён.</p>\n\n <p>Спасибо.</p>"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "password_reset_complete_email_html_text" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "password_reset_complete_email_html_text" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:first_time_external_email_html_text.Vitro
+uil-data:first_time_external_email_html_text.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "<p>${userAccount.firstName} ${userAccount.lastName}</p>\n\n <p><strong>Поздравляем!</strong></p>\n\n <p>Мы создали Вашу новую учётную запись VIVO, связанную с почтовым адресом ${userAccount.emailAddress}.</p>\n\n <p>Спасибо!</p>"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "first_time_external_email_html_text" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "first_time_external_email_html_text" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:default.Vitro
+uil-data:default.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Стандартный"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "default" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "default" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_password_mismatch.Vitro
+uil-data:error_password_mismatch.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Пароли не совпадают."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_password_mismatch" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_password_mismatch" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:and.Vitro
+uil-data:and.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "и"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "and" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "and" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:no_matching_results.Vitro
+uil-data:no_matching_results.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Не найдено подходящих результатов."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "no_matching_results" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "no_matching_results" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:internal_class_i_capped.Vitro
+uil-data:internal_class_i_capped.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "​﻿​﻿​Собственный класс для учреждения"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "internal_class_i_capped" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "internal_class_i_capped" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:decimal_only.Vitro
+uil-data:decimal_only.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Неверный ввод.  Десятичная точка разрешена, а разделители тысяч - нет."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "decimal_only" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "decimal_only" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:new_account_2.Vitro
+uil-data:new_account_2.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "успешно создана."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "new_account_2" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "new_account_2" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:listed_page_title.Vitro
+uil-data:listed_page_title.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "заголовок указанной страницы"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "listed_page_title" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "listed_page_title" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:delete_profile_editor.Vitro
+uil-data:delete_profile_editor.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Удалить профиль"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "delete_profile_editor" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "delete_profile_editor" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_no_first_name.Vitro
+uil-data:error_no_first_name.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Следует указать имя."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_no_first_name" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_no_first_name" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:browse_all_in_class.Vitro
+uil-data:browse_all_in_class.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Просмотреть всех лиц в этом классе"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "browse_all_in_class" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "browse_all_in_class" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:save_entry.Vitro
+uil-data:save_entry.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Сохранить запись"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "save_entry" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "save_entry" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:confirm_initial_password.Vitro
+uil-data:confirm_initial_password.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Подтвердите начальный пароль"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "confirm_initial_password" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "confirm_initial_password" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:ingest_tools.Vitro
+uil-data:ingest_tools.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Инструменты для ввода данных"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "ingest_tools" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "ingest_tools" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:application_error_email_html_text.Vitro
+uil-data:application_error_email_html_text.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "<p>В ${datetime!} на сайте ${siteName!} произошла ошибка \n </p>\n\n <p>\n <strong>Запрашиваемый url:</strong> ${requestedUrl!}\n </p>\n\n <p>\n <#if errorMessage?has_content>\n <strong>Сообщение об ошибке:</strong> ${errorMessage!}\n </#if>\n </p>\n\n <p>\n <strong>Трассировка стека</strong> (полная трассировка стека находится в лог файлах сервера приложений):\n <pre>${stackTrace!}</pre>\n </p>\n\n <#if cause?has_content>\n <p><strong>Причина:</strong>\n <pre>${cause!}</pre>\n </p>\n </#if>"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "application_error_email_html_text" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "application_error_email_html_text" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:log_in.Vitro
+uil-data:log_in.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "войдите"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "log_in" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "log_in" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:new_account_1.Vitro
+uil-data:new_account_1.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Новая учётная запись для"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "new_account_1" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "new_account_1" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:imageUpload.errorUnrecognizedFileType.Vitro
+uil-data:imageUpload.errorUnrecognizedFileType.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "''{0}'' не является поддерживаемым типом файла изображения. Пожалуйста, загружайте только файлы JPEG, GIF или PNG."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "imageUpload.errorUnrecognizedFileType" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "imageUpload.errorUnrecognizedFileType" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:replace_page_title_with_name.Vitro
+uil-data:replace_page_title_with_name.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Заменить изображение для {0}"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "replace_page_title_with_name" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "replace_page_title_with_name" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:unsupported_ie_version.Vitro
+uil-data:unsupported_ie_version.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Эта форма не поддерживается в версиях Internet Explorer ниже версии 8. Пожалуйста, обновите свой браузер или перейдите на другой браузер, например FireFox."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "unsupported_ie_version" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "unsupported_ie_version" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:logins_are_restricted.Vitro
+uil-data:logins_are_restricted.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Вход в систему ограничен."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "logins_are_restricted" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "logins_are_restricted" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:add_profile_editor.Vitro
+uil-data:add_profile_editor.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Добавьте редактора профиля"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "add_profile_editor" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "add_profile_editor" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:supply_name.Vitro
+uil-data:supply_name.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Надо задать заглавие"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "supply_name" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "supply_name" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:feedback_thanks_text.Vitro
+uil-data:feedback_thanks_text.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Благодарим вас за обращение к нашей команде кураторов и разработчиков. Мы ответим на ваш запрос при первой возможности."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "feedback_thanks_text" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "feedback_thanks_text" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_class_for_search.Vitro
+uil-data:select_class_for_search.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Чтобы отобразить его экземпляры класса, следует выбрать класс."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_class_for_search" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_class_for_search" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:since_elapsed_time.Vitro
+uil-data:since_elapsed_time.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "с {0}, прошло времени {1}"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "since_elapsed_time" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "since_elapsed_time" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:unknown_user_name.Vitro
+uil-data:unknown_user_name.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "фрэнд"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "unknown_user_name" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "unknown_user_name" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:faux_property_capitalized.Vitro
+uil-data:faux_property_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Номинальное свойство"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "faux_property_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "faux_property_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:enter_value_name_field.Vitro
+uil-data:enter_value_name_field.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Пожалуйста введите значение в поле названия."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "enter_value_name_field" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "enter_value_name_field" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:group_name.Vitro
+uil-data:group_name.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "название группы"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "group_name" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "group_name" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:data_property_hierarchy.Vitro
+uil-data:data_property_hierarchy.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Иерархия свойств данных"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "data_property_hierarchy" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "data_property_hierarchy" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:external_login_text.Vitro
+uil-data:external_login_text.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Вход с помощью сервиса внешней аутентификации"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "external_login_text" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "external_login_text" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:imageUpload.errorFileTooBig.Vitro
+uil-data:imageUpload.errorFileTooBig.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Пожалуйста, загрузите изображение размером менее {0} мегабайт."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "imageUpload.errorFileTooBig" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "imageUpload.errorFileTooBig" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:profile_editors.Vitro
+uil-data:profile_editors.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Редакторы профилей"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "profile_editors" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "profile_editors" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:implement_capitalized.Vitro
+uil-data:implement_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Внедрить"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "implement_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "implement_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:sparql_query_header.Vitro
+uil-data:sparql_query_header.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Запрос"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "sparql_query_header" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "sparql_query_header" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:view.Vitro
+uil-data:view.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "вид"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "view" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "view" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:manage_profile_editing.Vitro
+uil-data:manage_profile_editing.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Управление редактированием профиля"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "manage_profile_editing" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "manage_profile_editing" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:minimum_image_dimensions.Vitro
+uil-data:minimum_image_dimensions.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Минимальные размеры изображения: {0} x {1} пикселей"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "minimum_image_dimensions" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "minimum_image_dimensions" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:view_list_in_rdf.Vitro
+uil-data:view_list_in_rdf.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Показать список {0} в формате RDF"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "view_list_in_rdf" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "view_list_in_rdf" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:more_details_about_site.Vitro
+uil-data:more_details_about_site.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Больше информации об этом сайте"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "more_details_about_site" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "more_details_about_site" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:new_entry_for.Vitro
+uil-data:new_entry_for.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "\"{0}\" для {1}"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "new_entry_for" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "new_entry_for" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:july.Vitro
+uil-data:july.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "июль"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "july" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "july" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:page_uri.Vitro
+uil-data:page_uri.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "URI страницы"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "page_uri" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "page_uri" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:edit_date_time_value.Vitro
+uil-data:edit_date_time_value.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Обновить значение даты/времени"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "edit_date_time_value" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "edit_date_time_value" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:limited_to_type.Vitro
+uil-data:limited_to_type.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       " ограничены по типу объектов"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "limited_to_type" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "limited_to_type" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:class_name.Vitro
+uil-data:class_name.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "имя класса"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "class_name" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "class_name" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:create_date_time_value.Vitro
+uil-data:create_date_time_value.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Создать значение даты/времени"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "create_date_time_value" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "create_date_time_value" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:there_are_no_entries_for_selection.Vitro
+uil-data:there_are_no_entries_for_selection.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "В системе нет записей, из которых можно было бы выбрать."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "there_are_no_entries_for_selection" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "there_are_no_entries_for_selection" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:edit_this_individual.Vitro
+uil-data:edit_this_individual.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Редактировать данные этого лица"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "edit_this_individual" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "edit_this_individual" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:start_interval_must_precede_end_earlier.Vitro
+uil-data:start_interval_must_precede_end_earlier.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Дата и время начала должны прешествовать дате и времени окончания."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "start_interval_must_precede_end_earlier" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "start_interval_must_precede_end_earlier" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:type_capitalized.Vitro
+uil-data:type_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Тип"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "type_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "type_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:selected.Vitro
+uil-data:selected.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Выбранное"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "selected" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "selected" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:submit_upload.Vitro
+uil-data:submit_upload.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Загрузить фото"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "submit_upload" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "submit_upload" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:confirm_individual_deletion.Vitro
+uil-data:confirm_individual_deletion.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "confirm_individual_deletion" ;
-        prop:hasPackage  "Vitro-languages" .
+        rdf:type         uil:UILabel ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "confirm_individual_deletion" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:september.Vitro
+uil-data:september.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "сентябрь"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "september" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "september" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:verbose_turn_off.Vitro
+uil-data:verbose_turn_off.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Скрыть подробности"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "verbose_turn_off" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "verbose_turn_off" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_type.Vitro
+uil-data:select_type.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Выберите вид"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_type" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_type" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:comments_questions.Vitro
+uil-data:comments_questions.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Комментарии, вопросы или предложения"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "comments_questions" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "comments_questions" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:send_mail.Vitro
+uil-data:send_mail.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Отправить письмо "@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "send_mail" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "send_mail" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:change_profile.Vitro
+uil-data:change_profile.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "изменить профиль"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "change_profile" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "change_profile" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:logins_already_restricted.Vitro
+uil-data:logins_already_restricted.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Вход в систему уже ограничен."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "logins_already_restricted" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "logins_already_restricted" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:photo_types.Vitro
+uil-data:photo_types.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "(JPEG, GIF или PNG)"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "photo_types" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "photo_types" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:search_term_error_near.Vitro
+uil-data:search_term_error_near.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Поисковый запрос содержал ошибку рядом с"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "search_term_error_near" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "search_term_error_near" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:share_profile_uri.Vitro
+uil-data:share_profile_uri.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "поделиться URI этой схемы"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "share_profile_uri" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "share_profile_uri" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:no_html_specified.Vitro
+uil-data:no_html_specified.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "HTML не задан."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "no_html_specified" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "no_html_specified" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:first_name.Vitro
+uil-data:first_name.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Имя"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "first_name" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "first_name" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:class_link.Vitro
+uil-data:class_link.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "ссылка на класс"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "class_link" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "class_link" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:view_profile_page_for.Vitro
+uil-data:view_profile_page_for.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Просмотр страницы профиля для"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "view_profile_page_for" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "view_profile_page_for" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_classes_to_display.Vitro
+uil-data:select_classes_to_display.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Следует выбрать классы для отображения."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_classes_to_display" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_classes_to_display" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:password_mismatch.Vitro
+uil-data:password_mismatch.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Пароли не совпадают."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "password_mismatch" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "password_mismatch" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:page_management.Vitro
+uil-data:page_management.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Управление страницей"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "page_management" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "page_management" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:resource_uri.Vitro
+uil-data:resource_uri.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "URI ресурса"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "resource_uri" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "resource_uri" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:sparql_query_run_query.Vitro
+uil-data:sparql_query_run_query.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Выполнить запрос"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "sparql_query_run_query" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "sparql_query_run_query" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:enter_fixed_html_here.Vitro
+uil-data:enter_fixed_html_here.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Здесь можно ввести статический HTML-код"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "enter_fixed_html_here" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "enter_fixed_html_here" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:verify_this_match.Vitro
+uil-data:verify_this_match.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "проверить это соответствие"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "verify_this_match" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "verify_this_match" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:properties_capitalized.Vitro
+uil-data:properties_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Свойства"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "properties_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "properties_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:raw_string_literals.Vitro
+uil-data:raw_string_literals.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Литералы необработанных строк"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "raw_string_literals" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "raw_string_literals" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:no_content_create_groups_classes.Vitro
+uil-data:no_content_create_groups_classes.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "В системе пока не найдено содержимое или необходимо создать группу классов и назначить ей классы."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "no_content_create_groups_classes" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "no_content_create_groups_classes" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:home_page.Vitro
+uil-data:home_page.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "главную страницу"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "home_page" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "home_page" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:restriction_on.Vitro
+uil-data:restriction_on.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "ограничения на"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "restriction_on" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "restriction_on" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:processing_indicator.Vitro
+uil-data:processing_indicator.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "индикатор времени обработки"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "processing_indicator" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "processing_indicator" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:selected_page_content_type.Vitro
+uil-data:selected_page_content_type.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Выбранный тип содержимого для связанной страницы"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "selected_page_content_type" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "selected_page_content_type" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:create_entry.Vitro
+uil-data:create_entry.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Создать запись"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "create_entry" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "create_entry" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:password_change_not_pending.Vitro
+uil-data:password_change_not_pending.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Пароль для {0} уже был сброшен."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "password_change_not_pending" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "password_change_not_pending" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:javascript_instructions.Vitro
+uil-data:javascript_instructions.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "инструкции по java script"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "javascript_instructions" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "javascript_instructions" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_invalid_email.Vitro
+uil-data:error_invalid_email.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "''{0}'' не является действительным адресом электронной почты."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_invalid_email" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_invalid_email" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:new_pwd_matches_existing.Vitro
+uil-data:new_pwd_matches_existing.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ваш новый пароль должен отличаться от действующего пароля."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "new_pwd_matches_existing" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "new_pwd_matches_existing" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:or.Vitro
+uil-data:or.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "или"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "or" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "or" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:search_form.Vitro
+uil-data:search_form.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Поисковая форма"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "search_form" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "search_form" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:menu_item_name.Vitro
+uil-data:menu_item_name.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Название пункта меню"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "menu_item_name" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "menu_item_name" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:june.Vitro
+uil-data:june.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "июнь"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "june" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "june" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:last_name.Vitro
+uil-data:last_name.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Фамилия"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "last_name" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "last_name" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:placeholder_image.Vitro
+uil-data:placeholder_image.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "стандартное изображение"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "placeholder_image" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "placeholder_image" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:requested_url.Vitro
+uil-data:requested_url.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Запрашиваемый url"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "requested_url" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "requested_url" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:first_time_login_note.Vitro
+uil-data:first_time_login_note.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Примечание: На указанный выше адрес будет отправлено электронное письмо с уведомлением о создании учетной записи."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "first_time_login_note" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "first_time_login_note" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_external_auth_already_exists.Vitro
+uil-data:error_external_auth_already_exists.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Учетная запись с таким идентификатором внешней авторизации уже существует."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_external_auth_already_exists" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_external_auth_already_exists" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:contains_no_pears.Vitro
+uil-data:contains_no_pears.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Не содержит груш"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "contains_no_pears" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "contains_no_pears" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:index_page.Vitro
+uil-data:index_page.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "страницы каталога"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "index_page" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "index_page" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:search_tip_one.Vitro
+uil-data:search_tip_one.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Будьте проще! Используйте короткие, односложные термины, если только поиск не дает слишком много результатов."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "search_tip_one" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "search_tip_one" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:sparql_query_construct_describe_results.Vitro
+uil-data:sparql_query_construct_describe_results.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Формат результатов запросов CONSTRUCT и DESCRIBE"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "sparql_query_construct_describe_results" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "sparql_query_construct_describe_results" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:password_capitalized.Vitro
+uil-data:password_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Пароль"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "password_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "password_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:file_upload_submit_label.Vitro
+uil-data:file_upload_submit_label.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "file_upload_submit_label" ;
-        prop:hasPackage  "Vitro-languages" .
+        rdf:type         uil:UILabel ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "file_upload_submit_label" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:please.Vitro
+uil-data:please.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Пожалуйста"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "please" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "please" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:account_created.Vitro
+uil-data:account_created.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ваша учетная запись {0} была создана."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "account_created" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "account_created" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:add.Vitro
+uil-data:add.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "добавить"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "add" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "add" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:limit.Vitro
+uil-data:limit.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ограничить"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "limit" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "limit" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:november.Vitro
+uil-data:november.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "ноябрь"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "november" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "november" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:confirm_delete.Vitro
+uil-data:confirm_delete.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Вы точно хотите удалить эту фотографию?"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "confirm_delete" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "confirm_delete" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:login_welcome_message.Vitro
+uil-data:login_welcome_message.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Добро пожаловать, {0}"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "login_welcome_message" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "login_welcome_message" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:password_changed_subject.Vitro
+uil-data:password_changed_subject.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Пароль изменен."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "password_changed_subject" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "password_changed_subject" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:incorrect_email_password.Vitro
+uil-data:incorrect_email_password.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Адрес электронной почты или пароль неверны."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "incorrect_email_password" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "incorrect_email_password" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:identifiers.Vitro
+uil-data:identifiers.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Идентификаторы"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "identifiers" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "identifiers" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:javascript_ie_alert_text.Vitro
+uil-data:javascript_ie_alert_text.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "На этом сайте используются элементы HTML, которые не распознаются Internet Explorer 8 и ниже в отсутствие JavaScript. В результате сайт не будет отображаться должным образом. Чтобы исправить ситуацию, пожалуйста, включите JavaScript, перейдите на Internet Explorer 9 или используйте другой браузер."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "javascript_ie_alert_text" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "javascript_ie_alert_text" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:zoo_two.Vitro
+uil-data:zoo_two.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Зверинец 2"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "zoo_two" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "zoo_two" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:verbose_turn_on.Vitro
+uil-data:verbose_turn_on.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Включить"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "verbose_turn_on" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "verbose_turn_on" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:selection_in_process.Vitro
+uil-data:selection_in_process.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Идёт обработка выбранной вами информации."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "selection_in_process" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "selection_in_process" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:please_create.Vitro
+uil-data:please_create.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Пожалуйста создайте"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "please_create" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "please_create" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:verbose_status_off.Vitro
+uil-data:verbose_status_off.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "отключено"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "verbose_status_off" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "verbose_status_off" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:page_not_configured.Vitro
+uil-data:page_not_configured.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Эта страница еще не настроена."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "page_not_configured" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "page_not_configured" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:new_account_notification.Vitro
+uil-data:new_account_notification.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "На адрес {0} было отправлено письмо с инструкциями по активации учетной записи и созданию пароля."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "new_account_notification" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "new_account_notification" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:full_list_startup.Vitro
+uil-data:full_list_startup.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Полный список стартовых событий и сообщений."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "full_list_startup" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "full_list_startup" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:user_role.Vitro
+uil-data:user_role.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Роль"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "user_role" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "user_role" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:or_enter_valid_address.Vitro
+uil-data:or_enter_valid_address.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "или введите другой полный и действительный адрес электронной почты."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "or_enter_valid_address" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "or_enter_valid_address" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:all.Vitro
+uil-data:all.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "все"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "all" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "all" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:logged_in_but_no_profile.Vitro
+uil-data:logged_in_but_no_profile.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Вы вошли в систему, но в системе нет вашего профиля."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "logged_in_but_no_profile" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "logged_in_but_no_profile" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:page_text.Vitro
+uil-data:page_text.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "текст страницы"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "page_text" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "page_text" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:create_new_entry.Vitro
+uil-data:create_new_entry.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Пожалуйста, создайте новую запись."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "create_new_entry" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "create_new_entry" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:enter_in_security_field.Vitro
+uil-data:enter_in_security_field.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Пожалуйста, введите показанные ниже буквы в поле безопасности "@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "enter_in_security_field" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "enter_in_security_field" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_an_existing_or_create_a_new_one.Vitro
+uil-data:select_an_existing_or_create_a_new_one.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Выберите существующий или создайте новый"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_an_existing_or_create_a_new_one" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_an_existing_or_create_a_new_one" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:not.Vitro
+uil-data:not.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "не"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "not" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "not" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:range_data_type.Vitro
+uil-data:range_data_type.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Тип данных Диапазон"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "range_data_type" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "range_data_type" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:august.Vitro
+uil-data:august.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "август"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "august" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "august" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:terms_of_use.Vitro
+uil-data:terms_of_use.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Условия использования"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "terms_of_use" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "terms_of_use" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:dump_restore.Vitro
+uil-data:dump_restore.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Сброс/восстановление приложения"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "dump_restore" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "dump_restore" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:show_properties.Vitro
+uil-data:show_properties.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "показать свойства"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "show_properties" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "show_properties" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:associated_individuals.Vitro
+uil-data:associated_individuals.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Связанные персоны"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "associated_individuals" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "associated_individuals" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:name_capitalized.Vitro
+uil-data:name_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Название"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "name_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "name_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:manage_labels.Vitro
+uil-data:manage_labels.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "управлять метками"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "manage_labels" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "manage_labels" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:current_user.Vitro
+uil-data:current_user.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Текущий пользователь"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "current_user" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "current_user" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:minimum_ymd.Vitro
+uil-data:minimum_ymd.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Неверный ввод. Пожалуйста, введите хотя бы год, месяц и день."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "minimum_ymd" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "minimum_ymd" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:try_another_letter.Vitro
+uil-data:try_another_letter.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Попробуйте другую букву или просмотрите все."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "try_another_letter" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "try_another_letter" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:alt_image_to_crop.Vitro
+uil-data:alt_image_to_crop.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Фотография, которую нужно обрезать"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "alt_image_to_crop" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "alt_image_to_crop" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:current_task.Vitro
+uil-data:current_task.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "{0} поисковый индекс"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "current_task" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "current_task" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:imageUpload.errorNoImageForCropping.Vitro
+uil-data:imageUpload.errorNoImageForCropping.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Нет файла изображения, который нужно обрезать."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "imageUpload.errorNoImageForCropping" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "imageUpload.errorNoImageForCropping" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:we_have_an_error.Vitro
+uil-data:we_have_an_error.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "В системе произошла ошибка"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "we_have_an_error" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "we_have_an_error" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_another_class.Vitro
+uil-data:select_another_class.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Пожалуйста, выберите другой класс из списка."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_another_class" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_another_class" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:manage_labels_for.Vitro
+uil-data:manage_labels_for.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Управлять метками"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "manage_labels_for" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "manage_labels_for" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:revision_info.Vitro
+uil-data:revision_info.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Информация о версии"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "revision_info" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "revision_info" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:rebuild_vis_cache.Vitro
+uil-data:rebuild_vis_cache.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Перестроить кэш визуализаций"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "rebuild_vis_cache" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "rebuild_vis_cache" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:delete.Vitro
+uil-data:delete.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "удалить"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "delete" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "delete" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:update_button.Vitro
+uil-data:update_button.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Обновить"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "update_button" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "update_button" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:imageUpload.errorNoPhotoSelected.Vitro
+uil-data:imageUpload.errorNoPhotoSelected.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Пожалуйста, просмотрите и выберите фотографию."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "imageUpload.errorNoPhotoSelected" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "imageUpload.errorNoPhotoSelected" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:imageUpload.errorUnrecognizedURI.Vitro
+uil-data:imageUpload.errorUnrecognizedURI.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Этот URI не распознан как принадлежащий кому-либо: ''{0}''"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "imageUpload.errorUnrecognizedURI" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "imageUpload.errorUnrecognizedURI" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:menu_item.Vitro
+uil-data:menu_item.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "пункт меню"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "menu_item" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "menu_item" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:auth_id_label.Vitro
+uil-data:auth_id_label.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Идентификатор внешней аутентификации"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "auth_id_label" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "auth_id_label" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:may.Vitro
+uil-data:may.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "май"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "may" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "may" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:what_is_vitro.Vitro
+uil-data:what_is_vitro.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Что такое VITRO?"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "what_is_vitro" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "what_is_vitro" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_a_language.Vitro
+uil-data:select_a_language.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Выберите язык"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_a_language" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_a_language" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:ip_address.Vitro
+uil-data:ip_address.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "IP-адреса"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "ip_address" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "ip_address" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:unrecognized_user.Vitro
+uil-data:unrecognized_user.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Нераспознанный пользователь"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "unrecognized_user" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "unrecognized_user" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:password_change_invalid_key.Vitro
+uil-data:password_change_invalid_key.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ссылка, которую вы использовали для {0}, недействительна. Пожалуйста, попросите администратора сайта повторно отправить ссылку."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "password_change_invalid_key" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "password_change_invalid_key" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:change_text_for.Vitro
+uil-data:change_text_for.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Изменить текст для:"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "change_text_for" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "change_text_for" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:to_enable_javascript.Vitro
+uil-data:to_enable_javascript.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Как разрешить JavaScript в браузере"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "to_enable_javascript" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "to_enable_javascript" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:warning.Vitro
+uil-data:warning.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Предупреждение"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "warning" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "warning" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:revision.Vitro
+uil-data:revision.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "версия"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "revision" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "revision" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:filter_by_roles.Vitro
+uil-data:filter_by_roles.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Фильтровать по ролям"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "filter_by_roles" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "filter_by_roles" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:page_uri_missing_msg.Vitro
+uil-data:page_uri_missing_msg.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Не удалось сгенерировать страницу, потому что неясно, какая страница запрашивается.  Возможно, отсутствует сопоставление URL."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "page_uri_missing_msg" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "page_uri_missing_msg" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:fatal_error.Vitro
+uil-data:fatal_error.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Фатальная ошибка"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "fatal_error" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "fatal_error" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:page_select_permission_option.Vitro
+uil-data:page_select_permission_option.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Выберите права доступа"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "page_select_permission_option" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "page_select_permission_option" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:january.Vitro
+uil-data:january.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "январь"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "january" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "january" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:property.Vitro
+uil-data:property.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "свойство"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "property" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "property" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:external_auth_id.Vitro
+uil-data:external_auth_id.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Внешний идентификатор авторизации"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "external_auth_id" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "external_auth_id" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:date_time_value_for.Vitro
+uil-data:date_time_value_for.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "дата/время для"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "date_time_value_for" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "date_time_value_for" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:sparql_query_title.Vitro
+uil-data:sparql_query_title.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Запрос SPARQL"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "sparql_query_title" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "sparql_query_title" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:previous.Vitro
+uil-data:previous.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Предыдущая"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "previous" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "previous" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:upload_page_title_with_name.Vitro
+uil-data:upload_page_title_with_name.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Загрузить изображение для {0}"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "upload_page_title_with_name" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "upload_page_title_with_name" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:cant_change_password_while_logged_in.Vitro
+uil-data:cant_change_password_while_logged_in.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Вы не можете сбросить пароль для {0}, если вошли в систему под именем {1}. Пожалуйста, выйдите из системы и повторите попытку."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "cant_change_password_while_logged_in" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "cant_change_password_while_logged_in" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:rejected_spam.Vitro
+uil-data:rejected_spam.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "ОТКЛОНЕНО — СПАМ"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "rejected_spam" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "rejected_spam" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:logins_are_open.Vitro
+uil-data:logins_are_open.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Вход в систему открыт для всех."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "logins_are_open" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "logins_are_open" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:confirm_delete_account_singular.Vitro
+uil-data:confirm_delete_account_singular.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Вы уверены, что хотите удалить эту учётную запись?"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "confirm_delete_account_singular" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "confirm_delete_account_singular" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:all_capitalized.Vitro
+uil-data:all_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Все"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "all_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "all_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:of_the_results.Vitro
+uil-data:of_the_results.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "результатов"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "of_the_results" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "of_the_results" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_content_type.Vitro
+uil-data:select_content_type.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Следует выбрать содержимое, которое будет включено в страницу"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_content_type" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_content_type" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:visit_project_website.Vitro
+uil-data:visit_project_website.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Посетите сайт национального проекта"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "visit_project_website" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "visit_project_website" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:view_labels_for.Vitro
+uil-data:view_labels_for.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Просмотреть метки для"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "view_labels_for" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "view_labels_for" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:new_account_note.Vitro
+uil-data:new_account_note.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Примечание: На указанный выше адрес будет отправлено электронное письмо с уведомлением о создании учетной записи. В нем будут содержаться инструкции по активации учетной записи и созданию пароля."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "new_account_note" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "new_account_note" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_alert_icon.Vitro
+uil-data:error_alert_icon.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Значок оповещения об ошибке"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_alert_icon" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_alert_icon" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:imageUpload.errorImageTooSmall.Vitro
+uil-data:imageUpload.errorImageTooSmall.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Загружаемое изображение должно быть не менее {0} пикселей в высоту и {1} пикселей в ширину."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "imageUpload.errorImageTooSmall" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "imageUpload.errorImageTooSmall" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_account_to_delete.Vitro
+uil-data:select_account_to_delete.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "выберите эту учетную запись, чтобы удалить ее"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_account_to_delete" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_account_to_delete" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:interest_thanks.Vitro
+uil-data:interest_thanks.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Благодарим вас за интерес к {0}. Пожалуйста, отправьте эту форму с вопросами, комментариями или отзывами о содержании этого сайта."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "interest_thanks" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "interest_thanks" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:year_numeric.Vitro
+uil-data:year_numeric.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Неверный ввод. Год должен быть вводится как число."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "year_numeric" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "year_numeric" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_an_existing_document.Vitro
+uil-data:select_an_existing_document.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Выбрать существующий материал"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_an_existing_document" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_an_existing_document" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:password_length.Vitro
+uil-data:password_length.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Длина пароля должна составлять от {0} до {1} символов."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "password_length" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "password_length" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:monday.Vitro
+uil-data:monday.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "понедельник"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "monday" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "monday" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:account_created_subject.Vitro
+uil-data:account_created_subject.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ваша учетная запись {0} была создана."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "account_created_subject" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "account_created_subject" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:vitro_bullet_three.Vitro
+uil-data:vitro_bullet_three.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Создать вебсайт для отображения ваших данных"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "vitro_bullet_three" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "vitro_bullet_three" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:photo.Vitro
+uil-data:photo.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Фотография"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "photo" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "photo" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:file_must_be_entered_msg.Vitro
+uil-data:file_must_be_entered_msg.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "в этом поле должно быть иимя файла."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "file_must_be_entered_msg" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "file_must_be_entered_msg" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:entity_to_query_for.Vitro
+uil-data:entity_to_query_for.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Это идентификатор объекта, который нужно запросить. Подойдёт также и идентификатор netid."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "entity_to_query_for" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "entity_to_query_for" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:manage_grants_and_projects_link.Vitro
+uil-data:manage_grants_and_projects_link.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "управление грантами и проектами"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "manage_grants_and_projects_link" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "manage_grants_and_projects_link" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:manage_labels_intro.Vitro
+uil-data:manage_labels_intro.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "В случае, если на одном языке существует несколько меток, воспользуйтесь ссылкой для удаления, чтобы удалить метки, которые вы не хотите отображать на странице профиля для данного языка. "@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "manage_labels_intro" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "manage_labels_intro" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:hide_show_properties.Vitro
+uil-data:hide_show_properties.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "спрятать/показать свойства"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "hide_show_properties" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "hide_show_properties" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:untitled.Vitro
+uil-data:untitled.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "-untitled-"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "untitled" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "untitled" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:manage_publications_link.Vitro
+uil-data:manage_publications_link.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "управление публикациями"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "manage_publications_link" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "manage_publications_link" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_all.Vitro
+uil-data:select_all.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "выбирать всех"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_all" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_all" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:local_name.Vitro
+uil-data:local_name.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Локальное название"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "local_name" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "local_name" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:end_interval_must_follow_start_interval.Vitro
+uil-data:end_interval_must_follow_start_interval.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Дата и время окончания должны идти после даты и времени начала."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "end_interval_must_follow_start_interval" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "end_interval_must_follow_start_interval" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:view_page.Vitro
+uil-data:view_page.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Посмотреть страницу"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "view_page" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "view_page" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:browse_page_javascript_one.Vitro
+uil-data:browse_page_javascript_one.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Для просмотра этой страницы требуется JavaScript, но в Вашем браузере JavaScript отключён. Либо включите JavaScript, либо используйте"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "browse_page_javascript_one" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "browse_page_javascript_one" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:sparql_query_builder.Vitro
+uil-data:sparql_query_builder.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Конструктор запросов SPARQL"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "sparql_query_builder" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "sparql_query_builder" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:sub_properties.Vitro
+uil-data:sub_properties.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Подсвойство"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "sub_properties" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "sub_properties" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:add_label_for_language.Vitro
+uil-data:add_label_for_language.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Язык"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "add_label_for_language" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "add_label_for_language" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:file_upload_error_file_not_found.Vitro
+uil-data:file_upload_error_file_not_found.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "file_upload_error_file_not_found" ;
-        prop:hasPackage  "Vitro-languages" .
+        rdf:type         uil:UILabel ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "file_upload_error_file_not_found" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:file_upload_predicate.Vitro
+uil-data:file_upload_predicate.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "file_upload_predicate" ;
-        prop:hasPackage  "Vitro-languages" .
+        rdf:type         uil:UILabel ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "file_upload_predicate" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:start_with_leading_slash.Vitro
+uil-data:start_with_leading_slash.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Должен начинаться с косой черты: / (например, /people)"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "start_with_leading_slash" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "start_with_leading_slash" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:trace_available.Vitro
+uil-data:trace_available.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "полная трассировка стека находится в лог файлах сервера приложений"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "trace_available" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "trace_available" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:editing_prohibited.Vitro
+uil-data:editing_prohibited.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "В настоящее время для этого свойства действует запрет на редактирование."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "editing_prohibited" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "editing_prohibited" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:verbose_status_on.Vitro
+uil-data:verbose_status_on.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "включено"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "verbose_status_on" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "verbose_status_on" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:use_capitalized.Vitro
+uil-data:use_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Воспользуйтесь пунктом"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "use_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "use_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:search_index_status.Vitro
+uil-data:search_index_status.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Состояние поискового индекса"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "search_index_status" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "search_index_status" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:filter_search.Vitro
+uil-data:filter_search.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "ограничить поиск"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "filter_search" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "filter_search" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:with_vitro.Vitro
+uil-data:with_vitro.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "С помощью Vitro, вы можете:"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "with_vitro" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "with_vitro" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:site_information.Vitro
+uil-data:site_information.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Информация о сайте"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "site_information" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "site_information" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:logins_temporarily_disabled.Vitro
+uil-data:logins_temporarily_disabled.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Вход пользователей в систему временно отключен на время обслуживания системы."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "logins_temporarily_disabled" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "logins_temporarily_disabled" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:leave_password_unchanged.Vitro
+uil-data:leave_password_unchanged.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Если оставить это поле пустым, пароль не будет изменен."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "leave_password_unchanged" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "leave_password_unchanged" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:query_model.Vitro
+uil-data:query_model.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Query Model"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "query_model" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "query_model" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:restrict_logins_mixed_caps.Vitro
+uil-data:restrict_logins_mixed_caps.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ограничить вход в систему"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "restrict_logins_mixed_caps" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "restrict_logins_mixed_caps" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:wednesday.Vitro
+uil-data:wednesday.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "среда"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "wednesday" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "wednesday" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:berries.Vitro
+uil-data:berries.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ягоды:"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "berries" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "berries" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:full_name.Vitro
+uil-data:full_name.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Полное имя"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "full_name" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "full_name" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:no_email_supplied.Vitro
+uil-data:no_email_supplied.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Адрес электронной почты не задан."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "no_email_supplied" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "no_email_supplied" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_was_reported.Vitro
+uil-data:error_was_reported.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Об этой ошибке было сообщено администратору сайта."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_was_reported" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_was_reported" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:search_results_for.Vitro
+uil-data:search_results_for.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Результаты поиска по запросу"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "search_results_for" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "search_results_for" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:search_tip_three.Vitro
+uil-data:search_tip_three.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "За исключением булевых операторов, поиск <strong>не</strong> чувствителен к регистру, поэтому запросы \"Женева\" и \"женева\" эквивалентны."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "search_tip_three" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "search_tip_three" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:view_profile_for_page.Vitro
+uil-data:view_profile_for_page.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "просмотр индивидуального профиля для этой страницы"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "view_profile_for_page" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "view_profile_for_page" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:reordering_menus_failed.Vitro
+uil-data:reordering_menus_failed.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Переупорядочивание пунктов меню не удалось."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "reordering_menus_failed" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "reordering_menus_failed" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:verbose_control.Vitro
+uil-data:verbose_control.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "детальное управление"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "verbose_control" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "verbose_control" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:ontology_list.Vitro
+uil-data:ontology_list.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Список онтологий"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "ontology_list" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "ontology_list" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:edit_entry.Vitro
+uil-data:edit_entry.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "редактировать эту запись"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "edit_entry" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "edit_entry" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:label.dateTimeWithPrecision.minutes_capitalized.Vitro
+uil-data:label.dateTimeWithPrecision.minutes_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Минуты"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "label.dateTimeWithPrecision.minutes_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "label.dateTimeWithPrecision.minutes_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:object.Vitro
+uil-data:object.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "объект"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "object" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "object" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:confirm_email_changed_email_html_text.Vitro
+uil-data:confirm_email_changed_email_html_text.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "<p>Здравствуйте, ${userAccount.firstName} ${userAccount.lastName}</p>\n\n <p>Вы недавно изменили адрес электронной почты, связанный с ${userAccount.firstName} ${userAccount.lastName}</p>\n\n <p>Спасибо.</p>"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "confirm_email_changed_email_html_text" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "confirm_email_changed_email_html_text" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_no_new_password.Vitro
+uil-data:error_no_new_password.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Пожалуйста, введите свой новый пароль."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_no_new_password" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_no_new_password" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:page_loggedin_permission_option.Vitro
+uil-data:page_loggedin_permission_option.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Эту страницу могут просматривать пользователи, вошедшие в систему"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "page_loggedin_permission_option" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "page_loggedin_permission_option" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:expecting_content.Vitro
+uil-data:expecting_content.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ожидаете содержание?"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "expecting_content" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "expecting_content" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:required_fields.Vitro
+uil-data:required_fields.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "эти поля должны быть непременно заполнены"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "required_fields" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "required_fields" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:edit_page_title.Vitro
+uil-data:edit_page_title.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Редактировать"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "edit_page_title" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "edit_page_title" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_existing.Vitro
+uil-data:select_existing.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Выберите существующую"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_existing" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_existing" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:invalid_url_msg.Vitro
+uil-data:invalid_url_msg.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Этот URL должен начинаться с http:// или https://"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "invalid_url_msg" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "invalid_url_msg" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:search_button.Vitro
+uil-data:search_button.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Искать"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "search_button" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "search_button" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:advanced_search_tips_header.Vitro
+uil-data:advanced_search_tips_header.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Дополнительные советы"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "advanced_search_tips_header" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "advanced_search_tips_header" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:supply_url.Vitro
+uil-data:supply_url.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Следует задать понятный URL"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "supply_url" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "supply_url" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_profiles.Vitro
+uil-data:select_profiles.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Выбрать профили"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_profiles" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_profiles" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_one.Vitro
+uil-data:select_one.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Выберите"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_one" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_one" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:continue.Vitro
+uil-data:continue.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Продолжить"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "continue" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "continue" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:language_selection_failed.Vitro
+uil-data:language_selection_failed.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "В системе произошла ошибка. Выбор языка был отклонён."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "language_selection_failed" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "language_selection_failed" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:display_has_element_error.Vitro
+uil-data:display_has_element_error.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "В системе произошла ошибка. Не удалось получить свойство display:hasElement."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "display_has_element_error" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "display_has_element_error" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:file_upload_error_file_is_too_big.Vitro
+uil-data:file_upload_error_file_is_too_big.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "file_upload_error_file_is_too_big" ;
-        prop:hasPackage  "Vitro-languages" .
+        rdf:type         uil:UILabel ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "file_upload_error_file_is_too_big" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:template_capitalized.Vitro
+uil-data:template_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Шаблон"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "template_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "template_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:file_upload_supported_media.Vitro
+uil-data:file_upload_supported_media.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "file_upload_supported_media" ;
-        prop:hasPackage  "Vitro-languages" .
+        rdf:type         uil:UILabel ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "file_upload_supported_media" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:user_accounts_title.Vitro
+uil-data:user_accounts_title.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "учётные записи пользователей"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "user_accounts_title" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "user_accounts_title" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:create_your_password.Vitro
+uil-data:create_your_password.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Придумайте свой пароль"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "create_your_password" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "create_your_password" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:create_account.Vitro
+uil-data:create_account.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Создать учетную запись"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "create_account" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "create_account" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:remove_menu_item.Vitro
+uil-data:remove_menu_item.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Удалить пункт меню"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "remove_menu_item" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "remove_menu_item" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:click_to_view_account.Vitro
+uil-data:click_to_view_account.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "нажмите для просмотра информации об учетной записи"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "click_to_view_account" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "click_to_view_account" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:add_new_entry_for.Vitro
+uil-data:add_new_entry_for.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Добавить новую запись для:"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "add_new_entry_for" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "add_new_entry_for" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:menu_ordering.Vitro
+uil-data:menu_ordering.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Упорядочить меню"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "menu_ordering" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "menu_ordering" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:map_processor_error.Vitro
+uil-data:map_processor_error.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Произошла ошибка, и карта процессоров для этого контента отсутствует. Пожалуйста, свяжитесь с администратором"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "map_processor_error" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "map_processor_error" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:change_profile_title.Vitro
+uil-data:change_profile_title.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "изменить профиль"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "change_profile_title" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "change_profile_title" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:domain_class.Vitro
+uil-data:domain_class.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Класс домена"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "domain_class" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "domain_class" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:manage_labels_capitalized.Vitro
+uil-data:manage_labels_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Управление метками"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "manage_labels_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "manage_labels_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_passwords_dont_match.Vitro
+uil-data:error_passwords_dont_match.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Введенные пароли не совпадают."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_passwords_dont_match" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_passwords_dont_match" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:save_profile_changes.Vitro
+uil-data:save_profile_changes.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Сохранить изменения профилей"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "save_profile_changes" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "save_profile_changes" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:site_administration.Vitro
+uil-data:site_administration.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Администрирование сайта"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "site_administration" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "site_administration" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:vitro_bullet_one.Vitro
+uil-data:vitro_bullet_one.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Создавать и загружать онтологии в формате OWL"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "vitro_bullet_one" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "vitro_bullet_one" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:pages.Vitro
+uil-data:pages.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "страницы"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "pages" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "pages" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:inferred_class_hierarchy.Vitro
+uil-data:inferred_class_hierarchy.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Иерархия выводимых классов"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "inferred_class_hierarchy" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "inferred_class_hierarchy" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:auth_id_in_use.Vitro
+uil-data:auth_id_in_use.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Этот идентификатор уже используется."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "auth_id_in_use" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "auth_id_in_use" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:data_input.Vitro
+uil-data:data_input.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ввод данных"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "data_input" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "data_input" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:recompute_inferences_mixed_caps.Vitro
+uil-data:recompute_inferences_mixed_caps.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Перестроить интерфейс"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "recompute_inferences_mixed_caps" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "recompute_inferences_mixed_caps" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:individual_name.Vitro
+uil-data:individual_name.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "имя объекта"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "individual_name" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "individual_name" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:thursday.Vitro
+uil-data:thursday.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "четверг"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "thursday" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "thursday" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:alert_icon.Vitro
+uil-data:alert_icon.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Значок оповещения"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "alert_icon" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "alert_icon" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:if_blank_page_title_used.Vitro
+uil-data:if_blank_page_title_used.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Если оставить поле пустым, будет использоваться заголовок страницы."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "if_blank_page_title_used" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "if_blank_page_title_used" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:password_reset_pending_email_plain_text.Vitro
+uil-data:password_reset_pending_email_plain_text.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Здравствуйте ${userAccount.firstName} ${userAccount.lastName}:\n\nМы получили запрос на сброс пароля для вашей учётной записи на сайте ${siteName}, связанной с адресом\n(${userAccount.emailAddress}).\n\nПожалуйста, следуйте приведенным ниже инструкциям, чтобы выполнить сброс пароля.\n\nЕсли вы не запрашивали новую учетную запись, можете смело игнорировать это письмо.\nСрок действия этого запроса истечет, если в течение 30 дней не будет предпринято никаких действий.\n\nСкопируйте и вставьте приведённую ниже ссылку в адресную строку браузера, чтобы сбросить пароль\nпри помощи нашего защищенного сервера.\n\n${passwordLink}\n\nСпасибо!"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "password_reset_pending_email_plain_text" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "password_reset_pending_email_plain_text" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:hide_properties.Vitro
+uil-data:hide_properties.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "скрыть свойства"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "hide_properties" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "hide_properties" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:file_upload_error_file_type_not_recognized.Vitro
+uil-data:file_upload_error_file_type_not_recognized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "file_upload_error_file_type_not_recognized" ;
-        prop:hasPackage  "Vitro-languages" .
+        rdf:type         uil:UILabel ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "file_upload_error_file_type_not_recognized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_no_role.Vitro
+uil-data:error_no_role.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Вам необходимо выбрать роль.."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_no_role" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_no_role" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:new_account_title.Vitro
+uil-data:new_account_title.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "новая учётная запись"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "new_account_title" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "new_account_title" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:file_upload_no_allowed_media.Vitro
+uil-data:file_upload_no_allowed_media.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "file_upload_no_allowed_media" ;
-        prop:hasPackage  "Vitro-languages" .
+        rdf:type         uil:UILabel ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "file_upload_no_allowed_media" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:property_groups.Vitro
+uil-data:property_groups.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Группы свойств"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "property_groups" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "property_groups" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:startup_trace.Vitro
+uil-data:startup_trace.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Трассировка запуска"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "startup_trace" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "startup_trace" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:search_accounts_button.Vitro
+uil-data:search_accounts_button.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Искать учетные записи"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "search_accounts_button" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "search_accounts_button" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:operation_unsuccessful.Vitro
+uil-data:operation_unsuccessful.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Операция завершилась неудачно. Детали можно найти в файлах журналов системы. Все подробности можно найти в системном журнале."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "operation_unsuccessful" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "operation_unsuccessful" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:submit_button.Vitro
+uil-data:submit_button.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Отправить"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "submit_button" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "submit_button" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:page_uri_missing.Vitro
+uil-data:page_uri_missing.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Не указан URI страницы"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "page_uri_missing" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "page_uri_missing" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_no_email_address.Vitro
+uil-data:error_no_email_address.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Пожалуйста, введите свой адрес электронной почты."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_no_email_address" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_no_email_address" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:controls.Vitro
+uil-data:controls.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Средства управления"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "controls" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "controls" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:fruit.Vitro
+uil-data:fruit.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Фрукт"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "fruit" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "fruit" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:admin_panel.Vitro
+uil-data:admin_panel.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Панель управления"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "admin_panel" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "admin_panel" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:the_range_class_does_not_exist.Vitro
+uil-data:the_range_class_does_not_exist.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Класс диапазона для данного отношения не определён в системе."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "the_range_class_does_not_exist" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "the_range_class_does_not_exist" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:reset_your_password.Vitro
+uil-data:reset_your_password.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Сброс пароля"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "reset_your_password" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "reset_your_password" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:advanced_search_tip_two.Vitro
+uil-data:advanced_search_tip_two.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "\"NOT\" может помочь ограничить поиск, например <i>климат</i> NOT <i>изменение</i>."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "advanced_search_tip_two" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "advanced_search_tip_two" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:save_new_page.Vitro
+uil-data:save_new_page.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Сохранить новую страницу"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "save_new_page" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "save_new_page" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:book_title.Vitro
+uil-data:book_title.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Название книги:"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "book_title" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "book_title" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:view_content_index.Vitro
+uil-data:view_content_index.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ознакомиться с кратким содержанием этого сайта"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "view_content_index" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "view_content_index" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:or_create_new_one.Vitro
+uil-data:or_create_new_one.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "или создайте новый."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "or_create_new_one" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "or_create_new_one" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:remove_selection.Vitro
+uil-data:remove_selection.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Снять выделение"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "remove_selection" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "remove_selection" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:cardinality.Vitro
+uil-data:cardinality.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "значимость"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "cardinality" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "cardinality" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:apostrophe_not_allowed.Vitro
+uil-data:apostrophe_not_allowed.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "В имени переменной не должно быть апострофа."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "apostrophe_not_allowed" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "apostrophe_not_allowed" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:confirm_menu_item_delete.Vitro
+uil-data:confirm_menu_item_delete.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Вы уверены, что хотите удалить"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "confirm_menu_item_delete" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "confirm_menu_item_delete" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:work_level.Vitro
+uil-data:work_level.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Рабочий уровень"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "work_level" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "work_level" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:acct_created_external_only_email_html_text.Vitro
+uil-data:acct_created_external_only_email_html_text.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "<p> ${userAccount.firstName} ${userAccount.lastName}</p>\n\n <p><strong>Поздравляем!</strong></p>\n\n <p>Мы создали новую учётную запись на сайте ${siteName}, связанную с адресом ${userAccount.emailAddress}.</p>\n\n <p>Если Вы не запрашивали создания учётной записи, просто проигнорируйте это электронное письмо. Если не предпринимать никаких действий через 30 дней срок действия этого запроса закончится.</p>\n\n <p>Нажмите на ссылку ниже, чтобы создать пароль для новой учетной записи с помощью нашего защищенного сервера.</p>\n\n <p> <a href=&quot;${passwordLink}&quot; title=&quot;password&quot;>${passwordLink}</a></p>\n\n <p>Если приведенная выше ссылка не работает, вы можете скопировать и вставить ссылку непосредственно в адресную строку вашего браузера.</p>\n\n <p>Спасибо!</p>"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "acct_created_external_only_email_html_text" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "acct_created_external_only_email_html_text" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:friday.Vitro
+uil-data:friday.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "пятница"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "friday" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "friday" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:return_to_the.Vitro
+uil-data:return_to_the.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Вернуться на "@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "return_to_the" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "return_to_the" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:sparql_query.Vitro
+uil-data:sparql_query.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Запрос SPARQL"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "sparql_query" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "sparql_query" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:myAccount_confirm_changes.Vitro
+uil-data:myAccount_confirm_changes.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ваши изменения были сохранены."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "myAccount_confirm_changes" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "myAccount_confirm_changes" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:to.Vitro
+uil-data:to.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "до"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "to" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "to" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:login_to_manage_site.Vitro
+uil-data:login_to_manage_site.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "войдите, чтобы работать с сайтом"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "login_to_manage_site" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "login_to_manage_site" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:a_classgroup.Vitro
+uil-data:a_classgroup.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "группа классов"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "a_classgroup" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "a_classgroup" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:upload_page_title.Vitro
+uil-data:upload_page_title.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Загрузить изображение"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "upload_page_title" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "upload_page_title" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_existing_collaborator.Vitro
+uil-data:select_existing_collaborator.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Выбрать существующего партнёра для {0}"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_existing_collaborator" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_existing_collaborator" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:label.dateTimeWithPrecision.day_capitalized.Vitro
+uil-data:label.dateTimeWithPrecision.day_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "День"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "label.dateTimeWithPrecision.day_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "label.dateTimeWithPrecision.day_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:login_button.Vitro
+uil-data:login_button.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Войти"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "login_button" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "login_button" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:internal_login.Vitro
+uil-data:internal_login.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Внутренний логин"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "internal_login" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "internal_login" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_occurred.Vitro
+uil-data:error_occurred.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "На сайте VIVO произошла ошибка"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_occurred" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_occurred" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:advanced_search_tip_four.Vitro
+uil-data:advanced_search_tip_four.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Также можно найти близкие варианты слов, например <i>очередь</i> подойдёт для поиска и <i>очереди</i>, и <i>очередной</i>."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "advanced_search_tip_four" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "advanced_search_tip_four" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:updated_account_title.Vitro
+uil-data:updated_account_title.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "обновить учётную запись"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "updated_account_title" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "updated_account_title" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:year_month_day.Vitro
+uil-data:year_month_day.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Неверный ввод. Пожалуйста, введите год, месяц и день."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "year_month_day" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "year_month_day" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:log_out.Vitro
+uil-data:log_out.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Выйти"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "log_out" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "log_out" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:application_error_email_plain_text.Vitro
+uil-data:application_error_email_plain_text.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "В ${datetime!} на сайте ${siteName!} произошла ошибка \nЗапрашиваемый url: ${requestedUrl!}\n\n<#if errorMessage?has_content>\n Сообщение об ошибке: ${errorMessage!}\n</#if>\n\nТрассировка стека (полная трассировка стека находится в лог файлах сервера приложений):\n${stackTrace!}\n\n<#if cause?has_content>\nПричина:\n${cause!}\n</#if>"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "application_error_email_plain_text" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "application_error_email_plain_text" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_vclass_uri.Vitro
+uil-data:select_vclass_uri.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Выберите VClass"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_vclass_uri" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_vclass_uri" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:custom_template_requiring_content.Vitro
+uil-data:custom_template_requiring_content.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Пользовательский шаблон, требующий ввода данных"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "custom_template_requiring_content" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "custom_template_requiring_content" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:file_upload_error_uri_not_exists.Vitro
+uil-data:file_upload_error_uri_not_exists.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "file_upload_error_uri_not_exists" ;
-        prop:hasPackage  "Vitro-languages" .
+        rdf:type         uil:UILabel ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "file_upload_error_uri_not_exists" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:external_id_not_provided.Vitro
+uil-data:external_id_not_provided.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Вход не удался — внешний идентификатор не найден."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "external_id_not_provided" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "external_id_not_provided" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:imageUpload.errorBadMultipartRequest.Vitro
+uil-data:imageUpload.errorBadMultipartRequest.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Не удалось разобрать многокомпонентный запрос на загрузку изображения."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "imageUpload.errorBadMultipartRequest" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "imageUpload.errorBadMultipartRequest" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:view_all_accounts.Vitro
+uil-data:view_all_accounts.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Просмотреть все учетные записи"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "view_all_accounts" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "view_all_accounts" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:file_upload_file.Vitro
+uil-data:file_upload_file.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "file_upload_file" ;
-        prop:hasPackage  "Vitro-languages" .
+        rdf:type         uil:UILabel ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "file_upload_file" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:search_failed.Vitro
+uil-data:search_failed.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Поиск не удался."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "search_failed" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "search_failed" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:minimum_hour.Vitro
+uil-data:minimum_hour.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Неверный ввод. Пожалуйста, укажите хотя бы час."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "minimum_hour" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "minimum_hour" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:faux_property_alpha.Vitro
+uil-data:faux_property_alpha.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "номинальные свойства в алфавитном порядке"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "faux_property_alpha" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "faux_property_alpha" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:info_icon.Vitro
+uil-data:info_icon.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "значок информации"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "info_icon" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "info_icon" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:save_button.Vitro
+uil-data:save_button.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Сохранить"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "save_button" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "save_button" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:who_can_edit_profile.Vitro
+uil-data:who_can_edit_profile.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Кто может редактировать мой профиль"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "who_can_edit_profile" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "who_can_edit_profile" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:add_an_entry_to.Vitro
+uil-data:add_an_entry_to.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Добавить запись к"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "add_an_entry_to" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "add_an_entry_to" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:page_not_found_msg.Vitro
+uil-data:page_not_found_msg.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Страница не найдена в системе."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "page_not_found_msg" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "page_not_found_msg" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:no_content_in_system.Vitro
+uil-data:no_content_in_system.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "{0} не найдены в системе"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "no_content_in_system" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "no_content_in_system" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:rdf.Vitro
+uil-data:rdf.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "RDF"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "rdf" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "rdf" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:datetime_year_required.Vitro
+uil-data:datetime_year_required.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Интервалы времени должны начинаться с года. Введите либо год начала, либо год окончания, либо оба."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "datetime_year_required" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "datetime_year_required" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:external_auth_name.Vitro
+uil-data:external_auth_name.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "имя сервиса внешней аутентификации"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "external_auth_name" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "external_auth_name" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:external_login_failed.Vitro
+uil-data:external_login_failed.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Не удалось выполнить внешний вход"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "external_login_failed" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "external_login_failed" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:label.dateTimeWithPrecision.seconds_capitalized.Vitro
+uil-data:label.dateTimeWithPrecision.seconds_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Секунды"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "label.dateTimeWithPrecision.seconds_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "label.dateTimeWithPrecision.seconds_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:custom_template.Vitro
+uil-data:custom_template.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Пользовательский шаблон"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "custom_template" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "custom_template" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:associated_profile_label.Vitro
+uil-data:associated_profile_label.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Связанный профиль:"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "associated_profile_label" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "associated_profile_label" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:page_not_found.Vitro
+uil-data:page_not_found.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Страница не найдена."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "page_not_found" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "page_not_found" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_existing_last_name.Vitro
+uil-data:select_existing_last_name.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Выберите существующую фамилию"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_existing_last_name" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_existing_last_name" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:title_capitalized.Vitro
+uil-data:title_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Заголовок"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "title_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "title_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:file_upload_error_no_action.Vitro
+uil-data:file_upload_error_no_action.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "file_upload_error_no_action" ;
-        prop:hasPackage  "Vitro-languages" .
+        rdf:type         uil:UILabel ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "file_upload_error_no_action" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:change_entry_for.Vitro
+uil-data:change_entry_for.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Изменить запись для:"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "change_entry_for" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "change_entry_for" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:cause.Vitro
+uil-data:cause.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Cause:"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "cause" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "cause" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:may_edit.Vitro
+uil-data:may_edit.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Разрешается редактировать"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "may_edit" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "may_edit" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:properties.Vitro
+uil-data:properties.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "свойства"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "properties" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "properties" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:add_new.Vitro
+uil-data:add_new.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Добавить новый(ое)"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "add_new" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "add_new" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:apples.Vitro
+uil-data:apples.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Яблоки"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "apples" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "apples" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:tuesday.Vitro
+uil-data:tuesday.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "вторник"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "tuesday" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "tuesday" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:email_changed_subject.Vitro
+uil-data:email_changed_subject.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ваша учетная запись электронной почты {0} была изменена."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "email_changed_subject" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "email_changed_subject" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:site_admin.Vitro
+uil-data:site_admin.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Администрирование"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "site_admin" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "site_admin" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:code_processing_error.Vitro
+uil-data:code_processing_error.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Произошла ошибка, и в коде обработки этого содержимого отсутствует компонент. Пожалуйста, свяжитесь с администратором."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "code_processing_error" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "code_processing_error" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:base_property_capitalized.Vitro
+uil-data:base_property_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Базовое свойство"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "base_property_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "base_property_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:username.Vitro
+uil-data:username.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Имя пользователя"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "username" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "username" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:to_order_menu_items.Vitro
+uil-data:to_order_menu_items.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "для установки порядка следования пунктов меню."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "to_order_menu_items" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "to_order_menu_items" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:none.Vitro
+uil-data:none.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "нет"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "none" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "none" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:classes_capitalized.Vitro
+uil-data:classes_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Классы"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "classes_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "classes_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:cancel_link.Vitro
+uil-data:cancel_link.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Отменить"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "cancel_link" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "cancel_link" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:send_feedback_questions.Vitro
+uil-data:send_feedback_questions.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Отправьте свой отзыв или задайте вопрос"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "send_feedback_questions" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "send_feedback_questions" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:account_already_activated.Vitro
+uil-data:account_already_activated.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Учетная запись для {0} уже активирована."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "account_already_activated" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "account_already_activated" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:page.Vitro
+uil-data:page.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "страница"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "page" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "page" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:type_more_characters.Vitro
+uil-data:type_more_characters.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "продолжайте вводить"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "type_more_characters" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "type_more_characters" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:search_tips_header.Vitro
+uil-data:search_tips_header.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Советы для поиска"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "search_tips_header" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "search_tips_header" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:data_not_past_msg.Vitro
+uil-data:data_not_past_msg.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Пожалуйста, укажите будущую дату публикации (прошедшие даты недопустимы)."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "data_not_past_msg" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "data_not_past_msg" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_associated_profile.Vitro
+uil-data:select_associated_profile.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Выбрать связанный профиль"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_associated_profile" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_associated_profile" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:edit_capitalized.Vitro
+uil-data:edit_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Редактирование"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "edit_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "edit_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:site_name.Vitro
+uil-data:site_name.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "имя сайта"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "site_name" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "site_name" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:replace_photo.Vitro
+uil-data:replace_photo.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Заменить фо"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "replace_photo" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "replace_photo" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:rebuild_button.Vitro
+uil-data:rebuild_button.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Перестроить"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "rebuild_button" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "rebuild_button" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:numbers.Vitro
+uil-data:numbers.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Цифры"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "numbers" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "numbers" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:acct_created_external_only_email_plain_text.Vitro
+uil-data:acct_created_external_only_email_plain_text.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "${userAccount.firstName} ${userAccount.lastName}\n\nПоздравляем!\n\nМы создали новую учётную запись на сайте ${siteName},\nсвязанную с адресом ${userAccount.emailAddress}.\n\nЕсли Вы не запрашивали создания учётной записи, просто проигнорируйте это электронное письмо.\nЕсли не предпринимать никаких действий через 30 дней срок действия этого запроса закончится.\n\nЧтобы создать пароль для Вашей новой учетной записи при помощи нашего защищенного сервера,\nскопируйте и вставьте приведённую ниже ссылку в адресную строку вашего браузера.\n\n${passwordLink}\n\nСпасибо!"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "acct_created_external_only_email_plain_text" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "acct_created_external_only_email_plain_text" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:auth_id_explanation.Vitro
+uil-data:auth_id_explanation.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Может использоваться для связи учетной записи с профилем пользователя с помощью свойства соответствия."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "auth_id_explanation" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "auth_id_explanation" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:support.Vitro
+uil-data:support.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Поддержка"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "support" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "support" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:enter_search_term.Vitro
+uil-data:enter_search_term.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Пожалуйста, введите поисковый запрос."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "enter_search_term" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "enter_search_term" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:feedback_thanks_heading.Vitro
+uil-data:feedback_thanks_heading.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Благодарим вас за отзыв"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "feedback_thanks_heading" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "feedback_thanks_heading" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:updated_account_notification.Vitro
+uil-data:updated_account_notification.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "На адрес {0} было отправлено письмо с подтверждением, содержащее инструкции по сбросу пароля. Пароль не будет сброшен, пока пользователь не перейдет по ссылке, указанной в этом письме."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "updated_account_notification" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "updated_account_notification" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:menu_ordering_mixed_caps.Vitro
+uil-data:menu_ordering_mixed_caps.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Упорядочивание меню"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "menu_ordering_mixed_caps" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "menu_ordering_mixed_caps" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:expand_all.Vitro
+uil-data:expand_all.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "всё развернуть"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "expand_all" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "expand_all" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:confirm_password_capitalized.Vitro
+uil-data:confirm_password_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Подтвердите пароль"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "confirm_password_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "confirm_password_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:uri_not_defined.Vitro
+uil-data:uri_not_defined.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "URI для страницы не задан"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "uri_not_defined" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "uri_not_defined" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:a_link.Vitro
+uil-data:a_link.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "ссылка"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "a_link" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "a_link" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:view_list_of_labels.Vitro
+uil-data:view_list_of_labels.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "просмотр списков меток"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "view_list_of_labels" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "view_list_of_labels" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:not_logged_in.Vitro
+uil-data:not_logged_in.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Не вошли в систему"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "not_logged_in" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "not_logged_in" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:page_public_permission_option.Vitro
+uil-data:page_public_permission_option.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Эту страницу разрешено просматривать всем"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "page_public_permission_option" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "page_public_permission_option" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:file_upload_error_uri_not_given.Vitro
+uil-data:file_upload_error_uri_not_given.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "file_upload_error_uri_not_given" ;
-        prop:hasPackage  "Vitro-languages" .
+        rdf:type         uil:UILabel ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "file_upload_error_uri_not_given" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:file_upload_heading.Vitro
+uil-data:file_upload_heading.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "file_upload_heading" ;
-        prop:hasPackage  "Vitro-languages" .
+        rdf:type         uil:UILabel ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "file_upload_heading" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:save_this_content.Vitro
+uil-data:save_this_content.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Сохранить это содержимое"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "save_this_content" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "save_this_content" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:data.Vitro
+uil-data:data.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "данные "@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "data" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "data" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_incorrect_credentials.Vitro
+uil-data:error_incorrect_credentials.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Неправильно введён адрес электронной почты или пароль."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_incorrect_credentials" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_incorrect_credentials" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:start_url_with_slash.Vitro
+uil-data:start_url_with_slash.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Понятный URL следует начинать с косой черты"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "start_url_with_slash" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "start_url_with_slash" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:february.Vitro
+uil-data:february.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "февраль"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "february" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "february" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:delete_entry.Vitro
+uil-data:delete_entry.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "удалить эту запись"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "delete_entry" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "delete_entry" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:imageUpload.errorFormFieldMissing.Vitro
+uil-data:imageUpload.errorFormFieldMissing.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Форма не содержала поля ''{0}''."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "imageUpload.errorFormFieldMissing" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "imageUpload.errorFormFieldMissing" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:formatted_date_time.Vitro
+uil-data:formatted_date_time.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Форматированные данные даты и времени"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "formatted_date_time" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "formatted_date_time" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:imageUpload.errorUnknown.Vitro
+uil-data:imageUpload.errorUnknown.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "К сожалению, мы не смогли обработать предоставленную вами фотографию. Пожалуйста, попробуйте другую фотографию."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "imageUpload.errorUnknown" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "imageUpload.errorUnknown" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:password_reset_pending_email_html_text.Vitro
+uil-data:password_reset_pending_email_html_text.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "<p>Уважаемый пользователь ${userAccount.firstName} ${userAccount.lastName}:</p>\n\n <p>Мы получили запрос на сброс пароля для вашей учётной записи на сайте ${siteName}, связанной с адресом (${userAccount.emailAddress}).</p>\n\n <p>Пожалуйста, следуйте приведенным ниже инструкциям, чтобы выполнить сброс пароля.</p>\n\n <p>Если вы не запрашивали новую учетную запись, можете смело игнорировать это письмо. Срок действия этого запроса истечет, если в течение 30 дней не будет предпринято никаких действий.</p>\n\n <p>Щёлкните по ссылке ниже или вставьте её в адресную строку браузера, чтобы сбросить пароль с помощью нашего защищенного сервера.</p>\n <p>\n <a href=&quot;${passwordLink}&quot; title=&quot;password&quot;>${passwordLink}</a>\n </p>\n\n <p>Спасибо!</p>"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "password_reset_pending_email_html_text" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "password_reset_pending_email_html_text" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:ontology_editor.Vitro
+uil-data:ontology_editor.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Редактор онтологий"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "ontology_editor" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "ontology_editor" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:from_capitalized.Vitro
+uil-data:from_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "C"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "from_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "from_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:logged_out.Vitro
+uil-data:logged_out.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Вы вышли из системы."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "logged_out" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "logged_out" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:search_for.Vitro
+uil-data:search_for.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Результаты поиска по запросу «{0}»"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "search_for" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "search_for" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:other.Vitro
+uil-data:other.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "прочее"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "other" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "other" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:supply_variable_name.Vitro
+uil-data:supply_variable_name.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Необходимо задать переменную для сохранения содержимого HTML."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "supply_variable_name" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "supply_variable_name" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:remove_restrictions.Vitro
+uil-data:remove_restrictions.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Снять ограничения"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "remove_restrictions" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "remove_restrictions" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:variable_name_all_caps.Vitro
+uil-data:variable_name_all_caps.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Имя переменной"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "variable_name_all_caps" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "variable_name_all_caps" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:levels.Vitro
+uil-data:levels.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Уровни"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "levels" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "levels" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:range_class.Vitro
+uil-data:range_class.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Класс диапазона"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "range_class" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "range_class" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:type_more_chars.Vitro
+uil-data:type_more_chars.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "продолжайте набирать"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "type_more_chars" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "type_more_chars" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:advanced_data_tools.Vitro
+uil-data:advanced_data_tools.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Расширенные инструменты работы с данными"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "advanced_data_tools" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "advanced_data_tools" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:current_date.Vitro
+uil-data:current_date.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Текущая дата:"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "current_date" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "current_date" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:since_elapsed_time_est_total.Vitro
+uil-data:since_elapsed_time_est_total.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "с {0}, прошло времени {1}, предполагаемое полное время выполнения {2}"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "since_elapsed_time_est_total" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "since_elapsed_time_est_total" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:close.Vitro
+uil-data:close.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "закрыть"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "close" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "close" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:change_selection.Vitro
+uil-data:change_selection.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Изменить выбранное"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "change_selection" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "change_selection" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:copyright.Vitro
+uil-data:copyright.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "авторские права"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "copyright" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "copyright" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_page_content_type.Vitro
+uil-data:select_page_content_type.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Выбрать тип содержимого для связанной страницы"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_page_content_type" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_page_content_type" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:zoo_one.Vitro
+uil-data:zoo_one.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Зверинец 1"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "zoo_one" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "zoo_one" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:cancel_title.Vitro
+uil-data:cancel_title.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "отменить"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "cancel_title" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "cancel_title" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:add_individual_of_class.Vitro
+uil-data:add_individual_of_class.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Добавить экземпляр данного класса"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "add_individual_of_class" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "add_individual_of_class" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:label.dateTimeWithPrecision.year_capitalized.Vitro
+uil-data:label.dateTimeWithPrecision.year_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "год"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "label.dateTimeWithPrecision.year_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "label.dateTimeWithPrecision.year_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:relate_editors_profiles.Vitro
+uil-data:relate_editors_profiles.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Соотнести редакторов профилей с профилями"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "relate_editors_profiles" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "relate_editors_profiles" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:vitro_bullet_four.Vitro
+uil-data:vitro_bullet_four.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Строить поисковые запросы к данным"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "vitro_bullet_four" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "vitro_bullet_four" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:save_changes.Vitro
+uil-data:save_changes.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Сохранить изменения"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "save_changes" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "save_changes" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:cant_activate_while_logged_in.Vitro
+uil-data:cant_activate_while_logged_in.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Вы не можете активировать учетную запись для {0}, если вошли в систему как {1}. Пожалуйста, выйдите из системы и повторите попытку."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "cant_activate_while_logged_in" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "cant_activate_while_logged_in" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:next_capitalized.Vitro
+uil-data:next_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Следующая"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "next_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "next_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:end_capitalized.Vitro
+uil-data:end_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Окончание,"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "end_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "end_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:custom_template_containing_content.Vitro
+uil-data:custom_template_containing_content.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Заполненный пользовательский шаблон"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "custom_template_containing_content" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "custom_template_containing_content" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:name_of.Vitro
+uil-data:name_of.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "name_of" ;
-        prop:hasPackage  "Vitro-languages" .
+        rdf:type         uil:UILabel ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "name_of" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:content_type.Vitro
+uil-data:content_type.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Тип содержимого"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "content_type" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "content_type" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:add_label.Vitro
+uil-data:add_label.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "добавить метк"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "add_label" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "add_label" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:activate_developer_panel_mixed_caps.Vitro
+uil-data:activate_developer_panel_mixed_caps.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Включить панель разработчика"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "activate_developer_panel_mixed_caps" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "activate_developer_panel_mixed_caps" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:reset_search_index.Vitro
+uil-data:reset_search_index.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Сбросить и перестроить поисковый индекс."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "reset_search_index" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "reset_search_index" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:please_provide_contact_information.Vitro
+uil-data:please_provide_contact_information.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Укажите свою контактную информацию, чтобы завершить создание учетной записи."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "please_provide_contact_information" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "please_provide_contact_information" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:continued.Vitro
+uil-data:continued.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "продолжение следует"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "continued" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "continued" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_no_email.Vitro
+uil-data:error_no_email.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Необходимо указать адрес электронной почты."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_no_email" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_no_email" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_no_last_name.Vitro
+uil-data:error_no_last_name.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Следует указать фамилию."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_no_last_name" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_no_last_name" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:december.Vitro
+uil-data:december.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "декабря"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "december" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "december" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:multiple_content_default_template_error.Vitro
+uil-data:multiple_content_default_template_error.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "При использовании нескольких типов содержимого необходимо задать пользовательский шаблон."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "multiple_content_default_template_error" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "multiple_content_default_template_error" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:all_classes.Vitro
+uil-data:all_classes.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Все классы"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "all_classes" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "all_classes" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:viewing_page.Vitro
+uil-data:viewing_page.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Вероятная просматриваемая страница"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "viewing_page" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "viewing_page" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:individual_not_found_msg.Vitro
+uil-data:individual_not_found_msg.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Данный экземпляр класса не был найден в системе."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "individual_not_found_msg" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "individual_not_found_msg" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:setup_navigation_menu.Vitro
+uil-data:setup_navigation_menu.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Настройка основного навигационного меню для вашего сайта"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "setup_navigation_menu" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "setup_navigation_menu" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:external_id_already_in_use.Vitro
+uil-data:external_id_already_in_use.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Учетная запись пользователя ''{0}'&#039 уже существует;"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "external_id_already_in_use" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "external_id_already_in_use" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:ascending_order.Vitro
+uil-data:ascending_order.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "в порядке возрастания"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "ascending_order" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "ascending_order" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:browse_all_content.Vitro
+uil-data:browse_all_content.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "просмотреть всё содержимое"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "browse_all_content" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "browse_all_content" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:begin_with_slash_no_example.Vitro
+uil-data:begin_with_slash_no_example.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Должен начинаться с косой черты: /"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "begin_with_slash_no_example" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "begin_with_slash_no_example" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_occurred_at.Vitro
+uil-data:error_occurred_at.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "На вашем сайте VIVO произошла ошибка в {0}."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_occurred_at" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_occurred_at" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_editors.Vitro
+uil-data:select_editors.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Выбрать редакторов"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_editors" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_editors" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:supply_html.Vitro
+uil-data:supply_html.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Здесь следует ввести HTML-код или текст."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "supply_html" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "supply_html" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:slash_example.Vitro
+uil-data:slash_example.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "(например, /people)"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "slash_example" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "slash_example" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:property_hierarchy.Vitro
+uil-data:property_hierarchy.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Иерархия свойств"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "property_hierarchy" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "property_hierarchy" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:try_rebuilding_index.Vitro
+uil-data:try_rebuilding_index.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Попробуйте перестроить поисковый индекс."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "try_rebuilding_index" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "try_rebuilding_index" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_in_search_request.Vitro
+uil-data:error_in_search_request.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Поисковый запрос содержал ошибки."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_in_search_request" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_in_search_request" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:first_time_login.Vitro
+uil-data:first_time_login.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Первый вход в систему"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "first_time_login" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "first_time_login" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:first_time_external_email_plain_text.Vitro
+uil-data:first_time_external_email_plain_text.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "${userAccount.firstName} ${userAccount.lastName}\n\nПоздравляем!\n\nМы создали новую учётную запись VIVO, связанную с адресом\n${userAccount.emailAddress}.\n\nСпасибо!"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "first_time_external_email_plain_text" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "first_time_external_email_plain_text" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:faux_property_by_base.Vitro
+uil-data:faux_property_by_base.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "номинальные свойства, упорядоченные по базовому свойству"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "faux_property_by_base" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "faux_property_by_base" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:alt_thumbnail_photo.Vitro
+uil-data:alt_thumbnail_photo.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Личное фото"@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "alt_thumbnail_photo" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "alt_thumbnail_photo" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:no_individual_associated_with_id.Vitro
+uil-data:no_individual_associated_with_id.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "По какой-то причине в системе не найдено человека, связанного с вашим Net ID. Возможно, вам следует обратиться к администратору."@ru-RU ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "no_individual_associated_with_id" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "no_individual_associated_with_id" ;
+        uil:hasPackage  "Vitro-languages" .

--- a/home/src/main/resources/rdf/i18n/sr_Latn_RS/interface-i18n/firsttime/vitro_UiLabel.ttl
+++ b/home/src/main/resources/rdf/i18n/sr_Latn_RS/interface-i18n/firsttime/vitro_UiLabel.ttl
@@ -1,6266 +1,6266 @@
 @prefix owl:   <http://www.w3.org/2002/07/owl#> .
 @prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
-@prefix prop-data: <http://vivoweb.org/ontology/core/properties/individual#> .
-@prefix prop:  <http://vivoweb.org/ontology/core/properties/vocabulary#> .
+@prefix uil-data: <http://vivoweb.org/ontology/vitro/ui-label/individual#> .
+@prefix uil:  <http://vivoweb.org/ontology/vitro/ui-label/vocabulary#> .
 @prefix xsd:   <http://www.w3.org/2001/XMLSchema#> .
 @prefix skos:  <http://www.w3.org/2004/02/skos/core#> .
 @prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> .
 
-prop-data:collapse_all.Vitro
+uil-data:collapse_all.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "minimizirajte sve"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "collapse_all" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "collapse_all" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:no_password_supplied.Vitro
+uil-data:no_password_supplied.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Nije uneta lozinka."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "no_password_supplied" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "no_password_supplied" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:crop_page_title.Vitro
+uil-data:crop_page_title.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Isecite sliku"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "crop_page_title" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "crop_page_title" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:label.dateTimeWithPrecision.month_capitalized.Vitro
+uil-data:label.dateTimeWithPrecision.month_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Mesec"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "label.dateTimeWithPrecision.month_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "label.dateTimeWithPrecision.month_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:advanced_search_tip_three.Vitro
+uil-data:advanced_search_tip_three.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Možete kombinovati boolean operatore i pretragu po frazama -- npr. \"<i>klimatske promene</i>\" OR \"<i>globalno zagrejavanje</i>\"."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "advanced_search_tip_three" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "advanced_search_tip_three" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:file_upload_error_file_size_is_zero.Vitro
+uil-data:file_upload_error_file_size_is_zero.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "file_upload_error_file_size_is_zero" ;
-        prop:hasPackage  "Vitro-languages" .
+        rdf:type         uil:UILabel ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "file_upload_error_file_size_is_zero" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:delete_entry_capitalized.Vitro
+uil-data:delete_entry_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Obrišite ovu stavku?"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "delete_entry_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "delete_entry_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:remove_selection_title.Vitro
+uil-data:remove_selection_title.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "uklonite odabrano"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "remove_selection_title" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "remove_selection_title" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:powered_by.Vitro
+uil-data:powered_by.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Omogućeno od strane"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "powered_by" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "powered_by" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:accounts_search_results.Vitro
+uil-data:accounts_search_results.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Rezultati pretrage za"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "accounts_search_results" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "accounts_search_results" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:search_individual_results.Vitro
+uil-data:search_individual_results.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Pretražite pojedince klase"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "search_individual_results" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "search_individual_results" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:vclassAlpha_not_implemented.Vitro
+uil-data:vclassAlpha_not_implemented.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "vclassAlpha još nije implementirana."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "vclassAlpha_not_implemented" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "vclassAlpha_not_implemented" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_an_existing.Vitro
+uil-data:select_an_existing.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Odaberite postojeći"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_an_existing" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_an_existing" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:no_appropriate_entry.Vitro
+uil-data:no_appropriate_entry.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ako ne možete da pronađete odgovarajuću stavku iz liste iznad"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "no_appropriate_entry" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "no_appropriate_entry" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:descending_order.Vitro
+uil-data:descending_order.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "opadajući redosled"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "descending_order" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "descending_order" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:label.dateTimeWithPrecision.hour_capitalized.Vitro
+uil-data:label.dateTimeWithPrecision.hour_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Sati"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "label.dateTimeWithPrecision.hour_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "label.dateTimeWithPrecision.hour_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:add_remove_rdf.Vitro
+uil-data:add_remove_rdf.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Dodajte/Uklonite RDF podatke"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "add_remove_rdf" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "add_remove_rdf" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:account.Vitro
+uil-data:account.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "nalog"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "account" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "account" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:label.Vitro
+uil-data:label.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "labela"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "label" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "label" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:no_classes_to_select.Vitro
+uil-data:no_classes_to_select.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "U sistemu se ne nalazi ni jedna klasa koju bi ste mogli odabrati."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "no_classes_to_select" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "no_classes_to_select" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:page_curator_permission_option.Vitro
+uil-data:page_curator_permission_option.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ovu stranicu mogu da vide korisnici sa ulogom koja nije niža od kuratora"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "page_curator_permission_option" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "page_curator_permission_option" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:individuals_in_system.Vitro
+uil-data:individuals_in_system.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "osoba u sistemu."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "individuals_in_system" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "individuals_in_system" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:search_help.Vitro
+uil-data:search_help.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "pomoć za pretragu"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "search_help" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "search_help" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:there_are_no_entries_starting_with.Vitro
+uil-data:there_are_no_entries_starting_with.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ne postoje stavke koje počinju sa"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "there_are_no_entries_starting_with" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "there_are_no_entries_starting_with" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:user_accounts_link.Vitro
+uil-data:user_accounts_link.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Korisnički nalozi"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "user_accounts_link" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "user_accounts_link" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:ontology_capitalized.Vitro
+uil-data:ontology_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ontologija"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "ontology_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "ontology_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:change_password_to_login.Vitro
+uil-data:change_password_to_login.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Promenite lozinku kako bi mogli da se prijavite"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "change_password_to_login" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "change_password_to_login" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:a_menu_page.Vitro
+uil-data:a_menu_page.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ovo je meni-stranica"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "a_menu_page" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "a_menu_page" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:comments.Vitro
+uil-data:comments.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Komentari"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "comments" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "comments" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:add_new_of_type.Vitro
+uil-data:add_new_of_type.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Dodajte novu stavku ovog tipa"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "add_new_of_type" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "add_new_of_type" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:reset_password_note.Vitro
+uil-data:reset_password_note.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Napomena: Uputstva za resetovanje lozinke će biti poslata na email adresu koju ste uneli. Lozinka neće biti resetovana sve dok korisnik ne klikne na link koji se nalazi u email-u."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "reset_password_note" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "reset_password_note" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:startup_status.Vitro
+uil-data:startup_status.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Status pokretanja"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "startup_status" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "startup_status" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:no_results_returned.Vitro
+uil-data:no_results_returned.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Nisu vraćeni rezultati."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "no_results_returned" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "no_results_returned" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:submit_add_new_account.Vitro
+uil-data:submit_add_new_account.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Dodajte novi nalog"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "submit_add_new_account" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "submit_add_new_account" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:password_reset_complete_subject.Vitro
+uil-data:password_reset_complete_subject.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Vaša {0} lozinka je promenjena."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "password_reset_complete_subject" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "password_reset_complete_subject" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:file_upload_error_supported_actions.Vitro
+uil-data:file_upload_error_supported_actions.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "file_upload_error_supported_actions" ;
-        prop:hasPackage  "Vitro-languages" .
+        rdf:type         uil:UILabel ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "file_upload_error_supported_actions" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:create_classgroup.Vitro
+uil-data:create_classgroup.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Kreirajte grupu klasa"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "create_classgroup" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "create_classgroup" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:accounts.Vitro
+uil-data:accounts.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "nalozi"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "accounts" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "accounts" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:page_not_created_msg.Vitro
+uil-data:page_not_created_msg.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Došlo je do greške prilikom kreiranja stranica, molimo Vas pogledajte logove."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "page_not_created_msg" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "page_not_created_msg" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:login_count.Vitro
+uil-data:login_count.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Broj prijava"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "login_count" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "login_count" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:not_expected_results.Vitro
+uil-data:not_expected_results.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ovo nisu rezultati koje ste očekivali?"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "not_expected_results" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "not_expected_results" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:paging_link_more.Vitro
+uil-data:paging_link_more.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "više..."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "paging_link_more" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "paging_link_more" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:sparql_query_description_1.Vitro
+uil-data:sparql_query_description_1.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "# i njihove labele (ako su dostupne)"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "sparql_query_description_1" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "sparql_query_description_1" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:acct_created_email_plain_text.Vitro
+uil-data:acct_created_email_plain_text.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "${userAccount.firstName} ${userAccount.lastName}\n\nČestitamo!\n\nKreirali smo vaš novi nalog za ${siteName},\npovezan sa ${userAccount.emailAddress} email adresom.\n\nAko niste zatražili kreiranje novog naloga možete ignorisati ovaj email.\nZahtev će isteći za 30 dana.\n\nNalepite link koji se nalazi ispred u navigacioni bar Vašeg pretraživača kako biste\nkreirali lozinku za Vaš nov nalog koristeći naše zaštićene servere.\n\n${passwordLink}\n\nHvala Vam!\n"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "acct_created_email_plain_text" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "acct_created_email_plain_text" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:all_rights_reserved.Vitro
+uil-data:all_rights_reserved.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Sva prava su zadržana."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "all_rights_reserved" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "all_rights_reserved" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:submit_save.Vitro
+uil-data:submit_save.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Sačuvajte fotografiju"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "submit_save" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "submit_save" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:associate_classes_with_group.Vitro
+uil-data:associate_classes_with_group.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "i povežite klase sa grupom koju ste kreirali."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "associate_classes_with_group" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "associate_classes_with_group" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:about.Vitro
+uil-data:about.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "O sajtu"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "about" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "about" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:activate_developer_panel.Vitro
+uil-data:activate_developer_panel.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Aktivirajte panel za programere"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "activate_developer_panel" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "activate_developer_panel" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:since.Vitro
+uil-data:since.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Od"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "since" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "since" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:limit_to.Vitro
+uil-data:limit_to.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ograničite na"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "limit_to" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "limit_to" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:password_created_subject.Vitro
+uil-data:password_created_subject.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Vaša {0} lozinka je uspešno kreirana."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "password_created_subject" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "password_created_subject" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:vitro_description.Vitro
+uil-data:vitro_description.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Vitro je veb editor opšte namene za rad sa ontologijama koji omogućava javnu pretragu istih. Vitro je Java veb aplikacija koja se pokreće unutar Tomcat servlet kontejnera."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "vitro_description" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "vitro_description" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:logins_disabled_for_maintenance.Vitro
+uil-data:logins_disabled_for_maintenance.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Prijavljivanje korisnika je trenutno onemogućeno zbog održavanja sistema."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "logins_disabled_for_maintenance" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "logins_disabled_for_maintenance" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:current_time.Vitro
+uil-data:current_time.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Trenutno vreme:"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "current_time" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "current_time" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:release.Vitro
+uil-data:release.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "izdanje"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "release" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "release" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:authenticator.Vitro
+uil-data:authenticator.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Autentifikatori"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "authenticator" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "authenticator" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:preparing_to_rebuild_index.Vitro
+uil-data:preparing_to_rebuild_index.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Priprema za kreiranje indeksa pretrage."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "preparing_to_rebuild_index" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "preparing_to_rebuild_index" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:login_status.Vitro
+uil-data:login_status.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Status prijave:"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "login_status" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "login_status" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:scroll_to_menus.Vitro
+uil-data:scroll_to_menus.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "idite na grupu menija za svojstva"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "scroll_to_menus" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "scroll_to_menus" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:sparql_query_description_0.Vitro
+uil-data:sparql_query_description_0.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "# Ovaj upit dobavlja 20 geografskih lokacije"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "sparql_query_description_0" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "sparql_query_description_0" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:delete_button.Vitro
+uil-data:delete_button.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Obrišite"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "delete_button" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "delete_button" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:fixed_html.Vitro
+uil-data:fixed_html.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Fiksni HTML"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "fixed_html" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "fixed_html" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:you_can.Vitro
+uil-data:you_can.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Možete "@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "you_can" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "you_can" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:supply_sparql_query.Vitro
+uil-data:supply_sparql_query.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Morate uneti Sparql upit."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "supply_sparql_query" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "supply_sparql_query" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:enter_email_password.Vitro
+uil-data:enter_email_password.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Unesite email i lozinku za Vaš interni Vitro nalog."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "enter_email_password" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "enter_email_password" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:selected_editors.Vitro
+uil-data:selected_editors.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Odabrani urednici"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "selected_editors" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "selected_editors" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:custom_template_mixed_caps.Vitro
+uil-data:custom_template_mixed_caps.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Prilagođen šablon"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "custom_template_mixed_caps" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "custom_template_mixed_caps" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:animal.Vitro
+uil-data:animal.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Životinja:"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "animal" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "animal" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:enter_sparql_query_here.Vitro
+uil-data:enter_sparql_query_here.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ovde unesite SPRQL upit"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "enter_sparql_query_here" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "enter_sparql_query_here" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:recompute_inferences.Vitro
+uil-data:recompute_inferences.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Rekompajlirajte interfejse"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "recompute_inferences" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "recompute_inferences" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:restrict_logins.Vitro
+uil-data:restrict_logins.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ograničite prijavljivanje"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "restrict_logins" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "restrict_logins" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:email_address.Vitro
+uil-data:email_address.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Email adresa"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "email_address" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "email_address" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:alt_confirmation.Vitro
+uil-data:alt_confirmation.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ikonica za potvrdu"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "alt_confirmation" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "alt_confirmation" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:drag_drop_to_reorder_menus.Vitro
+uil-data:drag_drop_to_reorder_menus.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Prevucite kako bi ste promenili redosled stavki u meniju "@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "drag_drop_to_reorder_menus" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "drag_drop_to_reorder_menus" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:most_recent_update.Vitro
+uil-data:most_recent_update.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Poslednje ažuriranje je bilo u"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "most_recent_update" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "most_recent_update" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:delete_link.Vitro
+uil-data:delete_link.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Obrišite fotografiju"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "delete_link" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "delete_link" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:check_startup_status.Vitro
+uil-data:check_startup_status.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Proverite stranicu 'status pokretanja' i/ili logove veb servera za više informacija."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "check_startup_status" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "check_startup_status" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:no_pages_defined.Vitro
+uil-data:no_pages_defined.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Još ne postoje definisane stranice."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "no_pages_defined" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "no_pages_defined" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:advanced_search_tip_five.Vitro
+uil-data:advanced_search_tip_five.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Koristite Džoker karakter * da bi ste pronašli još više varijacija izraza po kom pretražujete -- npr. <i>nano*</i> će vratiti i izraz <i>nanotehnologija</i> i izraz <i>nanofabrikacija</i>."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "advanced_search_tip_five" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "advanced_search_tip_five" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_message.Vitro
+uil-data:error_message.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Poruka o grešci"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_message" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_message" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:double_quote_note_allowed.Vitro
+uil-data:double_quote_note_allowed.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Naziv promenjive ne treba da ima navodnike."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "double_quote_note_allowed" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "double_quote_note_allowed" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:crop_page_title_with_name.Vitro
+uil-data:crop_page_title_with_name.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Isecite sliku za {0}"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "crop_page_title_with_name" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "crop_page_title_with_name" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:logins_not_restricted.Vitro
+uil-data:logins_not_restricted.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Prijavljivanje više nije ograničeno."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "logins_not_restricted" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "logins_not_restricted" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:deleted_accounts.Vitro
+uil-data:deleted_accounts.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "{0} {0, choice, 0#naloga|1#nalog|1<naloga} je {0, choice, 0#obrisano|1#obrisan|1<obrisano}."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "deleted_accounts" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "deleted_accounts" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:whole_number.Vitro
+uil-data:whole_number.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Neispravan unos. Molimo Vas unesite ceo broj bez ikakvih separatora."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "whole_number" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "whole_number" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:edit_account.Vitro
+uil-data:edit_account.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Izmenite nalog"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "edit_account" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "edit_account" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:search_tip_two.Vitro
+uil-data:search_tip_two.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Koristite navodnike kako bi ste tražili čitave fraze -- npr. \"<i>savijanje proteina</i>\"."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "search_tip_two" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "search_tip_two" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:email_capitalized.Vitro
+uil-data:email_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Email"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "email_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "email_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:policies.Vitro
+uil-data:policies.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Politike"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "policies" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "policies" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:failed.Vitro
+uil-data:failed.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "nije uspelo"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "failed" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "failed" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:containers_do_not_pick_up_changes.Vitro
+uil-data:containers_do_not_pick_up_changes.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Kontejneri ne prepoznaju promene u vrednostima svojih elemenata"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "containers_do_not_pick_up_changes" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "containers_do_not_pick_up_changes" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:file_upload_error_media_type_not_allowed.Vitro
+uil-data:file_upload_error_media_type_not_allowed.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "file_upload_error_media_type_not_allowed" ;
-        prop:hasPackage  "Vitro-languages" .
+        rdf:type         uil:UILabel ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "file_upload_error_media_type_not_allowed" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:add_new_classes.Vitro
+uil-data:add_new_classes.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Dodajte novu klasu"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "add_new_classes" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "add_new_classes" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:identifier_factories.Vitro
+uil-data:identifier_factories.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Centri za identifikatore"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "identifier_factories" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "identifier_factories" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:show_subclasses.Vitro
+uil-data:show_subclasses.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "prikažite podklase"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "show_subclasses" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "show_subclasses" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:enter_id_to_login.Vitro
+uil-data:enter_id_to_login.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Unesite userID sa kojim želite da se prikavite, ili kliknite Poništi."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "enter_id_to_login" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "enter_id_to_login" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:upload_heading.Vitro
+uil-data:upload_heading.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Odabir slike"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "upload_heading" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "upload_heading" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:warnings_issued.Vitro
+uil-data:warnings_issued.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "{0} je izdao upozorenja za vreme pokretanja aplikacije."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "warnings_issued" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "warnings_issued" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:account_management.Vitro
+uil-data:account_management.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Upravljanje nalozima "@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "account_management" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "account_management" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_content_display.Vitro
+uil-data:select_content_display.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Odaberite sadržaj za prikaz"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_content_display" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_content_display" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:account_no_longer_exists.Vitro
+uil-data:account_no_longer_exists.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Nalog za koji pokušavate da kreirate lozinku više nije dostupan. Molimo Vas kontaktirajte administratora ako mislite da je došlo do greške."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "account_no_longer_exists" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "account_no_longer_exists" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:page_select_permission.Vitro
+uil-data:page_select_permission.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Odaberite dozvole za stranicu"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "page_select_permission" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "page_select_permission" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:test_for_logged_in_users.Vitro
+uil-data:test_for_logged_in_users.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ovo je test vidžet za prijavljene korisnike."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "test_for_logged_in_users" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "test_for_logged_in_users" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:edit_page.Vitro
+uil-data:edit_page.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ažurirajte {0} stranicu"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "edit_page" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "edit_page" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:no_match.Vitro
+uil-data:no_match.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "nema podudaranja"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "no_match" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "no_match" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:add_new_page.Vitro
+uil-data:add_new_page.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Dodajte novu stranicu"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "add_new_page" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "add_new_page" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:class_groups.Vitro
+uil-data:class_groups.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Grupe klasa"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "class_groups" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "class_groups" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:password_reset_pending_email_subject.Vitro
+uil-data:password_reset_pending_email_subject.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "${siteName} zahtev za reset lozinke"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "password_reset_pending_email_subject" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "password_reset_pending_email_subject" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:manage.Vitro
+uil-data:manage.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "upravljajte"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "manage" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "manage" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_password_length.Vitro
+uil-data:error_password_length.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Molimo Vas unesite lozinku koja sadrži između {0} and {1} karaktera."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_password_length" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_password_length" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:view_profile_editors.Vitro
+uil-data:view_profile_editors.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Pogledajte sve urednike profila"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "view_profile_editors" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "view_profile_editors" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:subclasses_capitalized.Vitro
+uil-data:subclasses_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Podklase"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "subclasses_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "subclasses_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:auth_matching_id_label.Vitro
+uil-data:auth_matching_id_label.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Spoljni ID/Podudarajući ID"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "auth_matching_id_label" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "auth_matching_id_label" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:page_editor_permission_option.Vitro
+uil-data:page_editor_permission_option.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ovu stranicu mogu da vide korisnici sa ulogom koja nije niža od urednika"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "page_editor_permission_option" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "page_editor_permission_option" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:delete_page.Vitro
+uil-data:delete_page.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "obrišite ovu stranicu"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "delete_page" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "delete_page" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:for.Vitro
+uil-data:for.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "za"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "for" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "for" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:manage_list_of_labels.Vitro
+uil-data:manage_list_of_labels.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "upravljajte listom labela"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "manage_list_of_labels" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "manage_list_of_labels" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:content.Vitro
+uil-data:content.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "sadržaj"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "content" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "content" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:match_by.Vitro
+uil-data:match_by.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Povežite po {0}"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "match_by" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "match_by" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:alt_preview_crop.Vitro
+uil-data:alt_preview_crop.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Izgled slike koju sečete"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "alt_preview_crop" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "alt_preview_crop" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:pretty_url.Vitro
+uil-data:pretty_url.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ulepšan URL"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "pretty_url" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "pretty_url" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:operation_successful.Vitro
+uil-data:operation_successful.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Naredba je uspešno izvršena."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "operation_successful" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "operation_successful" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:add_capitalized.Vitro
+uil-data:add_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Dodajte"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "add_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "add_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:accounts_per_page.Vitro
+uil-data:accounts_per_page.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "naloga po stranici"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "accounts_per_page" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "accounts_per_page" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_editor_and_profile.Vitro
+uil-data:select_editor_and_profile.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Morate odabrati makar jednog urednika i profil."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_editor_and_profile" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_editor_and_profile" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:request_failed.Vitro
+uil-data:request_failed.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Zahtev nije uspeo. Molimo Vas kontaktirajte Vašeg administratora."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "request_failed" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "request_failed" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:from_site_admin_page.Vitro
+uil-data:from_site_admin_page.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "iz stranice za administratora sajta."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "from_site_admin_page" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "from_site_admin_page" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:new_password_capitalized.Vitro
+uil-data:new_password_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Nova lozinka"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "new_password_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "new_password_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:advanced_search_tip_one.Vitro
+uil-data:advanced_search_tip_one.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Kada unesete više od jednog izraza, pretraga će vratiti samo rezultate koji sadrže svaki oid njih osim ako ne iskoristite boolean operator \"OR\" -- npr. <i>piletina</i> OR <i>jaja</i>."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "advanced_search_tip_one" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "advanced_search_tip_one" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:password_reset_complete_email_plain_text.Vitro
+uil-data:password_reset_complete_email_plain_text.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "${userAccount.firstName} ${userAccount.lastName}\n\nLozinka je uspešno promenjena.\n\nVaša lozinka povezana sa nalogom ${userAccount.emailAddress} je promenjena.\n\nHvala Vam."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "password_reset_complete_email_plain_text" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "password_reset_complete_email_plain_text" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:application_error_email_subject.Vitro
+uil-data:application_error_email_subject.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Došlo je do greške na Vašem sajtu ${siteName!}"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "application_error_email_subject" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "application_error_email_subject" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:return_to.Vitro
+uil-data:return_to.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "vratite se na {0}"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "return_to" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "return_to" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:last_login.Vitro
+uil-data:last_login.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Poslednja prijava"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "last_login" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "last_login" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:view_profile_in_rdf.Vitro
+uil-data:view_profile_in_rdf.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "pogledajte profil u RDF formatu"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "view_profile_in_rdf" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "view_profile_in_rdf" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:minimum_password_length.Vitro
+uil-data:minimum_password_length.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Lozinka mora da sadrži između {0} i {1} karaktera."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "minimum_password_length" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "minimum_password_length" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:contact_us.Vitro
+uil-data:contact_us.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Kontaktirajte nas"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "contact_us" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "contact_us" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:download_results.Vitro
+uil-data:download_results.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Rezultati skidanja"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "download_results" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "download_results" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:selected_profiles.Vitro
+uil-data:selected_profiles.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Odabrani profili"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "selected_profiles" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "selected_profiles" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:has_value.Vitro
+uil-data:has_value.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "sadrži vrednost"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "has_value" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "has_value" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:faux_property_listing.Vitro
+uil-data:faux_property_listing.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Lista faux svojstva"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "faux_property_listing" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "faux_property_listing" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:display_admin_header.Vitro
+uil-data:display_admin_header.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Administracija i Konfiguracija Prikaza"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "display_admin_header" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "display_admin_header" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_no_password.Vitro
+uil-data:error_no_password.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Molimo Vas unesite Vašu lozinku."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_no_password" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_no_password" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:remove_capitalized.Vitro
+uil-data:remove_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Uklonite"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "remove_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "remove_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:october.Vitro
+uil-data:october.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "oktobar"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "october" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "october" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:file_upload_subject.Vitro
+uil-data:file_upload_subject.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "file_upload_subject" ;
-        prop:hasPackage  "Vitro-languages" .
+        rdf:type         uil:UILabel ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "file_upload_subject" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:manage_site.Vitro
+uil-data:manage_site.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Upravljajte ovim sajtom"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "manage_site" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "manage_site" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:confirm_delete_account_plural.Vitro
+uil-data:confirm_delete_account_plural.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Da li ste sigurni da želite da obrišete ove naloge?"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "confirm_delete_account_plural" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "confirm_delete_account_plural" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:sunday.Vitro
+uil-data:sunday.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "nedelja"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "sunday" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "sunday" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:password_system_has_changed.Vitro
+uil-data:password_system_has_changed.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "password_system_has_changed" ;
-        prop:hasPackage  "Vitro-languages" .
+        rdf:type         uil:UILabel ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "password_system_has_changed" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:rebuild_search_index.Vitro
+uil-data:rebuild_search_index.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ponovo kreirajte indeks pretrage"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "rebuild_search_index" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "rebuild_search_index" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:password_saved.Vitro
+uil-data:password_saved.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Vaša lozinka je sačuvana."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "password_saved" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "password_saved" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:supply_query_variable.Vitro
+uil-data:supply_query_variable.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Morate navesti promenjivu kako bi ste sačuvali rezultate upita."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "supply_query_variable" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "supply_query_variable" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:configure_page_if_permissable.Vitro
+uil-data:configure_page_if_permissable.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "za konfiguraciju ove stranice ako korisnik ima dozvolu."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "configure_page_if_permissable" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "configure_page_if_permissable" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:invalid_date_form_msg.Vitro
+uil-data:invalid_date_form_msg.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "mora biti u ispravnom formatu datuma: mm/dd/yyyy."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "invalid_date_form_msg" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "invalid_date_form_msg" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:manage_list_of.Vitro
+uil-data:manage_list_of.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Upravljajte listom"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "manage_list_of" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "manage_list_of" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:verbose_property_status.Vitro
+uil-data:verbose_property_status.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Detaljan prikaz je"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "verbose_property_status" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "verbose_property_status" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:sparql_query_select_ask_results.Vitro
+uil-data:sparql_query_select_ask_results.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Format za rezultate SELECT i ASK upita"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "sparql_query_select_ask_results" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "sparql_query_select_ask_results" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:individual_not_found.Vitro
+uil-data:individual_not_found.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Osoba nije pronađena"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "individual_not_found" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "individual_not_found" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:classes_by_classgroup.Vitro
+uil-data:classes_by_classgroup.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Klase po grupama klasa"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "classes_by_classgroup" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "classes_by_classgroup" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:confirm_email_changed_email_plain_text.Vitro
+uil-data:confirm_email_changed_email_plain_text.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Poštovani ${userAccount.firstName} ${userAccount.lastName}:\n\nNedavno ste promenili email adresu povezanu sa nalogom za korisnika\n${userAccount.firstName} ${userAccount.lastName}\n\nHvala Vam."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "confirm_email_changed_email_plain_text" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "confirm_email_changed_email_plain_text" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:close_capitalized.Vitro
+uil-data:close_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Zatvorite"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "close_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "close_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:browse_class_group.Vitro
+uil-data:browse_class_group.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Pretražite grupe klasa"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "browse_class_group" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "browse_class_group" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:statistics.Vitro
+uil-data:statistics.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Statistika"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "statistics" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "statistics" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:new_password.Vitro
+uil-data:new_password.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Nova lozinka"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "new_password" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "new_password" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:hide_show_subclasses.Vitro
+uil-data:hide_show_subclasses.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "sakrijte/prikažite podklase"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "hide_show_subclasses" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "hide_show_subclasses" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:class_hierarchy.Vitro
+uil-data:class_hierarchy.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Hijerarhija klasa"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "class_hierarchy" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "class_hierarchy" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:add_content_manage_site.Vitro
+uil-data:add_content_manage_site.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "dodati sadržaj i upravljajte sajtom"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "add_content_manage_site" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "add_content_manage_site" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:background_threads.Vitro
+uil-data:background_threads.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Pozadinske niti"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "background_threads" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "background_threads" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:create_capitalized.Vitro
+uil-data:create_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Kreirajte"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "create_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "create_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_previous_password.Vitro
+uil-data:error_previous_password.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Vaša nova lozinka ne sme da bude ista kao trenutna."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_previous_password" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_previous_password" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:change_password.Vitro
+uil-data:change_password.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Morate promeniti Vašu lčozinku kako bi ste se prijavili."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "change_password" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "change_password" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:menu_management.Vitro
+uil-data:menu_management.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Upravljajne menijem"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "menu_management" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "menu_management" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:email_change_will_be_confirmed.Vitro
+uil-data:email_change_will_be_confirmed.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Napomena: ako promenite email adresu, email sa potvrdom će biti poslat na novu adresu."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "email_change_will_be_confirmed" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "email_change_will_be_confirmed" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:fake_external_auth.Vitro
+uil-data:fake_external_auth.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Simulacija eksterne autentifikacije"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "fake_external_auth" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "fake_external_auth" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:run_sdb_setup.Vitro
+uil-data:run_sdb_setup.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Pokrenite SDB setup"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "run_sdb_setup" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "run_sdb_setup" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:property_management.Vitro
+uil-data:property_management.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Upravljanje svojstvima"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "property_management" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "property_management" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:end_your_Session.Vitro
+uil-data:end_your_Session.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Završite Vašu sesiju"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "end_your_Session" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "end_your_Session" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:search_index_not_connected.Vitro
+uil-data:search_index_not_connected.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Indeks pretrage nije dostupan."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "search_index_not_connected" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "search_index_not_connected" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:change_content_type.Vitro
+uil-data:change_content_type.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Promenite tip sadržaja"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "change_content_type" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "change_content_type" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:invalid_search_term.Vitro
+uil-data:invalid_search_term.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Izraz za pretragu nije validan"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "invalid_search_term" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "invalid_search_term" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:index_recs_completed.Vitro
+uil-data:index_recs_completed.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Izvršeno {0} od {1} zapisa iz indeksa."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "index_recs_completed" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "index_recs_completed" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:add_profile.Vitro
+uil-data:add_profile.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Dodajte profil"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "add_profile" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "add_profile" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:view_labels_capitalized.Vitro
+uil-data:view_labels_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Pogledajte labele"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "view_labels_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "view_labels_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:maximum_cardinality.Vitro
+uil-data:maximum_cardinality.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "maksimalni kardinalitet"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "maximum_cardinality" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "maximum_cardinality" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:please_format_email.Vitro
+uil-data:please_format_email.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Molimo Vas formatirajte Vašu email adresu kao:"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "please_format_email" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "please_format_email" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:external_auth_only.Vitro
+uil-data:external_auth_only.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Autentifikacije isključivo putem eksternih servisa"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "external_auth_only" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "external_auth_only" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:return_to_individual.Vitro
+uil-data:return_to_individual.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Vratite se na stranicu pojedinca"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "return_to_individual" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "return_to_individual" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:all_x_properties.Vitro
+uil-data:all_x_properties.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Sva {0} svojstva"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "all_x_properties" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "all_x_properties" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:password_created_email_plain_text.Vitro
+uil-data:password_created_email_plain_text.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "${userAccount.firstName} ${userAccount.lastName}\n\nLozinka je uspešno kreirana.\n\nVaša nova lozinka povezana sa nalogom ${userAccount.emailAddress} je kreirana.\n\nHvala Vam."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "password_created_email_plain_text" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "password_created_email_plain_text" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:already_logged_in.Vitro
+uil-data:already_logged_in.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Već ste prijavljeni."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "already_logged_in" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "already_logged_in" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:supply_class_group.Vitro
+uil-data:supply_class_group.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Morate uneti grupu klasa."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "supply_class_group" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "supply_class_group" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:matching_prop_not_defined.Vitro
+uil-data:matching_prop_not_defined.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Svojstvo po kom vršite povezivanje nije definisano"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "matching_prop_not_defined" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "matching_prop_not_defined" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:display_rank.Vitro
+uil-data:display_rank.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Prikažite Rang"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "display_rank" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "display_rank" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:profile_editing_title.Vitro
+uil-data:profile_editing_title.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Urednike koje odaberete sa leve strane će moći da ažuriraju VIVO profile koje odaberete sa desne strane. Možete odabrati više urednika i više profila, ali morate odabrati makar pa jedan entitet oba."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "profile_editing_title" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "profile_editing_title" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:test_for_nonlogged_in_users.Vitro
+uil-data:test_for_nonlogged_in_users.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ovo je test vidžet za neprijavljene korisnike."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "test_for_nonlogged_in_users" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "test_for_nonlogged_in_users" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:insufficient_authorization.Vitro
+uil-data:insufficient_authorization.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Nemate autoritet da pristupite stranici koju ste zatražili. Ako smatrate da je došlo do greške, molimo Vas kontaktirajte nas kako bi Vam pomogli."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "insufficient_authorization" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "insufficient_authorization" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:supply_content_type.Vitro
+uil-data:supply_content_type.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Morate uneti tip sadržaja"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "supply_content_type" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "supply_content_type" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:back_to_results.Vitro
+uil-data:back_to_results.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Nazad na rezultate"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "back_to_results" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "back_to_results" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:may_not_edit.Vitro
+uil-data:may_not_edit.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Nije dozvoljeno ažuriranje"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "may_not_edit" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "may_not_edit" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:four_digit_year.Vitro
+uil-data:four_digit_year.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Neispravan unos. Molimo Vas upišite godinu sa 4 cifre."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "four_digit_year" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "four_digit_year" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:browse_page_javascript_two.Vitro
+uil-data:browse_page_javascript_two.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "za pretraživanje informacija."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "browse_page_javascript_two" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "browse_page_javascript_two" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:password_created_email_html_text.Vitro
+uil-data:password_created_email_html_text.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "<p>\n ${userAccount.firstName} ${userAccount.lastName}\n </p>\n\n <p>\n <strong>Lozinka je uspešno kreirana.</strong>\n </p>\n\n <p>\n Vaša nova lozinka povezana sa nalogom ${userAccount.emailAddress} je kreirana.\n </p>\n\n <p>\n Hvala Vam.\n </p>"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "password_created_email_html_text" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "password_created_email_html_text" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:current_photo.Vitro
+uil-data:current_photo.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Trenutna slika"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "current_photo" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "current_photo" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_last_name.Vitro
+uil-data:select_last_name.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Odaberite postojeće prezime"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_last_name" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_last_name" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:supply_template.Vitro
+uil-data:supply_template.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Morate uneti neki šablon"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "supply_template" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "supply_template" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:view_all_accounts_title.Vitro
+uil-data:view_all_accounts_title.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "prikažite sve naloge"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "view_all_accounts_title" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "view_all_accounts_title" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:cropping_note.Vitro
+uil-data:cropping_note.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Možete pomerati i promeniti veličinu slike sa desne strane kako bi ste je prilagodili. Kada budete zadovoljni sa izgledom slike, pritisnije dugme \"Sačuvajte fotografiju\"."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "cropping_note" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "cropping_note" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:page_not_created.Vitro
+uil-data:page_not_created.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Stranica ne može da se kreira"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "page_not_created" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "page_not_created" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_email_already_exists.Vitro
+uil-data:error_email_already_exists.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Nalog sa unetom email adresom već postoji."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_email_already_exists" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_email_already_exists" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:required_field_empty_msg.Vitro
+uil-data:required_field_empty_msg.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ovo polje ne sme biti prazno."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "required_field_empty_msg" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "required_field_empty_msg" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:site_maintenance.Vitro
+uil-data:site_maintenance.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Održavanje sajta"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "site_maintenance" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "site_maintenance" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:current_date_time.Vitro
+uil-data:current_date_time.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Trenutni datum i vreme:"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "current_date_time" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "current_date_time" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:page_link.Vitro
+uil-data:page_link.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "link stranice"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "page_link" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "page_link" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:object_property_hierarchy.Vitro
+uil-data:object_property_hierarchy.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Hijerarhije svojstva objekata"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "object_property_hierarchy" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "object_property_hierarchy" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:user_accounts.Vitro
+uil-data:user_accounts.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Korisnički nalozi"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "user_accounts" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "user_accounts" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:maximum_file_size.Vitro
+uil-data:maximum_file_size.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Najveća veličina fajla: {0} megabajta"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "maximum_file_size" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "maximum_file_size" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:add_new_account.Vitro
+uil-data:add_new_account.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Dodajte novi nalog"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "add_new_account" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "add_new_account" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:browse_all_starts_with.Vitro
+uil-data:browse_all_starts_with.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Pretražite sve osobe čije ime počinje sa {0}"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "browse_all_starts_with" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "browse_all_starts_with" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:status.Vitro
+uil-data:status.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Status"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "status" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "status" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:index.Vitro
+uil-data:index.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Indeks"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "index" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "index" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:verify_this_match_title.Vitro
+uil-data:verify_this_match_title.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "proverite podudaranje"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "verify_this_match_title" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "verify_this_match_title" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:search_indexer_idle.Vitro
+uil-data:search_indexer_idle.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Indeks pretrage je neaktivan."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "search_indexer_idle" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "search_indexer_idle" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:start_capitalized.Vitro
+uil-data:start_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Početak"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "start_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "start_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:minimum_cardinality.Vitro
+uil-data:minimum_cardinality.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "minimalni kardinalitet"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "minimum_cardinality" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "minimum_cardinality" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:manage_affiliated_people_link.Vitro
+uil-data:manage_affiliated_people_link.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "upravljanje povezanim ljudima"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "manage_affiliated_people_link" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "manage_affiliated_people_link" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:initial_password.Vitro
+uil-data:initial_password.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Početna lozinka"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "initial_password" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "initial_password" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:invalid_format.Vitro
+uil-data:invalid_format.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Invalid format"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "invalid_format" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "invalid_format" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:menu_orering.Vitro
+uil-data:menu_orering.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Redosled opcija unutar menija"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "menu_orering" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "menu_orering" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:confirm_entry_deletion_from.Vitro
+uil-data:confirm_entry_deletion_from.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Da li ste sigurni da želite da obrišete sledeći unos iz"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "confirm_entry_deletion_from" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "confirm_entry_deletion_from" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:add_types.Vitro
+uil-data:add_types.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Dodajte jedan ili više tipova"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "add_types" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "add_types" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:group_capitalized.Vitro
+uil-data:group_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Grupa"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "group_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "group_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:entry.Vitro
+uil-data:entry.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "unos"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "entry" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "entry" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:search_vitro.Vitro
+uil-data:search_vitro.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Pretražite Vitro"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "search_vitro" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "search_vitro" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:version.Vitro
+uil-data:version.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Verzija"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "version" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "version" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:hide_subclasses.Vitro
+uil-data:hide_subclasses.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "sakrijte podklase"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "hide_subclasses" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "hide_subclasses" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:caused_by.Vitro
+uil-data:caused_by.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Izazvano od strane"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "caused_by" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "caused_by" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:show_more_content.Vitro
+uil-data:show_more_content.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "prikažite više sadržaja"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "show_more_content" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "show_more_content" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:advanced_search_tip_six.Vitro
+uil-data:advanced_search_tip_six.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Pretraga koristi osnove izraza koje unesete -- npr. pretraga po izrazu <i>cogniti*</i> neće vratiti ništa, dok pretraga po izrazu <i>cognit*</i> vraća i <i>cognitive</i> i <i>cognition</i>."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "advanced_search_tip_six" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "advanced_search_tip_six" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:myAccount_confirm_changes_plus_note.Vitro
+uil-data:myAccount_confirm_changes_plus_note.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Unete izmene su sačuvane. Email sa potvrdom je poslat na adresu {0}."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "myAccount_confirm_changes_plus_note" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "myAccount_confirm_changes_plus_note" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:class_management.Vitro
+uil-data:class_management.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Upravljanje klasama"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "class_management" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "class_management" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:display_less.Vitro
+uil-data:display_less.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "manje"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "display_less" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "display_less" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:add_property_group.Vitro
+uil-data:add_property_group.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Dodajte novu grupu svojstava "@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "add_property_group" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "add_property_group" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:browse_by.Vitro
+uil-data:browse_by.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Pregledajte po"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "browse_by" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "browse_by" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:class_group_link.Vitro
+uil-data:class_group_link.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "link grupe klasa"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "class_group_link" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "class_group_link" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:confirm_password.Vitro
+uil-data:confirm_password.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ponovite novu lozinku"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "confirm_password" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "confirm_password" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:saturday.Vitro
+uil-data:saturday.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "subota"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "saturday" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "saturday" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:_publications_link.Vitro
+uil-data:_publications_link.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "_publications_link" ;
-        prop:hasPackage  "Vitro-languages" .
+        rdf:type         uil:UILabel ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "_publications_link" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:javascript_require_to_edit.Vitro
+uil-data:javascript_require_to_edit.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Da bi ste ažurirali sadržaj, morate da omogućite JavaScript."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "javascript_require_to_edit" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "javascript_require_to_edit" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:fatal_error_detected.Vitro
+uil-data:fatal_error_detected.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "{0} je naišao na greške za vreme pokretanja aplikacije."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "fatal_error_detected" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "fatal_error_detected" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:menu_page.Vitro
+uil-data:menu_page.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Meni stranica"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "menu_page" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "menu_page" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:create_new_individual_of_the_following_type.Vitro
+uil-data:create_new_individual_of_the_following_type.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Kreiranje objekta sledećeg tipa"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "create_new_individual_of_the_following_type" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "create_new_individual_of_the_following_type" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:logins_not_already_restricted.Vitro
+uil-data:logins_not_already_restricted.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Prijavljivanje već nije ograničeno."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "logins_not_already_restricted" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "logins_not_already_restricted" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:stack_trace.Vitro
+uil-data:stack_trace.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Informacije o grešci"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "stack_trace" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "stack_trace" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:confirm_page_deletion.Vitro
+uil-data:confirm_page_deletion.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Da li ste sigurni da želite da obrišete ovu stranicu:"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "confirm_page_deletion" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "confirm_page_deletion" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_locale.Vitro
+uil-data:select_locale.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "izaberite lokalizaciju"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_locale" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_locale" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:reset_password.Vitro
+uil-data:reset_password.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Resetujte lozinku"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "reset_password" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "reset_password" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:vitro_bullet_two.Vitro
+uil-data:vitro_bullet_two.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ažurirati instance i njihove veze"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "vitro_bullet_two" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "vitro_bullet_two" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:replace_page_title.Vitro
+uil-data:replace_page_title.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Zamena slike"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "replace_page_title" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "replace_page_title" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:subproperty.Vitro
+uil-data:subproperty.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "pod-svojstvo"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "subproperty" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "subproperty" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:rdf_export.Vitro
+uil-data:rdf_export.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "RDF eksportovanje"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "rdf_export" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "rdf_export" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:click_to_view_larger.Vitro
+uil-data:click_to_view_larger.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "kliknite kako bi ste videli veću sliku"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "click_to_view_larger" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "click_to_view_larger" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:build_date.Vitro
+uil-data:build_date.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Datum izrade"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "build_date" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "build_date" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:flags.Vitro
+uil-data:flags.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Zastavice"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "flags" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "flags" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:march.Vitro
+uil-data:march.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "mart"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "march" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "march" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:display_only.Vitro
+uil-data:display_only.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Prikažite samo"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "display_only" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "display_only" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:to_manage_content.Vitro
+uil-data:to_manage_content.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "da bi ste upravljali sadržajem."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "to_manage_content" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "to_manage_content" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:acct_created_email_html_text.Vitro
+uil-data:acct_created_email_html_text.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "<p>\n ${userAccount.firstName} ${userAccount.lastName}\n </p>\n\n <p>\n <strong>Čestitamo!</strong>\n </p>\n\n <p>\n Kreirali smo vaš novi nalog za ${siteName}, povezan sa ${userAccount.emailAddress} email adresom.\n </p>\n\n <p>\n Ako niste zatražili kreiranje novog naloga možete ignorisati ovaj email.\n Zahtev će isteći za 30 dana.\n </p>\n\n <p>\n Kliknite link ispod kako bi ste kreirali lozinku za Vaš novi nalog koristeći naše zaštićene servere.\n </p>\n\n <p>\n <a href=\"${passwordLink}\" title=\"password\">${passwordLink}</a>\n </p>\n\n <p>\n Ako link iznad ne funkcioniše, možete ga kopirati i nalepiti direktno unutar Vašeg pretraživača.\n </p>\n\n <p>\n Hvala Vam!\n </p>"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "acct_created_email_html_text" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "acct_created_email_html_text" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:file_upload_confirm_delete.Vitro
+uil-data:file_upload_confirm_delete.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "file_upload_confirm_delete" ;
-        prop:hasPackage  "Vitro-languages" .
+        rdf:type         uil:UILabel ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "file_upload_confirm_delete" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:cropping_caption.Vitro
+uil-data:cropping_caption.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Vaša profilna slika će izgledati kao fotografila ispor."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "cropping_caption" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "cropping_caption" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:browse_capitalized.Vitro
+uil-data:browse_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Pregledajte"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "browse_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "browse_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:display_options.Vitro
+uil-data:display_options.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Opcije za prikazivanje"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "display_options" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "display_options" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:site_config.Vitro
+uil-data:site_config.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Konfiguracija sajta"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "site_config" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "site_config" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:undo_camelcasing.Vitro
+uil-data:undo_camelcasing.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ukloniti CamelCase notaciju"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "undo_camelcasing" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "undo_camelcasing" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:view_all_capitalized.Vitro
+uil-data:view_all_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Pogledajte sve"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "view_all_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "view_all_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_processing_labels.Vitro
+uil-data:error_processing_labels.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Greška priliko obrade zahteva: neoznačene labele se ne mogu obrisati."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_processing_labels" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_processing_labels" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:dates.Vitro
+uil-data:dates.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Datumi"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "dates" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "dates" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:myAccount_heading.Vitro
+uil-data:myAccount_heading.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Moj nalog"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "myAccount_heading" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "myAccount_heading" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:roles.Vitro
+uil-data:roles.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Uloge"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "roles" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "roles" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:april.Vitro
+uil-data:april.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "april"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "april" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "april" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:password_reset_pending_subject.Vitro
+uil-data:password_reset_pending_subject.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "{0} zahtev za reset lozinke."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "password_reset_pending_subject" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "password_reset_pending_subject" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:some_values_from.Vitro
+uil-data:some_values_from.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "neke vrednosti iz"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "some_values_from" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "some_values_from" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:browse_all_public_content.Vitro
+uil-data:browse_all_public_content.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Možete pretražiti sav javno dostupan sadržaj u okviru ovog sistema koristeći"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "browse_all_public_content" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "browse_all_public_content" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:all_values_from.Vitro
+uil-data:all_values_from.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "sve vrednosti iz"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "all_values_from" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "all_values_from" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:updated_account_2.Vitro
+uil-data:updated_account_2.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "je ažuriran."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "updated_account_2" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "updated_account_2" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:alt_error_alert.Vitro
+uil-data:alt_error_alert.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ikonica za upozorenje o grešci"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "alt_error_alert" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "alt_error_alert" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:year_month.Vitro
+uil-data:year_month.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Neispravan unos. Molimo Vas unesite godinu i mesec."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "year_month" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "year_month" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:name.Vitro
+uil-data:name.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "naziv"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "name" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "name" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:no_image.Vitro
+uil-data:no_image.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "nema slike"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "no_image" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "no_image" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:sparql_query_save_results.Vitro
+uil-data:sparql_query_save_results.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Sačuvajte rezultate u fajl"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "sparql_query_save_results" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "sparql_query_save_results" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:add_new_group.Vitro
+uil-data:add_new_group.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Dodajte novu grupu"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "add_new_group" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "add_new_group" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:browse_all.Vitro
+uil-data:browse_all.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "pretražite sve"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "browse_all" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "browse_all" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:processing_icon.Vitro
+uil-data:processing_icon.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "obrada"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "processing_icon" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "processing_icon" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:logins_restricted.Vitro
+uil-data:logins_restricted.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Prijavljivanje je od sada ograničeno."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "logins_restricted" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "logins_restricted" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:search_tip_four.Vitro
+uil-data:search_tip_four.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ako niste sigurni kako pravilno da napišete reč, stavite ~ na kraj izraza po kom radite pretragu -- npr. <i>cabage~</i> će pronaći <i>cabbage</i>, <i>steven~</i> će pronaći <i>Stephen</i> i <i>Stefan</i> (i ostala slična imena)."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "search_tip_four" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "search_tip_four" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:imageUpload.errorNoURI.Vitro
+uil-data:imageUpload.errorNoURI.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Niste uneli URI za entitet"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "imageUpload.errorNoURI" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "imageUpload.errorNoURI" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:password_saved_please_login.Vitro
+uil-data:password_saved_please_login.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Vaša lozinka je sačuvana. Please log in."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "password_saved_please_login" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "password_saved_please_login" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:upload_photo.Vitro
+uil-data:upload_photo.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Postavite sliku"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "upload_photo" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "upload_photo" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:sparql_query_results.Vitro
+uil-data:sparql_query_results.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Rezultati SPARQL upita "@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "sparql_query_results" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "sparql_query_results" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:enter_new_password.Vitro
+uil-data:enter_new_password.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Molimo Vas unesite novu lozinku za korisnika {0}"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "enter_new_password" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "enter_new_password" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:display_more_ellipsis.Vitro
+uil-data:display_more_ellipsis.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "... više"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "display_more_ellipsis" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "display_more_ellipsis" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:updated_account_1.Vitro
+uil-data:updated_account_1.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Nalog za"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "updated_account_1" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "updated_account_1" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:add_page.Vitro
+uil-data:add_page.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Dodajte stranicu"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "add_page" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "add_page" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:list_elements_of.Vitro
+uil-data:list_elements_of.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Izlistajte elemente od"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "list_elements_of" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "list_elements_of" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:class_group_all_caps.Vitro
+uil-data:class_group_all_caps.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Grupa klase"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "class_group_all_caps" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "class_group_all_caps" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:no_class_restrictions.Vitro
+uil-data:no_class_restrictions.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ne postoje klase sa restrikcijom za ovo svojstvo."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "no_class_restrictions" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "no_class_restrictions" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:refresh_page_after_reordering.Vitro
+uil-data:refresh_page_after_reordering.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ponovo učitajte stranicu nakon napravljenih promena "@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "refresh_page_after_reordering" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "refresh_page_after_reordering" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:asserted_class_hierarchy.Vitro
+uil-data:asserted_class_hierarchy.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Hijerarhija utvrđenih klasa"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "asserted_class_hierarchy" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "asserted_class_hierarchy" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:page_admin_permission_option.Vitro
+uil-data:page_admin_permission_option.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Samo administratori mogu da pristupe ovoj stranici"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "page_admin_permission_option" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "page_admin_permission_option" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:create_associated_profile.Vitro
+uil-data:create_associated_profile.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Kreirajte povezani profil"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "create_associated_profile" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "create_associated_profile" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:password_reset_complete_email_html_text.Vitro
+uil-data:password_reset_complete_email_html_text.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "<p>\n ${userAccount.firstName} ${userAccount.lastName}\n </p>\n\n <p>\n <strong>Lozinka je uspešno promenjena.</strong>\n </p>\n\n <p>\n Vaša lozinka povezana sa nalogom ${userAccount.emailAddress} je promenjena.\n </p>\n\n <p>\n Hvala Vam.\n </p>\n"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "password_reset_complete_email_html_text" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "password_reset_complete_email_html_text" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:first_time_external_email_html_text.Vitro
+uil-data:first_time_external_email_html_text.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "<p>\n ${userAccount.firstName} ${userAccount.lastName}\n </p>\n\n <p>\n <strong>Čestitamo!</strong>\n </p>\n\n <p>\n Kreirali smo novi VIVO nalog povezan sa ${userAccount.emailAddress} email adresom.\n </p>\n\n <p>\n Hvala!\n </p>"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "first_time_external_email_html_text" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "first_time_external_email_html_text" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:default.Vitro
+uil-data:default.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Podrazumevana"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "default" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "default" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_password_mismatch.Vitro
+uil-data:error_password_mismatch.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Unete lozinke se ne podudaraju."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_password_mismatch" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_password_mismatch" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:and.Vitro
+uil-data:and.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "i"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "and" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "and" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:no_matching_results.Vitro
+uil-data:no_matching_results.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Nema rezultata koji se podudaraju."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "no_matching_results" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "no_matching_results" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:internal_class_i_capped.Vitro
+uil-data:internal_class_i_capped.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Institucionalna interna klasa"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "internal_class_i_capped" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "internal_class_i_capped" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:decimal_only.Vitro
+uil-data:decimal_only.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Neispravan unos.  Dozvoljeno je koristiti tačku da napišete decimalan broj, ali nije dozvoljeno korišćenje separatora između hiljada."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "decimal_only" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "decimal_only" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:new_account_2.Vitro
+uil-data:new_account_2.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "je uspešno kreiran."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "new_account_2" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "new_account_2" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:listed_page_title.Vitro
+uil-data:listed_page_title.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "navedeni naslov stranice"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "listed_page_title" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "listed_page_title" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:delete_profile_editor.Vitro
+uil-data:delete_profile_editor.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Obrišite urednike profila"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "delete_profile_editor" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "delete_profile_editor" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_no_first_name.Vitro
+uil-data:error_no_first_name.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Morate uneti ime."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_no_first_name" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_no_first_name" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:browse_all_in_class.Vitro
+uil-data:browse_all_in_class.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Pretražite sve osobe unutar ove klase"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "browse_all_in_class" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "browse_all_in_class" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:save_entry.Vitro
+uil-data:save_entry.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Sačuvajte entitet"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "save_entry" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "save_entry" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:confirm_initial_password.Vitro
+uil-data:confirm_initial_password.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Promenite početnu lozinku"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "confirm_initial_password" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "confirm_initial_password" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:ingest_tools.Vitro
+uil-data:ingest_tools.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Alati za prikupljanje podataka"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "ingest_tools" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "ingest_tools" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:application_error_email_html_text.Vitro
+uil-data:application_error_email_html_text.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "<p>Došlo je do greške na Vašem sajtu ${siteName!} u ${datetime!}</p>\n\n <p>\n <strong>Zatražen url:</strong> ${requestedUrl!}\n </p>\n\n <p>\n <#if errorMessage?has_content>\n <strong>Poruka o grešci:</strong> ${errorMessage!}\n </#if>\n </p>\n\n <p>\n <strong>Informacije o grešci</strong> (detaljne informacije o greškama možete naći u log-u):\n <pre>${stackTrace!}</pre>\n </p>\n\n <#if cause?has_content>\n <p><strong>Izazvano od strane:</strong>\n <pre>${cause!}</pre>\n </p>\n </#if>"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "application_error_email_html_text" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "application_error_email_html_text" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:log_in.Vitro
+uil-data:log_in.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "prijavite se"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "log_in" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "log_in" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:new_account_1.Vitro
+uil-data:new_account_1.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Novi nalog za"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "new_account_1" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "new_account_1" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:imageUpload.errorUnrecognizedFileType.Vitro
+uil-data:imageUpload.errorUnrecognizedFileType.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "''{0}'' ne spada u prepoznatljive formate za slike. Molimo Vas odaberite fajl JPEG, GIF, ili PNG formata."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "imageUpload.errorUnrecognizedFileType" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "imageUpload.errorUnrecognizedFileType" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:replace_page_title_with_name.Vitro
+uil-data:replace_page_title_with_name.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Zamena slike za {0}"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "replace_page_title_with_name" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "replace_page_title_with_name" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:unsupported_ie_version.Vitro
+uil-data:unsupported_ie_version.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ova forma nije podržana u verzijama Internet Explorer-a starijim od IE 8. Molimo Vas skinite noviju verziju pretraživača, ili odaberite neki drugi pretraživač, poput Firefox-a."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "unsupported_ie_version" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "unsupported_ie_version" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:logins_are_restricted.Vitro
+uil-data:logins_are_restricted.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Prijavljivanje je ograničeno."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "logins_are_restricted" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "logins_are_restricted" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:add_profile_editor.Vitro
+uil-data:add_profile_editor.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Dodajte urednika profila"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "add_profile_editor" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "add_profile_editor" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:supply_name.Vitro
+uil-data:supply_name.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Morate uneti naslov"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "supply_name" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "supply_name" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:feedback_thanks_text.Vitro
+uil-data:feedback_thanks_text.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Hvala Vam što ste kontaktirali timove za razvoj i održavanje aplikacije. Odgovorićemo Vam u što kraćem vremensokm periodu."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "feedback_thanks_text" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "feedback_thanks_text" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_class_for_search.Vitro
+uil-data:select_class_for_search.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Morate odabrati klasu kako bi ste prikazali pojedince koji joj pripadaju."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_class_for_search" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_class_for_search" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:since_elapsed_time.Vitro
+uil-data:since_elapsed_time.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "od {0}, proteklo vreme {1}"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "since_elapsed_time" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "since_elapsed_time" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:unknown_user_name.Vitro
+uil-data:unknown_user_name.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "prijatelj"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "unknown_user_name" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "unknown_user_name" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:faux_property_capitalized.Vitro
+uil-data:faux_property_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Faux svojstvo"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "faux_property_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "faux_property_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:enter_value_name_field.Vitro
+uil-data:enter_value_name_field.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Molimo Vas unesite vrednost u polje za naziv."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "enter_value_name_field" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "enter_value_name_field" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:group_name.Vitro
+uil-data:group_name.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "naziv grupe"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "group_name" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "group_name" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:data_property_hierarchy.Vitro
+uil-data:data_property_hierarchy.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Hijerarhije svojstva podataka"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "data_property_hierarchy" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "data_property_hierarchy" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:external_login_text.Vitro
+uil-data:external_login_text.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Prijavite se koristeći BearCat Shibboleth"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "external_login_text" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "external_login_text" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:imageUpload.errorFileTooBig.Vitro
+uil-data:imageUpload.errorFileTooBig.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Odaberite sliku koja zauzima manje od {0} megabajta."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "imageUpload.errorFileTooBig" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "imageUpload.errorFileTooBig" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:profile_editors.Vitro
+uil-data:profile_editors.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Urednici profila"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "profile_editors" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "profile_editors" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:implement_capitalized.Vitro
+uil-data:implement_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Implementirajte"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "implement_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "implement_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:sparql_query_header.Vitro
+uil-data:sparql_query_header.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Upit"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "sparql_query_header" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "sparql_query_header" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:view.Vitro
+uil-data:view.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "prikažite"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "view" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "view" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:manage_profile_editing.Vitro
+uil-data:manage_profile_editing.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Upravljajte ažuriranjem profila"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "manage_profile_editing" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "manage_profile_editing" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:minimum_image_dimensions.Vitro
+uil-data:minimum_image_dimensions.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Najmanje dimenzije slike: {0} x {1} piksela"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "minimum_image_dimensions" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "minimum_image_dimensions" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:view_list_in_rdf.Vitro
+uil-data:view_list_in_rdf.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Pogledajte {0} listu u RDF formatu"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "view_list_in_rdf" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "view_list_in_rdf" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:more_details_about_site.Vitro
+uil-data:more_details_about_site.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Više detalja o sajtu"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "more_details_about_site" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "more_details_about_site" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:new_entry_for.Vitro
+uil-data:new_entry_for.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "\"{0}\" za {1}"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "new_entry_for" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "new_entry_for" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:july.Vitro
+uil-data:july.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "jul"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "july" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "july" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:page_uri.Vitro
+uil-data:page_uri.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "URI stranice"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "page_uri" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "page_uri" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:edit_date_time_value.Vitro
+uil-data:edit_date_time_value.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ažurirajte datum/vreme"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "edit_date_time_value" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "edit_date_time_value" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:limited_to_type.Vitro
+uil-data:limited_to_type.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "ograničeno na tip"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "limited_to_type" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "limited_to_type" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:class_name.Vitro
+uil-data:class_name.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "naziv klase"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "class_name" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "class_name" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:create_date_time_value.Vitro
+uil-data:create_date_time_value.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Unesite datum/vreme"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "create_date_time_value" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "create_date_time_value" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:there_are_no_entries_for_selection.Vitro
+uil-data:there_are_no_entries_for_selection.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "U sistemu se ne nalazi ništa što možete odabrati."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "there_are_no_entries_for_selection" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "there_are_no_entries_for_selection" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:edit_this_individual.Vitro
+uil-data:edit_this_individual.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ažurirajte osobu"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "edit_this_individual" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "edit_this_individual" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:start_interval_must_precede_end_earlier.Vitro
+uil-data:start_interval_must_precede_end_earlier.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Početak intervala mora biti pre kraja intervala."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "start_interval_must_precede_end_earlier" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "start_interval_must_precede_end_earlier" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:type_capitalized.Vitro
+uil-data:type_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Tip"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "type_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "type_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:selected.Vitro
+uil-data:selected.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Odabran"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "selected" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "selected" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:submit_upload.Vitro
+uil-data:submit_upload.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Postavite fotografiju"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "submit_upload" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "submit_upload" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:confirm_individual_deletion.Vitro
+uil-data:confirm_individual_deletion.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "confirm_individual_deletion" ;
-        prop:hasPackage  "Vitro-languages" .
+        rdf:type         uil:UILabel ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "confirm_individual_deletion" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:september.Vitro
+uil-data:september.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "septembar"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "september" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "september" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:verbose_turn_off.Vitro
+uil-data:verbose_turn_off.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Isključite"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "verbose_turn_off" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "verbose_turn_off" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_type.Vitro
+uil-data:select_type.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Odaberite tip"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_type" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_type" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:comments_questions.Vitro
+uil-data:comments_questions.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Komentari, pitanja, ili predlozi"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "comments_questions" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "comments_questions" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:send_mail.Vitro
+uil-data:send_mail.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Pošaljite email"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "send_mail" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "send_mail" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:change_profile.Vitro
+uil-data:change_profile.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "promenite profil"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "change_profile" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "change_profile" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:logins_already_restricted.Vitro
+uil-data:logins_already_restricted.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Prijavljivanje je već ograničeno."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "logins_already_restricted" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "logins_already_restricted" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:photo_types.Vitro
+uil-data:photo_types.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "(JPEG, GIF ili PNG)"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "photo_types" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "photo_types" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:search_term_error_near.Vitro
+uil-data:search_term_error_near.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Izraz za pretragu je imao grešku u okolini"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "search_term_error_near" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "search_term_error_near" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:share_profile_uri.Vitro
+uil-data:share_profile_uri.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "podelite URI za ovaj profil"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "share_profile_uri" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "share_profile_uri" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:no_html_specified.Vitro
+uil-data:no_html_specified.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "HTML nije specificiran."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "no_html_specified" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "no_html_specified" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:first_name.Vitro
+uil-data:first_name.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ime"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "first_name" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "first_name" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:class_link.Vitro
+uil-data:class_link.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "link klase"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "class_link" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "class_link" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:view_profile_page_for.Vitro
+uil-data:view_profile_page_for.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Pogledajte profilnu stranicu za"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "view_profile_page_for" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "view_profile_page_for" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_classes_to_display.Vitro
+uil-data:select_classes_to_display.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Morate odabrati klase koje će biti prikazane."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_classes_to_display" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_classes_to_display" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:password_mismatch.Vitro
+uil-data:password_mismatch.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Lozinke se ne podudaraju."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "password_mismatch" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "password_mismatch" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:page_management.Vitro
+uil-data:page_management.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "upravljanje stranicama"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "page_management" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "page_management" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:resource_uri.Vitro
+uil-data:resource_uri.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "URI Resursa"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "resource_uri" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "resource_uri" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:sparql_query_run_query.Vitro
+uil-data:sparql_query_run_query.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Pokrenite Upit"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "sparql_query_run_query" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "sparql_query_run_query" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:enter_fixed_html_here.Vitro
+uil-data:enter_fixed_html_here.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ovde unesite fiksan HTML"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "enter_fixed_html_here" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "enter_fixed_html_here" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:verify_this_match.Vitro
+uil-data:verify_this_match.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "proverite podudaranje"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "verify_this_match" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "verify_this_match" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:properties_capitalized.Vitro
+uil-data:properties_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Svojstva"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "properties_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "properties_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:raw_string_literals.Vitro
+uil-data:raw_string_literals.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Neobrađeni String-Literali"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "raw_string_literals" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "raw_string_literals" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:no_content_create_groups_classes.Vitro
+uil-data:no_content_create_groups_classes.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Trenutno nema sadržaja u sistemu, ili treba da kreirate grupu klasa i pridružite joj Vaše klase."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "no_content_create_groups_classes" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "no_content_create_groups_classes" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:home_page.Vitro
+uil-data:home_page.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "početna stranica"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "home_page" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "home_page" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:restriction_on.Vitro
+uil-data:restriction_on.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "restrikcija nad"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "restriction_on" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "restriction_on" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:processing_indicator.Vitro
+uil-data:processing_indicator.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "indikator vremena potrebnog za obradu"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "processing_indicator" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "processing_indicator" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:selected_page_content_type.Vitro
+uil-data:selected_page_content_type.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Odabran tip sadržaja za povezanu stranicu"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "selected_page_content_type" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "selected_page_content_type" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:create_entry.Vitro
+uil-data:create_entry.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Kreirajte unos "@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "create_entry" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "create_entry" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:password_change_not_pending.Vitro
+uil-data:password_change_not_pending.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Lozinka korisnika {0} je već resetovana."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "password_change_not_pending" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "password_change_not_pending" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:javascript_instructions.Vitro
+uil-data:javascript_instructions.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "java script instrukcije"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "javascript_instructions" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "javascript_instructions" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_invalid_email.Vitro
+uil-data:error_invalid_email.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "''{0}'' nije ispravna email adresa."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_invalid_email" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_invalid_email" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:new_pwd_matches_existing.Vitro
+uil-data:new_pwd_matches_existing.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Vaša nova lozinka mora biti različita od Vaše trenutne lozinke."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "new_pwd_matches_existing" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "new_pwd_matches_existing" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:or.Vitro
+uil-data:or.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "ili"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "or" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "or" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:search_form.Vitro
+uil-data:search_form.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Forma za pretragu"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "search_form" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "search_form" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:menu_item_name.Vitro
+uil-data:menu_item_name.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Naziv stavke menija"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "menu_item_name" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "menu_item_name" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:june.Vitro
+uil-data:june.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "jun"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "june" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "june" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:last_name.Vitro
+uil-data:last_name.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Prezime"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "last_name" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "last_name" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:placeholder_image.Vitro
+uil-data:placeholder_image.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "privremena slika"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "placeholder_image" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "placeholder_image" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:requested_url.Vitro
+uil-data:requested_url.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Zatražen url"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "requested_url" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "requested_url" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:first_time_login_note.Vitro
+uil-data:first_time_login_note.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Napomena: Email će biti poslat na unetu adresu sa obaveštenjem o kreiranju naloga."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "first_time_login_note" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "first_time_login_note" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_external_auth_already_exists.Vitro
+uil-data:error_external_auth_already_exists.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Nalog sa unetim ID-em Eksterne Autorizacije već postoji."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_external_auth_already_exists" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_external_auth_already_exists" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:contains_no_pears.Vitro
+uil-data:contains_no_pears.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "ne sadrži kruške"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "contains_no_pears" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "contains_no_pears" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:index_page.Vitro
+uil-data:index_page.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "indeks stranica"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "index_page" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "index_page" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:search_tip_one.Vitro
+uil-data:search_tip_one.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Pretraga treba da bude jednostavna! Koristite kratke, pojedinačne izraze osim ako Vaša pretraga vraća previše rezultata"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "search_tip_one" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "search_tip_one" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:sparql_query_construct_describe_results.Vitro
+uil-data:sparql_query_construct_describe_results.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Format za rezultate CONSTRUCT i DESCRIBE upita"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "sparql_query_construct_describe_results" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "sparql_query_construct_describe_results" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:password_capitalized.Vitro
+uil-data:password_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Lozinka"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "password_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "password_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:file_upload_submit_label.Vitro
+uil-data:file_upload_submit_label.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "file_upload_submit_label" ;
-        prop:hasPackage  "Vitro-languages" .
+        rdf:type         uil:UILabel ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "file_upload_submit_label" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:please.Vitro
+uil-data:please.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Molimo Vas"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "please" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "please" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:account_created.Vitro
+uil-data:account_created.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Vaš {0} nalog je kreiran."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "account_created" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "account_created" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:add.Vitro
+uil-data:add.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "dodajte"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "add" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "add" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:limit.Vitro
+uil-data:limit.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ograničite"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "limit" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "limit" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:november.Vitro
+uil-data:november.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "novembar"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "november" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "november" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:confirm_delete.Vitro
+uil-data:confirm_delete.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Da li ste sigurni da želite da obrišete ovu fotografiju?"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "confirm_delete" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "confirm_delete" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:login_welcome_message.Vitro
+uil-data:login_welcome_message.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Dobrodošli{1, choice, 1# |1< nazad}, {0}"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "login_welcome_message" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "login_welcome_message" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:password_changed_subject.Vitro
+uil-data:password_changed_subject.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Lozinka je promenjena."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "password_changed_subject" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "password_changed_subject" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:incorrect_email_password.Vitro
+uil-data:incorrect_email_password.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Email ili lozinka nisu ispravni."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "incorrect_email_password" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "incorrect_email_password" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:identifiers.Vitro
+uil-data:identifiers.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Identifikatori"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "identifiers" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "identifiers" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:javascript_ie_alert_text.Vitro
+uil-data:javascript_ie_alert_text.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ovaj sajt koristi HTML elemente koje Internet Explorer 8 i starije verzije ne prepoznaju ako JavaScript nije omogućen. Kao posledica, sajt neće biti prikazan ispravno. Da bi ste ovo ispravili, molimo Vas omogućite JavaScript, skinite noviju verziju Internet Explorer-a, ili promenite pretraživač."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "javascript_ie_alert_text" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "javascript_ie_alert_text" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:zoo_two.Vitro
+uil-data:zoo_two.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Zoo 2"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "zoo_two" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "zoo_two" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:verbose_turn_on.Vitro
+uil-data:verbose_turn_on.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Uključite"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "verbose_turn_on" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "verbose_turn_on" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:selection_in_process.Vitro
+uil-data:selection_in_process.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Vaš izbor se obrađuje."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "selection_in_process" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "selection_in_process" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:please_create.Vitro
+uil-data:please_create.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Molimo Vas kreirajte"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "please_create" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "please_create" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:verbose_status_off.Vitro
+uil-data:verbose_status_off.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "isključen"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "verbose_status_off" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "verbose_status_off" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:page_not_configured.Vitro
+uil-data:page_not_configured.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ova stranica još nije konfigurisana."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "page_not_configured" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "page_not_configured" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:new_account_notification.Vitro
+uil-data:new_account_notification.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Email sa uputstvina za aktiviranje naloga i kreiranje lozinke je poslat na adresu {0} "@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "new_account_notification" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "new_account_notification" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:full_list_startup.Vitro
+uil-data:full_list_startup.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Lista događaja i poruka nastalih za vreme pokretanja aplikacije."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "full_list_startup" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "full_list_startup" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:user_role.Vitro
+uil-data:user_role.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Uloga"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "user_role" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "user_role" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:or_enter_valid_address.Vitro
+uil-data:or_enter_valid_address.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "ili unesite drugu kompletnu i validnu email adresu."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "or_enter_valid_address" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "or_enter_valid_address" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:all.Vitro
+uil-data:all.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "sve"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "all" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "all" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:logged_in_but_no_profile.Vitro
+uil-data:logged_in_but_no_profile.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Uspešno ste se prijavili, ali se unutar sistema ne nalazi vaš profil."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "logged_in_but_no_profile" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "logged_in_but_no_profile" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:page_text.Vitro
+uil-data:page_text.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "tekst stranice"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "page_text" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "page_text" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:create_new_entry.Vitro
+uil-data:create_new_entry.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Molimo Vas kreirajte novu stavku."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "create_new_entry" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "create_new_entry" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:enter_in_security_field.Vitro
+uil-data:enter_in_security_field.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Molimo Vas unesite slova ispod u sigurnosno polje"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "enter_in_security_field" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "enter_in_security_field" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_an_existing_or_create_a_new_one.Vitro
+uil-data:select_an_existing_or_create_a_new_one.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Odaberite postojeći ili kreirajte novi."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_an_existing_or_create_a_new_one" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_an_existing_or_create_a_new_one" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:not.Vitro
+uil-data:not.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "ne"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "not" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "not" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:range_data_type.Vitro
+uil-data:range_data_type.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Tip podataka za raspon"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "range_data_type" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "range_data_type" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:august.Vitro
+uil-data:august.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "avgust"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "august" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "august" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:terms_of_use.Vitro
+uil-data:terms_of_use.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "uslovi korišćenja"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "terms_of_use" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "terms_of_use" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:dump_restore.Vitro
+uil-data:dump_restore.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Resetujte apliakciju"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "dump_restore" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "dump_restore" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:show_properties.Vitro
+uil-data:show_properties.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "prikažite svojstva"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "show_properties" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "show_properties" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:associated_individuals.Vitro
+uil-data:associated_individuals.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Povezane osobe"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "associated_individuals" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "associated_individuals" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:name_capitalized.Vitro
+uil-data:name_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ime"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "name_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "name_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:manage_labels.Vitro
+uil-data:manage_labels.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "upravljajte labelama"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "manage_labels" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "manage_labels" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:current_user.Vitro
+uil-data:current_user.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Trenutni korisnik"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "current_user" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "current_user" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:minimum_ymd.Vitro
+uil-data:minimum_ymd.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Neispravan unos. Molimo Vas unesite makar godinu, mesec i dan."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "minimum_ymd" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "minimum_ymd" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:try_another_letter.Vitro
+uil-data:try_another_letter.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Molimo Vas pokušajte neko drugo slovo ili pretražite sve."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "try_another_letter" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "try_another_letter" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:alt_image_to_crop.Vitro
+uil-data:alt_image_to_crop.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Slika koja treba da se iseče"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "alt_image_to_crop" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "alt_image_to_crop" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:current_task.Vitro
+uil-data:current_task.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "{0} indeks pretrage"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "current_task" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "current_task" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:imageUpload.errorNoImageForCropping.Vitro
+uil-data:imageUpload.errorNoImageForCropping.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ne postoji datoteka slike koju želite da isečete."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "imageUpload.errorNoImageForCropping" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "imageUpload.errorNoImageForCropping" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:we_have_an_error.Vitro
+uil-data:we_have_an_error.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Došlo je do greške u sistemu."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "we_have_an_error" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "we_have_an_error" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_another_class.Vitro
+uil-data:select_another_class.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Molimo Vas odaberite neku drugu klasu iz liste."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_another_class" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_another_class" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:manage_labels_for.Vitro
+uil-data:manage_labels_for.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Upravljajte labelama za"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "manage_labels_for" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "manage_labels_for" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:revision_info.Vitro
+uil-data:revision_info.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Informacije o revizijama"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "revision_info" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "revision_info" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:rebuild_vis_cache.Vitro
+uil-data:rebuild_vis_cache.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ponovo kreirajte keširanu vizualizaciju"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "rebuild_vis_cache" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "rebuild_vis_cache" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:delete.Vitro
+uil-data:delete.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "obrišite"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "delete" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "delete" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:update_button.Vitro
+uil-data:update_button.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ažurirajte"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "update_button" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "update_button" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:imageUpload.errorNoPhotoSelected.Vitro
+uil-data:imageUpload.errorNoPhotoSelected.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Molimo Vas odaberite sliku."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "imageUpload.errorNoPhotoSelected" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "imageUpload.errorNoPhotoSelected" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:imageUpload.errorUnrecognizedURI.Vitro
+uil-data:imageUpload.errorUnrecognizedURI.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "URI koji ste uneli ne pripada ni jednom entitetu: ''{0}''"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "imageUpload.errorUnrecognizedURI" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "imageUpload.errorUnrecognizedURI" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:menu_item.Vitro
+uil-data:menu_item.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Stavka menija"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "menu_item" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "menu_item" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:auth_id_label.Vitro
+uil-data:auth_id_label.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "ID spoljne/eksterne autentifikacije"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "auth_id_label" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "auth_id_label" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:may.Vitro
+uil-data:may.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "maj"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "may" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "may" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:what_is_vitro.Vitro
+uil-data:what_is_vitro.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Šta je Vitro?"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "what_is_vitro" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "what_is_vitro" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_a_language.Vitro
+uil-data:select_a_language.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Odaberite jezik"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_a_language" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_a_language" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:ip_address.Vitro
+uil-data:ip_address.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "IP adresa"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "ip_address" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "ip_address" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:unrecognized_user.Vitro
+uil-data:unrecognized_user.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Korisnik nije prepoznat"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "unrecognized_user" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "unrecognized_user" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:password_change_invalid_key.Vitro
+uil-data:password_change_invalid_key.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Link koji ste isoristili za {0} nije ispravan. Molimo Vas tražite od administaratora da Vam ponovo pošalje link."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "password_change_invalid_key" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "password_change_invalid_key" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:change_text_for.Vitro
+uil-data:change_text_for.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Promenite tekst za:"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "change_text_for" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "change_text_for" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:to_enable_javascript.Vitro
+uil-data:to_enable_javascript.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ovo su instrukcija kako da omogućite JavaScript u okviru Vašeg pretraživača"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "to_enable_javascript" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "to_enable_javascript" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:warning.Vitro
+uil-data:warning.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Upozorenje"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "warning" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "warning" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:revision.Vitro
+uil-data:revision.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "revizija"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "revision" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "revision" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:filter_by_roles.Vitro
+uil-data:filter_by_roles.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Filtrirajte po ulogama"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "filter_by_roles" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "filter_by_roles" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:page_uri_missing_msg.Vitro
+uil-data:page_uri_missing_msg.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Generisanje stranice nije uspelo jer nije jasno koju stranicu tražite. Možda nedostaje URL mapiranje."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "page_uri_missing_msg" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "page_uri_missing_msg" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:fatal_error.Vitro
+uil-data:fatal_error.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Fatalna greška "@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "fatal_error" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "fatal_error" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:page_select_permission_option.Vitro
+uil-data:page_select_permission_option.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Odaberite dozvole"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "page_select_permission_option" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "page_select_permission_option" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:january.Vitro
+uil-data:january.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "januar"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "january" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "january" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:property.Vitro
+uil-data:property.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "svjojstvo"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "property" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "property" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:external_auth_id.Vitro
+uil-data:external_auth_id.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Eksterni ID za autentifikaciju"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "external_auth_id" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "external_auth_id" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:date_time_value_for.Vitro
+uil-data:date_time_value_for.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "datum i vreme za"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "date_time_value_for" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "date_time_value_for" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:sparql_query_title.Vitro
+uil-data:sparql_query_title.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "SPARQL Upit"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "sparql_query_title" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "sparql_query_title" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:previous.Vitro
+uil-data:previous.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Prošli"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "previous" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "previous" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:upload_page_title_with_name.Vitro
+uil-data:upload_page_title_with_name.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Odabir slike za {0}"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "upload_page_title_with_name" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "upload_page_title_with_name" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:cant_change_password_while_logged_in.Vitro
+uil-data:cant_change_password_while_logged_in.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ne možete resetovati lozinku korisnika {0} dok ste prijavljeni kao {1}. Odjavite se i pokušajte ponovo."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "cant_change_password_while_logged_in" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "cant_change_password_while_logged_in" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:rejected_spam.Vitro
+uil-data:rejected_spam.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "ODBIJENO - SPAM"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "rejected_spam" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "rejected_spam" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:logins_are_open.Vitro
+uil-data:logins_are_open.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Prijavljivanje je dozvoljeno svima."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "logins_are_open" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "logins_are_open" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:confirm_delete_account_singular.Vitro
+uil-data:confirm_delete_account_singular.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Da li ste sigurni da želite da obrišete ovaj nalog?"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "confirm_delete_account_singular" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "confirm_delete_account_singular" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:all_capitalized.Vitro
+uil-data:all_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Sve"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "all_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "all_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:of_the_results.Vitro
+uil-data:of_the_results.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "rezultata"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "of_the_results" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "of_the_results" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_content_type.Vitro
+uil-data:select_content_type.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Morate odabrati sadržaj koji će biti prikazan na stranici"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_content_type" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_content_type" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:visit_project_website.Vitro
+uil-data:visit_project_website.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Posetite veb sajt nacionalnog projekta"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "visit_project_website" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "visit_project_website" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:view_labels_for.Vitro
+uil-data:view_labels_for.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Pogledajte labele za"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "view_labels_for" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "view_labels_for" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:new_account_note.Vitro
+uil-data:new_account_note.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Napomena: Email sa obaveštenjem o kreiranju novog naloga će biti poslat na adresu koju ste uneli. Sadržaće uputstva za aktiviranje naloga i kreiranje lozinke."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "new_account_note" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "new_account_note" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_alert_icon.Vitro
+uil-data:error_alert_icon.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ikonica za upozorenje o grešci"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_alert_icon" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_alert_icon" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:imageUpload.errorImageTooSmall.Vitro
+uil-data:imageUpload.errorImageTooSmall.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Slika koju hoćete da postavite mora biti makar {0} piksela visoka i {1} piksela siroka."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "imageUpload.errorImageTooSmall" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "imageUpload.errorImageTooSmall" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_account_to_delete.Vitro
+uil-data:select_account_to_delete.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "odaberite ovaj nalog za brisanje"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_account_to_delete" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_account_to_delete" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:interest_thanks.Vitro
+uil-data:interest_thanks.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Hvala Vam na interesovanju za {0}. Molimo Vas popunite ovu formu sa pitanjima, komentarima, i povratnim informacijama o sadržaju sajta."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "interest_thanks" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "interest_thanks" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:year_numeric.Vitro
+uil-data:year_numeric.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Neispravan unos. Godina mora biti broj."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "year_numeric" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "year_numeric" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_an_existing_document.Vitro
+uil-data:select_an_existing_document.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Odaberite postojeći dokument"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_an_existing_document" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_an_existing_document" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:password_length.Vitro
+uil-data:password_length.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Lozinka mora da sadrži između {0} i {1} karaktera."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "password_length" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "password_length" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:monday.Vitro
+uil-data:monday.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "ponedeljak"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "monday" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "monday" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:account_created_subject.Vitro
+uil-data:account_created_subject.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Vaš {0} nalog je kreiran."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "account_created_subject" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "account_created_subject" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:vitro_bullet_three.Vitro
+uil-data:vitro_bullet_three.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Kreirate veb sajt za prikaz Vaših podataka"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "vitro_bullet_three" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "vitro_bullet_three" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:photo.Vitro
+uil-data:photo.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Slika"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "photo" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "photo" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:file_must_be_entered_msg.Vitro
+uil-data:file_must_be_entered_msg.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "u ovo polje morate uneti fajl."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "file_must_be_entered_msg" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "file_must_be_entered_msg" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:entity_to_query_for.Vitro
+uil-data:entity_to_query_for.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ovaj id je id entiteta za pretragu. Možete koristiti i identifikator netid."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "entity_to_query_for" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "entity_to_query_for" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:manage_grants_and_projects_link.Vitro
+uil-data:manage_grants_and_projects_link.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "upravljanje grantovima i projektima"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "manage_grants_and_projects_link" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "manage_grants_and_projects_link" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:manage_labels_intro.Vitro
+uil-data:manage_labels_intro.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "U slučaju da postoji više labela na istom jeziku, molimo Vas obrišite labele koje ne želite da budu prikazane na stranici jezika."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "manage_labels_intro" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "manage_labels_intro" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:hide_show_properties.Vitro
+uil-data:hide_show_properties.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "sakrijte/prikažite svojstva"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "hide_show_properties" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "hide_show_properties" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:untitled.Vitro
+uil-data:untitled.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "-bez naslova-"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "untitled" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "untitled" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:manage_publications_link.Vitro
+uil-data:manage_publications_link.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "upravljajte publikacijama"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "manage_publications_link" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "manage_publications_link" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_all.Vitro
+uil-data:select_all.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "odaberite sve"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_all" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_all" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:local_name.Vitro
+uil-data:local_name.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Lokalni naziv"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "local_name" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "local_name" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:end_interval_must_follow_start_interval.Vitro
+uil-data:end_interval_must_follow_start_interval.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Kraj intervala mora biti posle početka intervala."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "end_interval_must_follow_start_interval" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "end_interval_must_follow_start_interval" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:view_page.Vitro
+uil-data:view_page.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Prikažite stranicu"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "view_page" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "view_page" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:browse_page_javascript_one.Vitro
+uil-data:browse_page_javascript_one.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ova stranica zahteva javascript, ali je u Vašem pretraživaču javascript onemogućen. Ili uključite javascript ili koristite"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "browse_page_javascript_one" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "browse_page_javascript_one" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:sparql_query_builder.Vitro
+uil-data:sparql_query_builder.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Alat za kreiranje SPARQL upita"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "sparql_query_builder" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "sparql_query_builder" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:sub_properties.Vitro
+uil-data:sub_properties.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Pod-svojstva"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "sub_properties" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "sub_properties" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:add_label_for_language.Vitro
+uil-data:add_label_for_language.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Jezik"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "add_label_for_language" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "add_label_for_language" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:file_upload_error_file_not_found.Vitro
+uil-data:file_upload_error_file_not_found.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "file_upload_error_file_not_found" ;
-        prop:hasPackage  "Vitro-languages" .
+        rdf:type         uil:UILabel ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "file_upload_error_file_not_found" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:file_upload_predicate.Vitro
+uil-data:file_upload_predicate.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "file_upload_predicate" ;
-        prop:hasPackage  "Vitro-languages" .
+        rdf:type         uil:UILabel ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "file_upload_predicate" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:start_with_leading_slash.Vitro
+uil-data:start_with_leading_slash.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Mora da počinje sa kosom: / (npr. /osobe)"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "start_with_leading_slash" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "start_with_leading_slash" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:trace_available.Vitro
+uil-data:trace_available.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "detaljne informacije o greškama možete naći u log-u"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "trace_available" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "trace_available" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:editing_prohibited.Vitro
+uil-data:editing_prohibited.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ovo svojstvo je trenutno konfigurisano tako da ne dozvoljava ažuriranje."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "editing_prohibited" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "editing_prohibited" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:verbose_status_on.Vitro
+uil-data:verbose_status_on.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "uključen"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "verbose_status_on" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "verbose_status_on" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:use_capitalized.Vitro
+uil-data:use_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Koristite"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "use_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "use_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:search_index_status.Vitro
+uil-data:search_index_status.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Status indeksa pretrage"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "search_index_status" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "search_index_status" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:filter_search.Vitro
+uil-data:filter_search.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "filtrirajte pretragu"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "filter_search" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "filter_search" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:with_vitro.Vitro
+uil-data:with_vitro.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Sa Vitro-om možete:"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "with_vitro" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "with_vitro" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:site_information.Vitro
+uil-data:site_information.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Informacije o sajtu"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "site_information" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "site_information" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:logins_temporarily_disabled.Vitro
+uil-data:logins_temporarily_disabled.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Prijavljivanje korisnika je trenutno onemogućeno zbog održavanja sistema."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "logins_temporarily_disabled" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "logins_temporarily_disabled" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:leave_password_unchanged.Vitro
+uil-data:leave_password_unchanged.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ako ovo polje ostavite prazno lozinka neće biti promenjena."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "leave_password_unchanged" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "leave_password_unchanged" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:query_model.Vitro
+uil-data:query_model.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Model upita"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "query_model" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "query_model" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:restrict_logins_mixed_caps.Vitro
+uil-data:restrict_logins_mixed_caps.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ograničite prijavljivanje"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "restrict_logins_mixed_caps" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "restrict_logins_mixed_caps" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:wednesday.Vitro
+uil-data:wednesday.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "sreda"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "wednesday" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "wednesday" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:berries.Vitro
+uil-data:berries.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Bobice:"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "berries" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "berries" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:full_name.Vitro
+uil-data:full_name.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Puno ime"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "full_name" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "full_name" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:no_email_supplied.Vitro
+uil-data:no_email_supplied.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Nije unet email."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "no_email_supplied" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "no_email_supplied" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_was_reported.Vitro
+uil-data:error_was_reported.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ova greška je prijavljena administratoru."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_was_reported" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_was_reported" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:search_results_for.Vitro
+uil-data:search_results_for.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Rezultati pretrage za"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "search_results_for" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "search_results_for" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:search_tip_three.Vitro
+uil-data:search_tip_three.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Izuzev boolean operatora, pretrage <strong>NE RAZLIKUJU</strong> mala i velika slova, te su izrazi \"Ženeva\" i \"ženeva\" ekvivalentni."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "search_tip_three" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "search_tip_three" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:view_profile_for_page.Vitro
+uil-data:view_profile_for_page.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "pogledajte profil za ovu stranicu"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "view_profile_for_page" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "view_profile_for_page" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:reordering_menus_failed.Vitro
+uil-data:reordering_menus_failed.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Promena redosleda stavki u meniju nije uspela."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "reordering_menus_failed" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "reordering_menus_failed" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:verbose_control.Vitro
+uil-data:verbose_control.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "kontrola detaljnog prikaza"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "verbose_control" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "verbose_control" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:ontology_list.Vitro
+uil-data:ontology_list.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Lista ontologija"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "ontology_list" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "ontology_list" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:edit_entry.Vitro
+uil-data:edit_entry.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "ažurirajte ovaj unos"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "edit_entry" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "edit_entry" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:label.dateTimeWithPrecision.minutes_capitalized.Vitro
+uil-data:label.dateTimeWithPrecision.minutes_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Minute"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "label.dateTimeWithPrecision.minutes_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "label.dateTimeWithPrecision.minutes_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:object.Vitro
+uil-data:object.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "objekat"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "object" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "object" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:confirm_email_changed_email_html_text.Vitro
+uil-data:confirm_email_changed_email_html_text.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "<p>\n Poštovani ${userAccount.firstName} ${userAccount.lastName}:\n </p>\n\n <p>\n Nedavno ste promenili email adresu povezanu sa nalogom za korisnika\n ${userAccount.firstName} ${userAccount.lastName}\n </p>\n\n <p>\n Hvala Vam.\n </p>"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "confirm_email_changed_email_html_text" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "confirm_email_changed_email_html_text" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_no_new_password.Vitro
+uil-data:error_no_new_password.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Molimo Vas unesite Vašu novu lozinku."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_no_new_password" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_no_new_password" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:page_loggedin_permission_option.Vitro
+uil-data:page_loggedin_permission_option.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Prijavljeni korisnici mogu da pristupe ovoj stranici"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "page_loggedin_permission_option" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "page_loggedin_permission_option" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:expecting_content.Vitro
+uil-data:expecting_content.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Očekujete sadržaj?"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "expecting_content" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "expecting_content" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:required_fields.Vitro
+uil-data:required_fields.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "obavezna polja"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "required_fields" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "required_fields" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:edit_page_title.Vitro
+uil-data:edit_page_title.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ažuriranje"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "edit_page_title" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "edit_page_title" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_existing.Vitro
+uil-data:select_existing.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Odaberite postojeći"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_existing" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_existing" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:invalid_url_msg.Vitro
+uil-data:invalid_url_msg.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ovaj URL mora da počinje sa http:// ili https://"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "invalid_url_msg" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "invalid_url_msg" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:search_button.Vitro
+uil-data:search_button.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Pretraga"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "search_button" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "search_button" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:advanced_search_tips_header.Vitro
+uil-data:advanced_search_tips_header.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Saveti za naprednu pretragu"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "advanced_search_tips_header" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "advanced_search_tips_header" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:supply_url.Vitro
+uil-data:supply_url.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Morate uneti ulepšan URL"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "supply_url" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "supply_url" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_profiles.Vitro
+uil-data:select_profiles.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Odaberite profile"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_profiles" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_profiles" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_one.Vitro
+uil-data:select_one.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Odaberite jednu"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_one" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_one" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:continue.Vitro
+uil-data:continue.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Nastavite"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "continue" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "continue" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:language_selection_failed.Vitro
+uil-data:language_selection_failed.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Došlo je do problem. Jezik koji ste odabrali je odbijen."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "language_selection_failed" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "language_selection_failed" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:display_has_element_error.Vitro
+uil-data:display_has_element_error.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Došlo je do greške. Svojstvo \"display:hasElement\" nije uspešno dobavljeno."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "display_has_element_error" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "display_has_element_error" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:file_upload_error_file_is_too_big.Vitro
+uil-data:file_upload_error_file_is_too_big.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "file_upload_error_file_is_too_big" ;
-        prop:hasPackage  "Vitro-languages" .
+        rdf:type         uil:UILabel ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "file_upload_error_file_is_too_big" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:template_capitalized.Vitro
+uil-data:template_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Šablon"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "template_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "template_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:file_upload_supported_media.Vitro
+uil-data:file_upload_supported_media.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "file_upload_supported_media" ;
-        prop:hasPackage  "Vitro-languages" .
+        rdf:type         uil:UILabel ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "file_upload_supported_media" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:user_accounts_title.Vitro
+uil-data:user_accounts_title.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "korisnički nalozi"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "user_accounts_title" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "user_accounts_title" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:create_your_password.Vitro
+uil-data:create_your_password.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Kreirajte Vaušu lozinku"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "create_your_password" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "create_your_password" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:create_account.Vitro
+uil-data:create_account.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Napravite nalog"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "create_account" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "create_account" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:remove_menu_item.Vitro
+uil-data:remove_menu_item.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Obrišite stavku iz menija"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "remove_menu_item" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "remove_menu_item" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:click_to_view_account.Vitro
+uil-data:click_to_view_account.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Kliknite za detalje o nalogu"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "click_to_view_account" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "click_to_view_account" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:add_new_entry_for.Vitro
+uil-data:add_new_entry_for.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Dodajte novi unos za:"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "add_new_entry_for" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "add_new_entry_for" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:menu_ordering.Vitro
+uil-data:menu_ordering.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Redosle opcija unutar menija"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "menu_ordering" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "menu_ordering" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:map_processor_error.Vitro
+uil-data:map_processor_error.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Došlo je do greške i mapa procesora za ovaj sadržaj nije pronađena. Molimo Vas kontaktirajte administratora."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "map_processor_error" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "map_processor_error" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:change_profile_title.Vitro
+uil-data:change_profile_title.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "promenite profil"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "change_profile_title" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "change_profile_title" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:domain_class.Vitro
+uil-data:domain_class.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Klasa domena"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "domain_class" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "domain_class" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:manage_labels_capitalized.Vitro
+uil-data:manage_labels_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Upravljajte labelama"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "manage_labels_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "manage_labels_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_passwords_dont_match.Vitro
+uil-data:error_passwords_dont_match.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Lozinke koje ste uneli se ne podudaraju."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_passwords_dont_match" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_passwords_dont_match" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:save_profile_changes.Vitro
+uil-data:save_profile_changes.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Sačuvajte promene u okviru profila"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "save_profile_changes" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "save_profile_changes" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:site_administration.Vitro
+uil-data:site_administration.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Administriranje sajta"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "site_administration" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "site_administration" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:vitro_bullet_one.Vitro
+uil-data:vitro_bullet_one.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Kreirati ili učitavati ontologije u OWL formatu"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "vitro_bullet_one" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "vitro_bullet_one" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:pages.Vitro
+uil-data:pages.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "stranice"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "pages" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "pages" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:inferred_class_hierarchy.Vitro
+uil-data:inferred_class_hierarchy.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Hijerarhija pretpostavljenih klasa"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "inferred_class_hierarchy" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "inferred_class_hierarchy" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:auth_id_in_use.Vitro
+uil-data:auth_id_in_use.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ovaj identifikator je trenutno u upotrebi."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "auth_id_in_use" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "auth_id_in_use" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:data_input.Vitro
+uil-data:data_input.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Unos podataka"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "data_input" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "data_input" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:recompute_inferences_mixed_caps.Vitro
+uil-data:recompute_inferences_mixed_caps.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Rekompajlirajte interfejse"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "recompute_inferences_mixed_caps" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "recompute_inferences_mixed_caps" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:individual_name.Vitro
+uil-data:individual_name.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "naziv pojedinca"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "individual_name" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "individual_name" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:thursday.Vitro
+uil-data:thursday.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "četvrtak"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "thursday" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "thursday" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:alert_icon.Vitro
+uil-data:alert_icon.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ikonica za upozorenje"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "alert_icon" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "alert_icon" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:if_blank_page_title_used.Vitro
+uil-data:if_blank_page_title_used.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ako ostavite polje prazno, koristiće se naziv stranice."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "if_blank_page_title_used" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "if_blank_page_title_used" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:password_reset_pending_email_plain_text.Vitro
+uil-data:password_reset_pending_email_plain_text.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Poštovani:\n\nDobili smo zahtev za resetovanje šifre za Vaš ${siteName} nalog (${userAccount.emailAddress}).\n\nMolimo Vas da pratite dole navedene instrukcije kako bi ste nastavili sa resetovanjem Vaše lozinke.\n\nKliknite na link ispod ili ga kopirajte u navigacioni bar vašek pretraživača kako bi ste resetovali\nVašu lozinku koristeći naše zaštićene servere.\n\n${passwordLink}\n\nHvala Vam!"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "password_reset_pending_email_plain_text" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "password_reset_pending_email_plain_text" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:hide_properties.Vitro
+uil-data:hide_properties.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "sakrijte svojstva"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "hide_properties" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "hide_properties" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:file_upload_error_file_type_not_recognized.Vitro
+uil-data:file_upload_error_file_type_not_recognized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "file_upload_error_file_type_not_recognized" ;
-        prop:hasPackage  "Vitro-languages" .
+        rdf:type         uil:UILabel ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "file_upload_error_file_type_not_recognized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_no_role.Vitro
+uil-data:error_no_role.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Morate odabrati ulogu."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_no_role" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_no_role" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:new_account_title.Vitro
+uil-data:new_account_title.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "novi nalog"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "new_account_title" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "new_account_title" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:file_upload_no_allowed_media.Vitro
+uil-data:file_upload_no_allowed_media.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "file_upload_no_allowed_media" ;
-        prop:hasPackage  "Vitro-languages" .
+        rdf:type         uil:UILabel ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "file_upload_no_allowed_media" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:property_groups.Vitro
+uil-data:property_groups.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Grupe svojstava"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "property_groups" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "property_groups" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:startup_trace.Vitro
+uil-data:startup_trace.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Trag za vreme pokretanja"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "startup_trace" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "startup_trace" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:search_accounts_button.Vitro
+uil-data:search_accounts_button.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Pretražite naloge "@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "search_accounts_button" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "search_accounts_button" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:operation_unsuccessful.Vitro
+uil-data:operation_unsuccessful.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Naredba nije uspešno izvršena. Detalje omžete pogledati unutar sistemskih logova."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "operation_unsuccessful" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "operation_unsuccessful" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:submit_button.Vitro
+uil-data:submit_button.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Podnesite"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "submit_button" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "submit_button" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:page_uri_missing.Vitro
+uil-data:page_uri_missing.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Niste naveli URI stranice."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "page_uri_missing" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "page_uri_missing" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_no_email_address.Vitro
+uil-data:error_no_email_address.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Molimo Vas unesite Vašu email adresu."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_no_email_address" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_no_email_address" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:controls.Vitro
+uil-data:controls.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Kontrole"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "controls" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "controls" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:fruit.Vitro
+uil-data:fruit.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Voće"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "fruit" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "fruit" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:admin_panel.Vitro
+uil-data:admin_panel.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Panel za administratora"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "admin_panel" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "admin_panel" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:the_range_class_does_not_exist.Vitro
+uil-data:the_range_class_does_not_exist.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Klasa raspona za ovo svojstvo ne postoji u sistemu."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "the_range_class_does_not_exist" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "the_range_class_does_not_exist" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:reset_your_password.Vitro
+uil-data:reset_your_password.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Resetujte Vašu lozinku"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "reset_your_password" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "reset_your_password" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:advanced_search_tip_two.Vitro
+uil-data:advanced_search_tip_two.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "\"NOT\" Vam može pomoći u ograničenju pretrage -- npr. <i>klimatske</i> NOT <i>promene</i>."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "advanced_search_tip_two" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "advanced_search_tip_two" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:save_new_page.Vitro
+uil-data:save_new_page.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Sačuvajte novu stranicu"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "save_new_page" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "save_new_page" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:book_title.Vitro
+uil-data:book_title.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Nasliv Knjige:"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "book_title" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "book_title" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:view_content_index.Vitro
+uil-data:view_content_index.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Pogledajte kratak pregled sadržaja ovog sajta"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "view_content_index" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "view_content_index" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:or_create_new_one.Vitro
+uil-data:or_create_new_one.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "ili kreirajte novi."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "or_create_new_one" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "or_create_new_one" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:remove_selection.Vitro
+uil-data:remove_selection.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Uklonite odabrano"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "remove_selection" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "remove_selection" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:cardinality.Vitro
+uil-data:cardinality.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "kardinalitet"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "cardinality" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "cardinality" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:apostrophe_not_allowed.Vitro
+uil-data:apostrophe_not_allowed.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Naziv promenjive ne treba da sadrži apostrofe."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "apostrophe_not_allowed" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "apostrophe_not_allowed" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:confirm_menu_item_delete.Vitro
+uil-data:confirm_menu_item_delete.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Da li ste sigurni da želite da uklonite"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "confirm_menu_item_delete" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "confirm_menu_item_delete" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:work_level.Vitro
+uil-data:work_level.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Nivo rada"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "work_level" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "work_level" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:acct_created_external_only_email_html_text.Vitro
+uil-data:acct_created_external_only_email_html_text.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "<p>\n ${userAccount.firstName} ${userAccount.lastName}\n </p>\n\n <p>\n <strong>Čestitamo!</strong>\n </p>\n\n <p>\n Kreirali smo novi VIVO nalog povezan sa ${userAccount.emailAddress} email adresom.\n </p>\n\n <p>\n Hvala!\n </p>"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "acct_created_external_only_email_html_text" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "acct_created_external_only_email_html_text" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:friday.Vitro
+uil-data:friday.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "petak"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "friday" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "friday" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:return_to_the.Vitro
+uil-data:return_to_the.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Vratite se na"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "return_to_the" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "return_to_the" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:sparql_query.Vitro
+uil-data:sparql_query.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "SPARQL upiti"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "sparql_query" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "sparql_query" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:myAccount_confirm_changes.Vitro
+uil-data:myAccount_confirm_changes.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Unete izmene su sačuvane."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "myAccount_confirm_changes" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "myAccount_confirm_changes" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:to.Vitro
+uil-data:to.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "do"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "to" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "to" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:login_to_manage_site.Vitro
+uil-data:login_to_manage_site.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "prijavite se kako bi ste upravljali sajtom"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "login_to_manage_site" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "login_to_manage_site" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:a_classgroup.Vitro
+uil-data:a_classgroup.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "grupu za klase"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "a_classgroup" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "a_classgroup" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:upload_page_title.Vitro
+uil-data:upload_page_title.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Odabir slike"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "upload_page_title" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "upload_page_title" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_existing_collaborator.Vitro
+uil-data:select_existing_collaborator.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Odaberite postojećeg saradnika za {0}"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_existing_collaborator" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_existing_collaborator" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:label.dateTimeWithPrecision.day_capitalized.Vitro
+uil-data:label.dateTimeWithPrecision.day_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Dan"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "label.dateTimeWithPrecision.day_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "label.dateTimeWithPrecision.day_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:login_button.Vitro
+uil-data:login_button.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Prijava"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "login_button" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "login_button" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:internal_login.Vitro
+uil-data:internal_login.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Interno prijavljivanje"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "internal_login" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "internal_login" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_occurred.Vitro
+uil-data:error_occurred.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Došlo je do greške na sajtu"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_occurred" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_occurred" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:advanced_search_tip_four.Vitro
+uil-data:advanced_search_tip_four.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Pretraga takođe vraća rezultate koji sadrže reči slične izrazu pretrage -- npr., <i>sekvenca</i> će se podudarati sa <i>sekvencama</i>."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "advanced_search_tip_four" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "advanced_search_tip_four" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:updated_account_title.Vitro
+uil-data:updated_account_title.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "ažuriran nalog"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "updated_account_title" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "updated_account_title" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:year_month_day.Vitro
+uil-data:year_month_day.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Neispravan unos. Molimo Vas unesite godinu, mesec i dan."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "year_month_day" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "year_month_day" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:log_out.Vitro
+uil-data:log_out.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Odjavite se"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "log_out" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "log_out" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:application_error_email_plain_text.Vitro
+uil-data:application_error_email_plain_text.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Došlo je do greške na Vašem sajtu ${siteName!} u ${datetime!}\nZatražen url: ${requestedUrl!}\n\n<#if errorMessage?has_content>\n Poruka o grešci: ${errorMessage!}\n</#if>\n\nInformacije o grešci (detaljne informacije o greškama možete naći u log-u):\n${stackTrace!}\n\n<#if cause?has_content>\nIzazvano od strane:\n${cause!}\n</#if>"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "application_error_email_plain_text" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "application_error_email_plain_text" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_vclass_uri.Vitro
+uil-data:select_vclass_uri.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Odaberite VClass"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_vclass_uri" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_vclass_uri" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:custom_template_requiring_content.Vitro
+uil-data:custom_template_requiring_content.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Prilagođen šabloin zahteva sadržaj"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "custom_template_requiring_content" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "custom_template_requiring_content" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:file_upload_error_uri_not_exists.Vitro
+uil-data:file_upload_error_uri_not_exists.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "file_upload_error_uri_not_exists" ;
-        prop:hasPackage  "Vitro-languages" .
+        rdf:type         uil:UILabel ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "file_upload_error_uri_not_exists" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:external_id_not_provided.Vitro
+uil-data:external_id_not_provided.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Prijava neuspešna - Eksterni ID nije pronađen"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "external_id_not_provided" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "external_id_not_provided" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:imageUpload.errorBadMultipartRequest.Vitro
+uil-data:imageUpload.errorBadMultipartRequest.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Došlo je do greške prilikom parsiranja 'multi-part' zahteva prilikom postavljanja slike."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "imageUpload.errorBadMultipartRequest" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "imageUpload.errorBadMultipartRequest" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:view_all_accounts.Vitro
+uil-data:view_all_accounts.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Prikažite sve naloge"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "view_all_accounts" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "view_all_accounts" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:file_upload_file.Vitro
+uil-data:file_upload_file.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "file_upload_file" ;
-        prop:hasPackage  "Vitro-languages" .
+        rdf:type         uil:UILabel ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "file_upload_file" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:search_failed.Vitro
+uil-data:search_failed.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Pretraga nije uspela."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "search_failed" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "search_failed" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:minimum_hour.Vitro
+uil-data:minimum_hour.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Neispravan unos. Molimo Vas unesite makar sate."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "minimum_hour" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "minimum_hour" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:faux_property_alpha.Vitro
+uil-data:faux_property_alpha.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "faux svojstva abecedno"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "faux_property_alpha" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "faux_property_alpha" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:info_icon.Vitro
+uil-data:info_icon.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "ikonica za informacije"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "info_icon" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "info_icon" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:save_button.Vitro
+uil-data:save_button.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Sačuvajte"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "save_button" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "save_button" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:who_can_edit_profile.Vitro
+uil-data:who_can_edit_profile.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ko može da ažurira moj profil"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "who_can_edit_profile" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "who_can_edit_profile" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:add_an_entry_to.Vitro
+uil-data:add_an_entry_to.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Dodajte entitet tipa"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "add_an_entry_to" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "add_an_entry_to" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:page_not_found_msg.Vitro
+uil-data:page_not_found_msg.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Stranica nije pronađena u sistemu."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "page_not_found_msg" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "page_not_found_msg" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:no_content_in_system.Vitro
+uil-data:no_content_in_system.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Trenutno u sistemu nema sadržaja za tip \"{0}\""@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "no_content_in_system" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "no_content_in_system" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:rdf.Vitro
+uil-data:rdf.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "RDF"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "rdf" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "rdf" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:datetime_year_required.Vitro
+uil-data:datetime_year_required.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Intervali datuma moraju da počnu sa godinom. Unesite godinu početka, godinu završetka ili i jedno i drugo."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "datetime_year_required" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "datetime_year_required" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:external_auth_name.Vitro
+uil-data:external_auth_name.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "ime za eksternu autentifikaciju"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "external_auth_name" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "external_auth_name" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:external_login_failed.Vitro
+uil-data:external_login_failed.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Eksterna prijava nije uspela"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "external_login_failed" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "external_login_failed" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:label.dateTimeWithPrecision.seconds_capitalized.Vitro
+uil-data:label.dateTimeWithPrecision.seconds_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Sekunde"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "label.dateTimeWithPrecision.seconds_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "label.dateTimeWithPrecision.seconds_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:custom_template.Vitro
+uil-data:custom_template.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Prilagođen šablon"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "custom_template" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "custom_template" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:associated_profile_label.Vitro
+uil-data:associated_profile_label.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Povezani profile:"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "associated_profile_label" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "associated_profile_label" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:page_not_found.Vitro
+uil-data:page_not_found.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Stranica nije pronađena"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "page_not_found" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "page_not_found" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_existing_last_name.Vitro
+uil-data:select_existing_last_name.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Odaberite već postojeće prezime"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_existing_last_name" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_existing_last_name" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:title_capitalized.Vitro
+uil-data:title_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Naslov"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "title_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "title_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:file_upload_error_no_action.Vitro
+uil-data:file_upload_error_no_action.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "file_upload_error_no_action" ;
-        prop:hasPackage  "Vitro-languages" .
+        rdf:type         uil:UILabel ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "file_upload_error_no_action" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:change_entry_for.Vitro
+uil-data:change_entry_for.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Promenite unos za:"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "change_entry_for" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "change_entry_for" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:cause.Vitro
+uil-data:cause.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Uzrok:"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "cause" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "cause" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:may_edit.Vitro
+uil-data:may_edit.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Dozvoljeno ažuriranje"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "may_edit" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "may_edit" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:properties.Vitro
+uil-data:properties.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "svojstva"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "properties" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "properties" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:add_new.Vitro
+uil-data:add_new.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Dodajte novi"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "add_new" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "add_new" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:apples.Vitro
+uil-data:apples.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Jabuke"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "apples" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "apples" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:tuesday.Vitro
+uil-data:tuesday.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "utorak"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "tuesday" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "tuesday" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:email_changed_subject.Vitro
+uil-data:email_changed_subject.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Vaš {0} email nalog je promenjen."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "email_changed_subject" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "email_changed_subject" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:site_admin.Vitro
+uil-data:site_admin.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Administrator sajta"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "site_admin" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "site_admin" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:code_processing_error.Vitro
+uil-data:code_processing_error.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Došlo je do greške, nedostaje komponenta koda za obradu ovog sadržaja. Molimo Vas kontaktirajte administratora."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "code_processing_error" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "code_processing_error" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:base_property_capitalized.Vitro
+uil-data:base_property_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Bazno svojstvo"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "base_property_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "base_property_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:username.Vitro
+uil-data:username.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Korisničko ime"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "username" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "username" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:to_order_menu_items.Vitro
+uil-data:to_order_menu_items.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "da bi ste podesili redosled opcija unutar menija."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "to_order_menu_items" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "to_order_menu_items" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:none.Vitro
+uil-data:none.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "nijedan"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "none" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "none" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:classes_capitalized.Vitro
+uil-data:classes_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Klase"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "classes_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "classes_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:cancel_link.Vitro
+uil-data:cancel_link.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Poništite"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "cancel_link" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "cancel_link" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:send_feedback_questions.Vitro
+uil-data:send_feedback_questions.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Pošaljite nam vaše komentare o sajtu ili nam postavite pitanje"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "send_feedback_questions" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "send_feedback_questions" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:account_already_activated.Vitro
+uil-data:account_already_activated.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Nalog korisnika {0} je već aktiviran."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "account_already_activated" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "account_already_activated" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:page.Vitro
+uil-data:page.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "stranica"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "page" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "page" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:type_more_characters.Vitro
+uil-data:type_more_characters.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "unesite više karaktera"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "type_more_characters" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "type_more_characters" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:search_tips_header.Vitro
+uil-data:search_tips_header.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Saveti za Pretragu"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "search_tips_header" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "search_tips_header" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:data_not_past_msg.Vitro
+uil-data:data_not_past_msg.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Molimo Vas da unesete datum iz budućnosti za ciljani datum objavljivanja rada (datumi iz prošlosti nisu validni)."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "data_not_past_msg" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "data_not_past_msg" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_associated_profile.Vitro
+uil-data:select_associated_profile.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Odaberite povezani profil"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_associated_profile" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_associated_profile" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:edit_capitalized.Vitro
+uil-data:edit_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ažurirajte"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "edit_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "edit_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:site_name.Vitro
+uil-data:site_name.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "naziv sajta"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "site_name" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "site_name" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:replace_photo.Vitro
+uil-data:replace_photo.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Zamenite sliku"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "replace_photo" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "replace_photo" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:rebuild_button.Vitro
+uil-data:rebuild_button.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ponovo kreiraj"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "rebuild_button" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "rebuild_button" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:numbers.Vitro
+uil-data:numbers.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Brojevi"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "numbers" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "numbers" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:acct_created_external_only_email_plain_text.Vitro
+uil-data:acct_created_external_only_email_plain_text.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "${userAccount.firstName} ${userAccount.lastName}\n\nČestitamo!\n\nKreirali smo novi VIVO nalog povezan sa ${userAccount.emailAddress} email adresom.\n\nHvala!"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "acct_created_external_only_email_plain_text" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "acct_created_external_only_email_plain_text" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:auth_id_explanation.Vitro
+uil-data:auth_id_explanation.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Može se koristiti za povezivanje naloga sa korisničkim profilom preko svojsva podudaranja (matching property)."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "auth_id_explanation" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "auth_id_explanation" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:support.Vitro
+uil-data:support.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Podrška"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "support" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "support" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:enter_search_term.Vitro
+uil-data:enter_search_term.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Molimo vas unesite izraz za pretragu."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "enter_search_term" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "enter_search_term" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:feedback_thanks_heading.Vitro
+uil-data:feedback_thanks_heading.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Hvala Vam na povratnim informacijama"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "feedback_thanks_heading" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "feedback_thanks_heading" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:updated_account_notification.Vitro
+uil-data:updated_account_notification.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Email sa instrukcijama za resetovanje lozinke je poslat na adresu {0}. Lozinka neće biti resetovana sve dok korisnik ne klikne na link u email-u."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "updated_account_notification" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "updated_account_notification" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:menu_ordering_mixed_caps.Vitro
+uil-data:menu_ordering_mixed_caps.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Redosled opcija unutar menija"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "menu_ordering_mixed_caps" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "menu_ordering_mixed_caps" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:expand_all.Vitro
+uil-data:expand_all.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "proširite sve"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "expand_all" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "expand_all" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:confirm_password_capitalized.Vitro
+uil-data:confirm_password_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Potvrdite lozinku"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "confirm_password_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "confirm_password_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:uri_not_defined.Vitro
+uil-data:uri_not_defined.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "URI za stranicu nije pronađen"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "uri_not_defined" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "uri_not_defined" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:a_link.Vitro
+uil-data:a_link.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "link"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "a_link" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "a_link" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:view_list_of_labels.Vitro
+uil-data:view_list_of_labels.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "prikažite lisu labela"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "view_list_of_labels" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "view_list_of_labels" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:not_logged_in.Vitro
+uil-data:not_logged_in.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Nije prijavljen"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "not_logged_in" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "not_logged_in" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:page_public_permission_option.Vitro
+uil-data:page_public_permission_option.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Svako može da pristupi ovoj stranici"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "page_public_permission_option" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "page_public_permission_option" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:file_upload_error_uri_not_given.Vitro
+uil-data:file_upload_error_uri_not_given.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "file_upload_error_uri_not_given" ;
-        prop:hasPackage  "Vitro-languages" .
+        rdf:type         uil:UILabel ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "file_upload_error_uri_not_given" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:file_upload_heading.Vitro
+uil-data:file_upload_heading.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "file_upload_heading" ;
-        prop:hasPackage  "Vitro-languages" .
+        rdf:type         uil:UILabel ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "file_upload_heading" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:save_this_content.Vitro
+uil-data:save_this_content.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Sačuvajte ovaj sadržaj"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "save_this_content" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "save_this_content" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:data.Vitro
+uil-data:data.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "podatak"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "data" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "data" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_incorrect_credentials.Vitro
+uil-data:error_incorrect_credentials.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Uneli ste neispravnu email adresu i/ili lozinku."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_incorrect_credentials" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_incorrect_credentials" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:start_url_with_slash.Vitro
+uil-data:start_url_with_slash.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ulepšan URL mora da počinje sa kosom crtom"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "start_url_with_slash" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "start_url_with_slash" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:february.Vitro
+uil-data:february.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "februar"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "february" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "february" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:delete_entry.Vitro
+uil-data:delete_entry.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "obrišite ovaj unos"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "delete_entry" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "delete_entry" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:imageUpload.errorFormFieldMissing.Vitro
+uil-data:imageUpload.errorFormFieldMissing.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Forma ne sadrži polje ''{0}''."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "imageUpload.errorFormFieldMissing" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "imageUpload.errorFormFieldMissing" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:formatted_date_time.Vitro
+uil-data:formatted_date_time.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Formatirani datum i vreme"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "formatted_date_time" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "formatted_date_time" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:imageUpload.errorUnknown.Vitro
+uil-data:imageUpload.errorUnknown.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Došlo je do greške pri obradi slike. Molimo Vas odaberete neku drugu sliku."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "imageUpload.errorUnknown" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "imageUpload.errorUnknown" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:password_reset_pending_email_html_text.Vitro
+uil-data:password_reset_pending_email_html_text.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "<p>\n Poštovani:\n </p>\n\n <p>\n Dobili smo zahtev za resetovanje šifre za Vaš ${siteName} nalog (${userAccount.emailAddress}).\n </p>\n\n <p>\n Molimo Vas da pratite dole navedene instrukcije kako bi ste nastavili sa resetovanjem Vaše lozinke.\n </p>\n\n <p>\n Ako niste zahtevali resetovanje lozinke možete ignorisati ovaj mejl.\n Ovaj zahtev će isteći za 30 dana.\n </p>\n\n <p>\n Kliknite na link ispod ili ga kopirajte u navigacioni bar vašek pretraživača kako bi ste resetovali\n Vašu lozinku koristeći naše zaštićene servere.\n </p>\n\n <p><a href=\"${passwordLink}\" title=\"password\">${passwordLink}</a> </p>\n\n <p>Hvala Vam!</p>"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "password_reset_pending_email_html_text" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "password_reset_pending_email_html_text" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:ontology_editor.Vitro
+uil-data:ontology_editor.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Editor za ontologije"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "ontology_editor" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "ontology_editor" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:from_capitalized.Vitro
+uil-data:from_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Od"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "from_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "from_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:logged_out.Vitro
+uil-data:logged_out.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Uspešno ste se odjavili."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "logged_out" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "logged_out" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:search_for.Vitro
+uil-data:search_for.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Pretraga za ''{0}''"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "search_for" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "search_for" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:other.Vitro
+uil-data:other.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "ostalo"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "other" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "other" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:supply_variable_name.Vitro
+uil-data:supply_variable_name.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Morate uneti promenjivu kako bi ste sačuvali HTML sadržaj."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "supply_variable_name" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "supply_variable_name" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:remove_restrictions.Vitro
+uil-data:remove_restrictions.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Otklonite Ograničenja"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "remove_restrictions" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "remove_restrictions" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:variable_name_all_caps.Vitro
+uil-data:variable_name_all_caps.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Naziv promenjive"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "variable_name_all_caps" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "variable_name_all_caps" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:levels.Vitro
+uil-data:levels.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Nivoi"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "levels" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "levels" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:range_class.Vitro
+uil-data:range_class.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Klasa raspona"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "range_class" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "range_class" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:type_more_chars.Vitro
+uil-data:type_more_chars.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "unesite još karaktera"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "type_more_chars" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "type_more_chars" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:advanced_data_tools.Vitro
+uil-data:advanced_data_tools.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Napredni alati za rad sa podacima"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "advanced_data_tools" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "advanced_data_tools" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:current_date.Vitro
+uil-data:current_date.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Trenutni datum:"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "current_date" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "current_date" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:since_elapsed_time_est_total.Vitro
+uil-data:since_elapsed_time_est_total.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "od {0}, proteklo vreme {1}, procenjeno ukupno vreme {2}"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "since_elapsed_time_est_total" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "since_elapsed_time_est_total" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:close.Vitro
+uil-data:close.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "zatvorite"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "close" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "close" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:change_selection.Vitro
+uil-data:change_selection.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "promenite odabir"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "change_selection" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "change_selection" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:copyright.Vitro
+uil-data:copyright.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "autorska prava"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "copyright" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "copyright" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_page_content_type.Vitro
+uil-data:select_page_content_type.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Odaberite tip sadržaja za povezanu stranicu"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_page_content_type" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_page_content_type" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:zoo_one.Vitro
+uil-data:zoo_one.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Zoo 1"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "zoo_one" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "zoo_one" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:cancel_title.Vitro
+uil-data:cancel_title.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "poništite"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "cancel_title" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "cancel_title" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:add_individual_of_class.Vitro
+uil-data:add_individual_of_class.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Dodajte pojedinca ove klase"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "add_individual_of_class" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "add_individual_of_class" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:label.dateTimeWithPrecision.year_capitalized.Vitro
+uil-data:label.dateTimeWithPrecision.year_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Godina"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "label.dateTimeWithPrecision.year_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "label.dateTimeWithPrecision.year_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:relate_editors_profiles.Vitro
+uil-data:relate_editors_profiles.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Srodni urednici profila i profili"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "relate_editors_profiles" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "relate_editors_profiles" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:vitro_bullet_four.Vitro
+uil-data:vitro_bullet_four.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Pretraživati Vaše podatke"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "vitro_bullet_four" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "vitro_bullet_four" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:save_changes.Vitro
+uil-data:save_changes.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Sačuvajte promene"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "save_changes" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "save_changes" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:cant_activate_while_logged_in.Vitro
+uil-data:cant_activate_while_logged_in.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Ne možete aktivirati nalog korisnika {0} dok ste prijavljeni kao {1}. Odjavite se i pokušajte ponovo."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "cant_activate_while_logged_in" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "cant_activate_while_logged_in" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:next_capitalized.Vitro
+uil-data:next_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Sledeći"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "next_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "next_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:end_capitalized.Vitro
+uil-data:end_capitalized.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Kraj"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "end_capitalized" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "end_capitalized" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:custom_template_containing_content.Vitro
+uil-data:custom_template_containing_content.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Prilagođen šablon koji sadrži sav sadržaj"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "custom_template_containing_content" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "custom_template_containing_content" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:name_of.Vitro
+uil-data:name_of.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "name_of" ;
-        prop:hasPackage  "Vitro-languages" .
+        rdf:type         uil:UILabel ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "name_of" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:content_type.Vitro
+uil-data:content_type.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Tip sadržaja"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "content_type" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "content_type" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:add_label.Vitro
+uil-data:add_label.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Dodajte labelu"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "add_label" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "add_label" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:activate_developer_panel_mixed_caps.Vitro
+uil-data:activate_developer_panel_mixed_caps.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Aktivirajte panel za programere"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "activate_developer_panel_mixed_caps" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "activate_developer_panel_mixed_caps" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:reset_search_index.Vitro
+uil-data:reset_search_index.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Resetujte indeks pretrage i iznova ga kreirajte."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "reset_search_index" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "reset_search_index" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:please_provide_contact_information.Vitro
+uil-data:please_provide_contact_information.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Molimo Vas unesite kontakt informacije kako bi ste završili kreiranje naloga."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "please_provide_contact_information" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "please_provide_contact_information" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:continued.Vitro
+uil-data:continued.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "nastaviće se"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "continued" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "continued" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_no_email.Vitro
+uil-data:error_no_email.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Morate uneti email adresu."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_no_email" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_no_email" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_no_last_name.Vitro
+uil-data:error_no_last_name.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Morate uneti prezime."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_no_last_name" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_no_last_name" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:december.Vitro
+uil-data:december.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "decembar"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "december" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "december" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:multiple_content_default_template_error.Vitro
+uil-data:multiple_content_default_template_error.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Morate specificirati prilagođen šablon kada koristite više tipova sadržaja."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "multiple_content_default_template_error" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "multiple_content_default_template_error" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:all_classes.Vitro
+uil-data:all_classes.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Sve klase"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "all_classes" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "all_classes" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:viewing_page.Vitro
+uil-data:viewing_page.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Verovatno pregledana stranica"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "viewing_page" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "viewing_page" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:individual_not_found_msg.Vitro
+uil-data:individual_not_found_msg.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Osoba nije pronađena u sistemu."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "individual_not_found_msg" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "individual_not_found_msg" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:setup_navigation_menu.Vitro
+uil-data:setup_navigation_menu.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Podesite primarni navigacioni meni za sajt"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "setup_navigation_menu" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "setup_navigation_menu" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:external_id_already_in_use.Vitro
+uil-data:external_id_already_in_use.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Nalog već postoji za korisnika ''{0}''"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "external_id_already_in_use" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "external_id_already_in_use" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:ascending_order.Vitro
+uil-data:ascending_order.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "uzlazni redosled"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "ascending_order" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "ascending_order" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:browse_all_content.Vitro
+uil-data:browse_all_content.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "pretražite sav sadržaj"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "browse_all_content" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "browse_all_content" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:begin_with_slash_no_example.Vitro
+uil-data:begin_with_slash_no_example.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Mora početi sa kosom crtom: /"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "begin_with_slash_no_example" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "begin_with_slash_no_example" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_occurred_at.Vitro
+uil-data:error_occurred_at.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Došlo je do greške na Vašem sajtu na {0}."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_occurred_at" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_occurred_at" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:select_editors.Vitro
+uil-data:select_editors.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Odaberite urednike"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "select_editors" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "select_editors" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:supply_html.Vitro
+uil-data:supply_html.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Morate uneti HTML ili tekst."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "supply_html" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "supply_html" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:slash_example.Vitro
+uil-data:slash_example.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "(npr. /osobe)"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "slash_example" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "slash_example" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:property_hierarchy.Vitro
+uil-data:property_hierarchy.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Hijerarhija svojstava"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "property_hierarchy" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "property_hierarchy" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:try_rebuilding_index.Vitro
+uil-data:try_rebuilding_index.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Pokušajte ponovo da kreirate indeks pretrage"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "try_rebuilding_index" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "try_rebuilding_index" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:error_in_search_request.Vitro
+uil-data:error_in_search_request.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Zahtev za pretragu sadrži greške."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "error_in_search_request" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "error_in_search_request" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:first_time_login.Vitro
+uil-data:first_time_login.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Prvo prijavljivanje"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "first_time_login" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "first_time_login" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:first_time_external_email_plain_text.Vitro
+uil-data:first_time_external_email_plain_text.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "${userAccount.firstName} ${userAccount.lastName}\n\nČestitamo!\n\nKreirali smo novi VIVO nalog povezan sa ${userAccount.emailAddress} email adresom.\n\nHvala!"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "first_time_external_email_plain_text" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "first_time_external_email_plain_text" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:faux_property_by_base.Vitro
+uil-data:faux_property_by_base.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "faux svojstva po baznim svojstvima"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "faux_property_by_base" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "faux_property_by_base" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:alt_thumbnail_photo.Vitro
+uil-data:alt_thumbnail_photo.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Fotografija osobe"@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "alt_thumbnail_photo" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "alt_thumbnail_photo" ;
+        uil:hasPackage  "Vitro-languages" .
 
-prop-data:no_individual_associated_with_id.Vitro
+uil-data:no_individual_associated_with_id.Vitro
         rdf:type         owl:NamedIndividual ;
-        rdf:type         prop:PropertyKey ;
+        rdf:type         uil:UILabel ;
         rdfs:label       "Zbog nekog razloga, ne postoji osoba unutar sistema koja je povezana sa Vašim Net ID-em. Možda treba da kontaktirate Vašeg administratora."@sr-Latn-RS ;
-        prop:hasApp      "Vitro" ;
-        prop:hasKey      "no_individual_associated_with_id" ;
-        prop:hasPackage  "Vitro-languages" .
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "no_individual_associated_with_id" ;
+        uil:hasPackage  "Vitro-languages" .

--- a/home/src/main/resources/rdf/tbox/firsttime/UILabelsVocabulary.ttl
+++ b/home/src/main/resources/rdf/tbox/firsttime/UILabelsVocabulary.ttl
@@ -1,39 +1,38 @@
 @prefix owl:   <http://www.w3.org/2002/07/owl#> .
 @prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
-@prefix prop-data: <http://vivoweb.org/ontology/vitro-app/ui-label/individual#> .
-@prefix prop:  <http://vivoweb.org/ontology/vitro-app/ui-label/vocabulary#> .
+@prefix uil:  <http://vivoweb.org/ontology/vitro/ui-label/vocabulary#> .
 @prefix xsd:   <http://www.w3.org/2001/XMLSchema#> .
 @prefix skos:  <http://www.w3.org/2004/02/skos/core#> .
 @prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> .
 
-prop:hasPackage  rdf:type  owl:DatatypeProperty ;
-        rdfs:domain  prop:UILabel ;
+uil:hasPackage  rdf:type  owl:DatatypeProperty ;
+        rdfs:domain  uil:UILabel ;
         rdfs:label   "has package" ;
         rdfs:range   xsd:string .
 
-prop:hasKey  rdf:type  owl:DatatypeProperty ;
+uil:hasKey  rdf:type  owl:DatatypeProperty ;
         rdfs:comment  "value of the key" ;
-        rdfs:domain   prop:UILabel ;
+        rdfs:domain   uil:UILabel ;
         rdfs:label    "has key" ;
         rdfs:range    xsd:string .
 
-prop:hasTheme  rdf:type  owl:DatatypeProperty ;
-        rdfs:domain  prop:UILabel ;
+uil:hasTheme  rdf:type  owl:DatatypeProperty ;
+        rdfs:domain  uil:UILabel ;
         rdfs:label   "has theme" ;
         rdfs:range   xsd:string .
 
-prop:UILabel  rdf:type  owl:Class ;
+uil:UILabel  rdf:type  owl:Class ;
         rdfs:label       skos:Concept ;
         rdfs:subClassOf  owl:Thing ;
         rdfs:subClassOf  skos:Concept .
 
-prop:ftlUrl  rdf:type  owl:DatatypeProperty ;
+uil:ftlUrl  rdf:type  owl:DatatypeProperty ;
         rdfs:comment  "Points to the Freemarker template (.ftl) file containing the key." ;
-        rdfs:domain   prop:UILabel ;
+        rdfs:domain   uil:UILabel ;
         rdfs:label    ".ftl file url" ;
         rdfs:range    xsd:anyURI .
 
-prop:hasApp  rdf:type  owl:DatatypeProperty ;
-        rdfs:domain  prop:UILabel ;
+uil:hasApp  rdf:type  owl:DatatypeProperty ;
+        rdfs:domain  uil:UILabel ;
         rdfs:label   "has application" ;
         rdfs:range   xsd:string .

--- a/home/src/main/resources/rdf/tbox/firsttime/UILabelsVocabulary.ttl
+++ b/home/src/main/resources/rdf/tbox/firsttime/UILabelsVocabulary.ttl
@@ -1,39 +1,39 @@
 @prefix owl:   <http://www.w3.org/2002/07/owl#> .
 @prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
-@prefix prop-data: <http://vivoweb.org/ontology/core/properties/individual#> .
-@prefix prop:  <http://vivoweb.org/ontology/core/properties/vocabulary#> .
+@prefix prop-data: <http://vivoweb.org/ontology/vitro-app/ui-label/individual#> .
+@prefix prop:  <http://vivoweb.org/ontology/vitro-app/ui-label/vocabulary#> .
 @prefix xsd:   <http://www.w3.org/2001/XMLSchema#> .
 @prefix skos:  <http://www.w3.org/2004/02/skos/core#> .
 @prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> .
 
 prop:hasPackage  rdf:type  owl:DatatypeProperty ;
-        rdfs:domain  prop:PropertyKey ;
+        rdfs:domain  prop:UILabel ;
         rdfs:label   "has package" ;
         rdfs:range   xsd:string .
 
 prop:hasKey  rdf:type  owl:DatatypeProperty ;
-        rdfs:comment  "Value of the key" ;
-        rdfs:domain   prop:PropertyKey ;
-        rdfs:label    "Propertie file url " ;
+        rdfs:comment  "value of the key" ;
+        rdfs:domain   prop:UILabel ;
+        rdfs:label    "has key" ;
         rdfs:range    xsd:string .
 
 prop:hasTheme  rdf:type  owl:DatatypeProperty ;
-        rdfs:domain  prop:PropertyKey ;
+        rdfs:domain  prop:UILabel ;
         rdfs:label   "has theme" ;
         rdfs:range   xsd:string .
 
-prop:PropertyKey  rdf:type  owl:Class ;
+prop:UILabel  rdf:type  owl:Class ;
         rdfs:label       skos:Concept ;
         rdfs:subClassOf  owl:Thing ;
         rdfs:subClassOf  skos:Concept .
 
 prop:ftlUrl  rdf:type  owl:DatatypeProperty ;
-        rdfs:comment  "Points to the FTL file containing the key" ;
-        rdfs:domain   prop:PropertyKey ;
-        rdfs:label    "ftl file url" ;
+        rdfs:comment  "Points to the Freemarker template (.ftl) file containing the key." ;
+        rdfs:domain   prop:UILabel ;
+        rdfs:label    ".ftl file url" ;
         rdfs:range    xsd:anyURI .
 
 prop:hasApp  rdf:type  owl:DatatypeProperty ;
-        rdfs:domain  prop:PropertyKey ;
+        rdfs:domain  prop:UILabel ;
         rdfs:label   "has application" ;
         rdfs:range   xsd:string .


### PR DESCRIPTION
**[VIVO GitHub issue 3862](https://github.com/vivo-project/VIVO/issues/3862)**:

# What does this pull request do?
Changes PropertyKey class to UILabel to align with naming already in use, and changes /core/properties/ part of namespace to /vitro/ui-label/ to clearly differentiate this application ontology from the VIVO core ontology.

# How should this be tested?
A description of what steps someone could take to:
* Deploy and confirm that UI labels appear normally in Vitro/Wilma/Tenderfoot.

# Interested parties
@VIVO-project/vivo-committers
