### PR TITLE
Adding missing labels

### DIFF
--- a/home/src/main/resources/rdf/i18n/de_DE/interface-i18n/firsttime/vitro_UiLabel.ttl
+++ b/home/src/main/resources/rdf/i18n/de_DE/interface-i18n/firsttime/vitro_UiLabel.ttl
@@ -49,6 +49,7 @@ uil-data:advanced_search_tip_three.Vitro
 uil-data:file_upload_error_file_size_is_zero.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;
+        rdfs:label       "Die Größe der hochgeladenen Datei ist 0"@de-DE ;
         uil:hasApp      "Vitro" ;
         uil:hasKey      "file_upload_error_file_size_is_zero" ;
         uil:hasPackage  "Vitro-languages" .
@@ -288,6 +289,7 @@ uil-data:password_reset_complete_subject.Vitro
 uil-data:file_upload_error_supported_actions.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;
+        rdfs:label       "Es werden nur Lösch- und Upload-Vorgänge unterstützt"@de-DE ;
         uil:hasApp      "Vitro" ;
         uil:hasKey      "file_upload_error_supported_actions" ;
         uil:hasPackage  "Vitro-languages" .
@@ -743,6 +745,7 @@ uil-data:containers_do_not_pick_up_changes.Vitro
 uil-data:file_upload_error_media_type_not_allowed.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;
+        rdfs:label       "Dieser Dateityp ist nicht zulässig. Der aktuelle Dateityp ist {0}."@de-DE ;
         uil:hasApp      "Vitro" ;
         uil:hasKey      "file_upload_error_media_type_not_allowed" ;
         uil:hasPackage  "Vitro-languages" .
@@ -1166,6 +1169,7 @@ uil-data:october.Vitro
 uil-data:file_upload_subject.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;
+        rdfs:label       "Objekt"@de-DE ;
         uil:hasApp      "Vitro" ;
         uil:hasKey      "file_upload_subject" ;
         uil:hasPackage  "Vitro-languages" .
@@ -1978,13 +1982,6 @@ uil-data:saturday.Vitro
         uil:hasKey      "saturday" ;
         uil:hasPackage  "Vitro-languages" .
 
-uil-data:_publications_link.Vitro
-        rdf:type         owl:NamedIndividual ;
-        rdf:type         uil:UILabel ;
-        uil:hasApp      "Vitro" ;
-        uil:hasKey      "_publications_link" ;
-        uil:hasPackage  "Vitro-languages" .
-
 uil-data:javascript_require_to_edit.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;
@@ -2148,6 +2145,7 @@ uil-data:acct_created_email_html_text.Vitro
 uil-data:file_upload_confirm_delete.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;
+        rdfs:label       "Sind Sie sicher, dass Sie diese Datei löschen möchten?"@de-DE ;
         uil:hasApp      "Vitro" ;
         uil:hasKey      "file_upload_confirm_delete" ;
         uil:hasPackage  "Vitro-languages" .
@@ -2931,6 +2929,7 @@ uil-data:submit_upload.Vitro
 uil-data:confirm_individual_deletion.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;
+        rdfs:label       "Sind Sie sicher, dass Sie die folgenden Daten löschen möchten?"@de-DE ;
         uil:hasApp      "Vitro" ;
         uil:hasKey      "confirm_individual_deletion" ;
         uil:hasPackage  "Vitro-languages" .
@@ -3314,6 +3313,7 @@ uil-data:password_capitalized.Vitro
 uil-data:file_upload_submit_label.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;
+        rdfs:label       "Hochladen"@de-DE ;
         uil:hasApp      "Vitro" ;
         uil:hasKey      "file_upload_submit_label" ;
         uil:hasPackage  "Vitro-languages" .
@@ -4201,6 +4201,7 @@ uil-data:add_label_for_language.Vitro
 uil-data:file_upload_error_file_not_found.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;
+        rdfs:label       "Die hochzuladende Datei wurde nicht gefunden"@de-DE ;
         uil:hasApp      "Vitro" ;
         uil:hasKey      "file_upload_error_file_not_found" ;
         uil:hasPackage  "Vitro-languages" .
@@ -4208,6 +4209,7 @@ uil-data:file_upload_error_file_not_found.Vitro
 uil-data:file_upload_predicate.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;
+        rdfs:label       "Prädikat"@de-DE ;
         uil:hasApp      "Vitro" ;
         uil:hasKey      "file_upload_predicate" ;
         uil:hasPackage  "Vitro-languages" .
@@ -4559,6 +4561,7 @@ uil-data:display_has_element_error.Vitro
 uil-data:file_upload_error_file_is_too_big.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;
+        rdfs:label       "Die hochgeladene Datei ist zu groß. Die maximale Dateigröße beträgt {0} Byte. Die hochgeladene Datei ist {1} Byte groß."@de-DE ;
         uil:hasApp      "Vitro" ;
         uil:hasKey      "file_upload_error_file_is_too_big" ;
         uil:hasPackage  "Vitro-languages" .
@@ -4574,6 +4577,7 @@ uil-data:template_capitalized.Vitro
 uil-data:file_upload_supported_media.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;
+        rdfs:label       "Zulässige Medientypen:"@de-DE ;
         uil:hasApp      "Vitro" ;
         uil:hasKey      "file_upload_supported_media" ;
         uil:hasPackage  "Vitro-languages" .
@@ -4789,6 +4793,7 @@ uil-data:hide_properties.Vitro
 uil-data:file_upload_error_file_type_not_recognized.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;
+        rdfs:label       "Dateityp nicht erkannt"@de-DE ;
         uil:hasApp      "Vitro" ;
         uil:hasKey      "file_upload_error_file_type_not_recognized" ;
         uil:hasPackage  "Vitro-languages" .
@@ -4812,6 +4817,7 @@ uil-data:new_account_title.Vitro
 uil-data:file_upload_no_allowed_media.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;
+        rdfs:label       "In runtime.properties sind keine zulässigen Medientypen definiert"@de-DE ;
         uil:hasApp      "Vitro" ;
         uil:hasKey      "file_upload_no_allowed_media" ;
         uil:hasPackage  "Vitro-languages" .
@@ -5163,6 +5169,7 @@ uil-data:custom_template_requiring_content.Vitro
 uil-data:file_upload_error_uri_not_exists.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;
+        rdfs:label       "Die Uri {0} existiert nicht."@de-DE ;
         uil:hasApp      "Vitro" ;
         uil:hasKey      "file_upload_error_uri_not_exists" ;
         uil:hasPackage  "Vitro-languages" .
@@ -5194,6 +5201,7 @@ uil-data:view_all_accounts.Vitro
 uil-data:file_upload_file.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;
+        rdfs:label       "Datei"@de-DE ;
         uil:hasApp      "Vitro" ;
         uil:hasKey      "file_upload_file" ;
         uil:hasPackage  "Vitro-languages" .
@@ -5353,6 +5361,7 @@ uil-data:title_capitalized.Vitro
 uil-data:file_upload_error_no_action.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;
+        rdfs:label       "Keine Aktion angegeben"@de-DE ;
         uil:hasApp      "Vitro" ;
         uil:hasKey      "file_upload_error_no_action" ;
         uil:hasPackage  "Vitro-languages" .
@@ -5696,6 +5705,7 @@ uil-data:page_public_permission_option.Vitro
 uil-data:file_upload_error_uri_not_given.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;
+        rdfs:label       "Es wurde keine {0} URI angegeben."@de-DE ;
         uil:hasApp      "Vitro" ;
         uil:hasKey      "file_upload_error_uri_not_given" ;
         uil:hasPackage  "Vitro-languages" .
