### PR TITLE
Feature/setting locale url

### DIFF
--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/i18n/selection/SelectedLocale.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/i18n/selection/SelectedLocale.java
@@ -4,6 +4,7 @@ package edu.cornell.mannlib.vitro.webapp.i18n.selection;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.IllformedLocaleException;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
@@ -67,6 +68,20 @@ public abstract class SelectedLocale {
 		Optional<Locale> forcedLocale = getForcedLocale(ctxInfo);
 		if (forcedLocale.isPresent()) {
 			return forcedLocale.get();
+		}
+
+		String languageTag = req.getParameter("lang");
+		if (languageTag != null) {
+			try {
+				Locale locale = Locale.forLanguageTag(languageTag.replace('_', '-'));
+				setSelectedLocale(req, locale);
+				log.debug("Found and set locale from 'lang' parameter: "
+					+ languageTag);
+				return locale;
+			} catch (IllformedLocaleException e) {
+				log.debug("Tried to parse invalid language tag: "
+					+ languageTag);
+			}
 		}
 
 		Object sessionInfo = session.getAttribute(ATTRIBUTE_NAME);

--- a/webapp/src/main/webapp/templates/freemarker/page/partials/languageSelector.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/page/partials/languageSelector.ftl
@@ -28,6 +28,71 @@
 var i18nStringsLangMenu = {
     selectLanguage: "${i18n().select_a_language?js_string}"
 };
+
+function getSelectedLanguageHref() {
+    var languageMenu = document.getElementById("language-menu");
+    if (languageMenu) {
+        var listItems = languageMenu.querySelectorAll("li");
+
+        for (var i = 0; i < listItems.length; i++) {
+            if (listItems[i].getAttribute("status") === "selected") {
+                var selectedLanguageAnchor = listItems[i].querySelector("a");
+                if (selectedLanguageAnchor) {
+                    var selectedLanguageHref = selectedLanguageAnchor.getAttribute("href");
+                    return selectedLanguageHref;
+                }
+            }
+        }
+    }
+    return "#";
+}
+
+function parseLanguageFromPageURL() {
+    var currentURL = window.location.href;
+    var langParamRegex = /lang=([^&]+)/;
+    var match = currentURL.match(langParamRegex);
+
+    if (match) {
+        var langValue = match[1];
+        console.log(langValue);
+
+        if(getSelectedLanguageHref().endsWith(langValue)) {
+            return;
+        }
+
+        var languageLinks = document.querySelectorAll('a[href*="selectLocale?selection=' + langValue + '"]');
+        console.log(languageLinks);
+        if (languageLinks.length > 0) {
+            languageLinks[0].click();
+        }
+    }
+}
+
+function updateLangParamIfExists(langValue) {
+    var currentURL = window.location.href;
+    var langParamRegex = /lang=([^&]+)/;
+    var match = currentURL.match(langParamRegex);
+
+    if (match) {
+        var updatedURL = currentURL.replace(langParamRegex, 'lang=' + langValue);
+        window.history.replaceState({}, document.title, updatedURL);
+    }
+}
+
+function handleLanguageLinkClick(event, langValue) {
+    updateLangParamIfExists(langValue);
+}
+
+window.onload = parseLanguageFromPageURL;
+
+var languageLinks = document.querySelectorAll('a[href*="selectLocale?selection="]');
+languageLinks.forEach(function(link) {
+    var langValue = link.getAttribute('href').split('selectLocale?selection=')[1];
+    link.addEventListener('click', function(event) {
+        handleLanguageLinkClick(event, langValue);
+    });
+});
+
 </script>
 
 ${scripts.add('<script type="text/javascript" src="${urls.base}/js/languageMenuUtils.js"></script>')}

--- a/webapp/src/main/webapp/templates/freemarker/page/partials/languageSelector.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/page/partials/languageSelector.ftl
@@ -29,46 +29,11 @@ var i18nStringsLangMenu = {
     selectLanguage: "${i18n().select_a_language?js_string}"
 };
 
-function getSelectedLanguageHref() {
-    var languageMenu = document.getElementById("language-menu");
-    if (languageMenu) {
-        var listItems = languageMenu.querySelectorAll("li");
-
-        for (var i = 0; i < listItems.length; i++) {
-            if (listItems[i].getAttribute("status") === "selected") {
-                var selectedLanguageAnchor = listItems[i].querySelector("a");
-                if (selectedLanguageAnchor) {
-                    var selectedLanguageHref = selectedLanguageAnchor.getAttribute("href");
-                    return selectedLanguageHref;
-                }
-            }
-        }
-    }
-    return "#";
-}
-
 var langParamRegex = /lang=([^&]+)/;
 
 function checkForLangParameter() {
     let currentURL = window.location.href;
     return currentURL.match(langParamRegex);
-}
-
-function parseLanguageFromPageURL() {
-    let match = checkForLangParameter();
-
-    if (match) {
-        let langValue = match[1];
-
-        if(getSelectedLanguageHref().endsWith(langValue)) {
-            return;
-        }
-
-        let languageLinks = document.querySelectorAll('a[href*="selectLocale?selection=' + langValue + '"]');
-        if (languageLinks.length > 0) {
-            languageLinks[0].click();
-        }
-    }
 }
 
 function updateLangParamIfExists(langValue) {
@@ -84,8 +49,6 @@ function updateLangParamIfExists(langValue) {
 function handleLanguageLinkClick(event, langValue) {
     updateLangParamIfExists(langValue);
 }
-
-window.onload = parseLanguageFromPageURL;
 
 var languageLinks = document.querySelectorAll('a[href*="selectLocale?selection="]');
 languageLinks.forEach(function(link) {

--- a/webapp/src/main/webapp/templates/freemarker/page/partials/languageSelector.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/page/partials/languageSelector.ftl
@@ -85,7 +85,7 @@ window.onload = parseLanguageFromPageURL;
 
 var languageLinks = document.querySelectorAll('a[href*="selectLocale?selection="]');
 languageLinks.forEach(function(link) {
-    var langValue = link.getAttribute('href').split('selectLocale?selection=')[1];
+    var langValue = link.getAttribute('href').split('selectLocale?selection=')[1].split('&')[0];
     link.addEventListener('click', function(event) {
         handleLanguageLinkClick(event, langValue);
     });

--- a/webapp/src/main/webapp/templates/freemarker/page/partials/languageSelector.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/page/partials/languageSelector.ftl
@@ -47,19 +47,24 @@ function getSelectedLanguageHref() {
     return "#";
 }
 
+var langParamRegex = /lang=([^&]+)/;
+
+function checkForLangParameter() {
+    let currentURL = window.location.href;
+    return currentURL.match(langParamRegex);
+}
+
 function parseLanguageFromPageURL() {
-    var currentURL = window.location.href;
-    var langParamRegex = /lang=([^&]+)/;
-    var match = currentURL.match(langParamRegex);
+    let match = checkForLangParameter();
 
     if (match) {
-        var langValue = match[1];
+        let langValue = match[1];
 
         if(getSelectedLanguageHref().endsWith(langValue)) {
             return;
         }
 
-        var languageLinks = document.querySelectorAll('a[href*="selectLocale?selection=' + langValue + '"]');
+        let languageLinks = document.querySelectorAll('a[href*="selectLocale?selection=' + langValue + '"]');
         if (languageLinks.length > 0) {
             languageLinks[0].click();
         }
@@ -67,12 +72,11 @@ function parseLanguageFromPageURL() {
 }
 
 function updateLangParamIfExists(langValue) {
-    var currentURL = window.location.href;
-    var langParamRegex = /lang=([^&]+)/;
-    var match = currentURL.match(langParamRegex);
+    let match = checkForLangParameter();
 
     if (match) {
-        var updatedURL = currentURL.replace(langParamRegex, 'lang=' + langValue);
+        let currentURL = window.location.href;
+        let updatedURL = currentURL.replace(langParamRegex, 'lang=' + langValue);
         window.history.replaceState({}, document.title, updatedURL);
     }
 }

--- a/webapp/src/main/webapp/templates/freemarker/page/partials/languageSelector.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/page/partials/languageSelector.ftl
@@ -54,14 +54,12 @@ function parseLanguageFromPageURL() {
 
     if (match) {
         var langValue = match[1];
-        console.log(langValue);
 
         if(getSelectedLanguageHref().endsWith(langValue)) {
             return;
         }
 
         var languageLinks = document.querySelectorAll('a[href*="selectLocale?selection=' + langValue + '"]');
-        console.log(languageLinks);
         if (languageLinks.length > 0) {
             languageLinks[0].click();
         }


### PR DESCRIPTION
Solves this [VIVO GitHub issue](https://github.com/vivo-project/VIVO/issues/3906)

# What does this pull request do?
The link http://localhost/vivo/individual?uri=http://localhost/vivo/individual/pers_53a426a6-edc4-4f89-9bf6-c249fcf3b320&lang=pt_BR should open profile page for person with uri http://localhost/vivo/individual/pers_53a426a6-edc4-4f89-9bf6-c249fcf3b320 in the Portuguese language (IF PORTUGUESE LANGUAGE IS ADDED FIRST!).

# What's new?
Changed `languageSelector.ftl` so it parses URL as soon as the page is loaded to check if locale is specified. If it is, then the language list is checked to verify existance of such locale and, if successfull, updates the locale. Every successive change of locale will update the URL locale.

# How should this be tested?
Add some languages to VIVO first. Try to set any locale from URl (not just Potuguese :slightly_smiling_face:). Try to then manually change locale on that page. Everything should work as expected.

# Interested parties
@chenejac 
