### PR TITLE
Avoid lock on graph uri update (VIVO-3885)

### DIFF
--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/rdfservice/impl/jena/RDFServiceJena.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/rdfservice/impl/jena/RDFServiceJena.java
@@ -8,12 +8,24 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+
+import java.util.Set;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+
+import org.apache.jena.query.QuerySolutionMap;
+import org.apache.jena.query.ReadWrite;
+import org.apache.jena.query.Syntax;
+import org.apache.jena.rdf.model.Literal;
+import org.apache.jena.riot.RDFDataMgr;
+import org.apache.log4j.lf5.util.StreamUtils;
+
 import org.apache.jena.graph.Triple;
 import org.apache.jena.query.Dataset;
 import org.apache.jena.query.Query;
@@ -21,19 +33,14 @@ import org.apache.jena.query.QueryExecution;
 import org.apache.jena.query.QueryExecutionFactory;
 import org.apache.jena.query.QueryFactory;
 import org.apache.jena.query.QuerySolution;
-import org.apache.jena.query.QuerySolutionMap;
 import org.apache.jena.query.ResultSet;
 import org.apache.jena.query.ResultSetFormatter;
-import org.apache.jena.query.Syntax;
-import org.apache.jena.rdf.model.Literal;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
 import org.apache.jena.rdf.model.RDFNode;
-import org.apache.jena.riot.RDFDataMgr;
 import org.apache.jena.sdb.SDB;
 import org.apache.jena.shared.Lock;
 import org.apache.jena.sparql.core.Quad;
-import org.apache.log4j.lf5.util.StreamUtils;
 
 import edu.cornell.mannlib.vitro.webapp.controller.VitroRequest;
 import edu.cornell.mannlib.vitro.webapp.dao.jena.DatasetWrapper;
@@ -57,7 +64,7 @@ public abstract class RDFServiceJena extends RDFServiceImpl implements RDFServic
     protected abstract DatasetWrapper getDatasetWrapper();
 
     protected volatile boolean rebuildGraphURICache = true;
-    private final List<String> graphURIs = new ArrayList<>();
+    protected final List<String> graphURIs = Collections.synchronizedList(new ArrayList<>());
 
     @Override
 	public abstract boolean changeSetUpdate(ChangeSet changeSet) throws RDFServiceException;
@@ -313,26 +320,50 @@ public abstract class RDFServiceJena extends RDFServiceImpl implements RDFServic
     @Override
     public List<String> getGraphURIs() throws RDFServiceException {
         if (rebuildGraphURICache) {
-            synchronized (RDFServiceJena.class) {
-                if (rebuildGraphURICache) {
-                    DatasetWrapper dw = getDatasetWrapper();
-                    try {
-                        Dataset d = dw.getDataset();
-                        Iterator<String> nameIt = d.listNames();
-                        graphURIs.clear();
-                        while (nameIt.hasNext()) {
-                            graphURIs.add(nameIt.next());
+            rebuildGraphUris();
+        }
+        return graphURIs;
+    }
+
+    protected void rebuildGraphUris() {
+        Thread thread = new Thread(new Runnable() {
+            public void run() {
+                synchronized (RDFServiceJena.class) {
+                    if (rebuildGraphURICache) {
+                        DatasetWrapper dw = getDatasetWrapper();
+                        try {
+                            Dataset d = dw.getDataset();
+                            Set<String> newGraphUris = new HashSet<>();
+                            try {
+                                d.begin(ReadWrite.READ);
+                                Iterator<String> nameIt = d.listNames();
+                                while (nameIt.hasNext()) {
+                                    newGraphUris.add(nameIt.next());
+                                }
+                            } finally {
+                                d.end();
+                            }
+                            Set<String> oldGraphUris = new HashSet<String>(graphURIs);
+                            if (newGraphUris.equals(oldGraphUris)) {
+                                return;
+                            }
+                            Set<String> removedGraphUris = new HashSet<String>(oldGraphUris);
+                            removedGraphUris.removeAll(newGraphUris);
+                            graphURIs.removeAll(removedGraphUris);
+                            Set<String> addedGraphUris = new HashSet<String>(newGraphUris);
+                            addedGraphUris.removeAll(oldGraphUris);
+                            graphURIs.addAll(addedGraphUris);
+                        } catch (Exception e) {
+                            log.error(e, e);
+                        } finally {
+                            dw.close();
+                            rebuildGraphURICache = false;
                         }
-                        return graphURIs;
-                    } finally {
-                        dw.close();
-                        rebuildGraphURICache = false;
                     }
                 }
             }
-        }
-
-        return graphURIs;
+        });
+        thread.start();
     }
 
     @Override


### PR DESCRIPTION
**[VIVO GitHub issue](https://github.com/vivo-project/VIVO/issues/3885)**

# What does this pull request do?
Run graph uri update in a separate thread to avoid lock

# How should this be tested?
Test as in issue description:
*    Populate an instance with 10+ million triples.
*    Log in as root or admin: submit email and password.
*    There should not be any delay before you are redirected to Site Admin.
*    Log out, there should not be any delay before you are redirected to home page.

# Interested parties
@VIVO-project/vivo-committers @chenejac @brianjlowe 