@@ -5703,6 +5713,7 @@ uil-data:file_upload_error_uri_not_given.Vitro
 uil-data:file_upload_heading.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;
+        rdfs:label       "Datei hochladen"@de-DE ;
         uil:hasApp      "Vitro" ;
         uil:hasKey      "file_upload_heading" ;
         uil:hasPackage  "Vitro-languages" .
@@ -6017,13 +6028,6 @@ uil-data:custom_template_containing_content.Vitro
         rdfs:label       "Benutzerdefinierte Vorlage enthält allen Inhalte"@de-DE ;
         uil:hasApp      "Vitro" ;
         uil:hasKey      "custom_template_containing_content" ;
-        uil:hasPackage  "Vitro-languages" .
-
-uil-data:name_of.Vitro
-        rdf:type         owl:NamedIndividual ;
-        rdf:type         uil:UILabel ;
-        uil:hasApp      "Vitro" ;
-        uil:hasKey      "name_of" ;
         uil:hasPackage  "Vitro-languages" .
 
 uil-data:content_type.Vitro

--- a/home/src/main/resources/rdf/i18n/en_CA/interface-i18n/firsttime/vitro_UiLabel.ttl
+++ b/home/src/main/resources/rdf/i18n/en_CA/interface-i18n/firsttime/vitro_UiLabel.ttl
@@ -1201,6 +1201,7 @@ uil-data:sunday.Vitro
 uil-data:password_system_has_changed.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;
+        rdfs:label       "The password system has been updated to offer enhanced security. Please enter a new password."@en-CA ;
         uil:hasApp      "Vitro" ;
         uil:hasKey      "password_system_has_changed" ;
         uil:hasPackage  "Vitro-languages" .
@@ -1979,13 +1980,6 @@ uil-data:saturday.Vitro
         rdfs:label       "Saturday"@en-CA ;
         uil:hasApp      "Vitro" ;
         uil:hasKey      "saturday" ;
-        uil:hasPackage  "Vitro-languages" .
-
-uil-data:_publications_link.Vitro
-        rdf:type         owl:NamedIndividual ;
-        rdf:type         uil:UILabel ;
-        uil:hasApp      "Vitro" ;
-        uil:hasKey      "_publications_link" ;
         uil:hasPackage  "Vitro-languages" .
 
 uil-data:javascript_require_to_edit.Vitro
@@ -4479,6 +4473,7 @@ uil-data:required_fields.Vitro
 uil-data:edit_page_title.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;
+        rdfs:label       "Edit"@en-CA ;
         uil:hasApp      "Vitro" ;
         uil:hasKey      "edit_page_title" ;
         uil:hasPackage  "Vitro-languages" .
@@ -6033,13 +6028,6 @@ uil-data:custom_template_containing_content.Vitro
         rdfs:label       "Custom template containing all content"@en-CA ;
         uil:hasApp      "Vitro" ;
         uil:hasKey      "custom_template_containing_content" ;
-        uil:hasPackage  "Vitro-languages" .
-
-uil-data:name_of.Vitro
-        rdf:type         owl:NamedIndividual ;
-        rdf:type         uil:UILabel ;
-        uil:hasApp      "Vitro" ;
-        uil:hasKey      "name_of" ;
         uil:hasPackage  "Vitro-languages" .
 
 uil-data:content_type.Vitro

--- a/home/src/main/resources/rdf/i18n/en_US/interface-i18n/firsttime/vitro_UiLabel.ttl
+++ b/home/src/main/resources/rdf/i18n/en_US/interface-i18n/firsttime/vitro_UiLabel.ttl
@@ -1201,6 +1201,7 @@ uil-data:sunday.Vitro
 uil-data:password_system_has_changed.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;
+        rdfs:label       "The password system has been updated to offer enhanced security. Please enter a new password."@en-US ;
         uil:hasApp      "Vitro" ;
         uil:hasKey      "password_system_has_changed" ;
         uil:hasPackage  "Vitro-languages" .
@@ -1979,13 +1980,6 @@ uil-data:saturday.Vitro
         rdfs:label       "Saturday"@en-US ;
         uil:hasApp      "Vitro" ;
         uil:hasKey      "saturday" ;
-        uil:hasPackage  "Vitro-languages" .
-
-uil-data:_publications_link.Vitro
-        rdf:type         owl:NamedIndividual ;
-        rdf:type         uil:UILabel ;
-        uil:hasApp      "Vitro" ;
-        uil:hasKey      "_publications_link" ;
         uil:hasPackage  "Vitro-languages" .
 
 uil-data:javascript_require_to_edit.Vitro
@@ -6034,13 +6028,6 @@ uil-data:custom_template_containing_content.Vitro
         rdfs:label       "Custom template containing all content"@en-US ;
         uil:hasApp      "Vitro" ;
         uil:hasKey      "custom_template_containing_content" ;
-        uil:hasPackage  "Vitro-languages" .
-
-uil-data:name_of.Vitro
-        rdf:type         owl:NamedIndividual ;
-        rdf:type         uil:UILabel ;
-        uil:hasApp      "Vitro" ;
-        uil:hasKey      "name_of" ;
         uil:hasPackage  "Vitro-languages" .
 
 uil-data:content_type.Vitro

--- a/home/src/main/resources/rdf/i18n/es/interface-i18n/firsttime/vitro_UiLabel.ttl
+++ b/home/src/main/resources/rdf/i18n/es/interface-i18n/firsttime/vitro_UiLabel.ttl
@@ -49,6 +49,7 @@ uil-data:advanced_search_tip_three.Vitro
 uil-data:file_upload_error_file_size_is_zero.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;
+        rdfs:label       "El tamaño del fichero cargado es 0"@es ;
         uil:hasApp      "Vitro" ;
         uil:hasKey      "file_upload_error_file_size_is_zero" ;
         uil:hasPackage  "Vitro-languages" .
@@ -288,6 +289,7 @@ uil-data:password_reset_complete_subject.Vitro
 uil-data:file_upload_error_supported_actions.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;
+        rdfs:label       "Solo se admiten opciones de borrado o carga"@es ;
         uil:hasApp      "Vitro" ;
         uil:hasKey      "file_upload_error_supported_actions" ;
         uil:hasPackage  "Vitro-languages" .
@@ -743,6 +745,7 @@ uil-data:containers_do_not_pick_up_changes.Vitro
 uil-data:file_upload_error_media_type_not_allowed.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;
+        rdfs:label       "El tipo de fichero no está permitido. El tipo de fichero actual es {0}."@es ;
         uil:hasApp      "Vitro" ;
         uil:hasKey      "file_upload_error_media_type_not_allowed" ;
         uil:hasPackage  "Vitro-languages" .
@@ -1166,6 +1169,7 @@ uil-data:october.Vitro
 uil-data:file_upload_subject.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;
+        rdfs:label       "Asunto"@es ;
         uil:hasApp      "Vitro" ;
         uil:hasKey      "file_upload_subject" ;
         uil:hasPackage  "Vitro-languages" .
@@ -1197,6 +1201,7 @@ uil-data:sunday.Vitro
 uil-data:password_system_has_changed.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;
+        rdfs:label       "El sistema de contraseñas se ha actualizado para ofrecer mejoras en la seguridad. Por favor introduzca una nueva contraseña."@es ;
         uil:hasApp      "Vitro" ;
         uil:hasKey      "password_system_has_changed" ;
         uil:hasPackage  "Vitro-languages" .
@@ -1977,13 +1982,6 @@ uil-data:saturday.Vitro
         uil:hasKey      "saturday" ;
         uil:hasPackage  "Vitro-languages" .
 
