### PR TITLE
skip request for graph uri from name

### DIFF
--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/dynapi/data/implementation/DynapiModelFactory.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/dynapi/data/implementation/DynapiModelFactory.java
@@ -2,28 +2,34 @@ package edu.cornell.mannlib.vitro.webapp.dynapi.data.implementation;
 
 import javax.servlet.ServletContext;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.apache.jena.rdf.model.Model;
 
 import edu.cornell.mannlib.vitro.webapp.modelaccess.ContextModelAccess;
 import edu.cornell.mannlib.vitro.webapp.modelaccess.ModelAccess;
-import edu.cornell.mannlib.vitro.webapp.modelaccess.ModelNames;
 
 public class DynapiModelFactory {
 
+    private static final Log log = LogFactory.getLog(DynapiModelFactory.class);
+
     private static DynapiModelFactory INSTANCE = new DynapiModelFactory();
-	private static ContextModelAccess modelAccess;
+    private static ContextModelAccess modelAccess;
 
-	public static DynapiModelFactory getInstance() {
+    public static DynapiModelFactory getInstance() {
         return INSTANCE;
-	}
+    }
 
-	public void init(ServletContext ctx) {
-		modelAccess = ModelAccess.on(ctx);		
-	}
+    public void init(ServletContext ctx) {
+        modelAccess = ModelAccess.on(ctx);
+    }
 
-	public static Model getModel(String modelName) {
-		String uri = ModelNames.namesMap.get(modelName);
-		Model model = modelAccess.getOntModel(uri);
-		return model;
-	}
+    public static Model getModel(String uri) {
+        Model model = modelAccess.getOntModel(uri);
+        if (model == null) {
+            log.error(String.format("ModelAccess provided null on request for model with uri '%s' ", uri));
+            throw new RuntimeException();
+        }
+        return model;
+    }
 }


### PR DESCRIPTION
# What does this pull request do?
Fixes DynapiModelFactory. Previously model uri was returned by model names map.
Dynamic api instances were changed to store uri some time ago, but DynapiModelFactory didn't reflect that.
This PR removes request to ModelNames and adds error log in case returned model is null and throws exception to stop execution.


# Interested parties
@chenejac @ivanmrsulja 
