### PR TITLE
Added simple substitutions to sparql query component

### DIFF
--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/dynapi/components/operations/XMLTransformation.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/dynapi/components/operations/XMLTransformation.java
@@ -57,7 +57,7 @@ public class XMLTransformation extends AbstractOperation {
         String styles = SimpleDataView.getStringRepresentation(xsltParam.getName(), dataStore);
         ByteArrayOutputStream output = transform(is, styles);
         Data outputData = new Data(outputXmlParam);
-        outputData.setRawString(output.toString(StandardCharsets.UTF_8));
+        outputData.setRawString(output.toString(StandardCharsets.UTF_8.toString()));
         outputData.initializeFromString();
         dataStore.addData(outputXmlParam.getName(), outputData);
         return OperationResult.ok();

--- a/api/src/test/java/edu/cornell/mannlib/vitro/webapp/dynapi/components/SparqlSelectQueryTest.java
+++ b/api/src/test/java/edu/cornell/mannlib/vitro/webapp/dynapi/components/SparqlSelectQueryTest.java
@@ -26,9 +26,12 @@ public class SparqlSelectQueryTest {
 	private static final String S_VAR = "s";
 	private static final String O_VAR = "o";
 	private static final String ALL_VAR = "all";
+	private static final String LIMIT_VAR = "limit";
+    private static final String ORDER_VAR = "order";
 	private static final String QUERY_NO_VARS = "SELECT ?str WHERE { BIND(\"test\" as ?str) } ";
 	private static final String QUERY_OBJ_VAR = "SELECT ?s WHERE { ?s <test:property> ?str . } ";
 	private static final String QUERY_SUBJ_VAR = "SELECT ?o WHERE { ?str <test:property> ?o . } ";
+    private static final String QUERY_LIMIT_ORDER = "SELECT ?limit_o WHERE { ?str <test:property> ?limit_o . } ORDER BY ?order(?limit_o) LIMIT ?limit "; 
 	private static final String QUERY_LABEL = "SELECT ?o WHERE { ?str <http://www.w3.org/2000/01/rdf-schema#label> ?o . } ";
 
 	private OntModelImpl model;
@@ -183,5 +186,48 @@ public class SparqlSelectQueryTest {
 					JsonView.getJsonString(dataStore, outParam));
 		}
 	}
+	
+   @Test
+    public void orderWithLimit() throws Exception {
+        sparql.setQueryText(QUERY_LIMIT_ORDER);
+        Parameter modelParam = ParameterUtils.createModelParameter(MODEL);
+        sparql.setQueryModel(modelParam);
+        Data modelData = new Data(modelParam);
+        ParameterUtils.addStatement(model, "test:resource", "test:property", "alice");
+        ParameterUtils.addStatement(model, "test:resource", "test:property", "bob");
+        TestView.setObject(modelData, model);
+        dataStore.addData(MODEL, modelData);
+
+        Parameter limitParam = ParameterUtils.createStringLiteralParameter(LIMIT_VAR);
+        Data limitData = new Data(limitParam);
+        TestView.setObject(limitData, "1");
+        dataStore.addData(LIMIT_VAR, limitData);
+        sparql.addInputSubstitutionParameter(limitParam);
+        
+        Parameter orderParam = ParameterUtils.createStringLiteralParameter(ORDER_VAR);
+        Data orderData = new Data(orderParam);
+        TestView.setObject(orderData, "ASC");
+        dataStore.addData(ORDER_VAR, orderData);
+        sparql.addInputSubstitutionParameter(orderParam);
+
+        Parameter strParam = ParameterUtils.createUriParameter(STR_VAR);
+        sparql.addInputParameter(strParam);
+        // Not enough params
+        assertEquals(OperationResult.internalServerError(), sparql.run(dataStore));
+        Data strData = new Data(strParam);
+        TestView.setObject(strData, "test:resource");
+        dataStore.addData(STR_VAR, strData);
+        assertEquals(OperationResult.ok(), sparql.run(dataStore));
+        assertFalse(dataStore.contains(ALL_VAR));
+        Parameter outParam = ParameterUtils.createJsonParameter(ALL_VAR);
+        sparql.addOutputParameter(outParam);
+        assertEquals(OperationResult.ok(), sparql.run(dataStore));
+        assertTrue(dataStore.contains(ALL_VAR));
+        if (dataStore.contains(ALL_VAR)) {
+            assertEquals(
+                    "{\"head\":{\"vars\":[\"limit_o\"]},\"results\":{\"bindings\":[{\"limit_o\":{\"type\":\"literal\",\"value\":\"alice\"}}]}}",
+                    JsonView.getJsonString(dataStore, outParam));
+        }
+    }
 
 }