-uil-data:_publications_link.Vitro
-        rdf:type         owl:NamedIndividual ;
-        rdf:type         uil:UILabel ;
-        uil:hasApp      "Vitro" ;
-        uil:hasKey      "_publications_link" ;
-        uil:hasPackage  "Vitro-languages" .
-
 uil-data:javascript_require_to_edit.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;
@@ -2147,6 +2145,7 @@ uil-data:acct_created_email_html_text.Vitro
 uil-data:file_upload_confirm_delete.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;
+        rdfs:label       "¿Está seguro de querer borrar este fichero?"@es ;
         uil:hasApp      "Vitro" ;
         uil:hasKey      "file_upload_confirm_delete" ;
         uil:hasPackage  "Vitro-languages" .
@@ -2930,6 +2929,7 @@ uil-data:submit_upload.Vitro
 uil-data:confirm_individual_deletion.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;
+        rdfs:label       "¿Está seguro que desea eliminar la siguiente cuenta individual?"@es ;
         uil:hasApp      "Vitro" ;
         uil:hasKey      "confirm_individual_deletion" ;
         uil:hasPackage  "Vitro-languages" .
@@ -3313,6 +3313,7 @@ uil-data:password_capitalized.Vitro
 uil-data:file_upload_submit_label.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;
+        rdfs:label       "Cargar"@es ;
         uil:hasApp      "Vitro" ;
         uil:hasKey      "file_upload_submit_label" ;
         uil:hasPackage  "Vitro-languages" .
@@ -4200,6 +4201,7 @@ uil-data:add_label_for_language.Vitro
 uil-data:file_upload_error_file_not_found.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;
+        rdfs:label       "Fichero a cargar no encontrado"@es ;
         uil:hasApp      "Vitro" ;
         uil:hasKey      "file_upload_error_file_not_found" ;
         uil:hasPackage  "Vitro-languages" .
@@ -4207,6 +4209,7 @@ uil-data:file_upload_error_file_not_found.Vitro
 uil-data:file_upload_predicate.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;
+        rdfs:label       "predicado"@es ;
         uil:hasApp      "Vitro" ;
         uil:hasKey      "file_upload_predicate" ;
         uil:hasPackage  "Vitro-languages" .
@@ -4558,6 +4561,7 @@ uil-data:display_has_element_error.Vitro
 uil-data:file_upload_error_file_is_too_big.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;
+        rdfs:label       "El fichero cargado es demasiado grande. El máximo permitido es {0} bytes. El fichero cargado es de {1} bytes."@es ;
         uil:hasApp      "Vitro" ;
         uil:hasKey      "file_upload_error_file_is_too_big" ;
         uil:hasPackage  "Vitro-languages" .
@@ -4573,6 +4577,7 @@ uil-data:template_capitalized.Vitro
 uil-data:file_upload_supported_media.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;
+        rdfs:label       "Tipos de medios permitidos:"@es ;
         uil:hasApp      "Vitro" ;
         uil:hasKey      "file_upload_supported_media" ;
         uil:hasPackage  "Vitro-languages" .
@@ -4788,6 +4793,7 @@ uil-data:hide_properties.Vitro
 uil-data:file_upload_error_file_type_not_recognized.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;
+        rdfs:label       "Tipo de fichero no reconocido"@es ;
         uil:hasApp      "Vitro" ;
         uil:hasKey      "file_upload_error_file_type_not_recognized" ;
         uil:hasPackage  "Vitro-languages" .
@@ -4811,6 +4817,7 @@ uil-data:new_account_title.Vitro
 uil-data:file_upload_no_allowed_media.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;
+        rdfs:label       "No hay tipos de medios permitidos definidos en runtime.properties"@es ;
         uil:hasApp      "Vitro" ;
         uil:hasKey      "file_upload_no_allowed_media" ;
         uil:hasPackage  "Vitro-languages" .
@@ -5162,6 +5169,7 @@ uil-data:custom_template_requiring_content.Vitro
 uil-data:file_upload_error_uri_not_exists.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;
+        rdfs:label       "No existe la Uri {0}"@es ;
         uil:hasApp      "Vitro" ;
         uil:hasKey      "file_upload_error_uri_not_exists" ;
         uil:hasPackage  "Vitro-languages" .
@@ -5193,6 +5201,7 @@ uil-data:view_all_accounts.Vitro
 uil-data:file_upload_file.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;
+        rdfs:label       "Fichero"@es ;
         uil:hasApp      "Vitro" ;
         uil:hasKey      "file_upload_file" ;
         uil:hasPackage  "Vitro-languages" .
@@ -5352,6 +5361,7 @@ uil-data:title_capitalized.Vitro
 uil-data:file_upload_error_no_action.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;
+        rdfs:label       "No se ha especificado ninguna acción"@es ;
         uil:hasApp      "Vitro" ;
         uil:hasKey      "file_upload_error_no_action" ;
         uil:hasPackage  "Vitro-languages" .
@@ -5695,6 +5705,7 @@ uil-data:page_public_permission_option.Vitro
 uil-data:file_upload_error_uri_not_given.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;
+        rdfs:label       "No se ha proporcionado {0} uri"@es ;
         uil:hasApp      "Vitro" ;
         uil:hasKey      "file_upload_error_uri_not_given" ;
         uil:hasPackage  "Vitro-languages" .
@@ -5702,6 +5713,7 @@ uil-data:file_upload_error_uri_not_given.Vitro
 uil-data:file_upload_heading.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;
+        rdfs:label       "Carga de ficheros"@es ;
         uil:hasApp      "Vitro" ;
         uil:hasKey      "file_upload_heading" ;
         uil:hasPackage  "Vitro-languages" .
@@ -6016,13 +6028,6 @@ uil-data:custom_template_containing_content.Vitro
         rdfs:label       "Plantilla personalizada, con todo el contenido"@es ;
         uil:hasApp      "Vitro" ;
         uil:hasKey      "custom_template_containing_content" ;
-        uil:hasPackage  "Vitro-languages" .
-
-uil-data:name_of.Vitro
-        rdf:type         owl:NamedIndividual ;
-        rdf:type         uil:UILabel ;
-        uil:hasApp      "Vitro" ;
-        uil:hasKey      "name_of" ;
         uil:hasPackage  "Vitro-languages" .
 
 uil-data:content_type.Vitro

--- a/home/src/main/resources/rdf/i18n/fr_CA/interface-i18n/firsttime/vitro_UiLabel.ttl
+++ b/home/src/main/resources/rdf/i18n/fr_CA/interface-i18n/firsttime/vitro_UiLabel.ttl
@@ -49,6 +49,7 @@ uil-data:advanced_search_tip_three.Vitro
 uil-data:file_upload_error_file_size_is_zero.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;
+        rdfs:label       "La taille du fichier téléchargé est égale à 0"@fr-CA ;
         uil:hasApp      "Vitro" ;
         uil:hasKey      "file_upload_error_file_size_is_zero" ;
         uil:hasPackage  "Vitro-languages" .
@@ -288,6 +289,7 @@ uil-data:password_reset_complete_subject.Vitro
 uil-data:file_upload_error_supported_actions.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;
+        rdfs:label       "Seules les actions de suppression et de téléchargement sont prises en considération"@fr-CA ;
         uil:hasApp      "Vitro" ;
         uil:hasKey      "file_upload_error_supported_actions" ;
         uil:hasPackage  "Vitro-languages" .
@@ -743,6 +745,7 @@ uil-data:containers_do_not_pick_up_changes.Vitro
 uil-data:file_upload_error_media_type_not_allowed.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;
