### PR TITLE
Sparql select query fixes

### DIFF
--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/dynapi/components/operations/SparqlSelectQuery.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/dynapi/components/operations/SparqlSelectQuery.java
@@ -12,8 +12,10 @@ import edu.cornell.mannlib.vitro.webapp.dynapi.components.Parameter;
 import edu.cornell.mannlib.vitro.webapp.dynapi.data.DataStore;
 import edu.cornell.mannlib.vitro.webapp.dynapi.data.JsonContainerView;
 import edu.cornell.mannlib.vitro.webapp.dynapi.data.JsonView;
+import edu.cornell.mannlib.vitro.webapp.dynapi.data.ModelView;
 import edu.cornell.mannlib.vitro.webapp.dynapi.data.DefaultDataView;
 import edu.cornell.mannlib.vitro.webapp.dynapi.data.SimpleDataView;
+import edu.cornell.mannlib.vitro.webapp.dynapi.data.conversion.InitializationException;
 import edu.cornell.mannlib.vitro.webapp.rdfservice.RDFService;
 import edu.cornell.mannlib.vitro.webapp.rdfservice.impl.RDFServiceUtils;
 import edu.cornell.mannlib.vitro.webapp.utils.configuration.Property;
@@ -22,10 +24,13 @@ public class SparqlSelectQuery extends SparqlQuery {
 
 	public static final Log log = LogFactory.getLog(SparqlSelectQuery.class);
 
-	@Property(uri = "https://vivoweb.org/ontology/vitro-dynamic-api#providesParameter")
-	public void addOutputParameter(Parameter param) {
-		outputParams.add(param);
-	}
+    @Property(uri = "https://vivoweb.org/ontology/vitro-dynamic-api#providesParameter")
+    public void addOutputParameter(Parameter param) throws InitializationException {
+        if (ModelView.isModel(param)) {
+            throw new InitializationException("Model parameter can't be provided by SPARQL select query");
+        }
+        outputParams.add(param);
+    }
 
 	@Override
 	public OperationResult runOperation(DataStore dataStore) {

--- a/home/src/main/resources/rdf/dynapiAbox/everytime/model_parameters.n3
+++ b/home/src/main/resources/rdf/dynapiAbox/everytime/model_parameters.n3
@@ -18,7 +18,7 @@
         a                       dynapi:Model ;
         dynapi:name             "ABOX_ASSERTIONS" ;
         dynapi:isInternal       "true"^^xsd:boolean ;
-        dynapi:defaultValue     "http://vitro.mannlib.cornell.edu/default/vitro-kb-2ABOX_ASSERTIONS" ;
+        dynapi:defaultValue     "http://vitro.mannlib.cornell.edu/default/vitro-kb-2" ;
         rdfs:label              "abox assertions model"@en-US ;
         dynapi:hasType        	<https://vivoweb.org/ontology/vitro-dynamic-api/parameter/type/internal-model> ;
         vitro:mostSpecificType  dynapi:Model .


### PR DESCRIPTION
# What does this pull request do?
Fixed accidentally pasted text in model parameters (abox assertions graph uri).
Added check to prevent procedure initialization and if a model was configured as a parameter provided by SPARQL query.

# Interested parties
@chenejac @ivanmrsulja @milospp 
