### PR TITLE
Custom REST actions fixes to support specified http methods and provide correct documentation

### DIFF
--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/dynapi/DynamicAPIDocumentation.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/dynapi/DynamicAPIDocumentation.java
@@ -376,7 +376,24 @@ public class DynamicAPIDocumentation {
        
         if (targetRPC != null) {
             try (Procedure action = actionPool.get(targetRPC)) {
-                pathItem.setPut(customRESTActionPutOperation(action, tag));
+                String httpMethodName = customRESTAction.getHttpMethodName();
+                    switch (httpMethodName) {
+                    case "POST":
+                        pathItem.setPost(customRESTActionPostOperation(action, tag));
+                        break;
+                    case "GET":
+                        pathItem.setGet(customRESTActionGetOperation(action, tag));
+                        break;
+                    case "DELETE":
+                        pathItem.setDelete(customRESTActionDeleteOperation(action, tag));
+                        break;
+                    case "PUT":
+                        pathItem.setPut(customRESTActionPutOperation(action, tag));
+                        break;
+                    case "PATCH":
+                        pathItem.setPatch(customRESTActionPatchOperation(action, tag));
+                        break;
+                    }
             }
         }
 

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/dynapi/RESTEndpoint.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/dynapi/RESTEndpoint.java
@@ -96,14 +96,9 @@ public class RESTEndpoint extends Endpoint {
         String procedureUri = null;
 
         if (requestPath.isCustomRestAction()) {
-            
-            if (!"PUT".equals(method)) {
-                resourceAPI.removeClient();
-                OperationResult.methodNotAllowed().prepareResponse(response); return;
-            }
             String actionName = requestPath.getCustomRestActionName();
             try {
-                procedureUri = resourceAPI.getProcedureUriByActionName(actionName);
+                procedureUri = resourceAPI.getProcedureUriByActionName(method, actionName);
             } catch (UnsupportedOperationException e) {
                 log.error(format("Custom REST action %s not implemented for resource %s", actionName, key), e);
                 OperationResult.methodNotAllowed().prepareResponse(response);

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/dynapi/RESTEndpoint.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/dynapi/RESTEndpoint.java
@@ -100,7 +100,7 @@ public class RESTEndpoint extends Endpoint {
             try {
                 procedureUri = resourceAPI.getProcedureUriByActionName(method, actionName);
             } catch (UnsupportedOperationException e) {
-                log.error(format("Custom REST action %s not implemented for resource %s", actionName, key), e);
+                log.error(format("Custom REST action %s not implemented for resource %s and method %s", actionName, key, method), e);
                 OperationResult.methodNotAllowed().prepareResponse(response);
                 return;
             } finally {

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/dynapi/components/CustomRESTAction.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/dynapi/components/CustomRESTAction.java
@@ -6,6 +6,7 @@ public class CustomRESTAction implements Removable {
 
     private String name;
     private String targetProcedureUri;
+    private String httpMethodName = "PUT";
 
     @Override
     public void dereference() {
@@ -20,6 +21,11 @@ public class CustomRESTAction implements Removable {
     public void setName(String name) {
         this.name = name;
     }
+    
+    @Property(uri = "https://vivoweb.org/ontology/vitro-dynamic-api#hasDefaultMethod")
+    public void setHttpMethod(HTTPMethod httpMethod) {
+        this.httpMethodName = httpMethod.getName();
+    }
 
     public String getTargetProcedureUri() {
         return targetProcedureUri;
@@ -28,6 +34,10 @@ public class CustomRESTAction implements Removable {
     @Property(uri = "https://vivoweb.org/ontology/vitro-dynamic-api#forwardsTo", minOccurs = 1, maxOccurs = 1, asString = true)
     public void setTargetProcedureUri(String procedureUri) {
         this.targetProcedureUri = procedureUri;
+    }
+    
+    public String getHttpMethodName() {
+        return httpMethodName;
     }
 
 }

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/dynapi/components/ResourceAPI.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/dynapi/components/ResourceAPI.java
@@ -150,18 +150,18 @@ public class ResourceAPI extends AbstractPoolComponent implements Versionable<Re
         }
     }
 
-    public String getProcedureUriByActionName(String name) {
-        String uri = getProcedureUriByCustomActionName(name);
+    public String getProcedureUriByActionName(String method, String actionName) {
+        String uri = getProcedureUriByCustomActionName(method, actionName);
         if (uri != null) {
             return uri;
         }
         throw new UnsupportedOperationException("Unsupported custom action");
     }
 
-    private String getProcedureUriByCustomActionName(String name) {
+    private String getProcedureUriByCustomActionName(String method, String name) {
         String uri = null;
         for (CustomRESTAction customRestAction : customRESTActions) {
-            if (customRestAction.getName().equals(name)) {
+            if (customRestAction.getName().equals(name) && method.equals(customRestAction.getHttpMethodName())) {
                 uri = customRestAction.getTargetProcedureUri();
                 break;
             }

--- a/api/src/test/java/edu/cornell/mannlib/vitro/webapp/dynapi/LoggingControl.java
+++ b/api/src/test/java/edu/cornell/mannlib/vitro/webapp/dynapi/LoggingControl.java
@@ -6,7 +6,6 @@ import java.util.Map;
 import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
 
-import edu.cornell.mannlib.vitro.webapp.dynapi.components.ResourceAPI;
 import edu.cornell.mannlib.vitro.webapp.utils.configuration.ConfigurationBeanLoader;
 
 public class LoggingControl {

--- a/api/src/test/java/edu/cornell/mannlib/vitro/webapp/dynapi/LoggingControl.java
+++ b/api/src/test/java/edu/cornell/mannlib/vitro/webapp/dynapi/LoggingControl.java
@@ -6,6 +6,7 @@ import java.util.Map;
 import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
 
+import edu.cornell.mannlib.vitro.webapp.dynapi.components.ResourceAPI;
 import edu.cornell.mannlib.vitro.webapp.utils.configuration.ConfigurationBeanLoader;
 
 public class LoggingControl {
@@ -50,6 +51,7 @@ public class LoggingControl {
     }
 
     public static void offLogs() {
+        offLog(RESTEndpoint.class);
         offLog(ResourceAPIPool.class);
         offLog(RPCPool.class);
         offLog(ProcedurePool.class);
@@ -57,6 +59,7 @@ public class LoggingControl {
     }
 
     public static void restoreLogs() {
+        restoreLog(RESTEndpoint.class);
         restoreLog(ResourceAPIPool.class);
         restoreLog(RPCPool.class);
         restoreLog(ProcedurePool.class);

--- a/api/src/test/java/edu/cornell/mannlib/vitro/webapp/dynapi/RESTEndpointTest.java
+++ b/api/src/test/java/edu/cornell/mannlib/vitro/webapp/dynapi/RESTEndpointTest.java
@@ -167,13 +167,13 @@ public class RESTEndpointTest {
 
         String procedureUri = "resource_uri";
         when(resourceAPI.getProcedureUri(testMethod, false)).thenReturn(procedureUri);
-        when(resourceAPI.getProcedureUriByActionName(testActionName)).thenReturn(procedureUri);
+        when(resourceAPI.getProcedureUriByActionName(testMethod, testActionName)).thenReturn(procedureUri);
         doNothing().when(resourceAPI).removeClient();
 
         run(testMethod);
 
         verify(resourceAPI, times(testExpectedCounts[0])).getProcedureUri(any(), anyBoolean());
-        verify(resourceAPI, times(testExpectedCounts[1])).getProcedureUriByActionName(any());
+        verify(resourceAPI, times(testExpectedCounts[1])).getProcedureUriByActionName(testMethod, testActionName);
         verify(resourceAPI, times(testExpectedCounts[2])).removeClient();
         verify(procedure, times(testExpectedCounts[3])).run(any());
         verify(procedure, times(testExpectedCounts[4])).removeClient();
@@ -218,8 +218,8 @@ public class RESTEndpointTest {
             { "PATCH",  PATH_INFO,                actionName, new int[] { 0, 0, 0, 0, 0, 1 }, SC_METHOD_NOT_ALLOWED, "Cannot patch on resource collection" },
             { "DELETE", PATH_INFO,                actionName, new int[] { 0, 0, 0, 0, 0, 1 }, SC_METHOD_NOT_ALLOWED, "Cannot delete on resource collection" },
 
-            { "POST",   customRestActionPathInfo, actionName, new int[] { 0, 0, 1, 0, 0, 1 }, SC_METHOD_NOT_ALLOWED, "Resource found with supported method" },
-            { "GET",    customRestActionPathInfo, actionName, new int[] { 0, 0, 1, 0, 0, 1 }, SC_METHOD_NOT_ALLOWED, "Resource found with unsupported method" },
+            { "POST",   customRestActionPathInfo, actionName, new int[] { 0, 1, 1, 1, 1, 1 }, SC_METHOD_NOT_ALLOWED, "Resource found with supported method" },
+            { "GET",    customRestActionPathInfo, actionName, new int[] { 0, 1, 1, 1, 1, 1 }, SC_METHOD_NOT_ALLOWED, "Resource found with unsupported method" },
             { "PUT",    customRestActionPathInfo, actionName, new int[] { 0, 0, 0, 0, 0, 1 }, SC_METHOD_NOT_ALLOWED, "Method unsupported by custom REST action" },
             { "PATCH",  customRestActionPathInfo, actionName, new int[] { 0, 0, 0, 0, 0, 1 }, SC_METHOD_NOT_ALLOWED, "Method unsupported by custom REST action" },
             { "DELETE", customRestActionPathInfo, actionName, new int[] { 0, 0, 0, 0, 0, 1 }, SC_METHOD_NOT_ALLOWED, "Method unsupported by custom REST action" }

--- a/api/src/test/java/edu/cornell/mannlib/vitro/webapp/dynapi/RESTEndpointTest.java
+++ b/api/src/test/java/edu/cornell/mannlib/vitro/webapp/dynapi/RESTEndpointTest.java
@@ -219,7 +219,7 @@ public class RESTEndpointTest {
             { "DELETE", PATH_INFO,                actionName, new int[] { 0, 0, 0, 0, 0, 1 }, SC_METHOD_NOT_ALLOWED, "Cannot delete on resource collection" },
 
             { "POST",   customRestActionPathInfo, actionName, new int[] { 0, 1, 1, 1, 1, 1 }, SC_METHOD_NOT_ALLOWED, "Resource found with supported method" },
-            { "GET",    customRestActionPathInfo, actionName, new int[] { 0, 1, 1, 1, 1, 1 }, SC_METHOD_NOT_ALLOWED, "Resource found with unsupported method" },
+            { "GET",    customRestActionPathInfo, actionName, new int[] { 0, 1, 1, 1, 1, 1 }, SC_METHOD_NOT_ALLOWED, "Resource found with supported method" },
             { "PUT",    customRestActionPathInfo, actionName, new int[] { 0, 0, 0, 0, 0, 1 }, SC_METHOD_NOT_ALLOWED, "Method unsupported by custom REST action" },
             { "PATCH",  customRestActionPathInfo, actionName, new int[] { 0, 0, 0, 0, 0, 1 }, SC_METHOD_NOT_ALLOWED, "Method unsupported by custom REST action" },
             { "DELETE", customRestActionPathInfo, actionName, new int[] { 0, 0, 0, 0, 0, 1 }, SC_METHOD_NOT_ALLOWED, "Method unsupported by custom REST action" }


### PR DESCRIPTION
# What does this pull request do?
Fixes Custom REST actions support. 
Implemented support of http methods in custom rest actions.

# How should this be tested?
Create a custom REST action with specific HTTP method. 
Verify that rest documentation is correct, try access endpoint in swagger interface

# Interested parties
@chenejac 