+        rdfs:label       "Le type de média du fichier n'est pas autorisé. Le type de support de fichier actuel est {0}."@fr-CA ;
         uil:hasApp      "Vitro" ;
         uil:hasKey      "file_upload_error_media_type_not_allowed" ;
         uil:hasPackage  "Vitro-languages" .
@@ -1166,6 +1169,7 @@ uil-data:october.Vitro
 uil-data:file_upload_subject.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;
+        rdfs:label       "sujet"@fr-CA ;
         uil:hasApp      "Vitro" ;
         uil:hasKey      "file_upload_subject" ;
         uil:hasPackage  "Vitro-languages" .
@@ -1197,6 +1201,7 @@ uil-data:sunday.Vitro
 uil-data:password_system_has_changed.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;
+        rdfs:label       "Le système de mot de passe a été mis à jour pour offrir une sécurité accrue. Veuillez saisir un nouveau mot de passe."@fr-CA ;
         uil:hasApp      "Vitro" ;
         uil:hasKey      "password_system_has_changed" ;
         uil:hasPackage  "Vitro-languages" .
@@ -1977,14 +1982,6 @@ uil-data:saturday.Vitro
         uil:hasKey      "saturday" ;
         uil:hasPackage  "Vitro-languages" .
 
-uil-data:_publications_link.Vitro
-        rdf:type         owl:NamedIndividual ;
-        rdf:type         uil:UILabel ;
-        rdfs:label       "gérer les publications"@fr-CA ;
-        uil:hasApp      "Vitro" ;
-        uil:hasKey      "_publications_link" ;
-        uil:hasPackage  "Vitro-languages" .
-
 uil-data:javascript_require_to_edit.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;
@@ -2148,6 +2145,7 @@ uil-data:acct_created_email_html_text.Vitro
 uil-data:file_upload_confirm_delete.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;
+        rdfs:label       "Êtes-vous sûr de vouloir supprimer ce fichier?"@fr-CA ;
         uil:hasApp      "Vitro" ;
         uil:hasKey      "file_upload_confirm_delete" ;
         uil:hasPackage  "Vitro-languages" .
@@ -2931,6 +2929,7 @@ uil-data:submit_upload.Vitro
 uil-data:confirm_individual_deletion.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;
+        rdfs:label       "Êtes-vous sûr de vouloir effacer la donné suivante?"@fr-CA ;
         uil:hasApp      "Vitro" ;
         uil:hasKey      "confirm_individual_deletion" ;
         uil:hasPackage  "Vitro-languages" .
@@ -3314,6 +3313,7 @@ uil-data:password_capitalized.Vitro
 uil-data:file_upload_submit_label.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;
+        rdfs:label       "Télécharger"@fr-CA ;
         uil:hasApp      "Vitro" ;
         uil:hasKey      "file_upload_submit_label" ;
         uil:hasPackage  "Vitro-languages" .
@@ -4201,6 +4201,7 @@ uil-data:add_label_for_language.Vitro
 uil-data:file_upload_error_file_not_found.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;
+        rdfs:label       "Le fichier à télécharger n'a pas été trouvé"@fr-CA ;
         uil:hasApp      "Vitro" ;
         uil:hasKey      "file_upload_error_file_not_found" ;
         uil:hasPackage  "Vitro-languages" .
@@ -4208,6 +4209,7 @@ uil-data:file_upload_error_file_not_found.Vitro
 uil-data:file_upload_predicate.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;
+        rdfs:label       "prédicat"@fr-CA ;
         uil:hasApp      "Vitro" ;
         uil:hasKey      "file_upload_predicate" ;
         uil:hasPackage  "Vitro-languages" .
@@ -4559,6 +4561,7 @@ uil-data:display_has_element_error.Vitro
 uil-data:file_upload_error_file_is_too_big.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;
+        rdfs:label       "Le fichier téléchargé est trop volumineux. La taille maximale du fichier est de {0} octets alors que le fichier téléchargé est de {1} octets."@fr-CA ;
         uil:hasApp      "Vitro" ;
         uil:hasKey      "file_upload_error_file_is_too_big" ;
         uil:hasPackage  "Vitro-languages" .
@@ -4574,6 +4577,7 @@ uil-data:template_capitalized.Vitro
 uil-data:file_upload_supported_media.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;
+        rdfs:label       "Types de médias autorisés:"@fr-CA ;
         uil:hasApp      "Vitro" ;
         uil:hasKey      "file_upload_supported_media" ;
         uil:hasPackage  "Vitro-languages" .
@@ -4789,6 +4793,7 @@ uil-data:hide_properties.Vitro
 uil-data:file_upload_error_file_type_not_recognized.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;
+        rdfs:label       "Le type de fichier n'est pas reconnu"@fr-CA ;
         uil:hasApp      "Vitro" ;
         uil:hasKey      "file_upload_error_file_type_not_recognized" ;
         uil:hasPackage  "Vitro-languages" .
@@ -4812,6 +4817,7 @@ uil-data:new_account_title.Vitro
 uil-data:file_upload_no_allowed_media.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;
+        rdfs:label       "Aucun type de média autorisé n'est défini dans runtime.properties"@fr-CA ;
         uil:hasApp      "Vitro" ;
         uil:hasKey      "file_upload_no_allowed_media" ;
         uil:hasPackage  "Vitro-languages" .
@@ -5163,6 +5169,7 @@ uil-data:custom_template_requiring_content.Vitro
 uil-data:file_upload_error_uri_not_exists.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;
+        rdfs:label       "L'Uri {0} n'existe pas."@fr-CA ;
         uil:hasApp      "Vitro" ;
         uil:hasKey      "file_upload_error_uri_not_exists" ;
         uil:hasPackage  "Vitro-languages" .
@@ -5194,6 +5201,7 @@ uil-data:view_all_accounts.Vitro
 uil-data:file_upload_file.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;
+        rdfs:label       "fichier"@fr-CA ;
         uil:hasApp      "Vitro" ;
         uil:hasKey      "file_upload_file" ;
         uil:hasPackage  "Vitro-languages" .
@@ -5353,6 +5361,7 @@ uil-data:title_capitalized.Vitro
 uil-data:file_upload_error_no_action.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;
+        rdfs:label       "Aucune action n'est spécifiée"@fr-CA ;
         uil:hasApp      "Vitro" ;
         uil:hasKey      "file_upload_error_no_action" ;
         uil:hasPackage  "Vitro-languages" .
@@ -5696,6 +5705,7 @@ uil-data:page_public_permission_option.Vitro
 uil-data:file_upload_error_uri_not_given.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;
+        rdfs:label       "Aucun uri {0} n'a été fourni."@fr-CA ;
         uil:hasApp      "Vitro" ;
         uil:hasKey      "file_upload_error_uri_not_given" ;
         uil:hasPackage  "Vitro-languages" .
@@ -5703,6 +5713,7 @@ uil-data:file_upload_error_uri_not_given.Vitro
 uil-data:file_upload_heading.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;
+        rdfs:label       "Chargement du fichier"@fr-CA ;
         uil:hasApp      "Vitro" ;
         uil:hasKey      "file_upload_heading" ;
         uil:hasPackage  "Vitro-languages" .
@@ -6017,14 +6028,6 @@ uil-data:custom_template_containing_content.Vitro
         rdfs:label       "Gabarit personnalisé contenant tout le contenu"@fr-CA ;
         uil:hasApp      "Vitro" ;
         uil:hasKey      "custom_template_containing_content" ;
-        uil:hasPackage  "Vitro-languages" .
-
-uil-data:name_of.Vitro
-        rdf:type         owl:NamedIndividual ;
-        rdf:type         uil:UILabel ;
-        rdfs:label       "nom de"@fr-CA ;
-        uil:hasApp      "Vitro" ;
-        uil:hasKey      "name_of" ;
         uil:hasPackage  "Vitro-languages" .
 
 uil-data:content_type.Vitro

