### PR TITLE
fix: concurrent modification of rdfServiceJena getGraphURIs

### DIFF
--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/rdfservice/impl/jena/RDFServiceJena.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/rdfservice/impl/jena/RDFServiceJena.java
@@ -7,40 +7,11 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
-
 import java.util.Set;
-
-import org.apache.commons.io.IOUtils;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
-
-import org.apache.jena.query.QuerySolutionMap;
-import org.apache.jena.query.ReadWrite;
-import org.apache.jena.query.Syntax;
-import org.apache.jena.rdf.model.Literal;
-import org.apache.jena.riot.RDFDataMgr;
-import org.apache.log4j.lf5.util.StreamUtils;
-
-import org.apache.jena.graph.Triple;
-import org.apache.jena.query.Dataset;
-import org.apache.jena.query.Query;
-import org.apache.jena.query.QueryExecution;
-import org.apache.jena.query.QueryExecutionFactory;
-import org.apache.jena.query.QueryFactory;
-import org.apache.jena.query.QuerySolution;
-import org.apache.jena.query.ResultSet;
-import org.apache.jena.query.ResultSetFormatter;
-import org.apache.jena.rdf.model.Model;
-import org.apache.jena.rdf.model.ModelFactory;
-import org.apache.jena.rdf.model.RDFNode;
-import org.apache.jena.sdb.SDB;
-import org.apache.jena.shared.Lock;
-import org.apache.jena.sparql.core.Quad;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 import edu.cornell.mannlib.vitro.webapp.controller.VitroRequest;
 import edu.cornell.mannlib.vitro.webapp.dao.jena.DatasetWrapper;
@@ -57,6 +28,30 @@ import edu.cornell.mannlib.vitro.webapp.utils.logging.ToString;
 import edu.cornell.mannlib.vitro.webapp.utils.sparql.ResultSetIterators.ResultSetQuadsIterator;
 import edu.cornell.mannlib.vitro.webapp.utils.sparql.ResultSetIterators.ResultSetTriplesIterator;
 import edu.cornell.mannlib.vitro.webapp.utils.threads.VitroBackgroundThread;
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.jena.graph.Triple;
+import org.apache.jena.query.Dataset;
+import org.apache.jena.query.Query;
+import org.apache.jena.query.QueryExecution;
+import org.apache.jena.query.QueryExecutionFactory;
+import org.apache.jena.query.QueryFactory;
+import org.apache.jena.query.QuerySolution;
+import org.apache.jena.query.QuerySolutionMap;
+import org.apache.jena.query.ReadWrite;
+import org.apache.jena.query.ResultSet;
+import org.apache.jena.query.ResultSetFormatter;
+import org.apache.jena.query.Syntax;
+import org.apache.jena.rdf.model.Literal;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.ModelFactory;
+import org.apache.jena.rdf.model.RDFNode;
+import org.apache.jena.riot.RDFDataMgr;
+import org.apache.jena.sdb.SDB;
+import org.apache.jena.shared.Lock;
+import org.apache.jena.sparql.core.Quad;
+import org.apache.log4j.lf5.util.StreamUtils;
 
 public abstract class RDFServiceJena extends RDFServiceImpl implements RDFService {
 
@@ -66,7 +61,7 @@ public abstract class RDFServiceJena extends RDFServiceImpl implements RDFServic
 
     protected volatile boolean rebuildGraphURICache = true;
     protected volatile boolean isRebuildGraphURICacheRunning = false;
-    protected final List<String> graphURIs = Collections.synchronizedList(new ArrayList<>());
+    protected final List<String> graphURIs = new CopyOnWriteArrayList<String>(); 
 
     @Override
 	public abstract boolean changeSetUpdate(ChangeSet changeSet) throws RDFServiceException;

--- a/api/src/test/java/edu/cornell/mannlib/vitro/webapp/rdfservice/impl/jena/RDFServiceJenaTest.java
+++ b/api/src/test/java/edu/cornell/mannlib/vitro/webapp/rdfservice/impl/jena/RDFServiceJenaTest.java
@@ -1,0 +1,51 @@
+package edu.cornell.mannlib.vitro.webapp.rdfservice.impl.jena;
+
+import java.util.Iterator;
+import java.util.List;
+
+import edu.cornell.mannlib.vitro.webapp.rdfservice.RDFServiceException;
+import edu.cornell.mannlib.vitro.webapp.rdfservice.adapters.VitroModelFactory;
+import edu.cornell.mannlib.vitro.webapp.rdfservice.impl.jena.model.RDFServiceModel;
+import org.apache.jena.query.Dataset;
+import org.apache.jena.query.DatasetFactory;
+import org.apache.jena.rdf.model.Model;
+import org.junit.Test;
+
+public class RDFServiceJenaTest {
+
+    @Test
+    public void getConcurrentGraphUrisTest() throws RDFServiceException, InterruptedException {
+        Dataset testDataSet = DatasetFactory.createGeneral();
+        Model m1 = VitroModelFactory.createModel();
+        testDataSet.addNamedModel("test:init1", m1);
+        Model m2 = VitroModelFactory.createModel();
+        testDataSet.addNamedModel("test:init2", m2);
+        RDFServiceJena rdfService = new RDFServiceModel(testDataSet);
+        rdfService.getGraphURIs();
+        long i = 0;
+        while (rdfService.rebuildGraphURICache) {
+            Thread.sleep(10);
+            i += 10;
+            if (i > 10000) {
+                throw new RuntimeException();
+            }
+        }
+        List<String> uris = rdfService.getGraphURIs();
+        for (Iterator<String> iterator = uris.iterator(); iterator.hasNext();) {
+            Model m = VitroModelFactory.createModel();
+            testDataSet.addNamedModel("test" + i, m);
+            rdfService.rebuildGraphURICache = true;
+            rdfService.getGraphURIs();
+            while (rdfService.rebuildGraphURICache) {
+                Thread.sleep(10);
+                i += 10;
+                if (i > 20000) {
+                    throw new RuntimeException();
+                }
+            }
+            iterator.next();
+            i++;
+        }
+    }
+
+}


### PR DESCRIPTION
**[VIVO GitHub issue](https://github.com/vivo-project/VIVO/issues/3911)**

# What does this pull request do?
Replaced graph uri list with thread safe implementation.
Added test.

# How should this be tested?
Run test with old implementation and with new implementation.
# Interested parties
@VIVO-project/vivo-committers
