### PR TITLE
fix: Escape data property value

### DIFF
--- a/webapp/src/main/webapp/templates/freemarker/edit/forms/defaultDataPropertyForm.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/edit/forms/defaultDataPropertyForm.ftl
@@ -22,7 +22,7 @@
     </section>
 </#if>
 
-<#assign literalValues = "${editConfiguration.dataLiteralValuesAsString}" />
+<#assign literalValues = "${editConfiguration.dataLiteralValuesAsString?html}" />
 <#assign datatype = editConfiguration.dataPredicateProperty.rangeDatatypeURI!"none" />
 
 <form class="editForm" action = "${submitUrl}" method="post">


### PR DESCRIPTION
**[VIVO GitHub issue](https://github.com/vivo-project/VIVO/issues/3864)**

# What does this pull request do?
Escapes returned value in defaultDataPropertyForm

# How should this be tested?

1. Create a data property (range: XMLLiteral, text editor: plaintext)
2. Create a value with " in the middle, save
3. Edit this value again

# Interested parties
@chenejac 