--- a/home/src/main/resources/rdf/i18n/pt_BR/interface-i18n/firsttime/vitro_UiLabel.ttl
+++ b/home/src/main/resources/rdf/i18n/pt_BR/interface-i18n/firsttime/vitro_UiLabel.ttl
@@ -49,6 +49,7 @@ uil-data:advanced_search_tip_three.Vitro
 uil-data:file_upload_error_file_size_is_zero.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;
+        rdfs:label       "O tamanho do arquivo carregado é 0"@pt-BR ;
         uil:hasApp      "Vitro" ;
         uil:hasKey      "file_upload_error_file_size_is_zero" ;
         uil:hasPackage  "Vitro-languages" .
@@ -288,6 +289,7 @@ uil-data:password_reset_complete_subject.Vitro
 uil-data:file_upload_error_supported_actions.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;
+        rdfs:label       "Somente excluir e carregar ações que são suportadas"@pt-BR ;
         uil:hasApp      "Vitro" ;
         uil:hasKey      "file_upload_error_supported_actions" ;
         uil:hasPackage  "Vitro-languages" .
@@ -743,6 +745,7 @@ uil-data:containers_do_not_pick_up_changes.Vitro
 uil-data:file_upload_error_media_type_not_allowed.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;
+        rdfs:label       "O tipo de mídia do arquivo não é permitido. O tipo de mídia do arquivo atual é {0}."@pt-BR ;
         uil:hasApp      "Vitro" ;
         uil:hasKey      "file_upload_error_media_type_not_allowed" ;
         uil:hasPackage  "Vitro-languages" .
@@ -1166,6 +1169,7 @@ uil-data:october.Vitro
 uil-data:file_upload_subject.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;
+        rdfs:label       "Assunto"@pt-BR ;
         uil:hasApp      "Vitro" ;
         uil:hasKey      "file_upload_subject" ;
         uil:hasPackage  "Vitro-languages" .
@@ -1197,6 +1201,7 @@ uil-data:sunday.Vitro
 uil-data:password_system_has_changed.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;
+        rdfs:label       "O sistema de senhas foi atualizado para oferecer maior segurança. Introduza uma nova senha."@pt-BR ;
         uil:hasApp      "Vitro" ;
         uil:hasKey      "password_system_has_changed" ;
         uil:hasPackage  "Vitro-languages" .
@@ -1977,13 +1982,6 @@ uil-data:saturday.Vitro
         uil:hasKey      "saturday" ;
         uil:hasPackage  "Vitro-languages" .
 
-uil-data:_publications_link.Vitro
-        rdf:type         owl:NamedIndividual ;
-        rdf:type         uil:UILabel ;
-        uil:hasApp      "Vitro" ;
-        uil:hasKey      "_publications_link" ;
-        uil:hasPackage  "Vitro-languages" .
-
 uil-data:javascript_require_to_edit.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;
@@ -2147,6 +2145,7 @@ uil-data:acct_created_email_html_text.Vitro
 uil-data:file_upload_confirm_delete.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;
+        rdfs:label       "Tem certeza de que deseja excluir este arquivo?"@pt-BR ;
         uil:hasApp      "Vitro" ;
         uil:hasKey      "file_upload_confirm_delete" ;
         uil:hasPackage  "Vitro-languages" .
@@ -2930,6 +2929,7 @@ uil-data:submit_upload.Vitro
 uil-data:confirm_individual_deletion.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;
+        rdfs:label       "Tem certeza de que deseja excluir a seguinte conta individual?"@pt-BR ;
         uil:hasApp      "Vitro" ;
         uil:hasKey      "confirm_individual_deletion" ;
         uil:hasPackage  "Vitro-languages" .
@@ -3313,6 +3313,7 @@ uil-data:password_capitalized.Vitro
 uil-data:file_upload_submit_label.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;
+        rdfs:label       "Carregar"@pt-BR ;
         uil:hasApp      "Vitro" ;
         uil:hasKey      "file_upload_submit_label" ;
         uil:hasPackage  "Vitro-languages" .
@@ -4200,6 +4201,7 @@ uil-data:add_label_for_language.Vitro
 uil-data:file_upload_error_file_not_found.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;
+        rdfs:label       "Arquivo a ser carregado não encontrado"@pt-BR ;
         uil:hasApp      "Vitro" ;
         uil:hasKey      "file_upload_error_file_not_found" ;
         uil:hasPackage  "Vitro-languages" .
@@ -4207,6 +4209,7 @@ uil-data:file_upload_error_file_not_found.Vitro
 uil-data:file_upload_predicate.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;
+        rdfs:label       "predicado"@pt-BR ;
         uil:hasApp      "Vitro" ;
         uil:hasKey      "file_upload_predicate" ;
         uil:hasPackage  "Vitro-languages" .
@@ -4558,6 +4561,7 @@ uil-data:display_has_element_error.Vitro
 uil-data:file_upload_error_file_is_too_big.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;
+        rdfs:label       "O arquivo carregado é muito grande. O tamanho máximo do arquivo é de {0} bytes. O arquivo carregado tem {1} bytes."@pt-BR ;
         uil:hasApp      "Vitro" ;
         uil:hasKey      "file_upload_error_file_is_too_big" ;
         uil:hasPackage  "Vitro-languages" .
@@ -4573,6 +4577,7 @@ uil-data:template_capitalized.Vitro
 uil-data:file_upload_supported_media.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;
+        rdfs:label       "Tipos de mídia permitidos:"@pt-BR ;
         uil:hasApp      "Vitro" ;
         uil:hasKey      "file_upload_supported_media" ;
         uil:hasPackage  "Vitro-languages" .
@@ -4788,6 +4793,7 @@ uil-data:hide_properties.Vitro
 uil-data:file_upload_error_file_type_not_recognized.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;
+        rdfs:label       "Tipo de arquivo não reconhecido"@pt-BR ;
         uil:hasApp      "Vitro" ;
         uil:hasKey      "file_upload_error_file_type_not_recognized" ;
         uil:hasPackage  "Vitro-languages" .
@@ -4811,6 +4817,7 @@ uil-data:new_account_title.Vitro
 uil-data:file_upload_no_allowed_media.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;
+        rdfs:label       "Nenhum tipo de mídia permitido definido em runtime.properties"@pt-BR ;
         uil:hasApp      "Vitro" ;
         uil:hasKey      "file_upload_no_allowed_media" ;
         uil:hasPackage  "Vitro-languages" .
@@ -5162,6 +5169,7 @@ uil-data:custom_template_requiring_content.Vitro
 uil-data:file_upload_error_uri_not_exists.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;
+        rdfs:label       "Uri {0} não existe."@pt-BR ;
         uil:hasApp      "Vitro" ;
         uil:hasKey      "file_upload_error_uri_not_exists" ;
         uil:hasPackage  "Vitro-languages" .
@@ -5193,6 +5201,7 @@ uil-data:view_all_accounts.Vitro
 uil-data:file_upload_file.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;
+        rdfs:label       "arquivo"@pt-BR ;
         uil:hasApp      "Vitro" ;
         uil:hasKey      "file_upload_file" ;
         uil:hasPackage  "Vitro-languages" .
@@ -5352,6 +5361,7 @@ uil-data:title_capitalized.Vitro
 uil-data:file_upload_error_no_action.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;
+        rdfs:label       "Nenhuma ação especificada"@pt-BR ;
         uil:hasApp      "Vitro" ;
         uil:hasKey      "file_upload_error_no_action" ;
         uil:hasPackage  "Vitro-languages" .
