### PR TITLE
Fix broken links in the README.md file

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,6 @@ With Vitro, you can:
 * Search your data with Apache Solr
 
 Vitro was originally developed at Cornell University, and is used as the core of the popular
-research and scholarship portal, [VIVO](https://lyrasis.org/vivo/).
+research and scholarship portal, [VIVO](https://vivo.lyrasis.org/).
 
-For more information, contact the [VIVO community](https://lyrasis.org/vivo/resources/contact/).
-
-
+For more information, contact the [VIVO community](https://vivo.lyrasis.org/contact/).


### PR DESCRIPTION
**[VIVO GitHub issue](https://github.com/vivo-project/VIVO/issues)**: [3905
](https://github.com/vivo-project/VIVO/issues/3905)

# What does this pull request do?
Fix broken links in the Vitro r readme file. 

# How should this be tested?

- Open https://github.com/vivo-project/Vitro/blob/main/README.md
- Click on the "VIVO" link and "VIVO community" link (at the bottom of README.md) file
- Pages should be opened

