### PR TITLE
Use same logic to remove blank nodes from reasoner's internal model as used in RDFService

### DIFF
--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/dao/jena/JenaModelUtils.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/dao/jena/JenaModelUtils.java
@@ -2,7 +2,6 @@
 
 package edu.cornell.mannlib.vitro.webapp.dao.jena;
 
-import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Iterator;

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/dao/jena/JenaModelUtils.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/dao/jena/JenaModelUtils.java
@@ -456,9 +456,6 @@ public class JenaModelUtils {
         QueryExecution qe = QueryExecutionFactory.create(rootFinderQuery, blankNodeModel);
         try {
             ResultSet rs = qe.execSelect();
-            if (!rs.hasNext()) {
-                log.warn("No rooted blank node trees; deletion is not possible.");
-            }
             while (rs.hasNext()) {
                 QuerySolution qs = rs.next();
                 Resource s = qs.getResource("s");
@@ -467,32 +464,7 @@ public class JenaModelUtils {
                 QueryExecution qee = QueryExecutionFactory.create(treeFinderQuery, blankNodeModel);
                 try {
                     Model tree = qee.execDescribe();
-                    if (s.isAnon()) {
-                        JenaModelUtils.removeUsingSparqlConstruct(tree, removeFrom);
-                    } else {
-                        StmtIterator sit = tree.listStatements(s, null, (RDFNode) null);
-                        while (sit.hasNext()) {
-                            Statement stmt = sit.nextStatement();
-                            RDFNode n = stmt.getObject();
-                            Model m2 = ModelFactory.createDefaultModel();
-                            if (n.isResource()) {
-                                Resource s2 = (Resource) n;
-                                // now run yet another describe query
-                                String smallerTree = makeDescribe(s2);
-                                log.debug(smallerTree);
-                                Query smallerTreeQuery = QueryFactory.create(smallerTree);
-                                QueryExecution qe3 = QueryExecutionFactory.create(
-                                        smallerTreeQuery, tree);
-                                try {
-                                    qe3.execDescribe(m2);
-                                } finally {
-                                    qe3.close();
-                                }
-                            }
-                            m2.add(stmt);
-                            JenaModelUtils.removeUsingSparqlConstruct(m2, removeFrom);
-                        }
-                    }
+                    JenaModelUtils.removeUsingSparqlConstruct(tree, removeFrom);
                 } finally {
                     qee.close();
                 }

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/dao/jena/JenaModelUtils.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/dao/jena/JenaModelUtils.java
@@ -544,10 +544,6 @@ public class JenaModelUtils {
             Model constructedRemovals = qe.execConstruct();
             try {
             	removeFrom.enterCriticalSection(Lock.WRITE);
-            	log.info("Removing contructed:");
-            	StringWriter sw = new StringWriter();
-            	constructedRemovals.write(sw, "TTL");
-            	log.info(sw.toString());
             	removeFrom.remove(constructedRemovals);
             } finally {
             	removeFrom.leaveCriticalSection();

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/rdfservice/impl/RDFServiceImpl.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/rdfservice/impl/RDFServiceImpl.java
@@ -45,9 +45,7 @@ import edu.cornell.mannlib.vitro.webapp.utils.logging.ToString;
 public abstract class RDFServiceImpl implements RDFService {
 
 	private static final Log log = LogFactory.getLog(RDFServiceImpl.class);
-	protected static final String BNODE_ROOT_QUERY =
-	        "SELECT DISTINCT ?s WHERE { ?s ?p ?o OPTIONAL { ?ss ?pp ?s } FILTER (!isBlank(?s) || !bound(?ss)) }";
-
+	
 	protected String defaultWriteGraphURI;
 	protected List<ChangeListener> registeredListeners = new CopyOnWriteArrayList<ChangeListener>();
 	protected List<ModelChangedListener> registeredJenaListeners = new CopyOnWriteArrayList<ModelChangedListener>();

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/rdfservice/impl/jena/RDFServiceJena.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/rdfservice/impl/jena/RDFServiceJena.java
@@ -10,46 +10,40 @@ import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
-import java.util.concurrent.ConcurrentLinkedQueue;
 
-import edu.cornell.mannlib.vitro.webapp.rdfservice.ResultSetConsumer;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.apache.jena.query.QuerySolutionMap;
-import org.apache.jena.query.Syntax;
-import org.apache.jena.rdf.model.Literal;
-import org.apache.jena.riot.RDFDataMgr;
-import org.apache.log4j.lf5.util.StreamUtils;
-
 import org.apache.jena.graph.Triple;
 import org.apache.jena.query.Dataset;
-import org.apache.jena.query.DatasetFactory;
 import org.apache.jena.query.Query;
 import org.apache.jena.query.QueryExecution;
 import org.apache.jena.query.QueryExecutionFactory;
 import org.apache.jena.query.QueryFactory;
 import org.apache.jena.query.QuerySolution;
+import org.apache.jena.query.QuerySolutionMap;
 import org.apache.jena.query.ResultSet;
 import org.apache.jena.query.ResultSetFormatter;
+import org.apache.jena.query.Syntax;
+import org.apache.jena.rdf.model.Literal;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
 import org.apache.jena.rdf.model.RDFNode;
-import org.apache.jena.rdf.model.Resource;
-import org.apache.jena.rdf.model.Statement;
-import org.apache.jena.rdf.model.StmtIterator;
+import org.apache.jena.riot.RDFDataMgr;
 import org.apache.jena.sdb.SDB;
 import org.apache.jena.shared.Lock;
 import org.apache.jena.sparql.core.Quad;
+import org.apache.log4j.lf5.util.StreamUtils;
 
 import edu.cornell.mannlib.vitro.webapp.controller.VitroRequest;
 import edu.cornell.mannlib.vitro.webapp.dao.jena.DatasetWrapper;
+import edu.cornell.mannlib.vitro.webapp.dao.jena.JenaModelUtils;
 import edu.cornell.mannlib.vitro.webapp.dao.jena.RDFServiceDataset;
-import edu.cornell.mannlib.vitro.webapp.dao.jena.SparqlGraph;
 import edu.cornell.mannlib.vitro.webapp.rdfservice.ChangeSet;
 import edu.cornell.mannlib.vitro.webapp.rdfservice.ModelChange;
 import edu.cornell.mannlib.vitro.webapp.rdfservice.RDFService;
 import edu.cornell.mannlib.vitro.webapp.rdfservice.RDFServiceException;
+import edu.cornell.mannlib.vitro.webapp.rdfservice.ResultSetConsumer;
 import edu.cornell.mannlib.vitro.webapp.rdfservice.impl.RDFServiceImpl;
 import edu.cornell.mannlib.vitro.webapp.rdfservice.impl.RDFServiceUtils;
 import edu.cornell.mannlib.vitro.webapp.utils.logging.ToString;
@@ -115,9 +109,10 @@ public abstract class RDFServiceJena extends RDFServiceImpl implements RDFServic
             	model.add(addition);
             } else if (modelChange.getOperation() == ModelChange.Operation.REMOVE) {
                 Model removal = parseModel(modelChange);
-                model.remove(removal);
                 if (dataset != null) {
-                    removeBlankNodesWithSparqlUpdate(dataset, removal, modelChange.getGraphURI());
+                    JenaModelUtils.removeWithBlankNodesAsVariables(removal, dataset, modelChange.getGraphURI());
+                } else {
+                    model.remove(removal);
                 }
             } else {
                 log.error("unrecognized operation type");
@@ -178,216 +173,6 @@ public abstract class RDFServiceJena extends RDFServiceImpl implements RDFServic
 				modelChange.getGraphURI(), changeString,
 				ToString.modelToString(model)));
 	}
-
-	private void removeBlankNodesWithSparqlUpdate(Dataset dataset, Model model, String graphURI) {
-
-        List<Statement> blankNodeStatements = new ArrayList<Statement>();
-        StmtIterator stmtIt = model.listStatements();
-        while (stmtIt.hasNext()) {
-            Statement stmt = stmtIt.nextStatement();
-            if (stmt.getSubject().isAnon() || stmt.getObject().isAnon()) {
-                blankNodeStatements.add(stmt);
-            }
-        }
-
-        if(blankNodeStatements.size() == 0) {
-            return;
-        }
-
-        Model blankNodeModel = ModelFactory.createDefaultModel();
-        blankNodeModel.add(blankNodeStatements);
-
-        log.debug("removal model size " + model.size());
-        log.debug("blank node model size " + blankNodeModel.size());
-
-        if (blankNodeModel.size() == 1) {
-            log.debug("Deleting single triple with blank node: " + blankNodeModel);
-            log.debug("This could result in the deletion of multiple triples if multiple blank nodes match the same triple pattern.");
-        }
-
-        Query rootFinderQuery = QueryFactory.create(BNODE_ROOT_QUERY);
-        QueryExecution qe = QueryExecutionFactory.create(rootFinderQuery, blankNodeModel);
-        try {
-            ResultSet rs = qe.execSelect();
-            if (!rs.hasNext()) {
-                log.warn("No rooted blank node trees; deletion is not possible.");
-            }
-            while (rs.hasNext()) {
-                QuerySolution qs = rs.next();
-                Resource s = qs.getResource("s");
-                String treeFinder = makeDescribe(s);
-                Query treeFinderQuery = QueryFactory.create(treeFinder);
-                QueryExecution qee = QueryExecutionFactory.create(treeFinderQuery, blankNodeModel);
-                try {
-                    Model tree = qee.execDescribe();
-                    Dataset ds = DatasetFactory.createMem();
-                    if (graphURI == null) {
-                        ds.setDefaultModel(dataset.getDefaultModel());
-                    } else {
-                        ds.addNamedModel(graphURI, dataset.getNamedModel(graphURI));
-                    }
-                    if (s.isAnon()) {
-                        removeUsingSparqlUpdate(ds, tree, graphURI);
-                    } else {
-                        StmtIterator sit = tree.listStatements(s, null, (RDFNode) null);
-                        while (sit.hasNext()) {
-                            Statement stmt = sit.nextStatement();
-                            RDFNode n = stmt.getObject();
-                            Model m2 = ModelFactory.createDefaultModel();
-                            if (n.isResource()) {
-                                Resource s2 = (Resource) n;
-                                // now run yet another describe query
-                                String smallerTree = makeDescribe(s2);
-                                log.debug(smallerTree);
-                                Query smallerTreeQuery = QueryFactory.create(smallerTree);
-                                QueryExecution qe3 = QueryExecutionFactory.create(
-                                        smallerTreeQuery, tree);
-                                try {
-                                    qe3.execDescribe(m2);
-                                } finally {
-                                    qe3.close();
-                                }
-                            }
-                            m2.add(stmt);
-                            removeUsingSparqlUpdate(ds, m2, graphURI);
-                        }
-                    }
-                } finally {
-                    qee.close();
-                }
-            }
-        } finally {
-            qe.close();
-        }
-    }
-
-    private String makeDescribe(Resource s) {
-        StringBuilder query = new StringBuilder("DESCRIBE <") ;
-        if (s.isAnon()) {
-            query.append("_:").append(s.getId().toString());
-        } else {
-            query.append(s.getURI());
-        }
-        query.append(">");
-        return query.toString();
-    }
-
-    private void removeUsingSparqlUpdate(Dataset dataset, Model model, String graphURI) {
-        StmtIterator stmtIt = model.listStatements();
-
-        if (!stmtIt.hasNext()) {
-            stmtIt.close();
-            return;
-        }
-
-        StringBuffer queryBuff = new StringBuffer();
-        queryBuff.append("CONSTRUCT { \n");
-        List<Statement> stmts = stmtIt.toList();
-        stmts = sort(stmts);
-        addStatementPatterns(stmts, queryBuff, !WHERE_CLAUSE);
-        queryBuff.append("} WHERE { \n");
-        if (graphURI != null) {
-            queryBuff.append("    GRAPH <").append(graphURI).append("> { \n");
-        }
-        stmtIt = model.listStatements();
-        stmts = stmtIt.toList();
-        stmts = sort(stmts);
-        addStatementPatterns(stmts, queryBuff, WHERE_CLAUSE);
-        if (graphURI != null) {
-            queryBuff.append("    } \n");
-        }
-        queryBuff.append("} \n");
-
-        log.debug(queryBuff.toString());
-
-        Query construct = QueryFactory.create(queryBuff.toString());
-        // make a plain dataset to force the query to be run in a way that
-        // won't overwhelm MySQL with too many joins
-        Dataset ds = DatasetFactory.createMem();
-        if (graphURI == null) {
-            ds.setDefaultModel(dataset.getDefaultModel());
-        } else {
-            ds.addNamedModel(graphURI, dataset.getNamedModel(graphURI));
-        }
-        QueryExecution qe = QueryExecutionFactory.create(construct, ds);
-        try {
-            Model m = qe.execConstruct();
-            if (graphURI != null) {
-                dataset.getNamedModel(graphURI).remove(m);
-            } else {
-                dataset.getDefaultModel().remove(m);
-            }
-        } finally {
-            qe.close();
-        }
-    }
-
-    private List<Statement> sort(List<Statement> stmts) {
-        List<Statement> output = new ArrayList<Statement>();
-        int originalSize = stmts.size();
-        if(originalSize == 1) {
-            return stmts;
-        }
-        List <Statement> remaining = stmts;
-        ConcurrentLinkedQueue<Resource> subjQueue = new ConcurrentLinkedQueue<Resource>();
-        for(Statement stmt : remaining) {
-            if(stmt.getSubject().isURIResource()) {
-                subjQueue.add(stmt.getSubject());
-                break;
-            }
-        }
-        if (subjQueue.isEmpty()) {
-            log.warn("No named subject in statement patterns");
-            return stmts;
-        }
-        while(remaining.size() > 0) {
-            if(subjQueue.isEmpty()) {
-                subjQueue.add(remaining.get(0).getSubject());
-            }
-            while(!subjQueue.isEmpty()) {
-                Resource subj = subjQueue.poll();
-                List<Statement> temp = new ArrayList<Statement>();
-                for (Statement stmt : remaining) {
-                    if(stmt.getSubject().equals(subj)) {
-                        output.add(stmt);
-                        if (stmt.getObject().isResource()) {
-                            subjQueue.add((Resource) stmt.getObject());
-                        }
-                    } else {
-                        temp.add(stmt);
-                    }
-                }
-                remaining = temp;
-            }
-        }
-        if(output.size() != originalSize) {
-            throw new RuntimeException("original list size was " + originalSize +
-                    " but sorted size is " + output.size());
-        }
-        return output;
-    }
-
-    private static final boolean WHERE_CLAUSE = true;
-
-    private void addStatementPatterns(List<Statement> stmts, StringBuffer patternBuff, boolean whereClause) {
-        for(Statement stmt : stmts) {
-            Triple t = stmt.asTriple();
-            patternBuff.append(SparqlGraph.sparqlNodeDelete(t.getSubject(), null));
-            patternBuff.append(" ");
-            patternBuff.append(SparqlGraph.sparqlNodeDelete(t.getPredicate(), null));
-            patternBuff.append(" ");
-            patternBuff.append(SparqlGraph.sparqlNodeDelete(t.getObject(), null));
-            patternBuff.append(" .\n");
-            if (whereClause) {
-                if (t.getSubject().isBlank()) {
-                    patternBuff.append("    FILTER(isBlank(").append(SparqlGraph.sparqlNodeDelete(t.getSubject(), null)).append(")) \n");
-                }
-                if (t.getObject().isBlank()) {
-                    patternBuff.append("    FILTER(isBlank(").append(SparqlGraph.sparqlNodeDelete(t.getObject(), null)).append(")) \n");
-                }
-            }
-        }
-    }
 
     private Model parseModel(ModelChange modelChange) {
         Model model = ModelFactory.createDefaultModel();

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/rdfservice/impl/jena/RDFServiceJena.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/rdfservice/impl/jena/RDFServiceJena.java
@@ -7,6 +7,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
@@ -16,6 +17,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.jena.graph.Triple;
 import org.apache.jena.query.Dataset;
+import org.apache.jena.query.DatasetFactory;
 import org.apache.jena.query.Query;
 import org.apache.jena.query.QueryExecution;
 import org.apache.jena.query.QueryExecutionFactory;
@@ -34,6 +36,8 @@ import org.apache.jena.sdb.SDB;
 import org.apache.jena.shared.Lock;
 import org.apache.jena.sparql.core.Quad;
 import org.apache.log4j.lf5.util.StreamUtils;
+
+import com.github.benmanes.caffeine.cache.RemovalListener;
 
 import edu.cornell.mannlib.vitro.webapp.controller.VitroRequest;
 import edu.cornell.mannlib.vitro.webapp.dao.jena.DatasetWrapper;
@@ -85,7 +89,7 @@ public abstract class RDFServiceJena extends RDFServiceImpl implements RDFServic
 				Model model = (modelChange.getGraphURI() == null) ?
 						dataset.getDefaultModel() :
 						dataset.getNamedModel(modelChange.getGraphURI());
-				operateOnModel(model, modelChange, dataset);
+				operateOnModel(model, modelChange);
 			} finally {
 				dataset.getLock().leaveCriticalSection();
 			}
@@ -98,7 +102,7 @@ public abstract class RDFServiceJena extends RDFServiceImpl implements RDFServic
 		}
 	}
 
-    protected void operateOnModel(Model model, ModelChange modelChange, Dataset dataset) {
+    protected void operateOnModel(Model model, ModelChange modelChange) {
         model.enterCriticalSection(Lock.WRITE);
         try {
 			if (log.isDebugEnabled()) {
@@ -109,11 +113,7 @@ public abstract class RDFServiceJena extends RDFServiceImpl implements RDFServic
             	model.add(addition);
             } else if (modelChange.getOperation() == ModelChange.Operation.REMOVE) {
                 Model removal = parseModel(modelChange);
-                if (dataset != null) {
-                    JenaModelUtils.removeWithBlankNodesAsVariables(removal, dataset, modelChange.getGraphURI());
-                } else {
-                    model.remove(removal);
-                }
+                JenaModelUtils.removeWithBlankNodesAsVariables(removal, model);
             } else {
                 log.error("unrecognized operation type");
             }

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/rdfservice/impl/jena/RDFServiceJena.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/rdfservice/impl/jena/RDFServiceJena.java
@@ -7,7 +7,6 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
@@ -17,7 +16,6 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.jena.graph.Triple;
 import org.apache.jena.query.Dataset;
-import org.apache.jena.query.DatasetFactory;
 import org.apache.jena.query.Query;
 import org.apache.jena.query.QueryExecution;
 import org.apache.jena.query.QueryExecutionFactory;
@@ -36,8 +34,6 @@ import org.apache.jena.sdb.SDB;
 import org.apache.jena.shared.Lock;
 import org.apache.jena.sparql.core.Quad;
 import org.apache.log4j.lf5.util.StreamUtils;
-
-import com.github.benmanes.caffeine.cache.RemovalListener;
 
 import edu.cornell.mannlib.vitro.webapp.controller.VitroRequest;
 import edu.cornell.mannlib.vitro.webapp.dao.jena.DatasetWrapper;

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/rdfservice/impl/jena/model/RDFServiceModel.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/rdfservice/impl/jena/model/RDFServiceModel.java
@@ -95,7 +95,7 @@ public class RDFServiceModel extends RDFServiceJena implements RDFService {
                         m = dataset.getDefaultModel();
                     }
                 }
-                operateOnModel(m, modelChange, null);
+                operateOnModel(m, modelChange);
             }
 
             // notify listeners of triple changes

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/rdfservice/impl/sparql/RDFServiceSparql.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/rdfservice/impl/sparql/RDFServiceSparql.java
@@ -38,8 +38,6 @@ import org.apache.http.message.BasicNameValuePair;
 import org.apache.http.protocol.BasicHttpContext;
 import org.apache.http.protocol.HttpContext;
 import org.apache.http.util.EntityUtils;
-import org.apache.jena.riot.RDFDataMgr;
-
 import org.apache.jena.graph.Triple;
 import org.apache.jena.query.Query;
 import org.apache.jena.query.QueryExecution;
@@ -55,8 +53,10 @@ import org.apache.jena.rdf.model.RDFNode;
 import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.rdf.model.Statement;
 import org.apache.jena.rdf.model.StmtIterator;
+import org.apache.jena.riot.RDFDataMgr;
 import org.apache.jena.sparql.core.Quad;
 
+import edu.cornell.mannlib.vitro.webapp.dao.jena.JenaModelUtils;
 import edu.cornell.mannlib.vitro.webapp.dao.jena.RDFServiceDataset;
 import edu.cornell.mannlib.vitro.webapp.dao.jena.SparqlGraph;
 import edu.cornell.mannlib.vitro.webapp.rdfservice.ChangeListener;
@@ -691,7 +691,7 @@ public class RDFServiceSparql extends RDFServiceImpl implements RDFService {
 			log.warn("This likely indicates a problem; excessive data may be deleted.");
 		}
 
-		Query rootFinderQuery = QueryFactory.create(BNODE_ROOT_QUERY);
+		Query rootFinderQuery = QueryFactory.create(JenaModelUtils.BNODE_ROOT_QUERY);
 		QueryExecution qe = QueryExecutionFactory.create(rootFinderQuery, blankNodeModel);
 		try {
 			ResultSet rs = qe.execSelect();

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/tboxreasoner/impl/jfact/JFactTBoxReasoner.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/tboxreasoner/impl/jfact/JFactTBoxReasoner.java
@@ -16,8 +16,6 @@ import org.apache.jena.ontology.ObjectProperty;
 import org.apache.jena.ontology.OntModel;
 import org.apache.jena.ontology.OntModelSpec;
 import org.apache.jena.ontology.Restriction;
-import org.apache.jena.query.Dataset;
-import org.apache.jena.query.DatasetFactory;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
 import org.apache.jena.rdf.model.RDFNode;

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/tboxreasoner/impl/jfact/JFactTBoxReasoner.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/tboxreasoner/impl/jfact/JFactTBoxReasoner.java
@@ -2,6 +2,8 @@
 
 package edu.cornell.mannlib.vitro.webapp.tboxreasoner.impl.jfact;
 
+import static org.semanticweb.owlapi.vocab.OWLRDFVocabulary.OWL_AXIOM;
+
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.ArrayList;
@@ -9,6 +11,20 @@ import java.util.List;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.apache.jena.ontology.DatatypeProperty;
+import org.apache.jena.ontology.ObjectProperty;
+import org.apache.jena.ontology.OntModel;
+import org.apache.jena.ontology.OntModelSpec;
+import org.apache.jena.ontology.Restriction;
+import org.apache.jena.query.Dataset;
+import org.apache.jena.query.DatasetFactory;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.ModelFactory;
+import org.apache.jena.rdf.model.RDFNode;
+import org.apache.jena.rdf.model.ResourceFactory;
+import org.apache.jena.rdf.model.Statement;
+import org.apache.jena.rdf.model.StmtIterator;
+import org.apache.jena.vocabulary.RDF;
 import org.semanticweb.owlapi.apibinding.OWLManager;
 import org.semanticweb.owlapi.model.OWLOntology;
 import org.semanticweb.owlapi.model.OWLOntologyCreationException;
@@ -18,27 +34,12 @@ import org.semanticweb.owlapi.reasoner.OWLReasonerConfiguration;
 import org.semanticweb.owlapi.reasoner.OWLReasonerFactory;
 import org.semanticweb.owlapi.reasoner.SimpleConfiguration;
 
-import uk.ac.manchester.cs.jfact.JFactFactory;
-
-import org.apache.jena.ontology.DatatypeProperty;
-import org.apache.jena.ontology.ObjectProperty;
-import org.apache.jena.ontology.OntModel;
-import org.apache.jena.ontology.OntModelSpec;
-import org.apache.jena.ontology.Restriction;
-import org.apache.jena.rdf.model.Model;
-import org.apache.jena.rdf.model.ModelFactory;
-import org.apache.jena.rdf.model.RDFNode;
-import org.apache.jena.rdf.model.ResourceFactory;
-import org.apache.jena.rdf.model.Statement;
-import org.apache.jena.rdf.model.StmtIterator;
-import org.apache.jena.vocabulary.RDF;
-
+import edu.cornell.mannlib.vitro.webapp.dao.jena.JenaModelUtils;
 import edu.cornell.mannlib.vitro.webapp.tboxreasoner.ReasonerStatementPattern;
 import edu.cornell.mannlib.vitro.webapp.tboxreasoner.TBoxChanges;
 import edu.cornell.mannlib.vitro.webapp.tboxreasoner.TBoxReasoner;
 import edu.cornell.mannlib.vitro.webapp.tboxreasoner.impl.TBoxInferencesAccumulator;
-
-import static org.semanticweb.owlapi.vocab.OWLRDFVocabulary.OWL_AXIOM;
+import uk.ac.manchester.cs.jfact.JFactFactory;
 
 /**
  * An implementation of the JFact reasoner for the TBox.
@@ -81,7 +82,11 @@ public class JFactTBoxReasoner implements
 		log.debug("Adding " + changes.getAddedStatements().size()
 				+ ", removing " + changes.getRemovedStatements().size());
 		filteredAssertionsModel.add(changes.getAddedStatements());
-		filteredAssertionsModel.remove(changes.getRemovedStatements());
+		Model removals = ModelFactory.createDefaultModel();
+		removals.add(changes.getRemovedStatements());
+		Dataset dataset = DatasetFactory.createGeneral();
+		dataset.setDefaultModel(filteredAssertionsModel);
+		JenaModelUtils.removeWithBlankNodesAsVariables(removals, dataset, null);
 		clearEmptyAxiomStatements();
 	}
 

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/tboxreasoner/impl/jfact/JFactTBoxReasoner.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/tboxreasoner/impl/jfact/JFactTBoxReasoner.java
@@ -84,9 +84,7 @@ public class JFactTBoxReasoner implements
 		filteredAssertionsModel.add(changes.getAddedStatements());
 		Model removals = ModelFactory.createDefaultModel();
 		removals.add(changes.getRemovedStatements());
-		Dataset dataset = DatasetFactory.createGeneral();
-		dataset.setDefaultModel(filteredAssertionsModel);
-		JenaModelUtils.removeWithBlankNodesAsVariables(removals, dataset, null);
+		JenaModelUtils.removeWithBlankNodesAsVariables(removals, filteredAssertionsModel);
 		clearEmptyAxiomStatements();
 	}
 

--- a/api/src/test/java/edu/cornell/mannlib/vitro/webapp/tboxreasoner/impl/jfact/JFactTBoxReasonerTest.java
+++ b/api/src/test/java/edu/cornell/mannlib/vitro/webapp/tboxreasoner/impl/jfact/JFactTBoxReasonerTest.java
@@ -1,0 +1,106 @@
+package edu.cornell.mannlib.vitro.webapp.tboxreasoner.impl.jfact;
+
+import java.io.StringReader;
+
+import org.apache.jena.ontology.OntModel;
+import org.apache.jena.ontology.OntModelSpec;
+import org.apache.jena.query.Dataset;
+import org.apache.jena.query.DatasetFactory;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.ModelFactory;
+import org.apache.jena.rdf.model.RDFNode;
+import org.junit.Assert;
+import org.junit.Test;
+
+import edu.cornell.mannlib.vitro.webapp.dao.jena.JenaModelUtils;
+import edu.cornell.mannlib.vitro.webapp.dao.jena.event.EditEvent;
+import edu.cornell.mannlib.vitro.webapp.tboxreasoner.ReasonerConfiguration;
+import edu.cornell.mannlib.vitro.webapp.tboxreasoner.impl.BasicTBoxReasonerDriver;
+
+public class JFactTBoxReasonerTest {
+	
+	private final static String axioms = "@prefix obo: <http://purl.obolibrary.org/obo/> .\r\n" + 
+			"@prefix owl: <http://www.w3.org/2002/07/owl#> .\r\n" + 
+			"@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .\r\n" + 
+			"@prefix xml: <http://www.w3.org/XML/1998/namespace> .\r\n" + 
+			"@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .\r\n" + 
+			"@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\r\n" + 
+			"\r\n" + 
+			"<http://vivo.mydomain.edu/individual/class_c> rdf:type owl:Class ;\r\n" + 
+			"         \r\n" + 
+			"         rdfs:subClassOf [ rdf:type owl:Class ;\r\n" + 
+			"                           owl:intersectionOf ( <http://vivo.mydomain.edu/individual/class_a>\r\n" + 
+			"                                                <http://vivo.mydomain.edu/individual/class_b>\r\n" + 
+			"                                              )\r\n" + 
+			"                         ] .\r\n" + 
+			"\r\n" + 
+			"<http://vivo.mydomain.edu/individual/class_a>\r\n" + 
+			"        a                        owl:Class ;\r\n" + 
+			"        rdfs:label               \"Class A\"@en-US .\r\n" + 
+			"\r\n" + 
+			"<http://vivo.mydomain.edu/individual/class_b>\r\n" + 
+			"        a                        owl:Class ;\r\n" + 
+			"        rdfs:label               \"Class B\"@en-US .\r\n" + 
+			"\r\n" + 
+			"<http://vivo.mydomain.edu/individual/class_c>\r\n" + 
+			"        a                        owl:Class ;\r\n" + 
+			"        rdfs:label               \"Class C\"@en-US .\r\n";
+	
+	/**
+	 * Test that axioms containing blank nodes can be removed from the reasoner
+	 *  even if the internal blank node IDs are different from when first added.
+	 */
+	@Test
+	public void testRemoveAxiomsWithBlankNodes() {
+		OntModel tboxAssertions = ModelFactory.createOntologyModel(OntModelSpec.OWL_MEM);
+		OntModel tboxInferences = ModelFactory.createOntologyModel(OntModelSpec.OWL_MEM);
+		OntModel tboxUnion = ModelFactory.createOntologyModel(OntModelSpec.OWL_MEM,
+				ModelFactory.createUnion(tboxAssertions, tboxInferences));
+		JFactTBoxReasoner reasoner = new JFactTBoxReasoner();
+		BasicTBoxReasonerDriver driver = new BasicTBoxReasonerDriver(
+				tboxAssertions, tboxInferences.getBaseModel(), tboxUnion, reasoner,
+				ReasonerConfiguration.DEFAULT);
+		Model additions = ModelFactory.createDefaultModel();
+		additions.read(new StringReader(axioms), null, "TTL");
+		// Reading again will generate new internal blank node IDs
+		Model subtractions = ModelFactory.createDefaultModel();
+		subtractions.read(new StringReader(axioms), null, "TTL");
+		// Confirm that directly subtracting the models doesn't work because
+		// the blank node IDs do not match
+		Model incorrectSubtraction = additions.difference(subtractions);
+		Assert.assertFalse(incorrectSubtraction.isEmpty());
+		tboxAssertions.getBaseModel().add(additions);
+		tboxAssertions.getBaseModel().notifyEvent(new EditEvent(null, false));
+		waitForTBoxReasoning(driver);
+		// Confirm that union model now contains inferred triples
+		Assert.assertTrue(tboxUnion.size() > additions.size());
+		Dataset dataset = DatasetFactory.createGeneral();
+		dataset.setDefaultModel(tboxAssertions.getBaseModel());
+		JenaModelUtils.removeWithBlankNodesAsVariables(subtractions, dataset, null);
+		tboxAssertions.getBaseModel().notifyEvent(new EditEvent(null, false));
+		waitForTBoxReasoning(driver);
+		// Confirm that no statements related to classes a, b or c remain in the
+		// TBox union model.  (The inference model may not be completely empty, because
+		// the reasoner may supply unrelated triples related to OWL and RDFS vocabulary.)
+		Assert.assertFalse(tboxUnion.contains(tboxUnion.getResource(
+				"http://vivo.mydomain.edu/individual/class_a"), null, (RDFNode) null));
+		Assert.assertFalse(tboxUnion.contains(tboxUnion.getResource(
+				"http://vivo.mydomain.edu/individual/class_b"), null, (RDFNode) null));
+		Assert.assertFalse(tboxUnion.contains(tboxUnion.getResource(
+				"http://vivo.mydomain.edu/individual/class_c"), null, (RDFNode) null));
+	}
+	
+	private void waitForTBoxReasoning(BasicTBoxReasonerDriver driver) {
+		int sleeps = 0;
+		// sleep at least once to make sure the TBox reasoning gets started
+		while ((0 == sleeps) || ((sleeps < 1000) && driver.getStatus().isReasoning())) {
+			try {
+				Thread.sleep(200);
+			} catch (InterruptedException e) {
+				throw new RuntimeException(e);
+			}
+			sleeps++;
+		}
+	}
+	
+}

--- a/api/src/test/java/edu/cornell/mannlib/vitro/webapp/tboxreasoner/impl/jfact/JFactTBoxReasonerTest.java
+++ b/api/src/test/java/edu/cornell/mannlib/vitro/webapp/tboxreasoner/impl/jfact/JFactTBoxReasonerTest.java
@@ -74,9 +74,7 @@ public class JFactTBoxReasonerTest {
 		waitForTBoxReasoning(driver);
 		// Confirm that union model now contains inferred triples
 		Assert.assertTrue(tboxUnion.size() > additions.size());
-		Dataset dataset = DatasetFactory.createGeneral();
-		dataset.setDefaultModel(tboxAssertions.getBaseModel());
-		JenaModelUtils.removeWithBlankNodesAsVariables(subtractions, dataset, null);
+		JenaModelUtils.removeWithBlankNodesAsVariables(subtractions, tboxAssertions.getBaseModel());
 		tboxAssertions.getBaseModel().notifyEvent(new EditEvent(null, false));
 		waitForTBoxReasoning(driver);
 		// Confirm that no statements related to classes a, b or c remain in the

--- a/api/src/test/java/edu/cornell/mannlib/vitro/webapp/tboxreasoner/impl/jfact/JFactTBoxReasonerTest.java
+++ b/api/src/test/java/edu/cornell/mannlib/vitro/webapp/tboxreasoner/impl/jfact/JFactTBoxReasonerTest.java
@@ -4,8 +4,6 @@ import java.io.StringReader;
 
 import org.apache.jena.ontology.OntModel;
 import org.apache.jena.ontology.OntModelSpec;
-import org.apache.jena.query.Dataset;
-import org.apache.jena.query.DatasetFactory;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
 import org.apache.jena.rdf.model.RDFNode;


### PR DESCRIPTION
**[VIVO GitHub issue 3884](https://github.com/vivo-project/VIVO/issues/3884)**: 

# What does this pull request do?
Refactors the logic for treating removed blank nodes as variables from RDFServiceJena to JenaModelUtils where it can be used by the JFactTBoxReasoner.  This allows ontologies removed using Add/Remove RDF to properly update the reasoner and allow related inferences to be removed.  Adds some comments and a unit test.

# How should this be tested?
- Unit test should pass.
- For additional manual confirmation, run the steps in the linked issue to confirm that the bug can no longer be reproduced.

# Interested parties
@VIVO-project/vivo-committers