@@ -5695,6 +5705,7 @@ uil-data:page_public_permission_option.Vitro
 uil-data:file_upload_error_uri_not_given.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;
+        rdfs:label       "Nenhum uri {0} foi dado."@pt-BR ;
         uil:hasApp      "Vitro" ;
         uil:hasKey      "file_upload_error_uri_not_given" ;
         uil:hasPackage  "Vitro-languages" .
@@ -5702,6 +5713,7 @@ uil-data:file_upload_error_uri_not_given.Vitro
 uil-data:file_upload_heading.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;
+        rdfs:label       "Upload de arquivos"@pt-BR ;
         uil:hasApp      "Vitro" ;
         uil:hasKey      "file_upload_heading" ;
         uil:hasPackage  "Vitro-languages" .
@@ -6016,13 +6028,6 @@ uil-data:custom_template_containing_content.Vitro
         rdfs:label       "template personalizado que contém todo o conteúdo"@pt-BR ;
         uil:hasApp      "Vitro" ;
         uil:hasKey      "custom_template_containing_content" ;
-        uil:hasPackage  "Vitro-languages" .
-
-uil-data:name_of.Vitro
-        rdf:type         owl:NamedIndividual ;
-        rdf:type         uil:UILabel ;
-        uil:hasApp      "Vitro" ;
-        uil:hasKey      "name_of" ;
         uil:hasPackage  "Vitro-languages" .
 
 uil-data:content_type.Vitro

--- a/home/src/main/resources/rdf/i18n/ru_RU/interface-i18n/firsttime/vitro_UiLabel.ttl
+++ b/home/src/main/resources/rdf/i18n/ru_RU/interface-i18n/firsttime/vitro_UiLabel.ttl
@@ -4817,7 +4817,7 @@ uil-data:new_account_title.Vitro
 uil-data:file_upload_no_allowed_media.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;
-        rdfs:label       "Ни одного типа меди файлов не указанов в runtime.properties"@ru-RU ;
+        rdfs:label       "Ни одного типа медиа файлов не указано в runtime.properties"@ru-RU ;
         uil:hasApp      "Vitro" ;
         uil:hasKey      "file_upload_no_allowed_media" ;
         uil:hasPackage  "Vitro-languages" .

--- a/home/src/main/resources/rdf/i18n/ru_RU/interface-i18n/firsttime/vitro_UiLabel.ttl
+++ b/home/src/main/resources/rdf/i18n/ru_RU/interface-i18n/firsttime/vitro_UiLabel.ttl
@@ -49,6 +49,7 @@ uil-data:advanced_search_tip_three.Vitro
 uil-data:file_upload_error_file_size_is_zero.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;
+        rdfs:label       "Размер загруженного файла равен нулю"@ru-RU ;
         uil:hasApp      "Vitro" ;
         uil:hasKey      "file_upload_error_file_size_is_zero" ;
         uil:hasPackage  "Vitro-languages" .
@@ -288,6 +289,7 @@ uil-data:password_reset_complete_subject.Vitro
 uil-data:file_upload_error_supported_actions.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;
+        rdfs:label       "Поддерживаются только действия по загрузке и удалению"@ru-RU ;
         uil:hasApp      "Vitro" ;
         uil:hasKey      "file_upload_error_supported_actions" ;
         uil:hasPackage  "Vitro-languages" .
@@ -743,6 +745,7 @@ uil-data:containers_do_not_pick_up_changes.Vitro
 uil-data:file_upload_error_media_type_not_allowed.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;
+        rdfs:label       "Тип медиа файла не разрешен. Текущий тип медиа файла: {0}"@ru-RU ;
         uil:hasApp      "Vitro" ;
         uil:hasKey      "file_upload_error_media_type_not_allowed" ;
         uil:hasPackage  "Vitro-languages" .
@@ -1166,6 +1169,7 @@ uil-data:october.Vitro
 uil-data:file_upload_subject.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;
+        rdfs:label       "субъект"@ru-RU ;
         uil:hasApp      "Vitro" ;
         uil:hasKey      "file_upload_subject" ;
         uil:hasPackage  "Vitro-languages" .
@@ -1197,6 +1201,7 @@ uil-data:sunday.Vitro
 uil-data:password_system_has_changed.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;
+        rdfs:label       "Система доступа была обновлена для обеспечения безоапасности. Пожалуйста, введите новый пароль."@ru-RU ;
         uil:hasApp      "Vitro" ;
         uil:hasKey      "password_system_has_changed" ;
         uil:hasPackage  "Vitro-languages" .
@@ -1977,13 +1982,6 @@ uil-data:saturday.Vitro
         uil:hasKey      "saturday" ;
         uil:hasPackage  "Vitro-languages" .
 
-uil-data:_publications_link.Vitro
-        rdf:type         owl:NamedIndividual ;
-        rdf:type         uil:UILabel ;
-        uil:hasApp      "Vitro" ;
-        uil:hasKey      "_publications_link" ;
-        uil:hasPackage  "Vitro-languages" .
-
 uil-data:javascript_require_to_edit.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;
@@ -2147,6 +2145,7 @@ uil-data:acct_created_email_html_text.Vitro
 uil-data:file_upload_confirm_delete.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;
+        rdfs:label       "Вы уверены, что хотите удалить этот файл?"@ru-RU ;
         uil:hasApp      "Vitro" ;
         uil:hasKey      "file_upload_confirm_delete" ;
         uil:hasPackage  "Vitro-languages" .
@@ -2930,6 +2929,7 @@ uil-data:submit_upload.Vitro
 uil-data:confirm_individual_deletion.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;
+        rdfs:label       "Вы уверены, что хотите удалить следующий объект?"@ru-RU ;
         uil:hasApp      "Vitro" ;
         uil:hasKey      "confirm_individual_deletion" ;
         uil:hasPackage  "Vitro-languages" .
@@ -3313,6 +3313,7 @@ uil-data:password_capitalized.Vitro
 uil-data:file_upload_submit_label.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;
+        rdfs:label       "Загрузка"@ru-RU ;
         uil:hasApp      "Vitro" ;
         uil:hasKey      "file_upload_submit_label" ;
         uil:hasPackage  "Vitro-languages" .
@@ -4200,6 +4201,7 @@ uil-data:add_label_for_language.Vitro
 uil-data:file_upload_error_file_not_found.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;
+        rdfs:label       "Файл для загрузки не найден"@ru-RU ;
         uil:hasApp      "Vitro" ;
         uil:hasKey      "file_upload_error_file_not_found" ;
         uil:hasPackage  "Vitro-languages" .
@@ -4207,6 +4209,7 @@ uil-data:file_upload_error_file_not_found.Vitro
 uil-data:file_upload_predicate.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;
+        rdfs:label       "предикат"@ru-RU ;
         uil:hasApp      "Vitro" ;
         uil:hasKey      "file_upload_predicate" ;
         uil:hasPackage  "Vitro-languages" .
@@ -4558,6 +4561,7 @@ uil-data:display_has_element_error.Vitro
 uil-data:file_upload_error_file_is_too_big.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;
+        rdfs:label       "Размер загруженного файла больше допустимого. Допустимый размер файла ${0} байт. Размер текущего файла ${1} байт."@ru-RU ;
         uil:hasApp      "Vitro" ;
         uil:hasKey      "file_upload_error_file_is_too_big" ;
         uil:hasPackage  "Vitro-languages" .
@@ -4573,6 +4577,7 @@ uil-data:template_capitalized.Vitro
 uil-data:file_upload_supported_media.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;
