### PR TITLE
Fix for optional parameters

### DIFF
--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/dynapi/components/Parameter.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/dynapi/components/Parameter.java
@@ -45,7 +45,7 @@ public class Parameter implements Removable {
         }
     }
     
-    @Property(uri = "https://vivoweb.org/ontology/vitro-dynamic-api#isOptional", minOccurs = 0, maxOccurs = 1)
+    @Property(uri = "https://vivoweb.org/ontology/vitro-dynamic-api#isOptionalParam", minOccurs = 0, maxOccurs = 1)
     public void setOptional(boolean optional) {
         this.optional = optional;
         if (optional) {

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/dynapi/data/conversion/JSONConverter.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/dynapi/data/conversion/JSONConverter.java
@@ -206,7 +206,7 @@ public class JSONConverter {
 		} catch (JsonProcessingException e) {
 			log.error(e, e);
 		}
-		if (node == null) {
+		if (node == null || node.isMissingNode()) {
 			String message = "Error reading json:\n" + jsonString;
 			throw new ConversionException(message);
 		}
@@ -245,12 +245,15 @@ public class JSONConverter {
 		try {
 			if (request.getReader() != null && request.getReader().lines() != null) {
 				jsonString = request.getReader().lines().collect(Collectors.joining());
+				if (StringUtils.isBlank(jsonString)) {
+				    jsonString = "{}";
+				}
 				jsonRequest = readJson(jsonString);
 			}
 		} catch (IOException e) {
 			log.error(e, e);
 		}
-		if (jsonRequest == null) {
+		if (jsonRequest == null || jsonRequest.isMissingNode()) {
 			String message = "Error reading input json:\n" + jsonString;
 			throw new ConversionException(message);
 		}

--- a/home/src/main/resources/rdf/dynapiTbox/everytime/vitro-dynamic-api.n3
+++ b/home/src/main/resources/rdf/dynapiTbox/everytime/vitro-dynamic-api.n3
@@ -378,6 +378,13 @@
             rdfs:range xsd:boolean ;
             rdfs:label "is optional"@en-US .
 
+###  https://vivoweb.org/ontology/vitro-dynamic-api#isOptionalParam
+:isOptionalParam rdf:type owl:DatatypeProperty ,
+                     owl:FunctionalProperty ;
+            rdfs:domain :Parameter ;
+            rdfs:range xsd:boolean ;
+            rdfs:label "is optional"@en-US .
+
 
 ###  https://vivoweb.org/ontology/vitro-dynamic-api#languageFiltering
 :languageFiltering rdf:type owl:DatatypeProperty ,


### PR DESCRIPTION
# What does this pull request do?
* Renamed annotation with conflicting name
* Use empty json object if empty string was provided as input, treat missing node as invalid json in json converter.
* Added dynamic api ontology data property

# How to use
* To make parameter optional add default value, set parameter as internal and set parameter as optional.
        dynapi:defaultValue     "label" ;
        dynapi:isInternal       "true"^^xsd:boolean ;
        dynapi:isOptionalParam  "true"^^xsd:boolean ;



# Interested parties
@chenejac @ivanmrsulja @milospp 
