### PR TITLE
Autocomplete object property form fixes

### DIFF
--- a/webapp/src/main/webapp/templates/freemarker/edit/forms/autoCompleteObjectPropForm.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/edit/forms/autoCompleteObjectPropForm.ftl
@@ -119,7 +119,7 @@ Also multiple types parameter set to true only if more than one type returned-->
         acSelectOnly: 'true',
         sparqlForAcFilter: '${sparqlForAcFilter?js_string}',
         sparqlQueryUrl: '${sparqlQueryUrl?js_string}',
-        acFilterForIndividuals: ${acFilterForIndividuals?js_string},
+        acFilterForIndividuals: ${acFilterForIndividuals},
         defaultTypeName: '${propertyNameForDisplay?js_string}', // used in repair mode to generate button text
         baseHref: '${urls.base}/individual?uri='
     };

--- a/webapp/src/main/webapp/templates/freemarker/edit/forms/css/autocomplete.css
+++ b/webapp/src/main/webapp/templates/freemarker/edit/forms/css/autocomplete.css
@@ -1,0 +1,24 @@
+/* $This file is distributed under the terms of the license in LICENSE$ */
+
+/* Styles for autocomplete and autocomplete selections using jQuery UI. This is separated out so that forms
+that don't load customFormWithAutocomplete.css still have access to these styles. */
+
+.acSelection {
+    display: none;
+    margin-top: 1em;
+}
+.acSelectionInfo {
+    background-color: #d9d9d9;
+    padding: .2em .35em;
+}
+ul.ui-autocomplete {
+    font-size: .95em;
+}
+li.ui-menu-item a.ui-corner-all {
+    text-align: left;
+    padding-left: .25em;
+}
+.acSelectorWithHelpText{
+    font-style: italic;
+    color: #555;
+}


### PR DESCRIPTION
[VIVO Issue](https://github.com/vivo-project/VIVO/issues/3894)

# What does this pull request do?
Reverts escaping for autocomplete object property form type as the value provided already with quotes and brackets and escaping breaks js.
Also added autocomplete.css to Vitro project to fix broken request for it in Vitro.

# How should this be tested?
A description of what steps someone could take to:
* Reproduce the problem you are fixing (if applicable)
* Test that the pull request does what is intended.



# Interested parties
@chenejac 