+        rdfs:label       "Разрешенные типы файлов:"@ru-RU ;
         uil:hasApp      "Vitro" ;
         uil:hasKey      "file_upload_supported_media" ;
         uil:hasPackage  "Vitro-languages" .
@@ -4788,6 +4793,7 @@ uil-data:hide_properties.Vitro
 uil-data:file_upload_error_file_type_not_recognized.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;
+        rdfs:label       "Тип файла не опознан"@ru-RU ;
         uil:hasApp      "Vitro" ;
         uil:hasKey      "file_upload_error_file_type_not_recognized" ;
         uil:hasPackage  "Vitro-languages" .
@@ -4811,6 +4817,7 @@ uil-data:new_account_title.Vitro
 uil-data:file_upload_no_allowed_media.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;
+        rdfs:label       "Ни одного типа меди файлов не указанов в runtime.properties"@ru-RU ;
         uil:hasApp      "Vitro" ;
         uil:hasKey      "file_upload_no_allowed_media" ;
         uil:hasPackage  "Vitro-languages" .
@@ -5162,6 +5169,7 @@ uil-data:custom_template_requiring_content.Vitro
 uil-data:file_upload_error_uri_not_exists.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;
+        rdfs:label       "URI {0} не существует"@ru-RU ;
         uil:hasApp      "Vitro" ;
         uil:hasKey      "file_upload_error_uri_not_exists" ;
         uil:hasPackage  "Vitro-languages" .
@@ -5193,6 +5201,7 @@ uil-data:view_all_accounts.Vitro
 uil-data:file_upload_file.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;
+        rdfs:label       "файл"@ru-RU ;
         uil:hasApp      "Vitro" ;
         uil:hasKey      "file_upload_file" ;
         uil:hasPackage  "Vitro-languages" .
@@ -5352,6 +5361,7 @@ uil-data:title_capitalized.Vitro
 uil-data:file_upload_error_no_action.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;
+        rdfs:label       "Действие не было указан"@ru-RU ;
         uil:hasApp      "Vitro" ;
         uil:hasKey      "file_upload_error_no_action" ;
         uil:hasPackage  "Vitro-languages" .
@@ -5695,6 +5705,7 @@ uil-data:page_public_permission_option.Vitro
 uil-data:file_upload_error_uri_not_given.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;
+        rdfs:label       "URI {0} не задан"@ru-RU ;
         uil:hasApp      "Vitro" ;
         uil:hasKey      "file_upload_error_uri_not_given" ;
         uil:hasPackage  "Vitro-languages" .
@@ -5702,6 +5713,7 @@ uil-data:file_upload_error_uri_not_given.Vitro
 uil-data:file_upload_heading.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;
+        rdfs:label       "Загрузка файла"@ru-RU ;
         uil:hasApp      "Vitro" ;
         uil:hasKey      "file_upload_heading" ;
         uil:hasPackage  "Vitro-languages" .
@@ -6016,13 +6028,6 @@ uil-data:custom_template_containing_content.Vitro
         rdfs:label       "Заполненный пользовательский шаблон"@ru-RU ;
         uil:hasApp      "Vitro" ;
         uil:hasKey      "custom_template_containing_content" ;
-        uil:hasPackage  "Vitro-languages" .
-
-uil-data:name_of.Vitro
-        rdf:type         owl:NamedIndividual ;
-        rdf:type         uil:UILabel ;
-        uil:hasApp      "Vitro" ;
-        uil:hasKey      "name_of" ;
         uil:hasPackage  "Vitro-languages" .
 
 uil-data:content_type.Vitro

--- a/home/src/main/resources/rdf/i18n/ru_RU/interface-i18n/firsttime/vitro_UiLabel.ttl
+++ b/home/src/main/resources/rdf/i18n/ru_RU/interface-i18n/firsttime/vitro_UiLabel.ttl
@@ -5361,7 +5361,7 @@ uil-data:title_capitalized.Vitro
 uil-data:file_upload_error_no_action.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;
-        rdfs:label       "Действие не было указан"@ru-RU ;
+        rdfs:label       "Действие не было указано"@ru-RU ;
         uil:hasApp      "Vitro" ;
         uil:hasKey      "file_upload_error_no_action" ;
         uil:hasPackage  "Vitro-languages" .

--- a/home/src/main/resources/rdf/i18n/sr_Latn_RS/interface-i18n/firsttime/vitro_UiLabel.ttl
+++ b/home/src/main/resources/rdf/i18n/sr_Latn_RS/interface-i18n/firsttime/vitro_UiLabel.ttl
@@ -49,6 +49,7 @@ uil-data:advanced_search_tip_three.Vitro
 uil-data:file_upload_error_file_size_is_zero.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;
+        rdfs:label       "Veličina otpremljenog fajla je 0"@sr-Latn-RS ;
         uil:hasApp      "Vitro" ;
         uil:hasKey      "file_upload_error_file_size_is_zero" ;
         uil:hasPackage  "Vitro-languages" .
@@ -288,6 +289,7 @@ uil-data:password_reset_complete_subject.Vitro
 uil-data:file_upload_error_supported_actions.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;
+        rdfs:label       "Dozvoljeno je samo brisanje i otpremanje"@sr-Latn-RS ;
         uil:hasApp      "Vitro" ;
         uil:hasKey      "file_upload_error_supported_actions" ;
         uil:hasPackage  "Vitro-languages" .
@@ -743,6 +745,7 @@ uil-data:containers_do_not_pick_up_changes.Vitro
 uil-data:file_upload_error_media_type_not_allowed.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;
+        rdfs:label       "Fajl media tip nije dozvoljen. Media tip otpremljenog fajla je {0}."@sr-Latn-RS ;
         uil:hasApp      "Vitro" ;
         uil:hasKey      "file_upload_error_media_type_not_allowed" ;
         uil:hasPackage  "Vitro-languages" .
@@ -1166,6 +1169,7 @@ uil-data:october.Vitro
 uil-data:file_upload_subject.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;
+        rdfs:label       "subjekat"@sr-Latn-RS ;
         uil:hasApp      "Vitro" ;
         uil:hasKey      "file_upload_subject" ;
         uil:hasPackage  "Vitro-languages" .
@@ -1197,6 +1201,7 @@ uil-data:sunday.Vitro
 uil-data:password_system_has_changed.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;
+        rdfs:label       "Sistem je ažuriran kako bi bio sigurniji. Molimo Vas unesite novu lozinku."@sr-Latn-RS ;
         uil:hasApp      "Vitro" ;
         uil:hasKey      "password_system_has_changed" ;
         uil:hasPackage  "Vitro-languages" .
@@ -1977,13 +1982,6 @@ uil-data:saturday.Vitro
         uil:hasKey      "saturday" ;
         uil:hasPackage  "Vitro-languages" .
 
-uil-data:_publications_link.Vitro
-        rdf:type         owl:NamedIndividual ;
-        rdf:type         uil:UILabel ;
-        uil:hasApp      "Vitro" ;
-        uil:hasKey      "_publications_link" ;
-        uil:hasPackage  "Vitro-languages" .
-
 uil-data:javascript_require_to_edit.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;
@@ -2147,6 +2145,7 @@ uil-data:acct_created_email_html_text.Vitro
 uil-data:file_upload_confirm_delete.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;
+        rdfs:label       "Da li ste sigurni da želite da obrišete ovaj fajl?"@sr-Latn-RS ;
         uil:hasApp      "Vitro" ;
         uil:hasKey      "file_upload_confirm_delete" ;
         uil:hasPackage  "Vitro-languages" .
@@ -2930,6 +2929,7 @@ uil-data:submit_upload.Vitro
 uil-data:confirm_individual_deletion.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;