--- a/api/src/test/java/edu/cornell/mannlib/vitro/webapp/dynapi/components/operations/XMLValidationIntegrationTest.java
+++ b/api/src/test/java/edu/cornell/mannlib/vitro/webapp/dynapi/components/operations/XMLValidationIntegrationTest.java
@@ -9,6 +9,7 @@ import java.io.StringReader;
 import java.util.Arrays;
 import java.util.Collection;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.jena.ontology.OntModel;
 import org.apache.jena.ontology.OntModelSpec;
 import org.apache.jena.ontology.impl.OntModelImpl;
@@ -103,7 +104,7 @@ public class XMLValidationIntegrationTest extends ServletContextTest {
             assertTrue(store.contains(OUTPUT));
             Data output = store.getData(OUTPUT);
             boolean expectSuccess = false;
-            if (expectedResult.isBlank()) {
+            if (StringUtils.isBlank(expectedResult)) {
                 expectSuccess = true;
             }
             assertEquals(Boolean.toString(expectSuccess), output.getSerializedValue());

--- a/api/src/test/java/edu/cornell/mannlib/vitro/webapp/dynapi/components/operations/XMLValidationTest.java
+++ b/api/src/test/java/edu/cornell/mannlib/vitro/webapp/dynapi/components/operations/XMLValidationTest.java
@@ -7,6 +7,7 @@ import static org.junit.Assert.assertTrue;
 import java.util.Arrays;
 import java.util.Collection;
 
+import org.apache.tika.utils.StringUtils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -84,7 +85,7 @@ public class XMLValidationTest {
         Data outputData = ds.getData(OUTPUT_PARAM_NAME);
         String outputString = outputData.getSerializedValue();
         boolean expectSuccess = false;
-        if (expectedResult.isBlank()) {
+        if (StringUtils.isBlank(expectedResult)) {
             expectSuccess = true;
         }
         assertEquals(Boolean.toString(expectSuccess),outputString);

--- a/home/src/main/resources/rdf/dynapiTbox/everytime/vitro-dynamic-api.n3
+++ b/home/src/main/resources/rdf/dynapiTbox/everytime/vitro-dynamic-api.n3
@@ -247,6 +247,17 @@
                    rdfs:range :Parameter ;
                    rdfs:label "requires parameter"@en-US .
 
+###  https://vivoweb.org/ontology/vitro-dynamic-api#requiresPlainParameter
+:requiresPlainParameter rdf:type owl:ObjectProperty ;
+                   rdfs:subPropertyOf owl:topObjectProperty ;
+                   rdfs:domain [ rdf:type owl:Class ;
+                        owl:unionOf ( :SparqlSelectQuery
+                                      :SparqlConstructQuery
+                                    )
+                      ] ;
+                   rdfs:range :Parameter ;
+                   rdfs:label "requires parameter for plain substitution"@en-US .
+
 ###  https://vivoweb.org/ontology/vitro-dynamic-api#additionModel
 :additionModel rdf:type owl:ObjectProperty ;
                    rdfs:subPropertyOf owl:topObjectProperty ;


### PR DESCRIPTION
**[VIVO GitHub issue](https://github.com/vivo-project/VIVO/issues/3720)**

# What does this pull request do?
Added addInputSubstitutionParameter method in sparql query component to make simple replacements in SPARQL Queries without type specific formatting.

# How should this be tested?
* Define simple SPARQL Query, like it was done in added test, use <https://vivoweb.org/ontology/vitro-dynamic-api#requiresPlainParameter> property to provide parameter into operation component
* Check that limit and order by are substituted properly

# Interested parties
@chenejac 
