### PR TITLE
Escape html

### DIFF
--- a/webapp/src/main/webapp/templates/freemarker/edit/forms/confirmDeletePropertyForm.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/edit/forms/confirmDeletePropertyForm.ftl
@@ -24,7 +24,7 @@
                 <#include deletionTemplateName />
             </#if>
         <#else>
-            ${statement}
+            ${statement?html}
         </#if>
     </p>
 

--- a/webapp/src/main/webapp/templates/freemarker/lib/lib-properties.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/lib/lib-properties.ftl
@@ -296,7 +296,7 @@ name will be used as the label. -->
 		<#assign useEditLink = true/>
 	</#if>
     <#local label = individual.nameStatement>
-    ${label.value}
+    ${label.value?html}
     <#if useEditLink>
     	<@editingLinks "label" "" label editable ""/>
     <#elseif (editable && (labelCount > 0)) || (languageCount > 1)>

--- a/webapp/src/main/webapp/templates/freemarker/lib/lib-properties.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/lib/lib-properties.ftl
@@ -296,7 +296,7 @@ name will be used as the label. -->
 		<#assign useEditLink = true/>
 	</#if>
     <#local label = individual.nameStatement>
-    ${label.value?html}
+    ${label.value}
     <#if useEditLink>
     	<@editingLinks "label" "" label editable ""/>
     <#elseif (editable && (labelCount > 0)) || (languageCount > 1)>


### PR DESCRIPTION
**[VIVO GitHub issue](https://github.com/vivo-project/VIVO/issues/3869)**
[VIVO PR](https://github.com/vivo-project/VIVO/pull/3868)

# What does this pull request do?
Fixes some freemarker templates to avoid invalid html.

# How should this be tested?

1. Create data property with value `</div>"</div>`
2. Open form to delete this data property. Form shouldn't be broken

# Interested parties
Tag (@ mention) interested parties or, if unsure, @VIVO-project/vivo-committers
