### PR TITLE
Provide server url in DynamicAPIDocumentation

### DIFF
--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/dynapi/DynamicAPIDocumentation.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/dynapi/DynamicAPIDocumentation.java
@@ -2,7 +2,9 @@ package edu.cornell.mannlib.vitro.webapp.dynapi;
 
 import static java.lang.String.format;
 
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -49,6 +51,7 @@ import io.swagger.v3.oas.models.parameters.PathParameter;
 import io.swagger.v3.oas.models.parameters.RequestBody;
 import io.swagger.v3.oas.models.responses.ApiResponse;
 import io.swagger.v3.oas.models.responses.ApiResponses;
+import io.swagger.v3.oas.models.servers.Server;
 import io.swagger.v3.oas.models.tags.Tag;
 
 public class DynamicAPIDocumentation {
@@ -92,6 +95,8 @@ public class DynamicAPIDocumentation {
         log.info("Matched api (" + apiInformation.getVersion() + ") is " + apiInformation.getTitle() + ".");
 
         openApi.setInfo(info(apiInformation));
+        
+        openApi.setServers(getServers(requestPath));
 
         Paths paths = new Paths();
 
@@ -171,6 +176,14 @@ public class DynamicAPIDocumentation {
         return openApi;
     }
 
+    private List<Server> getServers(DocsRequestPath requestPath) {
+        List<Server> servers = new ArrayList<>();
+        Server server = new Server();
+        server.setUrl(requestPath.getServerUrl());
+        servers.add(server);
+        return servers;
+    }
+
     private OpenAPI generateRpcDocs(DocsRequestPath requestPath) {
         OpenAPI openApi = new OpenAPI();
 
@@ -185,6 +198,8 @@ public class DynamicAPIDocumentation {
         apiInformation.setVersion("");
 
         openApi.setInfo(info(apiInformation));
+        
+        openApi.setServers(getServers(requestPath));
 
         if (requestPath.getRPCName() == null) {
 

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/dynapi/request/DocsRequestPath.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/dynapi/request/DocsRequestPath.java
@@ -27,6 +27,8 @@ public class DocsRequestPath {
     private final String resourceName;
 
     private final String rpcName;
+    
+    private final String serverUrl;
 
     private DocsRequestPath(HttpServletRequest request) {
         servletPath = request != null && request.getServletPath() != null
@@ -54,6 +56,26 @@ public class DocsRequestPath {
             resourceName = null;
             rpcName = null;
         }
+        
+        serverUrl = getServerUrl(request);
+    }
+
+    private String getServerUrl(HttpServletRequest request) {
+        String scheme = request.getHeader("x-forwarded-proto");
+        if (scheme == null) {
+            scheme = request.getScheme();    
+        }
+        String serverName = request.getServerName();
+        int port = request.getServerPort();
+        String portPart; 
+        if ((scheme.equals("https") && port == 443) ||
+            (scheme.equals("http") && port == 80)){
+            portPart = "";
+        } else {
+            portPart = ":" + port ;
+        }
+        String servletPart = request.getContextPath();
+        return scheme + "://" + serverName + portPart + servletPart;
     }
 
     public RequestType getType() {
@@ -82,6 +104,10 @@ public class DocsRequestPath {
 
     public String getRPCName() {
         return rpcName;
+    }
+
+    public String getServerUrl() {
+        return serverUrl;
     }
 
     public boolean isValid() {

--- a/api/src/test/java/edu/cornell/mannlib/vitro/webapp/dynapi/RESTDocumentationEndpointIntegrationTest.java
+++ b/api/src/test/java/edu/cornell/mannlib/vitro/webapp/dynapi/RESTDocumentationEndpointIntegrationTest.java
@@ -101,6 +101,10 @@ public class RESTDocumentationEndpointIntegrationTest extends ServletContextInte
         }
 
         when(request.getServletPath()).thenReturn("/api/docs/rest");
+        when(request.getServerName()).thenReturn("127.0.0.1");
+        when(request.getScheme()).thenReturn("http");
+        when(request.getServerPort()).thenReturn(8080);
+        when(request.getContextPath()).thenReturn("/vitro");
         when(request.getPathInfo()).thenReturn(pathInfo);
         when(request.getHeader("Accept")).thenReturn(mimeType);
         when(request.getContentType()).thenReturn(mimeType);

--- a/api/src/test/java/edu/cornell/mannlib/vitro/webapp/dynapi/RPCDocumentationEndpointIntegrationTest.java
+++ b/api/src/test/java/edu/cornell/mannlib/vitro/webapp/dynapi/RPCDocumentationEndpointIntegrationTest.java
@@ -98,6 +98,10 @@ public class RPCDocumentationEndpointIntegrationTest extends ServletContextInteg
         }
 
         when(request.getServletPath()).thenReturn("/api/docs/rpc");
+        when(request.getServerName()).thenReturn("127.0.0.1");
+        when(request.getScheme()).thenReturn("http");
+        when(request.getServerPort()).thenReturn(8080);
+        when(request.getContextPath()).thenReturn("/vitro");
         when(request.getPathInfo()).thenReturn(pathInfo);
         when(request.getHeader("Accept")).thenReturn(mimeType);
         when(request.getContentType()).thenReturn(mimeType);

--- a/api/src/test/java/edu/cornell/mannlib/vitro/webapp/dynapi/matcher/APIResponseMatcher.java
+++ b/api/src/test/java/edu/cornell/mannlib/vitro/webapp/dynapi/matcher/APIResponseMatcher.java
@@ -1,6 +1,7 @@
 package edu.cornell.mannlib.vitro.webapp.dynapi.matcher;
 
 import java.io.File;
+import java.io.FileWriter;
 import java.io.IOException;
 import java.nio.file.Files;
 
@@ -15,6 +16,8 @@ public class APIResponseMatcher implements ArgumentMatcher<String>{
     private Boolean json;
 
     private String path;
+    
+    private boolean update = false;
 
     public APIResponseMatcher(Boolean json, String path) {
         this.json = json;
@@ -26,7 +29,25 @@ public class APIResponseMatcher implements ArgumentMatcher<String>{
         String expectedJson = readJson(path);
         OpenAPI expected = readSpec(true, expectedJson);
         OpenAPI actual = readSpec(json, actualString);
-        return actual.equals(expected);
+        boolean isEquals = actual.equals(expected);
+        if (update && !isEquals) {
+            updateFile(actualString);
+        }
+        return isEquals;
+    }
+
+    private void updateFile(String actualString) {
+        File file;
+        try {
+            file = getJson();
+            try (FileWriter writer = new FileWriter(file);) {
+                writer.write(actualString);
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        } catch (IOException e1) {
+            e1.printStackTrace();
+        }
     }
 
     private OpenAPI readSpec(Boolean json, String spec) {

--- a/api/src/test/resources/dynapi/mock/docs/response/rest/1/all.json
+++ b/api/src/test/resources/dynapi/mock/docs/response/rest/1/all.json
@@ -5,6 +5,9 @@
     "description" : "A test dynamic API",
     "version" : "1"
   },
+  "servers" : [ {
+    "url" : "http://127.0.0.1:8080/vitro"
+  } ],
   "tags" : [ {
     "name" : "test_collection_resource",
     "description" : "REST test_collection_resource (1.0.0)"

--- a/api/src/test/resources/dynapi/mock/docs/response/rest/1/test_collection_resource.json
+++ b/api/src/test/resources/dynapi/mock/docs/response/rest/1/test_collection_resource.json
@@ -5,6 +5,9 @@
     "description" : "A test dynamic API",
     "version" : "1"
   },
+  "servers" : [ {
+    "url" : "http://127.0.0.1:8080/vitro"
+  } ],
   "tags" : [ {
     "name" : "test_collection_resource",
     "description" : "REST test_collection_resource (1.0.0)"

--- a/api/src/test/resources/dynapi/mock/docs/response/rest/1/test_concept_resource.json
+++ b/api/src/test/resources/dynapi/mock/docs/response/rest/1/test_concept_resource.json
@@ -5,6 +5,9 @@
     "description" : "A test dynamic API",
     "version" : "1"
   },
+  "servers" : [ {
+    "url" : "http://127.0.0.1:8080/vitro"
+  } ],
   "tags" : [ {
     "name" : "test_concept_resource",
     "description" : "REST test_concept_resource (1.0.0)"

--- a/api/src/test/resources/dynapi/mock/docs/response/rest/1/test_document_resource.json
+++ b/api/src/test/resources/dynapi/mock/docs/response/rest/1/test_document_resource.json
@@ -5,6 +5,9 @@
     "description" : "A test dynamic API",
     "version" : "1"
   },
+  "servers" : [ {
+    "url" : "http://127.0.0.1:8080/vitro"
+  } ],
   "tags" : [ {
     "name" : "test_document_resource",
     "description" : "REST test_document_resource (1.0.0)"

--- a/api/src/test/resources/dynapi/mock/docs/response/rest/1/test_organization_resource.json
+++ b/api/src/test/resources/dynapi/mock/docs/response/rest/1/test_organization_resource.json
@@ -5,6 +5,9 @@
     "description" : "A test dynamic API",
     "version" : "1"
   },
+  "servers" : [ {
+    "url" : "http://127.0.0.1:8080/vitro"
+  } ],
   "tags" : [ {
     "name" : "test_organization_resource",
     "description" : "REST test_organization_resource (1.0.0)"

--- a/api/src/test/resources/dynapi/mock/docs/response/rest/1/test_person_resource.json
+++ b/api/src/test/resources/dynapi/mock/docs/response/rest/1/test_person_resource.json
@@ -5,6 +5,9 @@
     "description" : "A test dynamic API",
     "version" : "1"
   },
+  "servers" : [ {
+    "url" : "http://127.0.0.1:8080/vitro"
+  } ],
   "tags" : [ {
     "name" : "test_person_resource",
     "description" : "REST test_person_resource (1.1.0)"

--- a/api/src/test/resources/dynapi/mock/docs/response/rest/1/test_process_resource.json
+++ b/api/src/test/resources/dynapi/mock/docs/response/rest/1/test_process_resource.json
@@ -5,6 +5,9 @@
     "description" : "A test dynamic API",
     "version" : "1"
   },
+  "servers" : [ {
+    "url" : "http://127.0.0.1:8080/vitro"
+  } ],
   "tags" : [ {
     "name" : "test_process_resource",
     "description" : "REST test_process_resource (1.0.0)"

--- a/api/src/test/resources/dynapi/mock/docs/response/rest/1/test_relationship_resource.json
+++ b/api/src/test/resources/dynapi/mock/docs/response/rest/1/test_relationship_resource.json
@@ -5,6 +5,9 @@
     "description" : "A test dynamic API",
     "version" : "1"
   },
+  "servers" : [ {
+    "url" : "http://127.0.0.1:8080/vitro"
+  } ],
   "tags" : [ {
     "name" : "test_relationship_resource",
     "description" : "REST test_relationship_resource (1.0.0)"

--- a/api/src/test/resources/dynapi/mock/docs/response/rest/1/test_resource.json
+++ b/api/src/test/resources/dynapi/mock/docs/response/rest/1/test_resource.json
@@ -5,6 +5,9 @@
     "description" : "A test dynamic API",
     "version" : "1"
   },
+  "servers" : [ {
+    "url" : "http://127.0.0.1:8080/vitro"
+  } ],
   "tags" : [ {
     "name" : "test_resource",
     "description" : "REST test_resource (0.1.0)"

--- a/api/src/test/resources/dynapi/mock/docs/response/rest/2/all.json
+++ b/api/src/test/resources/dynapi/mock/docs/response/rest/2/all.json
@@ -5,6 +5,9 @@
     "description" : "A test of the newer dynamic API",
     "version" : "2"
   },
+  "servers" : [ {
+    "url" : "http://127.0.0.1:8080/vitro"
+  } ],
   "tags" : [ {
     "name" : "test_collection_resource",
     "description" : "REST test_collection_resource (1.0.0)"

--- a/api/src/test/resources/dynapi/mock/docs/response/rest/2/test_collection_resource.json
+++ b/api/src/test/resources/dynapi/mock/docs/response/rest/2/test_collection_resource.json
@@ -5,6 +5,9 @@
     "description" : "A test of the newer dynamic API",
     "version" : "2"
   },
+  "servers" : [ {
+    "url" : "http://127.0.0.1:8080/vitro"
+  } ],
   "tags" : [ {
     "name" : "test_collection_resource",
     "description" : "REST test_collection_resource (1.0.0)"

--- a/api/src/test/resources/dynapi/mock/docs/response/rest/2/test_concept_resource.json
+++ b/api/src/test/resources/dynapi/mock/docs/response/rest/2/test_concept_resource.json
@@ -5,6 +5,9 @@
     "description" : "A test of the newer dynamic API",
     "version" : "2"
   },
+  "servers" : [ {
+    "url" : "http://127.0.0.1:8080/vitro"
+  } ],
   "tags" : [ {
     "name" : "test_concept_resource",
     "description" : "REST test_concept_resource (1.0.0)"

--- a/api/src/test/resources/dynapi/mock/docs/response/rest/2/test_document_resource.json
+++ b/api/src/test/resources/dynapi/mock/docs/response/rest/2/test_document_resource.json
@@ -5,6 +5,9 @@
     "description" : "A test of the newer dynamic API",
     "version" : "2"
   },
+  "servers" : [ {
+    "url" : "http://127.0.0.1:8080/vitro"
+  } ],
   "tags" : [ {
     "name" : "test_document_resource",
     "description" : "REST test_document_resource (1.0.0)"

--- a/api/src/test/resources/dynapi/mock/docs/response/rest/2/test_organization_resource.json
+++ b/api/src/test/resources/dynapi/mock/docs/response/rest/2/test_organization_resource.json
@@ -5,6 +5,9 @@
     "description" : "A test of the newer dynamic API",
     "version" : "2"
   },
+  "servers" : [ {
+    "url" : "http://127.0.0.1:8080/vitro"
+  } ],
   "tags" : [ {
     "name" : "test_organization_resource",
     "description" : "REST test_organization_resource (1.0.0)"

--- a/api/src/test/resources/dynapi/mock/docs/response/rest/2/test_person_resource.json
+++ b/api/src/test/resources/dynapi/mock/docs/response/rest/2/test_person_resource.json
@@ -5,6 +5,9 @@
     "description" : "A test of the newer dynamic API",
     "version" : "2"
   },
+  "servers" : [ {
+    "url" : "http://127.0.0.1:8080/vitro"
+  } ],
   "tags" : [ {
     "name" : "test_person_resource",
     "description" : "REST test_person_resource (2.0.0)"

--- a/api/src/test/resources/dynapi/mock/docs/response/rest/2/test_process_resource.json
+++ b/api/src/test/resources/dynapi/mock/docs/response/rest/2/test_process_resource.json
@@ -5,6 +5,9 @@
     "description" : "A test of the newer dynamic API",
     "version" : "2"
   },
+  "servers" : [ {
+    "url" : "http://127.0.0.1:8080/vitro"
+  } ],
   "tags" : [ {
     "name" : "test_process_resource",
     "description" : "REST test_process_resource (1.0.0)"

--- a/api/src/test/resources/dynapi/mock/docs/response/rest/2/test_relationship_resource.json
+++ b/api/src/test/resources/dynapi/mock/docs/response/rest/2/test_relationship_resource.json
@@ -5,6 +5,9 @@
     "description" : "A test of the newer dynamic API",
     "version" : "2"
   },
+  "servers" : [ {
+    "url" : "http://127.0.0.1:8080/vitro"
+  } ],
   "tags" : [ {
     "name" : "test_relationship_resource",
     "description" : "REST test_relationship_resource (1.0.0)"

--- a/api/src/test/resources/dynapi/mock/docs/response/rest/2/test_resource.json
+++ b/api/src/test/resources/dynapi/mock/docs/response/rest/2/test_resource.json
@@ -5,6 +5,9 @@
     "description" : "A test of the newer dynamic API",
     "version" : "2"
   },
+  "servers" : [ {
+    "url" : "http://127.0.0.1:8080/vitro"
+  } ],
   "tags" : [ {
     "name" : "test_resource",
     "description" : "REST test_resource (0.1.0)"

--- a/api/src/test/resources/dynapi/mock/docs/response/rest/4/all.json
+++ b/api/src/test/resources/dynapi/mock/docs/response/rest/4/all.json
@@ -5,6 +5,9 @@
     "description" : "A test of thew improved newer dynamic API",
     "version" : "4"
   },
+  "servers" : [ {
+    "url" : "http://127.0.0.1:8080/vitro"
+  } ],
   "tags" : [ {
     "name" : "test_collection_resource",
     "description" : "REST test_collection_resource (1.0.0)"

--- a/api/src/test/resources/dynapi/mock/docs/response/rest/4/test_collection_resource.json
+++ b/api/src/test/resources/dynapi/mock/docs/response/rest/4/test_collection_resource.json
@@ -5,6 +5,9 @@
     "description" : "A test of thew improved newer dynamic API",
     "version" : "4"
   },
+  "servers" : [ {
+    "url" : "http://127.0.0.1:8080/vitro"
+  } ],
   "tags" : [ {
     "name" : "test_collection_resource",
     "description" : "REST test_collection_resource (1.0.0)"

--- a/api/src/test/resources/dynapi/mock/docs/response/rest/4/test_concept_resource.json
+++ b/api/src/test/resources/dynapi/mock/docs/response/rest/4/test_concept_resource.json
@@ -5,6 +5,9 @@
     "description" : "A test of thew improved newer dynamic API",
     "version" : "4"
   },
+  "servers" : [ {
+    "url" : "http://127.0.0.1:8080/vitro"
+  } ],
   "tags" : [ {
     "name" : "test_concept_resource",
     "description" : "REST test_concept_resource (1.0.0)"

--- a/api/src/test/resources/dynapi/mock/docs/response/rest/4/test_document_resource.json
+++ b/api/src/test/resources/dynapi/mock/docs/response/rest/4/test_document_resource.json
@@ -5,6 +5,9 @@
     "description" : "A test of thew improved newer dynamic API",
     "version" : "4"
   },
+  "servers" : [ {
+    "url" : "http://127.0.0.1:8080/vitro"
+  } ],
   "tags" : [ {
     "name" : "test_document_resource",
     "description" : "REST test_document_resource (1.0.0)"

--- a/api/src/test/resources/dynapi/mock/docs/response/rest/4/test_organization_resource.json
+++ b/api/src/test/resources/dynapi/mock/docs/response/rest/4/test_organization_resource.json
@@ -5,6 +5,9 @@
     "description" : "A test of thew improved newer dynamic API",
     "version" : "4"
   },
+  "servers" : [ {
+    "url" : "http://127.0.0.1:8080/vitro"
+  } ],
   "tags" : [ {
     "name" : "test_organization_resource",
     "description" : "REST test_organization_resource (1.0.0)"

--- a/api/src/test/resources/dynapi/mock/docs/response/rest/4/test_person_resource.json
+++ b/api/src/test/resources/dynapi/mock/docs/response/rest/4/test_person_resource.json
@@ -5,6 +5,9 @@
     "description" : "A test of thew improved newer dynamic API",
     "version" : "4"
   },
+  "servers" : [ {
+    "url" : "http://127.0.0.1:8080/vitro"
+  } ],
   "tags" : [ {
     "name" : "test_person_resource",
     "description" : "REST test_person_resource (4.3.7)"

--- a/api/src/test/resources/dynapi/mock/docs/response/rest/4/test_process_resource.json
+++ b/api/src/test/resources/dynapi/mock/docs/response/rest/4/test_process_resource.json
@@ -5,6 +5,9 @@
     "description" : "A test of thew improved newer dynamic API",
     "version" : "4"
   },
+  "servers" : [ {
+    "url" : "http://127.0.0.1:8080/vitro"
+  } ],
   "tags" : [ {
     "name" : "test_process_resource",
     "description" : "REST test_process_resource (1.0.0)"

--- a/api/src/test/resources/dynapi/mock/docs/response/rest/4/test_relationship_resource.json
+++ b/api/src/test/resources/dynapi/mock/docs/response/rest/4/test_relationship_resource.json
@@ -5,6 +5,9 @@
     "description" : "A test of thew improved newer dynamic API",
     "version" : "4"
   },
+  "servers" : [ {
+    "url" : "http://127.0.0.1:8080/vitro"
+  } ],
   "tags" : [ {
     "name" : "test_relationship_resource",
     "description" : "REST test_relationship_resource (1.0.0)"

--- a/api/src/test/resources/dynapi/mock/docs/response/rest/4/test_resource.json
+++ b/api/src/test/resources/dynapi/mock/docs/response/rest/4/test_resource.json
@@ -5,6 +5,9 @@
     "description" : "A test of thew improved newer dynamic API",
     "version" : "4"
   },
+  "servers" : [ {
+    "url" : "http://127.0.0.1:8080/vitro"
+  } ],
   "tags" : [ {
     "name" : "test_resource",
     "description" : "REST test_resource (0.1.0)"

--- a/api/src/test/resources/dynapi/mock/docs/response/rpc/all.json
+++ b/api/src/test/resources/dynapi/mock/docs/response/rpc/all.json
@@ -5,6 +5,9 @@
     "description" : "An RPC API.",
     "version" : ""
   },
+  "servers" : [ {
+    "url" : "http://127.0.0.1:8080/vitro"
+  } ],
   "tags" : [ {
     "name" : "All RPC",
     "description" : "All available custom actions"

--- a/api/src/test/resources/dynapi/mock/docs/response/rpc/test_action.json
+++ b/api/src/test/resources/dynapi/mock/docs/response/rpc/test_action.json
@@ -5,6 +5,9 @@
     "description" : "An RPC API.",
     "version" : ""
   },
+  "servers" : [ {
+    "url" : "http://127.0.0.1:8080/vitro"
+  } ],
   "tags" : [ {
     "name" : "test_action",
     "description" : "RPC test_action"

--- a/api/src/test/resources/dynapi/mock/docs/response/rpc/test_collection.json
+++ b/api/src/test/resources/dynapi/mock/docs/response/rpc/test_collection.json
@@ -5,6 +5,9 @@
     "description" : "An RPC API.",
     "version" : ""
   },
+  "servers" : [ {
+    "url" : "http://127.0.0.1:8080/vitro"
+  } ],
   "tags" : [ {
     "name" : "test_collection",
     "description" : "RPC test_collection"

--- a/api/src/test/resources/dynapi/mock/docs/response/rpc/test_concept.json
+++ b/api/src/test/resources/dynapi/mock/docs/response/rpc/test_concept.json
@@ -5,6 +5,9 @@
     "description" : "An RPC API.",
     "version" : ""
   },
+  "servers" : [ {
+    "url" : "http://127.0.0.1:8080/vitro"
+  } ],
   "tags" : [ {
     "name" : "test_concept",
     "description" : "RPC test_concept"

--- a/api/src/test/resources/dynapi/mock/docs/response/rpc/test_document.json
+++ b/api/src/test/resources/dynapi/mock/docs/response/rpc/test_document.json
@@ -5,6 +5,9 @@
     "description" : "An RPC API.",
     "version" : ""
   },
+  "servers" : [ {
+    "url" : "http://127.0.0.1:8080/vitro"
+  } ],
   "tags" : [ {
     "name" : "test_document",
     "description" : "RPC test_document"

--- a/api/src/test/resources/dynapi/mock/docs/response/rpc/test_organization.json
+++ b/api/src/test/resources/dynapi/mock/docs/response/rpc/test_organization.json
@@ -5,6 +5,9 @@
     "description" : "An RPC API.",
     "version" : ""
   },
+  "servers" : [ {
+    "url" : "http://127.0.0.1:8080/vitro"
+  } ],
   "tags" : [ {
     "name" : "test_organization",
     "description" : "RPC test_organization"

--- a/api/src/test/resources/dynapi/mock/docs/response/rpc/test_person.json
+++ b/api/src/test/resources/dynapi/mock/docs/response/rpc/test_person.json
@@ -5,6 +5,9 @@
     "description" : "An RPC API.",
     "version" : ""
   },
+  "servers" : [ {
+    "url" : "http://127.0.0.1:8080/vitro"
+  } ],
   "tags" : [ {
     "name" : "test_person",
     "description" : "RPC test_person"

--- a/api/src/test/resources/dynapi/mock/docs/response/rpc/test_process.json
+++ b/api/src/test/resources/dynapi/mock/docs/response/rpc/test_process.json
@@ -5,6 +5,9 @@
     "description" : "An RPC API.",
     "version" : ""
   },
+  "servers" : [ {
+    "url" : "http://127.0.0.1:8080/vitro"
+  } ],
   "tags" : [ {
     "name" : "test_process",
     "description" : "RPC test_process"

--- a/api/src/test/resources/dynapi/mock/docs/response/rpc/test_relationship.json
+++ b/api/src/test/resources/dynapi/mock/docs/response/rpc/test_relationship.json
@@ -5,6 +5,9 @@
     "description" : "An RPC API.",
     "version" : ""
   },
+  "servers" : [ {
+    "url" : "http://127.0.0.1:8080/vitro"
+  } ],
   "tags" : [ {
     "name" : "test_relationship",
     "description" : "RPC test_relationship"


### PR DESCRIPTION
# What does this pull request do?
Adds server url to Dynamic API documentation to fix swagger interface urls.

# What's new?
Added server url to open API. 
Added boolean variable in APIResponseMatcher to simplify updates of json responses.

# How should this be tested?
* Go to /dynapi-rpc-docs and /dynapi-rest-docs pages and try using endpoints via web interface

# Links 
[API Server and Base URL](https://swagger.io/docs/specification/api-host-and-base-path/) 
# Interested parties
@chenejac @ivanmrsulja @milospp @wwelling 