+        rdfs:label       "Da li ste sigurni da želite da obrišete sledeću instancu?"@sr-Latn-RS ;
         uil:hasApp      "Vitro" ;
         uil:hasKey      "confirm_individual_deletion" ;
         uil:hasPackage  "Vitro-languages" .
@@ -3313,6 +3313,7 @@ uil-data:password_capitalized.Vitro
 uil-data:file_upload_submit_label.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;
+        rdfs:label       "Otpremi (upload)"@sr-Latn-RS ;
         uil:hasApp      "Vitro" ;
         uil:hasKey      "file_upload_submit_label" ;
         uil:hasPackage  "Vitro-languages" .
@@ -4200,6 +4201,7 @@ uil-data:add_label_for_language.Vitro
 uil-data:file_upload_error_file_not_found.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;
+        rdfs:label       "Fajl koji je potrebno otpremiti nije pronađen"@sr-Latn-RS ;
         uil:hasApp      "Vitro" ;
         uil:hasKey      "file_upload_error_file_not_found" ;
         uil:hasPackage  "Vitro-languages" .
@@ -4207,6 +4209,7 @@ uil-data:file_upload_error_file_not_found.Vitro
 uil-data:file_upload_predicate.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;
+        rdfs:label       "predikat"@sr-Latn-RS ;
         uil:hasApp      "Vitro" ;
         uil:hasKey      "file_upload_predicate" ;
         uil:hasPackage  "Vitro-languages" .
@@ -4558,6 +4561,7 @@ uil-data:display_has_element_error.Vitro
 uil-data:file_upload_error_file_is_too_big.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;
+        rdfs:label       "Otpremljeni fajl je prevelik. Maksimalna dozvoljena veličina je {0} bajtova. Veličina otpremljenog fajla je {1} bajtova."@sr-Latn-RS ;
         uil:hasApp      "Vitro" ;
         uil:hasKey      "file_upload_error_file_is_too_big" ;
         uil:hasPackage  "Vitro-languages" .
@@ -4573,6 +4577,7 @@ uil-data:template_capitalized.Vitro
 uil-data:file_upload_supported_media.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;
+        rdfs:label       "Dozvoljeni media tipovi: "@sr-Latn-RS ;
         uil:hasApp      "Vitro" ;
         uil:hasKey      "file_upload_supported_media" ;
         uil:hasPackage  "Vitro-languages" .
@@ -4788,6 +4793,7 @@ uil-data:hide_properties.Vitro
 uil-data:file_upload_error_file_type_not_recognized.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;
+        rdfs:label       "Tip fajla nije prepoznat"@sr-Latn-RS ;
         uil:hasApp      "Vitro" ;
         uil:hasKey      "file_upload_error_file_type_not_recognized" ;
         uil:hasPackage  "Vitro-languages" .
@@ -4811,6 +4817,7 @@ uil-data:new_account_title.Vitro
 uil-data:file_upload_no_allowed_media.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;
+        rdfs:label       "Dozvoljeni media tipovi nisu definisani u runtime.properties"@sr-Latn-RS ;
         uil:hasApp      "Vitro" ;
         uil:hasKey      "file_upload_no_allowed_media" ;
         uil:hasPackage  "Vitro-languages" .
@@ -5162,6 +5169,7 @@ uil-data:custom_template_requiring_content.Vitro
 uil-data:file_upload_error_uri_not_exists.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;
+        rdfs:label       "URI {0} ne postoji."@sr-Latn-RS ;
         uil:hasApp      "Vitro" ;
         uil:hasKey      "file_upload_error_uri_not_exists" ;
         uil:hasPackage  "Vitro-languages" .
@@ -5193,6 +5201,7 @@ uil-data:view_all_accounts.Vitro
 uil-data:file_upload_file.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;
+        rdfs:label       "fajl"@sr-Latn-RS ;
         uil:hasApp      "Vitro" ;
         uil:hasKey      "file_upload_file" ;
         uil:hasPackage  "Vitro-languages" .
@@ -5352,6 +5361,7 @@ uil-data:title_capitalized.Vitro
 uil-data:file_upload_error_no_action.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;
+        rdfs:label       "Akcija nije definisana"@sr-Latn-RS ;
         uil:hasApp      "Vitro" ;
         uil:hasKey      "file_upload_error_no_action" ;
         uil:hasPackage  "Vitro-languages" .
@@ -5695,6 +5705,7 @@ uil-data:page_public_permission_option.Vitro
 uil-data:file_upload_error_uri_not_given.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;
+        rdfs:label       "URI {0} nije definisan"@sr-Latn-RS ;
         uil:hasApp      "Vitro" ;
         uil:hasKey      "file_upload_error_uri_not_given" ;
         uil:hasPackage  "Vitro-languages" .
@@ -5702,6 +5713,7 @@ uil-data:file_upload_error_uri_not_given.Vitro
 uil-data:file_upload_heading.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;
+        rdfs:label       "Otpremanje fajla"@sr-Latn-RS ;
         uil:hasApp      "Vitro" ;
         uil:hasKey      "file_upload_heading" ;
         uil:hasPackage  "Vitro-languages" .
@@ -6016,13 +6028,6 @@ uil-data:custom_template_containing_content.Vitro
         rdfs:label       "Prilagođen šablon koji sadrži sav sadržaj"@sr-Latn-RS ;
         uil:hasApp      "Vitro" ;
         uil:hasKey      "custom_template_containing_content" ;
-        uil:hasPackage  "Vitro-languages" .
-
-uil-data:name_of.Vitro
-        rdf:type         owl:NamedIndividual ;
-        rdf:type         uil:UILabel ;
-        uil:hasApp      "Vitro" ;
-        uil:hasKey      "name_of" ;
         uil:hasPackage  "Vitro-languages" .
 
 uil-data:content_type.Vitro

--- a/home/src/main/resources/rdf/i18n/sr_Latn_RS/interface-i18n/firsttime/vitro_UiLabel.ttl
+++ b/home/src/main/resources/rdf/i18n/sr_Latn_RS/interface-i18n/firsttime/vitro_UiLabel.ttl
@@ -745,7 +745,7 @@ uil-data:containers_do_not_pick_up_changes.Vitro
 uil-data:file_upload_error_media_type_not_allowed.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;
-        rdfs:label       "Fajl media tip nije dozvoljen. Media tip otpremljenog fajla je {0}."@sr-Latn-RS ;
+        rdfs:label       "Media tip fajla nije dozvoljen. Media tip otpremljenog fajla je {0}."@sr-Latn-RS ;
         uil:hasApp      "Vitro" ;
         uil:hasKey      "file_upload_error_media_type_not_allowed" ;
         uil:hasPackage  "Vitro-languages" .


### PR DESCRIPTION
**[VIVO GitHub issue](https://github.com/vivo-project/VIVO/issues)**: [3886](https://github.com/vivo-project/VIVO/issues/3886)

# What does this pull request do?
Adding translations for some UI label keys

# What's new?
Translations for 19 UI label keys has been added in accordance with this file - [link](https://docs.google.com/spreadsheets/d/1goXRUsp5QlDGYu5sLOeggisjremBbN8v3iJ1ovFxQ3A/edit?usp=sharing). Thanks @litvinovg @michel-heon Jose Salm Anna Guillaumet for translations

# How should this be tested?

- Include support for languages in runtime.properties
- Run VIVO
- Change UI language/locale (to non en-US)
- Try to upload a file by following instructions described at https://github.com/vivo-project/Vitro/pull/251
- Check UI labels translations.

# Interested parties
Tag (@ mention) interested parties or, if unsure, @VIVO-project/vivo-committers
