### PR TITLE
Avoid lock on graph uri update in RdfServiceSparql

### DIFF
--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/rdfservice/filter/SameAsFilteringRDFServiceFactory.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/rdfservice/filter/SameAsFilteringRDFServiceFactory.java
@@ -316,6 +316,10 @@ public class SameAsFilteringRDFServiceFactory implements RDFServiceFactory {
             s.close();
         }
 
+        @Override
+        protected void rebuildGraphUris() {
+        }
+
 
     }
 

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/rdfservice/filter/SameAsFilteringRDFServiceFactory.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/rdfservice/filter/SameAsFilteringRDFServiceFactory.java
@@ -10,9 +10,17 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 
+import edu.cornell.mannlib.vitro.webapp.rdfservice.ChangeListener;
+import edu.cornell.mannlib.vitro.webapp.rdfservice.ChangeSet;
+import edu.cornell.mannlib.vitro.webapp.rdfservice.RDFService;
+import edu.cornell.mannlib.vitro.webapp.rdfservice.RDFService.ModelSerializationFormat;
+import edu.cornell.mannlib.vitro.webapp.rdfservice.RDFServiceException;
+import edu.cornell.mannlib.vitro.webapp.rdfservice.RDFServiceFactory;
+import edu.cornell.mannlib.vitro.webapp.rdfservice.ResultSetConsumer;
+import edu.cornell.mannlib.vitro.webapp.rdfservice.impl.RDFServiceImpl;
+import edu.cornell.mannlib.vitro.webapp.rdfservice.impl.RDFServiceUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-
 import org.apache.jena.query.Query;
 import org.apache.jena.query.QueryExecution;
 import org.apache.jena.query.QueryExecutionFactory;
@@ -30,27 +38,18 @@ import org.apache.jena.rdf.model.Statement;
 import org.apache.jena.rdf.model.StmtIterator;
 import org.apache.jena.vocabulary.OWL;
 
-import edu.cornell.mannlib.vitro.webapp.rdfservice.ChangeListener;
-import edu.cornell.mannlib.vitro.webapp.rdfservice.ChangeSet;
-import edu.cornell.mannlib.vitro.webapp.rdfservice.RDFService;
-import edu.cornell.mannlib.vitro.webapp.rdfservice.RDFService.ModelSerializationFormat;
-import edu.cornell.mannlib.vitro.webapp.rdfservice.RDFServiceException;
-import edu.cornell.mannlib.vitro.webapp.rdfservice.RDFServiceFactory;
-import edu.cornell.mannlib.vitro.webapp.rdfservice.ResultSetConsumer;
-import edu.cornell.mannlib.vitro.webapp.rdfservice.impl.RDFServiceImpl;
-import edu.cornell.mannlib.vitro.webapp.rdfservice.impl.RDFServiceUtils;
-
 public class SameAsFilteringRDFServiceFactory implements RDFServiceFactory {
 
-    private final static Log log = LogFactory.getLog(
-            SameAsFilteringRDFServiceFactory.class);
+    private final static Log log = LogFactory.getLog(SameAsFilteringRDFServiceFactory.class);
     private RDFServiceFactory f;
     private Model sameAsModel;
 
     public SameAsFilteringRDFServiceFactory(RDFServiceFactory rdfServiceFactory) {
         this.f = rdfServiceFactory;
         try {
-            InputStream in = f.getRDFService().sparqlConstructQuery("CONSTRUCT { ?s <" + OWL.sameAs.getURI() + "> ?o } WHERE { ?s <" + OWL.sameAs.getURI() + "> ?o } ", ModelSerializationFormat.N3);
+            InputStream in = f.getRDFService().sparqlConstructQuery(
+                    "CONSTRUCT { ?s <" + OWL.sameAs.getURI() + "> ?o } WHERE { ?s <" + OWL.sameAs.getURI() + "> ?o } ",
+                    ModelSerializationFormat.N3);
             sameAsModel = RDFServiceUtils.parseModel(in, ModelSerializationFormat.N3);
         } catch (RDFServiceException e) {
             throw new RuntimeException(e);
@@ -98,11 +97,9 @@ public class SameAsFilteringRDFServiceFactory implements RDFServiceFactory {
         }
 
         @Override
-        public InputStream sparqlConstructQuery(String query,
-                RDFService.ModelSerializationFormat resultFormat)
-                        throws RDFServiceException {
-            Model m = RDFServiceUtils.parseModel(
-                    s.sparqlConstructQuery(query, resultFormat), resultFormat);
+        public InputStream sparqlConstructQuery(String query, RDFService.ModelSerializationFormat resultFormat)
+                throws RDFServiceException {
+            Model m = RDFServiceUtils.parseModel(s.sparqlConstructQuery(query, resultFormat), resultFormat);
             Model filtered = ModelFactory.createDefaultModel();
             StmtIterator stmtIt = m.listStatements();
             while (stmtIt.hasNext()) {
@@ -112,14 +109,12 @@ public class SameAsFilteringRDFServiceFactory implements RDFServiceFactory {
                 }
             }
             ByteArrayOutputStream out = new ByteArrayOutputStream();
-            filtered.write(out, RDFServiceUtils.getSerializationFormatString(
-                    resultFormat));
+            filtered.write(out, RDFServiceUtils.getSerializationFormatString(resultFormat));
             return new ByteArrayInputStream(out.toByteArray());
         }
 
         @Override
-        public void sparqlConstructQuery(String query, Model model)
-                throws RDFServiceException {
+        public void sparqlConstructQuery(String query, Model model) throws RDFServiceException {
             Model m = ModelFactory.createDefaultModel();
             s.sparqlConstructQuery(query, m);
 
@@ -133,11 +128,9 @@ public class SameAsFilteringRDFServiceFactory implements RDFServiceFactory {
         }
 
         @Override
-        public InputStream sparqlSelectQuery(String query, ResultFormat resultFormat)
-                throws RDFServiceException {
-            ResultSet rs = ResultSetFactory.load(
-                    s.sparqlSelectQuery(query, resultFormat),
-                            RDFServiceUtils.getJenaResultSetFormat(resultFormat));
+        public InputStream sparqlSelectQuery(String query, ResultFormat resultFormat) throws RDFServiceException {
+            ResultSet rs = ResultSetFactory.load(s.sparqlSelectQuery(query, resultFormat),
+                    RDFServiceUtils.getJenaResultSetFormat(resultFormat));
             List<QuerySolution> solutions = new ArrayList<QuerySolution>();
             while (rs.hasNext()) {
                 QuerySolution solution = rs.nextSolution();
@@ -148,27 +141,26 @@ public class SameAsFilteringRDFServiceFactory implements RDFServiceFactory {
             ResultSet resultSet = new FilteredResultSet(solutions, rs);
             ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
             switch (resultFormat) {
-               case CSV:
-                  ResultSetFormatter.outputAsCSV(outputStream,resultSet);
-                  break;
-               case TEXT:
-                  ResultSetFormatter.out(outputStream,resultSet);
-                  break;
-               case JSON:
-                  ResultSetFormatter.outputAsJSON(outputStream, resultSet);
-                  break;
-               case XML:
-                  ResultSetFormatter.outputAsXML(outputStream, resultSet);
-                  break;
-               default:
-                  throw new RDFServiceException("unrecognized result format");
+                case CSV:
+                    ResultSetFormatter.outputAsCSV(outputStream, resultSet);
+                    break;
+                case TEXT:
+                    ResultSetFormatter.out(outputStream, resultSet);
+                    break;
+                case JSON:
+                    ResultSetFormatter.outputAsJSON(outputStream, resultSet);
+                    break;
+                case XML:
+                    ResultSetFormatter.outputAsXML(outputStream, resultSet);
+                    break;
+                default:
+                    throw new RDFServiceException("unrecognized result format");
             }
             return new ByteArrayInputStream(outputStream.toByteArray());
         }
 
         @Override
-        public void sparqlSelectQuery(String query, ResultSetConsumer consumer)
-                throws RDFServiceException {
+        public void sparqlSelectQuery(String query, ResultSetConsumer consumer) throws RDFServiceException {
 
             s.sparqlSelectQuery(query, new ResultSetConsumer.Chaining(consumer) {
                 @Override
@@ -200,13 +192,14 @@ public class SameAsFilteringRDFServiceFactory implements RDFServiceFactory {
             if (resource.isAnon()) {
                 return sameAsResources;
             }
-            String queryStr = "SELECT DISTINCT ?s WHERE { <" + resource.getURI() + "> <" + OWL.sameAs.getURI() + "> ?s } ORDER BY ?s";
-            try  {
+            String queryStr = "SELECT DISTINCT ?s WHERE { <" + resource.getURI() + "> <" + OWL.sameAs.getURI()
+                    + "> ?s } ORDER BY ?s";
+            try {
                 Query query = QueryFactory.create(queryStr);
                 QueryExecution qe = QueryExecutionFactory.create(query, sameAsModel);
                 try {
                     ResultSet rs = qe.execSelect();
-                    //ResultSet rs = JSONInput.fromJSON(s.sparqlSelectQuery(queryStr, ResultFormat.JSON));
+                    // ResultSet rs = JSONInput.fromJSON(s.sparqlSelectQuery(queryStr, ResultFormat.JSON));
                     while (rs.hasNext()) {
                         QuerySolution q = rs.next();
                         Resource res = q.getResource("s");
@@ -219,14 +212,14 @@ public class SameAsFilteringRDFServiceFactory implements RDFServiceFactory {
                     qe.close();
                 }
                 return sameAsResources;
-            } catch (/*RDFService*/Exception e) {
+            } catch (/* RDFService */Exception e) {
                 throw new RuntimeException(e);
             }
         }
 
         private boolean isRedundant(QuerySolution q) {
             Iterator<String> varIt = q.varNames();
-            while(varIt.hasNext()) {
+            while (varIt.hasNext()) {
                 String varName = varIt.next();
                 RDFNode n = q.get(varName);
                 if (n.isResource()) {
@@ -241,17 +234,14 @@ public class SameAsFilteringRDFServiceFactory implements RDFServiceFactory {
         }
 
         @Override
-        public boolean changeSetUpdate(ChangeSet changeSet)
-                throws RDFServiceException {
+        public boolean changeSetUpdate(ChangeSet changeSet) throws RDFServiceException {
             return s.changeSetUpdate(changeSet);
         }
 
         @Override
-        public InputStream sparqlDescribeQuery(String query,
-                ModelSerializationFormat resultFormat)
+        public InputStream sparqlDescribeQuery(String query, ModelSerializationFormat resultFormat)
                 throws RDFServiceException {
-            Model m = RDFServiceUtils.parseModel(
-                    s.sparqlConstructQuery(query, resultFormat), resultFormat);
+            Model m = RDFServiceUtils.parseModel(s.sparqlConstructQuery(query, resultFormat), resultFormat);
             Model filtered = ModelFactory.createDefaultModel();
             StmtIterator stmtIt = m.listStatements();
             while (stmtIt.hasNext()) {
@@ -261,8 +251,7 @@ public class SameAsFilteringRDFServiceFactory implements RDFServiceFactory {
                 }
             }
             ByteArrayOutputStream out = new ByteArrayOutputStream();
-            filtered.write(out, RDFServiceUtils.getSerializationFormatString(
-                    resultFormat));
+            filtered.write(out, RDFServiceUtils.getSerializationFormatString(resultFormat));
             return new ByteArrayInputStream(out.toByteArray());
         }
 
@@ -282,27 +271,23 @@ public class SameAsFilteringRDFServiceFactory implements RDFServiceFactory {
         }
 
         @Override
-    	public void serializeAll(OutputStream outputStream)
-    			throws RDFServiceException {
-        	s.serializeAll(outputStream);
-    	}
-
-    	@Override
-    	public void serializeGraph(String graphURI, OutputStream outputStream)
-    			throws RDFServiceException {
-    		s.serializeGraph(graphURI, outputStream);
-    	}
-
-    	@Override
-    	public boolean isEquivalentGraph(String graphURI,
-    			InputStream serializedGraph,
-    			ModelSerializationFormat serializationFormat) throws RDFServiceException {
-    		return s.isEquivalentGraph(graphURI, serializedGraph, serializationFormat);
-    	}
+        public void serializeAll(OutputStream outputStream) throws RDFServiceException {
+            s.serializeAll(outputStream);
+        }
 
         @Override
-        public boolean isEquivalentGraph(String graphURI,
-                                         Model graph) throws RDFServiceException {
+        public void serializeGraph(String graphURI, OutputStream outputStream) throws RDFServiceException {
+            s.serializeGraph(graphURI, outputStream);
+        }
+
+        @Override
+        public boolean isEquivalentGraph(String graphURI, InputStream serializedGraph,
+                ModelSerializationFormat serializationFormat) throws RDFServiceException {
+            return s.isEquivalentGraph(graphURI, serializedGraph, serializationFormat);
+        }
+
+        @Override
+        public boolean isEquivalentGraph(String graphURI, Model graph) throws RDFServiceException {
             return s.isEquivalentGraph(graphURI, graph);
         }
 
@@ -320,8 +305,6 @@ public class SameAsFilteringRDFServiceFactory implements RDFServiceFactory {
         protected void rebuildGraphUris() {
         }
 
-
     }
-
 
 }

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/rdfservice/impl/RDFServiceImpl.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/rdfservice/impl/RDFServiceImpl.java
@@ -48,8 +48,8 @@ public abstract class RDFServiceImpl implements RDFService {
 	protected List<ChangeListener> registeredListeners = new CopyOnWriteArrayList<ChangeListener>();
 	protected List<ModelChangedListener> registeredJenaListeners = new CopyOnWriteArrayList<ModelChangedListener>();
 	protected final List<String> graphURIs = new CopyOnWriteArrayList<String>(); 
-    protected volatile boolean rebuildGraphURICache = true;
-    protected volatile boolean isRebuildGraphURICacheRunning = false;
+	protected volatile boolean rebuildGraphURICache = true;
+	protected volatile boolean isRebuildGraphURICacheRunning = false;
 
 	@Override
 	public void newIndividual(String individualURI,
@@ -88,22 +88,22 @@ public abstract class RDFServiceImpl implements RDFService {
        }
     }
 
-    /**
-     * Get a list of all the graph URIs in the RDF store.
-     */
-    @Override
-    public List<String> getGraphURIs() throws RDFServiceException {
-        if (rebuildGraphURICache && !isRebuildGraphURICacheRunning) {
-            rebuildGraphUris();
-        }
-        return graphURIs;
-    }
-    
+	/**
+	 * Get a list of all the graph URIs in the RDF store.
+	 */
+	@Override
+	public List<String> getGraphURIs() throws RDFServiceException {
+		if (rebuildGraphURICache && !isRebuildGraphURICacheRunning) {
+			rebuildGraphUris();
+		}
+		return graphURIs;
+	}
+	
 	protected abstract void rebuildGraphUris();
 
-    @Override
+	@Override
 	public String getDefaultWriteGraphURI() throws RDFServiceException {
-        return defaultWriteGraphURI;
+		return defaultWriteGraphURI;
 	}
 
 	@Override

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/rdfservice/impl/RDFServiceImpl.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/rdfservice/impl/RDFServiceImpl.java
@@ -5,8 +5,10 @@ package edu.cornell.mannlib.vitro.webapp.rdfservice.impl;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
 
 import edu.cornell.mannlib.vitro.webapp.controller.VitroRequest;
@@ -480,6 +482,19 @@ public abstract class RDFServiceImpl implements RDFService {
 
 	public VitroRequest getVitroRequest() {
 		return vitroRequest;
+	}
+
+	protected void updateGraphURIs(Set<String> newURIs) {
+		Set<String> oldURIs = new HashSet<String>(graphURIs);
+		if (newURIs.equals(oldURIs)) {
+			return;
+		}
+		Set<String> removedURIs = new HashSet<String>(oldURIs);
+		removedURIs.removeAll(newURIs);
+		graphURIs.removeAll(removedURIs);
+		Set<String> addedURIs = new HashSet<String>(newURIs);
+		addedURIs.removeAll(oldURIs);
+		graphURIs.addAll(addedURIs);
 	}
 
 }

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/rdfservice/impl/RDFServiceImpl.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/rdfservice/impl/RDFServiceImpl.java
@@ -44,113 +44,113 @@ import org.apache.jena.vocabulary.RDF;
 
 public abstract class RDFServiceImpl implements RDFService {
 
-	private static final Log log = LogFactory.getLog(RDFServiceImpl.class);
-	
-	protected String defaultWriteGraphURI;
-	protected List<ChangeListener> registeredListeners = new CopyOnWriteArrayList<ChangeListener>();
-	protected List<ModelChangedListener> registeredJenaListeners = new CopyOnWriteArrayList<ModelChangedListener>();
-	protected final List<String> graphURIs = new CopyOnWriteArrayList<String>(); 
-	protected volatile boolean rebuildGraphURICache = true;
-	protected volatile boolean isRebuildGraphURICacheRunning = false;
+    private static final Log log = LogFactory.getLog(RDFServiceImpl.class);
 
-	@Override
-	public void newIndividual(String individualURI,
-			                  String individualTypeURI) throws RDFServiceException {
-
-       newIndividual(individualURI, individualTypeURI, defaultWriteGraphURI);
-	}
+    protected String defaultWriteGraphURI;
+    protected List<ChangeListener> registeredListeners = new CopyOnWriteArrayList<ChangeListener>();
+    protected List<ModelChangedListener> registeredJenaListeners = new CopyOnWriteArrayList<ModelChangedListener>();
+    protected final List<String> graphURIs = new CopyOnWriteArrayList<String>();
+    protected volatile boolean rebuildGraphURICache = true;
+    protected volatile boolean isRebuildGraphURICacheRunning = false;
 
     @Override
-    public void newIndividual(String individualURI,
-                              String individualTypeURI,
-                              String graphURI) throws RDFServiceException {
+    public void newIndividual(String individualURI, String individualTypeURI) throws RDFServiceException {
 
-       StringBuilder containsQuery = new StringBuilder("ASK { \n");
-       if (graphURI != null) {
-           containsQuery.append("  GRAPH <").append(graphURI).append("> { ");
-       }
-       containsQuery.append("<");
-       containsQuery.append(individualURI);
-       containsQuery.append("> ");
-       containsQuery.append("?p ?o");
-       if (graphURI != null) {
-           containsQuery.append(" } \n");
-       }
-       containsQuery.append("\n}");
-
-       if (sparqlAskQuery(containsQuery.toString())) {
-            throw new RDFServiceException("individual already exists");
-       } else {
-            Triple triple = new Triple(NodeFactory.createURI(individualURI), RDF.type.asNode(), NodeFactory.createURI(individualTypeURI));
-            //addTriple(triple, graphURI);
-            ChangeSet cs = this.manufactureChangeSet();
-            cs.addAddition(new ByteArrayInputStream(
-                    sparqlTriple(triple).getBytes()), ModelSerializationFormat.N3, graphURI);
-            changeSetUpdate(cs);
-       }
+        newIndividual(individualURI, individualTypeURI, defaultWriteGraphURI);
     }
 
-	/**
-	 * Get a list of all the graph URIs in the RDF store.
-	 */
-	@Override
-	public List<String> getGraphURIs() throws RDFServiceException {
-		if (rebuildGraphURICache && !isRebuildGraphURICacheRunning) {
-			rebuildGraphUris();
-		}
-		return graphURIs;
-	}
-	
-	protected abstract void rebuildGraphUris();
+    @Override
+    public void newIndividual(String individualURI, String individualTypeURI, String graphURI)
+            throws RDFServiceException {
 
-	@Override
-	public String getDefaultWriteGraphURI() throws RDFServiceException {
-		return defaultWriteGraphURI;
-	}
+        StringBuilder containsQuery = new StringBuilder("ASK { \n");
+        if (graphURI != null) {
+            containsQuery.append("  GRAPH <").append(graphURI).append("> { ");
+        }
+        containsQuery.append("<");
+        containsQuery.append(individualURI);
+        containsQuery.append("> ");
+        containsQuery.append("?p ?o");
+        if (graphURI != null) {
+            containsQuery.append(" } \n");
+        }
+        containsQuery.append("\n}");
 
-	@Override
-	public synchronized void registerListener(ChangeListener changeListener) throws RDFServiceException {
-		if (!registeredListeners.contains(changeListener)) {
-		   registeredListeners.add(changeListener);
-		}
-	}
+        if (sparqlAskQuery(containsQuery.toString())) {
+            throw new RDFServiceException("individual already exists");
+        } else {
+            Triple triple = new Triple(NodeFactory.createURI(individualURI), RDF.type.asNode(),
+                    NodeFactory.createURI(individualTypeURI));
+            // addTriple(triple, graphURI);
+            ChangeSet cs = this.manufactureChangeSet();
+            cs.addAddition(new ByteArrayInputStream(sparqlTriple(triple).getBytes()), ModelSerializationFormat.N3,
+                    graphURI);
+            changeSetUpdate(cs);
+        }
+    }
 
-	@Override
-	public synchronized void unregisterListener(ChangeListener changeListener) throws RDFServiceException {
-		registeredListeners.remove(changeListener);
-	}
+    /**
+     * Get a list of all the graph URIs in the RDF store.
+     */
+    @Override
+    public List<String> getGraphURIs() throws RDFServiceException {
+        if (rebuildGraphURICache && !isRebuildGraphURICacheRunning) {
+            rebuildGraphUris();
+        }
+        return graphURIs;
+    }
 
-	@Override
-	public synchronized void registerJenaModelChangedListener(ModelChangedListener changeListener) throws RDFServiceException {
-	    if (!registeredJenaListeners.contains(changeListener)) {
-	        registeredJenaListeners.add(changeListener);
-	    }
-	}
+    protected abstract void rebuildGraphUris();
 
-	@Override
-	public synchronized void unregisterJenaModelChangedListener(ModelChangedListener changeListener) throws RDFServiceException {
-	    registeredJenaListeners.remove(changeListener);
-	}
+    @Override
+    public String getDefaultWriteGraphURI() throws RDFServiceException {
+        return defaultWriteGraphURI;
+    }
 
-	public synchronized List<ChangeListener> getRegisteredListeners() {
-	    return this.registeredListeners;
-	}
+    @Override
+    public synchronized void registerListener(ChangeListener changeListener) throws RDFServiceException {
+        if (!registeredListeners.contains(changeListener)) {
+            registeredListeners.add(changeListener);
+        }
+    }
 
-	public synchronized List<ModelChangedListener> getRegisteredJenaModelChangedListeners() {
-	    return this.registeredJenaListeners;
-	}
+    @Override
+    public synchronized void unregisterListener(ChangeListener changeListener) throws RDFServiceException {
+        registeredListeners.remove(changeListener);
+    }
 
-	@Override
-	public ChangeSet manufactureChangeSet() {
-		return new ChangeSetImpl();
-	}
+    @Override
+    public synchronized void registerJenaModelChangedListener(ModelChangedListener changeListener)
+            throws RDFServiceException {
+        if (!registeredJenaListeners.contains(changeListener)) {
+            registeredJenaListeners.add(changeListener);
+        }
+    }
 
-    protected void notifyListenersOfChanges(ChangeSet changeSet)
-            throws IOException {
+    @Override
+    public synchronized void unregisterJenaModelChangedListener(ModelChangedListener changeListener)
+            throws RDFServiceException {
+        registeredJenaListeners.remove(changeListener);
+    }
+
+    public synchronized List<ChangeListener> getRegisteredListeners() {
+        return this.registeredListeners;
+    }
+
+    public synchronized List<ModelChangedListener> getRegisteredJenaModelChangedListeners() {
+        return this.registeredJenaListeners;
+    }
+
+    @Override
+    public ChangeSet manufactureChangeSet() {
+        return new ChangeSetImpl();
+    }
+
+    protected void notifyListenersOfChanges(ChangeSet changeSet) throws IOException {
         if (registeredListeners.isEmpty() && registeredJenaListeners.isEmpty()) {
             return;
         }
-        for (ModelChange modelChange: changeSet.getModelChanges()) {
+        for (ModelChange modelChange : changeSet.getModelChanges()) {
             notifyListeners(modelChange);
         }
     }
@@ -174,12 +174,10 @@ public abstract class RDFServiceImpl implements RDFService {
         }
         if (Operation.ADD.equals(modelChange.getOperation())) {
             tempModel.read(modelChange.getSerializedModel(), null,
-                   RDFServiceUtils.getSerializationFormatString(
-                           modelChange.getSerializationFormat()));
+                    RDFServiceUtils.getSerializationFormatString(modelChange.getSerializationFormat()));
         } else if (Operation.REMOVE.equals(modelChange.getOperation())) {
-            tempModel.remove(RDFServiceUtils.parseModel(
-                    modelChange.getSerializedModel(),
-                    modelChange.getSerializationFormat()));
+            tempModel.remove(
+                    RDFServiceUtils.parseModel(modelChange.getSerializedModel(), modelChange.getSerializationFormat()));
         }
         while (jenaIter.hasNext()) {
             tempModel.unregister(jenaIter.next());
@@ -196,16 +194,15 @@ public abstract class RDFServiceImpl implements RDFService {
         }
     }
 
-    protected boolean isPreconditionSatisfied(String query,
-            RDFService.SPARQLQueryType queryType)
-                    throws RDFServiceException {
+    protected boolean isPreconditionSatisfied(String query, RDFService.SPARQLQueryType queryType)
+            throws RDFServiceException {
         Model model = ModelFactory.createDefaultModel();
         switch (queryType) {
             case DESCRIBE:
-                model.read(sparqlDescribeQuery(query,RDFService.ModelSerializationFormat.N3), null);
+                model.read(sparqlDescribeQuery(query, RDFService.ModelSerializationFormat.N3), null);
                 return !model.isEmpty();
             case CONSTRUCT:
-                model.read(sparqlConstructQuery(query,RDFService.ModelSerializationFormat.N3), null);
+                model.read(sparqlConstructQuery(query, RDFService.ModelSerializationFormat.N3), null);
                 return !model.isEmpty();
             case SELECT:
                 return sparqlSelectQueryHasResults(query);
@@ -281,36 +278,54 @@ public abstract class RDFServiceImpl implements RDFService {
         }
     }
 
-     // see http://www.python.org/doc/2.5.2/ref/strings.html
-     // or see jena's n3 grammar jena/src/org.apache/jena/n3/n3.g
-    protected static void pyString(StringBuffer sbuff, String s)  {
+    // see http://www.python.org/doc/2.5.2/ref/strings.html
+    // or see jena's n3 grammar jena/src/org.apache/jena/n3/n3.g
+    protected static void pyString(StringBuffer sbuff, String s) {
         for (int i = 0; i < s.length(); i++) {
             char c = s.charAt(i);
 
             // Escape escapes and quotes
-            if (c == '\\' || c == '"' )
-            {
-                sbuff.append('\\') ;
-                sbuff.append(c) ;
-                continue ;
+            if (c == '\\' || c == '"') {
+                sbuff.append('\\');
+                sbuff.append(c);
+                continue;
             }
 
             // Whitespace
-            if (c == '\n'){ sbuff.append("\\n");continue; }
-            if (c == '\t'){ sbuff.append("\\t");continue; }
-            if (c == '\r'){ sbuff.append("\\r");continue; }
-            if (c == '\f'){ sbuff.append("\\f");continue; }
-            if (c == '\b'){ sbuff.append("\\b");continue; }
-            if( c == 7 )  { sbuff.append("\\a");continue; }
+            if (c == '\n') {
+                sbuff.append("\\n");
+                continue;
+            }
+            if (c == '\t') {
+                sbuff.append("\\t");
+                continue;
+            }
+            if (c == '\r') {
+                sbuff.append("\\r");
+                continue;
+            }
+            if (c == '\f') {
+                sbuff.append("\\f");
+                continue;
+            }
+            if (c == '\b') {
+                sbuff.append("\\b");
+                continue;
+            }
+            if (c == 7) {
+                sbuff.append("\\a");
+                continue;
+            }
 
             // Output as is (subject to UTF-8 encoding on output that is)
-            sbuff.append(c) ;
+            sbuff.append(c);
         }
     }
 
     /**
-     * Returns a pair of models.  The first contains any statement containing at
-     * least one blank node.  The second contains all remaining statements.
+     * Returns a pair of models. The first contains any statement containing at least one blank node. The second
+     * contains all remaining statements.
+     * 
      * @param gm Jena model
      */
 
@@ -333,47 +348,45 @@ public abstract class RDFServiceImpl implements RDFService {
     }
 
     protected Query createQuery(String queryString) throws RDFServiceException {
-        List<Syntax> syntaxes = Arrays.asList(
-                Syntax.defaultQuerySyntax, Syntax.syntaxSPARQL_11,
-                Syntax.syntaxSPARQL_10, Syntax.syntaxSPARQL, Syntax.syntaxARQ);
+        List<Syntax> syntaxes = Arrays.asList(Syntax.defaultQuerySyntax, Syntax.syntaxSPARQL_11, Syntax.syntaxSPARQL_10,
+                Syntax.syntaxSPARQL, Syntax.syntaxARQ);
         Query q = null;
         Iterator<Syntax> syntaxIt = syntaxes.iterator();
         while (q == null) {
             Syntax syntax = syntaxIt.next();
             try {
-               q = QueryFactory.create(queryString, syntax);
+                q = QueryFactory.create(queryString, syntax);
             } catch (QueryParseException e) {
-               if (!syntaxIt.hasNext()) {
-					throw new RDFServiceException("Failed to parse query \""
-							+ queryString + "\"", e);
-               }
+                if (!syntaxIt.hasNext()) {
+                    throw new RDFServiceException("Failed to parse query \"" + queryString + "\"", e);
+                }
             }
         }
         return q;
     }
 
-	@Override
-	public String toString() {
-		return ToString.simpleName(this) + "[" + ToString.hashHex(this) + "]";
-	}
+    @Override
+    public String toString() {
+        return ToString.simpleName(this) + "[" + ToString.hashHex(this) + "]";
+    }
 
     @Override
     public long countTriples(RDFNode subject, RDFNode predicate, RDFNode object) throws RDFServiceException {
         StringBuilder whereClause = new StringBuilder();
 
-        if ( subject != null ) {
+        if (subject != null) {
             appendNode(whereClause.append(' '), subject);
         } else {
             whereClause.append(" ?s");
         }
 
-        if ( predicate != null ) {
+        if (predicate != null) {
             appendNode(whereClause.append(' '), predicate);
         } else {
             whereClause.append(" ?p");
         }
 
-        if ( object != null ) {
+        if (object != null) {
             appendNode(whereClause.append(' '), object);
         } else {
             whereClause.append(" ?o");
@@ -392,25 +405,26 @@ public abstract class RDFServiceImpl implements RDFService {
     }
 
     @Override
-    public Model getTriples(RDFNode subject, RDFNode predicate, RDFNode object, long limit, long offset) throws RDFServiceException {
+    public Model getTriples(RDFNode subject, RDFNode predicate, RDFNode object, long limit, long offset)
+            throws RDFServiceException {
         StringBuilder whereClause = new StringBuilder();
         StringBuilder orderBy = new StringBuilder();
 
-        if ( subject != null ) {
+        if (subject != null) {
             appendNode(whereClause.append(' '), subject);
         } else {
             whereClause.append(" ?s");
             orderBy.append(" ?s");
         }
 
-        if ( predicate != null ) {
+        if (predicate != null) {
             appendNode(whereClause.append(' '), predicate);
         } else {
             whereClause.append(" ?p");
             orderBy.append(" ?p");
         }
 
-        if ( object != null ) {
+        if (object != null) {
             appendNode(whereClause.append(' '), object);
         } else {
             whereClause.append(" ?o");
@@ -469,32 +483,34 @@ public abstract class RDFServiceImpl implements RDFService {
             }
         }
     }
-	/*
-	 * UQAM Useful among other things to transport the linguistic context in the service
-	 * (non-Javadoc)
-	 * @see edu.cornell.mannlib.vitro.webapp.rdfservice.RDFService#setVitroRequest(edu.cornell.mannlib.vitro.webapp.controller.VitroRequest)
-	 */
-	private VitroRequest vitroRequest;
 
-	public void setVitroRequest(VitroRequest vitroRequest) {
-		this.vitroRequest = vitroRequest;
-	}
+    /*
+     * UQAM Useful among other things to transport the linguistic context in the service (non-Javadoc)
+     * 
+     * @see edu.cornell.mannlib.vitro.webapp.rdfservice.RDFService#setVitroRequest(edu.cornell.mannlib.vitro.webapp.
+     * controller.VitroRequest)
+     */
+    private VitroRequest vitroRequest;
 
-	public VitroRequest getVitroRequest() {
-		return vitroRequest;
-	}
+    public void setVitroRequest(VitroRequest vitroRequest) {
+        this.vitroRequest = vitroRequest;
+    }
 
-	protected void updateGraphURIs(Set<String> newURIs) {
-		Set<String> oldURIs = new HashSet<String>(graphURIs);
-		if (newURIs.equals(oldURIs)) {
-			return;
-		}
-		Set<String> removedURIs = new HashSet<String>(oldURIs);
-		removedURIs.removeAll(newURIs);
-		graphURIs.removeAll(removedURIs);
-		Set<String> addedURIs = new HashSet<String>(newURIs);
-		addedURIs.removeAll(oldURIs);
-		graphURIs.addAll(addedURIs);
-	}
+    public VitroRequest getVitroRequest() {
+        return vitroRequest;
+    }
+
+    protected void updateGraphURIs(Set<String> newURIs) {
+        Set<String> oldURIs = new HashSet<String>(graphURIs);
+        if (newURIs.equals(oldURIs)) {
+            return;
+        }
+        Set<String> removedURIs = new HashSet<String>(oldURIs);
+        removedURIs.removeAll(newURIs);
+        graphURIs.removeAll(removedURIs);
+        Set<String> addedURIs = new HashSet<String>(newURIs);
+        addedURIs.removeAll(oldURIs);
+        graphURIs.addAll(addedURIs);
+    }
 
 }

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/rdfservice/impl/jena/RDFServiceJena.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/rdfservice/impl/jena/RDFServiceJena.java
@@ -57,53 +57,52 @@ public abstract class RDFServiceJena extends RDFServiceImpl implements RDFServic
     protected abstract DatasetWrapper getDatasetWrapper();
 
     @Override
-	public abstract boolean changeSetUpdate(ChangeSet changeSet) throws RDFServiceException;
+    public abstract boolean changeSetUpdate(ChangeSet changeSet) throws RDFServiceException;
 
     protected void notifyListenersOfPreChangeEvents(ChangeSet changeSet) {
-		for (Object o : changeSet.getPreChangeEvents()) {
-		    this.notifyListenersOfEvent(o);
-		}
-	}
+        for (Object o : changeSet.getPreChangeEvents()) {
+            this.notifyListenersOfEvent(o);
+        }
+    }
 
     protected void insureThatInputStreamsAreResettable(ChangeSet changeSet) throws IOException {
-		for (ModelChange modelChange: changeSet.getModelChanges()) {
+        for (ModelChange modelChange : changeSet.getModelChanges()) {
             if (!modelChange.getSerializedModel().markSupported()) {
                 byte[] bytes = IOUtils.toByteArray(modelChange.getSerializedModel());
                 modelChange.setSerializedModel(new ByteArrayInputStream(bytes));
             }
             modelChange.getSerializedModel().mark(Integer.MAX_VALUE);
         }
-	}
+    }
 
     protected void applyChangeSetToModel(ChangeSet changeSet, Dataset dataset) {
-		for (ModelChange modelChange: changeSet.getModelChanges()) {
-			dataset.getLock().enterCriticalSection(Lock.WRITE);
-			try {
-				Model model = (modelChange.getGraphURI() == null) ?
-						dataset.getDefaultModel() :
-						dataset.getNamedModel(modelChange.getGraphURI());
-				operateOnModel(model, modelChange);
-			} finally {
-				dataset.getLock().leaveCriticalSection();
-			}
-		}
-	}
+        for (ModelChange modelChange : changeSet.getModelChanges()) {
+            dataset.getLock().enterCriticalSection(Lock.WRITE);
+            try {
+                Model model = (modelChange.getGraphURI() == null) ? dataset.getDefaultModel()
+                        : dataset.getNamedModel(modelChange.getGraphURI());
+                operateOnModel(model, modelChange);
+            } finally {
+                dataset.getLock().leaveCriticalSection();
+            }
+        }
+    }
 
     protected void notifyListenersOfPostChangeEvents(ChangeSet changeSet) {
-		for (Object o : changeSet.getPostChangeEvents()) {
-		    this.notifyListenersOfEvent(o);
-		}
-	}
+        for (Object o : changeSet.getPostChangeEvents()) {
+            this.notifyListenersOfEvent(o);
+        }
+    }
 
     protected void operateOnModel(Model model, ModelChange modelChange) {
         model.enterCriticalSection(Lock.WRITE);
         try {
-			if (log.isDebugEnabled()) {
-				dumpOperation(model, modelChange);
-			}
+            if (log.isDebugEnabled()) {
+                dumpOperation(model, modelChange);
+            }
             if (modelChange.getOperation() == ModelChange.Operation.ADD) {
-            	Model addition = parseModel(modelChange);
-            	model.add(addition);
+                Model addition = parseModel(modelChange);
+                model.add(addition);
             } else if (modelChange.getOperation() == ModelChange.Operation.REMOVE) {
                 Model removal = parseModel(modelChange);
                 JenaModelUtils.removeWithBlankNodesAsVariables(removal, model);
@@ -115,56 +114,52 @@ public abstract class RDFServiceJena extends RDFServiceImpl implements RDFServic
         }
     }
 
-	/**
-	 * As a debug statement, log info about the model change operation: add or
-	 * delete, model URI, model class, punctuation count, beginning of the
-	 * string.
-	 */
-	private void dumpOperation(Model model, ModelChange modelChange) {
-		String op = String.valueOf(modelChange.getOperation());
+    /**
+     * As a debug statement, log info about the model change operation: add or delete, model URI, model class,
+     * punctuation count, beginning of the string.
+     */
+    private void dumpOperation(Model model, ModelChange modelChange) {
+        String op = String.valueOf(modelChange.getOperation());
 
-		byte[] changeBytes = new byte[0];
-		try {
-			modelChange.getSerializedModel().mark(Integer.MAX_VALUE);
-			changeBytes = IOUtils.toByteArray(modelChange.getSerializedModel());
-			modelChange.getSerializedModel().reset();
-		} catch (IOException e) {
-			// leave it empty.
-		}
+        byte[] changeBytes = new byte[0];
+        try {
+            modelChange.getSerializedModel().mark(Integer.MAX_VALUE);
+            changeBytes = IOUtils.toByteArray(modelChange.getSerializedModel());
+            modelChange.getSerializedModel().reset();
+        } catch (IOException e) {
+            // leave it empty.
+        }
 
-		int puncCount = 0;
-		boolean inUri = false;
-		boolean inQuotes = false;
-		for (byte b : changeBytes) {
-			if (inQuotes) {
-				if (b == '"') {
-					inQuotes = false;
-				}
-			} else if (inUri) {
-				if (b == '>') {
-					inUri = false;
-				}
-			} else {
-				if (b == '"') {
-					inQuotes = true;
-				} else if (b == '<') {
-					inUri = true;
-				} else if ((b == ',') || (b == ';') || (b == '.')) {
-					puncCount++;
-				}
-			}
-		}
+        int puncCount = 0;
+        boolean inUri = false;
+        boolean inQuotes = false;
+        for (byte b : changeBytes) {
+            if (inQuotes) {
+                if (b == '"') {
+                    inQuotes = false;
+                }
+            } else if (inUri) {
+                if (b == '>') {
+                    inUri = false;
+                }
+            } else {
+                if (b == '"') {
+                    inQuotes = true;
+                } else if (b == '<') {
+                    inUri = true;
+                } else if ((b == ',') || (b == ';') || (b == '.')) {
+                    puncCount++;
+                }
+            }
+        }
 
-		String changeString = new String(changeBytes).replace('\n', ' ');
+        String changeString = new String(changeBytes).replace('\n', ' ');
 
-		log.debug(String.format(
-				">>>>OPERATION: %3.3s %03dpunc, format=%s, graphUri='%s'\n"
-						+ "    start=%.200s\n" + "    model=%s",
-				modelChange.getOperation(), puncCount,
-				modelChange.getSerializationFormat(),
-				modelChange.getGraphURI(), changeString,
-				ToString.modelToString(model)));
-	}
+        log.debug(String.format(
+                ">>>>OPERATION: %3.3s %03dpunc, format=%s, graphUri='%s'\n" + "    start=%.200s\n" + "    model=%s",
+                modelChange.getOperation(), puncCount, modelChange.getSerializationFormat(), modelChange.getGraphURI(),
+                changeString, ToString.modelToString(model)));
+    }
 
     private Model parseModel(ModelChange modelChange) {
         Model model = ModelFactory.createDefaultModel();
@@ -173,8 +168,8 @@ public abstract class RDFServiceJena extends RDFServiceImpl implements RDFServic
         return model;
     }
 
-    private InputStream getRDFResultStream(String query, boolean construct,
-            ModelSerializationFormat resultFormat) throws RDFServiceException {
+    private InputStream getRDFResultStream(String query, boolean construct, ModelSerializationFormat resultFormat)
+            throws RDFServiceException {
         DatasetWrapper dw = getDatasetWrapper();
         try {
             Dataset d = dw.getDataset();
@@ -216,8 +211,8 @@ public abstract class RDFServiceJena extends RDFServiceImpl implements RDFServic
     private static final boolean DESCRIBE = false;
 
     @Override
-    public InputStream sparqlConstructQuery(String query,
-            ModelSerializationFormat resultFormat) throws RDFServiceException {
+    public InputStream sparqlConstructQuery(String query, ModelSerializationFormat resultFormat)
+            throws RDFServiceException {
         return getRDFResultStream(query, CONSTRUCT, resultFormat);
     }
 
@@ -226,17 +221,16 @@ public abstract class RDFServiceJena extends RDFServiceImpl implements RDFServic
     }
 
     @Override
-    public InputStream sparqlDescribeQuery(String query,
-            ModelSerializationFormat resultFormat) throws RDFServiceException {
+    public InputStream sparqlDescribeQuery(String query, ModelSerializationFormat resultFormat)
+            throws RDFServiceException {
         return getRDFResultStream(query, DESCRIBE, resultFormat);
     }
 
-	/**
-	 * TODO Is there a way to accomplish this without buffering the entire result?
-	 */
+    /**
+     * TODO Is there a way to accomplish this without buffering the entire result?
+     */
     @Override
-    public InputStream sparqlSelectQuery(String query, ResultFormat resultFormat)
-            throws RDFServiceException {
+    public InputStream sparqlSelectQuery(String query, ResultFormat resultFormat) throws RDFServiceException {
         DatasetWrapper dw = getDatasetWrapper();
         try {
             Dataset d = dw.getDataset();
@@ -246,20 +240,20 @@ public abstract class RDFServiceJena extends RDFServiceImpl implements RDFServic
                 ResultSet resultSet = qe.execSelect();
                 ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
                 switch (resultFormat) {
-                   case CSV:
-                      ResultSetFormatter.outputAsCSV(outputStream,resultSet);
-                      break;
-                   case TEXT:
-                      ResultSetFormatter.out(outputStream,resultSet);
-                      break;
-                   case JSON:
-                      ResultSetFormatter.outputAsJSON(outputStream, resultSet);
-                      break;
-                   case XML:
-                      ResultSetFormatter.outputAsXML(outputStream, resultSet);
-                      break;
-                   default:
-                      throw new RDFServiceException("unrecognized result format");
+                    case CSV:
+                        ResultSetFormatter.outputAsCSV(outputStream, resultSet);
+                        break;
+                    case TEXT:
+                        ResultSetFormatter.out(outputStream, resultSet);
+                        break;
+                    case JSON:
+                        ResultSetFormatter.outputAsJSON(outputStream, resultSet);
+                        break;
+                    case XML:
+                        ResultSetFormatter.outputAsXML(outputStream, resultSet);
+                        break;
+                    default:
+                        throw new RDFServiceException("unrecognized result format");
                 }
                 InputStream result = new ByteArrayInputStream(outputStream.toByteArray());
                 return result;
@@ -272,8 +266,7 @@ public abstract class RDFServiceJena extends RDFServiceImpl implements RDFServic
     }
 
     @Override
-    public void sparqlSelectQuery(String query, ResultSetConsumer consumer)
-            throws RDFServiceException {
+    public void sparqlSelectQuery(String query, ResultSetConsumer consumer) throws RDFServiceException {
         DatasetWrapper dw = getDatasetWrapper();
         try {
             Dataset d = dw.getDataset();
@@ -289,7 +282,7 @@ public abstract class RDFServiceJena extends RDFServiceImpl implements RDFServic
         }
     }
 
-     @Override
+    @Override
     public boolean sparqlAskQuery(String query) throws RDFServiceException {
         DatasetWrapper dw = getDatasetWrapper();
         try {
@@ -342,66 +335,64 @@ public abstract class RDFServiceJena extends RDFServiceImpl implements RDFServic
 
     @Override
     public void getGraphMetadata() throws RDFServiceException {
-    	// nothing to do
+        // nothing to do
     }
 
     @Override
-	public void serializeAll(OutputStream outputStream)
-			throws RDFServiceException {
-    	String query = "SELECT * WHERE { GRAPH ?g {?s ?p ?o}}";
-		serialize(outputStream, query);
-	}
+    public void serializeAll(OutputStream outputStream) throws RDFServiceException {
+        String query = "SELECT * WHERE { GRAPH ?g {?s ?p ?o}}";
+        serialize(outputStream, query);
+    }
 
-	@Override
-	public void serializeGraph(String graphURI, OutputStream outputStream)
-			throws RDFServiceException {
-		String query = "SELECT * WHERE { GRAPH <" + graphURI + "> {?s ?p ?o}}";
-		serialize(outputStream, query);
-	}
+    @Override
+    public void serializeGraph(String graphURI, OutputStream outputStream) throws RDFServiceException {
+        String query = "SELECT * WHERE { GRAPH <" + graphURI + "> {?s ?p ?o}}";
+        serialize(outputStream, query);
+    }
 
-	private void serialize(OutputStream outputStream, String query) throws RDFServiceException {
-		DatasetWrapper dw = getDatasetWrapper();
-		try {
-			Dataset d = dw.getDataset();
-			Query q = createQuery(query);
-			QueryExecution qe = createQueryExecution(query, q, d);
-			// These properties only help for SDB, but shouldn't hurt for TDB.
-			qe.getContext().set(SDB.jdbcFetchSize, Integer.MIN_VALUE);
-			qe.getContext().set(SDB.jdbcStream, true);
-			qe.getContext().set(SDB.streamGraphAPI, true);
-			try {
-				ResultSet resultSet = qe.execSelect();
-				if (resultSet.getResultVars().contains("g")) {
-					Iterator<Quad> quads = new ResultSetQuadsIterator(resultSet);
-					RDFDataMgr.writeQuads(outputStream, quads);
-				} else {
-					Iterator<Triple> triples = new ResultSetTriplesIterator(resultSet);
-					RDFDataMgr.writeTriples(outputStream, triples);
-				}
-			} finally {
-				qe.close();
-			}
-		} finally {
-			dw.close();
-		}
-	}
-
-	/**
-	 * The basic version. Parse the model from the file, read the model from the
-	 * tripleStore, and ask whether they are isomorphic.
-	 */
-	@Override
-	public boolean isEquivalentGraph(String graphURI, InputStream serializedGraph,
-			ModelSerializationFormat serializationFormat) throws RDFServiceException {
-		Model fileModel = RDFServiceUtils.parseModel(serializedGraph, serializationFormat);
-		Model tripleStoreModel = new RDFServiceDataset(this).getNamedModel(graphURI);
-		Model fromTripleStoreModel = ModelFactory.createDefaultModel().add(tripleStoreModel);
-		return fileModel.isIsomorphicWith(fromTripleStoreModel);
-	}
+    private void serialize(OutputStream outputStream, String query) throws RDFServiceException {
+        DatasetWrapper dw = getDatasetWrapper();
+        try {
+            Dataset d = dw.getDataset();
+            Query q = createQuery(query);
+            QueryExecution qe = createQueryExecution(query, q, d);
+            // These properties only help for SDB, but shouldn't hurt for TDB.
+            qe.getContext().set(SDB.jdbcFetchSize, Integer.MIN_VALUE);
+            qe.getContext().set(SDB.jdbcStream, true);
+            qe.getContext().set(SDB.streamGraphAPI, true);
+            try {
+                ResultSet resultSet = qe.execSelect();
+                if (resultSet.getResultVars().contains("g")) {
+                    Iterator<Quad> quads = new ResultSetQuadsIterator(resultSet);
+                    RDFDataMgr.writeQuads(outputStream, quads);
+                } else {
+                    Iterator<Triple> triples = new ResultSetTriplesIterator(resultSet);
+                    RDFDataMgr.writeTriples(outputStream, triples);
+                }
+            } finally {
+                qe.close();
+            }
+        } finally {
+            dw.close();
+        }
+    }
 
     /**
-     * The basic version. Parse the model from the file, read the model from the
-     * tripleStore, and ask whether they are isomorphic.
+     * The basic version. Parse the model from the file, read the model from the tripleStore, and ask whether they are
+     * isomorphic.
+     */
+    @Override
+    public boolean isEquivalentGraph(String graphURI, InputStream serializedGraph,
+            ModelSerializationFormat serializationFormat) throws RDFServiceException {
+        Model fileModel = RDFServiceUtils.parseModel(serializedGraph, serializationFormat);
+        Model tripleStoreModel = new RDFServiceDataset(this).getNamedModel(graphURI);
+        Model fromTripleStoreModel = ModelFactory.createDefaultModel().add(tripleStoreModel);
+        return fileModel.isIsomorphicWith(fromTripleStoreModel);
+    }
+
+    /**
+     * The basic version. Parse the model from the file, read the model from the tripleStore, and ask whether they are
+     * isomorphic.
      */
     @Override
     public boolean isEquivalentGraph(String graphURI, Model graph) throws RDFServiceException {
@@ -416,15 +407,16 @@ public abstract class RDFServiceJena extends RDFServiceImpl implements RDFServic
 
     @Override
     public long countTriples(RDFNode subject, RDFNode predicate, RDFNode object) throws RDFServiceException {
-        Query countQuery = QueryFactory.create("SELECT (COUNT(?s) AS ?count) WHERE { ?s ?p ?o } ORDER BY ?s ?p ?o", Syntax.syntaxSPARQL_11);
+        Query countQuery = QueryFactory.create("SELECT (COUNT(?s) AS ?count) WHERE { ?s ?p ?o } ORDER BY ?s ?p ?o",
+                Syntax.syntaxSPARQL_11);
         QuerySolutionMap map = new QuerySolutionMap();
-        if ( subject != null ) {
+        if (subject != null) {
             map.add("s", subject);
         }
-        if ( predicate != null ) {
+        if (predicate != null) {
             map.add("p", predicate);
         }
-        if ( object != null ) {
+        if (object != null) {
             map.add("o", object);
         }
 
@@ -434,7 +426,7 @@ public abstract class RDFServiceJena extends RDFServiceImpl implements RDFServic
             try (QueryExecution qexec = QueryExecutionFactory.create(countQuery, d, map)) {
                 ResultSet results = qexec.execSelect();
                 if (results.hasNext()) {
-                    QuerySolution soln = results.nextSolution() ;
+                    QuerySolution soln = results.nextSolution();
                     Literal literal = soln.getLiteral("count");
                     return literal.getLong();
                 }
@@ -447,16 +439,17 @@ public abstract class RDFServiceJena extends RDFServiceImpl implements RDFServic
     }
 
     @Override
-    public Model getTriples(RDFNode subject, RDFNode predicate, RDFNode object, long limit, long offset) throws RDFServiceException {
+    public Model getTriples(RDFNode subject, RDFNode predicate, RDFNode object, long limit, long offset)
+            throws RDFServiceException {
         Query query = QueryFactory.create("CONSTRUCT WHERE { ?s ?p ?o }", Syntax.syntaxSPARQL_11);
         QuerySolutionMap map = new QuerySolutionMap();
-        if ( subject != null ) {
+        if (subject != null) {
             map.add("s", subject);
         }
-        if ( predicate != null ) {
+        if (predicate != null) {
             map.add("p", predicate);
         }
-        if ( object != null ) {
+        if (object != null) {
             map.add("o", object);
         }
 
@@ -491,19 +484,22 @@ public abstract class RDFServiceJena extends RDFServiceImpl implements RDFServic
     protected QueryExecution createQueryExecution(String queryString, Query q, Dataset d) {
         return QueryExecutionFactory.create(q, d);
     }
-	/*
-	 * UQAM-Linguistic-Management Useful among other things to transport the linguistic context in the service
-	 * (non-Javadoc)
-	 * @see edu.cornell.mannlib.vitro.webapp.rdfservice.RDFService#setVitroRequest(edu.cornell.mannlib.vitro.webapp.controller.VitroRequest)
-	 */
-	private VitroRequest vitroRequest;
 
-	public void setVitroRequest(VitroRequest vitroRequest) {
-		this.vitroRequest = vitroRequest;
-	}
+    /*
+     * UQAM-Linguistic-Management Useful among other things to transport the linguistic context in the service
+     * (non-Javadoc)
+     * 
+     * @see edu.cornell.mannlib.vitro.webapp.rdfservice.RDFService#setVitroRequest(edu.cornell.mannlib.vitro.webapp.
+     * controller.VitroRequest)
+     */
+    private VitroRequest vitroRequest;
 
-	public VitroRequest getVitroRequest() {
-		return vitroRequest;
-	}
+    public void setVitroRequest(VitroRequest vitroRequest) {
+        this.vitroRequest = vitroRequest;
+    }
+
+    public VitroRequest getVitroRequest() {
+        return vitroRequest;
+    }
 
 }

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/rdfservice/impl/jena/RDFServiceJena.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/rdfservice/impl/jena/RDFServiceJena.java
@@ -315,26 +315,17 @@ public abstract class RDFServiceJena extends RDFServiceImpl implements RDFServic
                         try {
                             isRebuildGraphURICacheRunning = true;
                             Dataset d = dw.getDataset();
-                            Set<String> newGraphUris = new HashSet<>();
+                            Set<String> newURIs = new HashSet<>();
                             d.begin(ReadWrite.READ);
                             try {
                                 Iterator<String> nameIt = d.listNames();
                                 while (nameIt.hasNext()) {
-                                    newGraphUris.add(nameIt.next());
+                                    newURIs.add(nameIt.next());
                                 }
                             } finally {
                                 d.end();
                             }
-                            Set<String> oldGraphUris = new HashSet<String>(graphURIs);
-                            if (newGraphUris.equals(oldGraphUris)) {
-                                return;
-                            }
-                            Set<String> removedGraphUris = new HashSet<String>(oldGraphUris);
-                            removedGraphUris.removeAll(newGraphUris);
-                            graphURIs.removeAll(removedGraphUris);
-                            Set<String> addedGraphUris = new HashSet<String>(newGraphUris);
-                            addedGraphUris.removeAll(oldGraphUris);
-                            graphURIs.addAll(addedGraphUris);
+                            updateGraphURIs(newURIs);
                         } catch (Exception e) {
                             log.error(e, e);
                         } finally {

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/rdfservice/impl/jena/RDFServiceJena.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/rdfservice/impl/jena/RDFServiceJena.java
@@ -9,9 +9,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.HashSet;
 import java.util.Iterator;
-import java.util.List;
 import java.util.Set;
-import java.util.concurrent.CopyOnWriteArrayList;
 
 import edu.cornell.mannlib.vitro.webapp.controller.VitroRequest;
 import edu.cornell.mannlib.vitro.webapp.dao.jena.DatasetWrapper;
@@ -57,10 +55,6 @@ public abstract class RDFServiceJena extends RDFServiceImpl implements RDFServic
     private final static Log log = LogFactory.getLog(RDFServiceJena.class);
 
     protected abstract DatasetWrapper getDatasetWrapper();
-
-    protected volatile boolean rebuildGraphURICache = true;
-    protected volatile boolean isRebuildGraphURICacheRunning = false;
-    protected final List<String> graphURIs = new CopyOnWriteArrayList<String>();
 
     @Override
 	public abstract boolean changeSetUpdate(ChangeSet changeSet) throws RDFServiceException;
@@ -310,14 +304,6 @@ public abstract class RDFServiceJena extends RDFServiceImpl implements RDFServic
         } finally {
             dw.close();
         }
-    }
-
-    @Override
-    public List<String> getGraphURIs() throws RDFServiceException {
-        if (rebuildGraphURICache && !isRebuildGraphURICacheRunning) {
-            rebuildGraphUris();
-        }
-        return graphURIs;
     }
 
     protected void rebuildGraphUris() {

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/rdfservice/impl/jena/RDFServiceJena.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/rdfservice/impl/jena/RDFServiceJena.java
@@ -307,6 +307,7 @@ public abstract class RDFServiceJena extends RDFServiceImpl implements RDFServic
                         DatasetWrapper dw = getDatasetWrapper();
                         try {
                             isRebuildGraphURICacheRunning = true;
+                            rebuildGraphURICache = false;
                             Dataset d = dw.getDataset();
                             Set<String> newURIs = new HashSet<>();
                             d.begin(ReadWrite.READ);
@@ -324,7 +325,6 @@ public abstract class RDFServiceJena extends RDFServiceImpl implements RDFServic
                         } finally {
                             isRebuildGraphURICacheRunning = false;
                             dw.close();
-                            rebuildGraphURICache = false;
                         }
                     }
                 }

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/rdfservice/impl/sparql/RDFServiceSparql.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/rdfservice/impl/sparql/RDFServiceSparql.java
@@ -384,44 +384,44 @@ public class RDFServiceSparql extends RDFServiceImpl implements RDFService {
 	}
 
 	protected void rebuildGraphUris() {
-        Thread thread = new VitroBackgroundThread(new Runnable() {
-            public void run() {
-                synchronized (RDFServiceJena.class) {
-                    if (rebuildGraphURICache) {
-                        try {
-                            isRebuildGraphURICacheRunning = true;
-                            Set<String> newGraphUris = new HashSet<>();
-                            try {
-                                String fastJenaQuery = "SELECT DISTINCT ?g WHERE { GRAPH ?g {} } ORDER BY ?g";
-                                newGraphUris.addAll(getGraphURIsFromSparqlQuery(fastJenaQuery));
-                            } catch (Exception e) {
-                                log.debug("Unable to use non-standard ARQ query for graph list", e);
-                            }
-                            if (graphURIs.isEmpty()) {
-                                String standardQuery = "SELECT DISTINCT ?g WHERE { GRAPH ?g { ?s ?p ?o } }";
-                                newGraphUris.addAll(getGraphURIsFromSparqlQuery(standardQuery));
-                            }
-                            Set<String> oldGraphUris = new HashSet<String>(graphURIs);
-                            if (newGraphUris.equals(oldGraphUris)) {
-                                return;
-                            }
-                            Set<String> removedGraphUris = new HashSet<String>(oldGraphUris);
-                            removedGraphUris.removeAll(newGraphUris);
-                            graphURIs.removeAll(removedGraphUris);
-                            Set<String> addedGraphUris = new HashSet<String>(newGraphUris);
-                            addedGraphUris.removeAll(oldGraphUris);
-                            graphURIs.addAll(addedGraphUris);
-                        } catch (Exception e) {
-                            log.error(e, e);
-                        } finally {
-                            isRebuildGraphURICacheRunning = false;
-                            rebuildGraphURICache = false;
-                        }
-                    }
-                }
-            }
-        }, "Rebuild graphURI cache thread");
-        thread.start();
+		Thread thread = new VitroBackgroundThread(new Runnable() {
+			public void run() {
+				synchronized (RDFServiceJena.class) {
+					if (rebuildGraphURICache) {
+						try {
+							isRebuildGraphURICacheRunning = true;
+							Set<String> newGraphUris = new HashSet<>();
+							try {
+								String fastJenaQuery = "SELECT DISTINCT ?g WHERE { GRAPH ?g {} } ORDER BY ?g";
+								newGraphUris.addAll(getGraphURIsFromSparqlQuery(fastJenaQuery));
+							} catch (Exception e) {
+								log.debug("Unable to use non-standard ARQ query for graph list", e);
+							}
+							if (graphURIs.isEmpty()) {
+								String standardQuery = "SELECT DISTINCT ?g WHERE { GRAPH ?g { ?s ?p ?o } }";
+								newGraphUris.addAll(getGraphURIsFromSparqlQuery(standardQuery));
+							}
+							Set<String> oldGraphUris = new HashSet<String>(graphURIs);
+							if (newGraphUris.equals(oldGraphUris)) {
+								return;
+							}
+							Set<String> removedGraphUris = new HashSet<String>(oldGraphUris);
+							removedGraphUris.removeAll(newGraphUris);
+							graphURIs.removeAll(removedGraphUris);
+							Set<String> addedGraphUris = new HashSet<String>(newGraphUris);
+							addedGraphUris.removeAll(oldGraphUris);
+							graphURIs.addAll(addedGraphUris);
+						} catch (Exception e) {
+							log.error(e, e);
+						} finally {
+							isRebuildGraphURICacheRunning = false;
+							rebuildGraphURICache = false;
+						}
+					}
+				}
+			}
+		}, "Rebuild graphURI cache thread");
+		thread.start();
 	}
 
 	private List<String> getGraphURIsFromSparqlQuery(String queryString) throws RDFServiceException {

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/rdfservice/impl/sparql/RDFServiceSparql.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/rdfservice/impl/sparql/RDFServiceSparql.java
@@ -90,7 +90,6 @@ public class RDFServiceSparql extends RDFServiceImpl implements RDFService {
 
 	protected HttpClient httpClient;
 
-	protected boolean rebuildGraphURICache = true;
 	/**
 	 * Returns an RDFService for a remote repository
 	 * @param readEndpointURI - URI of the read SPARQL endpoint for the knowledge base

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/rdfservice/impl/sparql/RDFServiceSparql.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/rdfservice/impl/sparql/RDFServiceSparql.java
@@ -390,27 +390,18 @@ public class RDFServiceSparql extends RDFServiceImpl implements RDFService {
 					if (rebuildGraphURICache) {
 						try {
 							isRebuildGraphURICacheRunning = true;
-							Set<String> newGraphUris = new HashSet<>();
+							Set<String> newURIs = new HashSet<>();
 							try {
 								String fastJenaQuery = "SELECT DISTINCT ?g WHERE { GRAPH ?g {} } ORDER BY ?g";
-								newGraphUris.addAll(getGraphURIsFromSparqlQuery(fastJenaQuery));
+								newURIs.addAll(getGraphURIsFromSparqlQuery(fastJenaQuery));
 							} catch (Exception e) {
 								log.debug("Unable to use non-standard ARQ query for graph list", e);
 							}
 							if (graphURIs.isEmpty()) {
 								String standardQuery = "SELECT DISTINCT ?g WHERE { GRAPH ?g { ?s ?p ?o } }";
-								newGraphUris.addAll(getGraphURIsFromSparqlQuery(standardQuery));
+								newURIs.addAll(getGraphURIsFromSparqlQuery(standardQuery));
 							}
-							Set<String> oldGraphUris = new HashSet<String>(graphURIs);
-							if (newGraphUris.equals(oldGraphUris)) {
-								return;
-							}
-							Set<String> removedGraphUris = new HashSet<String>(oldGraphUris);
-							removedGraphUris.removeAll(newGraphUris);
-							graphURIs.removeAll(removedGraphUris);
-							Set<String> addedGraphUris = new HashSet<String>(newGraphUris);
-							addedGraphUris.removeAll(oldGraphUris);
-							graphURIs.addAll(addedGraphUris);
+							updateGraphURIs(newURIs);
 						} catch (Exception e) {
 							log.error(e, e);
 						} finally {

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/rdfservice/impl/sparql/RDFServiceSparql.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/rdfservice/impl/sparql/RDFServiceSparql.java
@@ -81,865 +81,848 @@ import org.apache.jena.sparql.core.Quad;
  */
 public class RDFServiceSparql extends RDFServiceImpl implements RDFService {
 
-	private static final Log log = LogFactory.getLog(RDFServiceImpl.class);
-	protected String readEndpointURI;
-	protected String updateEndpointURI;
-	// the number of triples to be
-	private static final int CHUNK_SIZE = 5000; // added/removed in a single
-	// SPARQL UPDATE
+    private static final Log log = LogFactory.getLog(RDFServiceImpl.class);
+    protected String readEndpointURI;
+    protected String updateEndpointURI;
+    // the number of triples to be
+    private static final int CHUNK_SIZE = 5000; // added/removed in a single
+    // SPARQL UPDATE
 
-	protected HttpClient httpClient;
+    protected HttpClient httpClient;
 
-	/**
-	 * Returns an RDFService for a remote repository
-	 * @param readEndpointURI - URI of the read SPARQL endpoint for the knowledge base
-	 * @param updateEndpointURI - URI of the update SPARQL endpoint for the knowledge base
-	 * @param defaultWriteGraphURI - URI of the default write graph within the knowledge base.
-	 *                   this is the graph that will be written to when a graph
-	 *                   is not explicitly specified.
-	 *
-	 * The default read graph is the union of all graphs in the
-	 * knowledge base
-	 */
-	public RDFServiceSparql(String readEndpointURI, String updateEndpointURI, String defaultWriteGraphURI) {
-		this.readEndpointURI = readEndpointURI;
-		this.updateEndpointURI = updateEndpointURI;
-		httpClient = HttpClientFactory.getHttpClient();
+    /**
+     * Returns an RDFService for a remote repository
+     * 
+     * @param readEndpointURI - URI of the read SPARQL endpoint for the knowledge base
+     * @param updateEndpointURI - URI of the update SPARQL endpoint for the knowledge base
+     * @param defaultWriteGraphURI - URI of the default write graph within the knowledge base. this is the graph that
+     * will be written to when a graph is not explicitly specified.
+     *
+     * The default read graph is the union of all graphs in the knowledge base
+     */
+    public RDFServiceSparql(String readEndpointURI, String updateEndpointURI, String defaultWriteGraphURI) {
+        this.readEndpointURI = readEndpointURI;
+        this.updateEndpointURI = updateEndpointURI;
+        httpClient = HttpClientFactory.getHttpClient();
 
-		if (RDFServiceSparql.class.getName().equals(this.getClass().getName())) {
-			testConnection();
-		}
-	}
+        if (RDFServiceSparql.class.getName().equals(this.getClass().getName())) {
+            testConnection();
+        }
+    }
 
-	protected void testConnection() {
-		try {
-			this.sparqlSelectQuery(
-					"SELECT ?s WHERE { ?s a " +
-							"<http://vitro.mannlib.cornell.edu/ns/vitro/nonsense/> }",
-					RDFService.ResultFormat.JSON);
-		} catch (Exception e) {
-			throw new RuntimeException("Unable to connect to endpoint at " +
-					readEndpointURI, e);
-		}
-	}
+    protected void testConnection() {
+        try {
+            this.sparqlSelectQuery(
+                    "SELECT ?s WHERE { ?s a " + "<http://vitro.mannlib.cornell.edu/ns/vitro/nonsense/> }",
+                    RDFService.ResultFormat.JSON);
+        } catch (Exception e) {
+            throw new RuntimeException("Unable to connect to endpoint at " + readEndpointURI, e);
+        }
+    }
 
-	/**
-	 * Returns an RDFService for a remote repository
-	 * @param readEndpointURI - URI of the read SPARQL endpoint for the knowledge base
-	 * @param updateEndpointURI - URI of the update SPARQL endpoint for the knowledge base
-	 *
-	 * The default read graph is the union of all graphs in the
-	 * knowledge base
-	 */
-	public RDFServiceSparql(String readEndpointURI, String updateEndpointURI) {
-		this(readEndpointURI, updateEndpointURI, null);
-	}
+    /**
+     * Returns an RDFService for a remote repository
+     * 
+     * @param readEndpointURI - URI of the read SPARQL endpoint for the knowledge base
+     * @param updateEndpointURI - URI of the update SPARQL endpoint for the knowledge base
+     *
+     * The default read graph is the union of all graphs in the knowledge base
+     */
+    public RDFServiceSparql(String readEndpointURI, String updateEndpointURI) {
+        this(readEndpointURI, updateEndpointURI, null);
+    }
 
-	/**
-	 * Returns an RDFService for a remote repository
-	 * @param endpointURI - URI of the read and update SPARQL endpoint for the knowledge base
-	 *
-	 * The default read graph is the union of all graphs in the
-	 * knowledge base
-	 */
-	public RDFServiceSparql(String endpointURI) {
-		this(endpointURI, endpointURI, null);
-	}
+    /**
+     * Returns an RDFService for a remote repository
+     * 
+     * @param endpointURI - URI of the read and update SPARQL endpoint for the knowledge base
+     *
+     * The default read graph is the union of all graphs in the knowledge base
+     */
+    public RDFServiceSparql(String endpointURI) {
+        this(endpointURI, endpointURI, null);
+    }
 
-	public void close() {
-		// nothing for now
-	}
+    public void close() {
+        // nothing for now
+    }
 
-	/**
-	 * Perform a series of additions to and or removals from specified graphs
-	 * in the RDF store.  preConditionSparql will be executed against the
-	 * union of all the graphs in the knowledge base before any updates are made.
-	 * If the precondition query returns a non-empty result no updates
-	 * will be made.
-	 *
-	 * @param changeSet - a set of changes to be performed on the RDF store.
-	 *
-	 * @return boolean - indicates whether the precondition was satisfied
-	 */
-	@Override
-	public boolean changeSetUpdate(ChangeSet changeSet)
-			throws RDFServiceException {
+    /**
+     * Perform a series of additions to and or removals from specified graphs in the RDF store. preConditionSparql will
+     * be executed against the union of all the graphs in the knowledge base before any updates are made. If the
+     * precondition query returns a non-empty result no updates will be made.
+     *
+     * @param changeSet - a set of changes to be performed on the RDF store.
+     *
+     * @return boolean - indicates whether the precondition was satisfied
+     */
+    @Override
+    public boolean changeSetUpdate(ChangeSet changeSet) throws RDFServiceException {
 
-		if (changeSet.getPreconditionQuery() != null
-				&& !isPreconditionSatisfied(
-				changeSet.getPreconditionQuery(),
-				changeSet.getPreconditionQueryType())) {
-		    return false;
-		}
+        if (changeSet.getPreconditionQuery() != null
+                && !isPreconditionSatisfied(changeSet.getPreconditionQuery(), changeSet.getPreconditionQueryType())) {
+            return false;
+        }
 
-		try {
+        try {
 
-		    for (Object o : changeSet.getPreChangeEvents()) {
-		        this.notifyListenersOfEvent(o);
-			}
+            for (Object o : changeSet.getPreChangeEvents()) {
+                this.notifyListenersOfEvent(o);
+            }
 
-			for (ModelChange modelChange : changeSet.getModelChanges()) {
-				if (!modelChange.getSerializedModel().markSupported()) {
-					byte[] bytes = IOUtils.toByteArray(modelChange.getSerializedModel());
-					modelChange.setSerializedModel(new ByteArrayInputStream(bytes));
-				}
-				modelChange.getSerializedModel().mark(Integer.MAX_VALUE);
-				performChange(modelChange);
-			}
+            for (ModelChange modelChange : changeSet.getModelChanges()) {
+                if (!modelChange.getSerializedModel().markSupported()) {
+                    byte[] bytes = IOUtils.toByteArray(modelChange.getSerializedModel());
+                    modelChange.setSerializedModel(new ByteArrayInputStream(bytes));
+                }
+                modelChange.getSerializedModel().mark(Integer.MAX_VALUE);
+                performChange(modelChange);
+            }
 
-			notifyListenersOfChanges(changeSet);
+            notifyListenersOfChanges(changeSet);
 
-			for (Object o : changeSet.getPostChangeEvents()) {
-				this.notifyListenersOfEvent(o);
-			}
+            for (Object o : changeSet.getPostChangeEvents()) {
+                this.notifyListenersOfEvent(o);
+            }
 
-		} catch (Exception e) {
-			log.error(e, e);
-			throw new RDFServiceException(e);
-		} finally {
-			rebuildGraphURICache = true;
-		}
-		return true;
-	}
+        } catch (Exception e) {
+            log.error(e, e);
+            throw new RDFServiceException(e);
+        } finally {
+            rebuildGraphURICache = true;
+        }
+        return true;
+    }
 
-	/**
-	 * Performs a SPARQL construct query against the knowledge base. The query may have
-	 * an embedded graph identifier.
-	 *
-	 * @param queryStr - the SPARQL query to be executed against the RDF store
-	 * @param resultFormat - type of serialization for RDF result of the SPARQL query
-	 */
-	@Override
-	public InputStream sparqlConstructQuery(String queryStr,
-											RDFServiceImpl.ModelSerializationFormat resultFormat) throws RDFServiceException {
+    /**
+     * Performs a SPARQL construct query against the knowledge base. The query may have an embedded graph identifier.
+     *
+     * @param queryStr - the SPARQL query to be executed against the RDF store
+     * @param resultFormat - type of serialization for RDF result of the SPARQL query
+     */
+    @Override
+    public InputStream sparqlConstructQuery(String queryStr, RDFServiceImpl.ModelSerializationFormat resultFormat)
+            throws RDFServiceException {
 
-		Model model = ModelFactory.createDefaultModel();
-		Query query = createQuery(queryStr);
-		QueryExecution qe = QueryExecutionFactory.sparqlService(readEndpointURI, query);
+        Model model = ModelFactory.createDefaultModel();
+        Query query = createQuery(queryStr);
+        QueryExecution qe = QueryExecutionFactory.sparqlService(readEndpointURI, query);
 
-		try {
-			qe.execConstruct(model);
-		} catch (Exception e) {
-			log.error("Error executing CONSTRUCT against remote endpoint: " + queryStr);
-		} finally {
-			qe.close();
-		}
+        try {
+            qe.execConstruct(model);
+        } catch (Exception e) {
+            log.error("Error executing CONSTRUCT against remote endpoint: " + queryStr);
+        } finally {
+            qe.close();
+        }
 
-		ByteArrayOutputStream serializedModel = new ByteArrayOutputStream();
-		model.write(serializedModel,getSerializationFormatString(resultFormat));
-		InputStream result = new ByteArrayInputStream(serializedModel.toByteArray());
-		return result;
-	}
+        ByteArrayOutputStream serializedModel = new ByteArrayOutputStream();
+        model.write(serializedModel, getSerializationFormatString(resultFormat));
+        InputStream result = new ByteArrayInputStream(serializedModel.toByteArray());
+        return result;
+    }
 
-	public void sparqlConstructQuery(String queryStr, Model model) throws RDFServiceException {
+    public void sparqlConstructQuery(String queryStr, Model model) throws RDFServiceException {
 
-		Query query = createQuery(queryStr);
-		QueryExecution qe = QueryExecutionFactory.sparqlService(readEndpointURI, query);
+        Query query = createQuery(queryStr);
+        QueryExecution qe = QueryExecutionFactory.sparqlService(readEndpointURI, query);
 
-		try {
-			qe.execConstruct(model);
-		} catch (Exception e) {
-			log.error("Error executing CONSTRUCT against remote endpoint: " + queryStr);
-		} finally {
-			qe.close();
-		}
-	}
+        try {
+            qe.execConstruct(model);
+        } catch (Exception e) {
+            log.error("Error executing CONSTRUCT against remote endpoint: " + queryStr);
+        } finally {
+            qe.close();
+        }
+    }
 
-	/**
-	 * Performs a SPARQL describe query against the knowledge base. The query may have
-	 * an embedded graph identifier.
-	 *
-	 * @param queryStr - the SPARQL query to be executed against the RDF store
-	 * @param resultFormat - type of serialization for RDF result of the SPARQL query
-	 *
-	 * @return InputStream - the result of the query
-	 *
-	 */
-	@Override
-	public InputStream sparqlDescribeQuery(String queryStr,
-										   RDFServiceImpl.ModelSerializationFormat resultFormat) throws RDFServiceException {
+    /**
+     * Performs a SPARQL describe query against the knowledge base. The query may have an embedded graph identifier.
+     *
+     * @param queryStr - the SPARQL query to be executed against the RDF store
+     * @param resultFormat - type of serialization for RDF result of the SPARQL query
+     *
+     * @return InputStream - the result of the query
+     *
+     */
+    @Override
+    public InputStream sparqlDescribeQuery(String queryStr, RDFServiceImpl.ModelSerializationFormat resultFormat)
+            throws RDFServiceException {
 
-		Model model = ModelFactory.createDefaultModel();
-		Query query = createQuery(queryStr);
-		QueryExecution qe = QueryExecutionFactory.sparqlService(readEndpointURI, query);
+        Model model = ModelFactory.createDefaultModel();
+        Query query = createQuery(queryStr);
+        QueryExecution qe = QueryExecutionFactory.sparqlService(readEndpointURI, query);
 
-		try {
-			qe.execDescribe(model);
-		} finally {
-			qe.close();
-		}
+        try {
+            qe.execDescribe(model);
+        } finally {
+            qe.close();
+        }
 
-		ByteArrayOutputStream serializedModel = new ByteArrayOutputStream();
-		model.write(serializedModel,getSerializationFormatString(resultFormat));
-		InputStream result = new ByteArrayInputStream(serializedModel.toByteArray());
-		return result;
-	}
+        ByteArrayOutputStream serializedModel = new ByteArrayOutputStream();
+        model.write(serializedModel, getSerializationFormatString(resultFormat));
+        InputStream result = new ByteArrayInputStream(serializedModel.toByteArray());
+        return result;
+    }
 
-	/**
-	 * Performs a SPARQL select query against the knowledge base. The query may have
-	 * an embedded graph identifier.
-	 *
-	 * @param queryStr - the SPARQL query to be executed against the RDF store
-	 * @param resultFormat - format for the result of the Select query
-	 *
-	 * @return InputStream - the result of the query
-	 *
-	 */
-	@Override
-	public InputStream sparqlSelectQuery(String queryStr, RDFService.ResultFormat resultFormat) throws RDFServiceException {
+    /**
+     * Performs a SPARQL select query against the knowledge base. The query may have an embedded graph identifier.
+     *
+     * @param queryStr - the SPARQL query to be executed against the RDF store
+     * @param resultFormat - format for the result of the Select query
+     *
+     * @return InputStream - the result of the query
+     *
+     */
+    @Override
+    public InputStream sparqlSelectQuery(String queryStr, RDFService.ResultFormat resultFormat)
+            throws RDFServiceException {
 
-		//QueryEngineHTTP qh = new QueryEngineHTTP(readEndpointURI, queryStr);
+        // QueryEngineHTTP qh = new QueryEngineHTTP(readEndpointURI, queryStr);
 
-		try {
-			HttpGet meth = new HttpGet(new URIBuilder(readEndpointURI).addParameter("query", queryStr).build());
-			meth.addHeader("Accept", "application/sparql-results+xml");
-			HttpContext context = getContext(meth);
-			HttpResponse response = context != null ? httpClient.execute(meth, context) : httpClient.execute(meth);
-			try {
-				int statusCode = response.getStatusLine().getStatusCode();
-				if (statusCode > 399) {
-					log.error("response " + statusCode + " to query. \n");
-					log.debug("update string: \n" + queryStr);
-					throw new RDFServiceException("Unable to perform SPARQL SELECT");
-				}
+        try {
+            HttpGet meth = new HttpGet(new URIBuilder(readEndpointURI).addParameter("query", queryStr).build());
+            meth.addHeader("Accept", "application/sparql-results+xml");
+            HttpContext context = getContext(meth);
+            HttpResponse response = context != null ? httpClient.execute(meth, context) : httpClient.execute(meth);
+            try {
+                int statusCode = response.getStatusLine().getStatusCode();
+                if (statusCode > 399) {
+                    log.error("response " + statusCode + " to query. \n");
+                    log.debug("update string: \n" + queryStr);
+                    throw new RDFServiceException("Unable to perform SPARQL SELECT");
+                }
 
-				try (InputStream in = response.getEntity().getContent()) {
-					ResultSet resultSet = ResultSetFactory.fromXML(in);
-					ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-					switch (resultFormat) {
-						case CSV:
-							ResultSetFormatter.outputAsCSV(outputStream, resultSet);
-							break;
-						case TEXT:
-							ResultSetFormatter.out(outputStream, resultSet);
-							break;
-						case JSON:
-							ResultSetFormatter.outputAsJSON(outputStream, resultSet);
-							break;
-						case XML:
-							ResultSetFormatter.outputAsXML(outputStream, resultSet);
-							break;
-						default:
-							throw new RDFServiceException("unrecognized result format");
-					}
-					InputStream result = new ByteArrayInputStream(
-							outputStream.toByteArray());
-					return result;
-				}
-			} finally {
-				EntityUtils.consume(response.getEntity());
-			}
-		} catch (IOException | URISyntaxException ioe) {
-			throw new RuntimeException(ioe);
-		}
-	}
+                try (InputStream in = response.getEntity().getContent()) {
+                    ResultSet resultSet = ResultSetFactory.fromXML(in);
+                    ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+                    switch (resultFormat) {
+                        case CSV:
+                            ResultSetFormatter.outputAsCSV(outputStream, resultSet);
+                            break;
+                        case TEXT:
+                            ResultSetFormatter.out(outputStream, resultSet);
+                            break;
+                        case JSON:
+                            ResultSetFormatter.outputAsJSON(outputStream, resultSet);
+                            break;
+                        case XML:
+                            ResultSetFormatter.outputAsXML(outputStream, resultSet);
+                            break;
+                        default:
+                            throw new RDFServiceException("unrecognized result format");
+                    }
+                    InputStream result = new ByteArrayInputStream(outputStream.toByteArray());
+                    return result;
+                }
+            } finally {
+                EntityUtils.consume(response.getEntity());
+            }
+        } catch (IOException | URISyntaxException ioe) {
+            throw new RuntimeException(ioe);
+        }
+    }
 
-	public void sparqlSelectQuery(String queryStr, ResultSetConsumer consumer) throws RDFServiceException {
+    public void sparqlSelectQuery(String queryStr, ResultSetConsumer consumer) throws RDFServiceException {
 
-		//QueryEngineHTTP qh = new QueryEngineHTTP(readEndpointURI, queryStr);
+        // QueryEngineHTTP qh = new QueryEngineHTTP(readEndpointURI, queryStr);
 
-		try {
-			HttpGet meth = new HttpGet(new URIBuilder(readEndpointURI).addParameter("query", queryStr).build());
-			meth.addHeader("Accept", "application/sparql-results+xml");
-			HttpContext context = getContext(meth);
-			HttpResponse response = context != null ? httpClient.execute(meth, context) : httpClient.execute(meth);
-			try {
-				int statusCode = response.getStatusLine().getStatusCode();
-				if (statusCode > 399) {
-					log.error("response " + statusCode + " to query. \n");
-					log.debug("update string: \n" + queryStr);
-					throw new RDFServiceException("Unable to perform SPARQL UPDATE");
-				}
+        try {
+            HttpGet meth = new HttpGet(new URIBuilder(readEndpointURI).addParameter("query", queryStr).build());
+            meth.addHeader("Accept", "application/sparql-results+xml");
+            HttpContext context = getContext(meth);
+            HttpResponse response = context != null ? httpClient.execute(meth, context) : httpClient.execute(meth);
+            try {
+                int statusCode = response.getStatusLine().getStatusCode();
+                if (statusCode > 399) {
+                    log.error("response " + statusCode + " to query. \n");
+                    log.debug("update string: \n" + queryStr);
+                    throw new RDFServiceException("Unable to perform SPARQL UPDATE");
+                }
 
-				try (InputStream in = response.getEntity().getContent()) {
-					consumer.processResultSet(ResultSetFactory.fromXML(in));
-				}
-			} finally {
-				EntityUtils.consume(response.getEntity());
-			}
-		} catch (IOException | URISyntaxException ioe) {
-			throw new RuntimeException(ioe);
-		}
-	}
+                try (InputStream in = response.getEntity().getContent()) {
+                    consumer.processResultSet(ResultSetFactory.fromXML(in));
+                }
+            } finally {
+                EntityUtils.consume(response.getEntity());
+            }
+        } catch (IOException | URISyntaxException ioe) {
+            throw new RuntimeException(ioe);
+        }
+    }
 
-	/**
-	 * Performs a SPARQL ASK query against the knowledge base. The query may have
-	 * an embedded graph identifier.
-	 *
-	 * @param queryStr - the SPARQL query to be executed against the RDF store
-	 *
-	 * @return  boolean - the result of the SPARQL query
-	 */
-	@Override
-	public boolean sparqlAskQuery(String queryStr) throws RDFServiceException {
+    /**
+     * Performs a SPARQL ASK query against the knowledge base. The query may have an embedded graph identifier.
+     *
+     * @param queryStr - the SPARQL query to be executed against the RDF store
+     *
+     * @return boolean - the result of the SPARQL query
+     */
+    @Override
+    public boolean sparqlAskQuery(String queryStr) throws RDFServiceException {
 
-		Query query = createQuery(queryStr);
-		QueryExecution qe = QueryExecutionFactory.sparqlService(readEndpointURI, query);
+        Query query = createQuery(queryStr);
+        QueryExecution qe = QueryExecutionFactory.sparqlService(readEndpointURI, query);
 
-		try {
-			return qe.execAsk();
-		} finally {
-			qe.close();
-		}
-	}
+        try {
+            return qe.execAsk();
+        } finally {
+            qe.close();
+        }
+    }
 
-	protected void rebuildGraphUris() {
-		Thread thread = new VitroBackgroundThread(new Runnable() {
-			public void run() {
-				synchronized (RDFServiceJena.class) {
-					if (rebuildGraphURICache) {
-						try {
-							isRebuildGraphURICacheRunning = true;
-							Set<String> newURIs = new HashSet<>();
-							try {
-								String fastJenaQuery = "SELECT DISTINCT ?g WHERE { GRAPH ?g {} } ORDER BY ?g";
-								newURIs.addAll(getGraphURIsFromSparqlQuery(fastJenaQuery));
-							} catch (Exception e) {
-								log.debug("Unable to use non-standard ARQ query for graph list", e);
-							}
-							if (graphURIs.isEmpty()) {
-								String standardQuery = "SELECT DISTINCT ?g WHERE { GRAPH ?g { ?s ?p ?o } }";
-								newURIs.addAll(getGraphURIsFromSparqlQuery(standardQuery));
-							}
-							updateGraphURIs(newURIs);
-						} catch (Exception e) {
-							log.error(e, e);
-						} finally {
-							isRebuildGraphURICacheRunning = false;
-							rebuildGraphURICache = false;
-						}
-					}
-				}
-			}
-		}, "Rebuild graphURI cache thread");
-		thread.start();
-	}
+    protected void rebuildGraphUris() {
+        Thread thread = new VitroBackgroundThread(new Runnable() {
+            public void run() {
+                synchronized (RDFServiceJena.class) {
+                    if (rebuildGraphURICache) {
+                        try {
+                            isRebuildGraphURICacheRunning = true;
+                            Set<String> newURIs = new HashSet<>();
+                            try {
+                                String fastJenaQuery = "SELECT DISTINCT ?g WHERE { GRAPH ?g {} } ORDER BY ?g";
+                                newURIs.addAll(getGraphURIsFromSparqlQuery(fastJenaQuery));
+                            } catch (Exception e) {
+                                log.debug("Unable to use non-standard ARQ query for graph list", e);
+                            }
+                            if (graphURIs.isEmpty()) {
+                                String standardQuery = "SELECT DISTINCT ?g WHERE { GRAPH ?g { ?s ?p ?o } }";
+                                newURIs.addAll(getGraphURIsFromSparqlQuery(standardQuery));
+                            }
+                            updateGraphURIs(newURIs);
+                        } catch (Exception e) {
+                            log.error(e, e);
+                        } finally {
+                            isRebuildGraphURICacheRunning = false;
+                            rebuildGraphURICache = false;
+                        }
+                    }
+                }
+            }
+        }, "Rebuild graphURI cache thread");
+        thread.start();
+    }
 
-	private List<String> getGraphURIsFromSparqlQuery(String queryString) throws RDFServiceException {
-		final List<String> graphURIs = new ArrayList<String>();
-		try {
-			sparqlSelectQuery(queryString, new ResultSetConsumer() {
-				@Override
-				protected void processQuerySolution(QuerySolution qs) {
-					if (qs != null) { // no idea how this happens, but it seems to
-						RDFNode n = qs.getResource("g");
-						if (n != null && n.isResource()) {
-							graphURIs.add(((Resource) n).getURI());
-						}
-					}
-				}
-			});
-		} catch (Exception e) {
-			throw new RDFServiceException("Unable to list graph URIs", e);
-		}
-		return graphURIs;
-	}
+    private List<String> getGraphURIsFromSparqlQuery(String queryString) throws RDFServiceException {
+        final List<String> graphURIs = new ArrayList<String>();
+        try {
+            sparqlSelectQuery(queryString, new ResultSetConsumer() {
+                @Override
+                protected void processQuerySolution(QuerySolution qs) {
+                    if (qs != null) { // no idea how this happens, but it seems to
+                        RDFNode n = qs.getResource("g");
+                        if (n != null && n.isResource()) {
+                            graphURIs.add(((Resource) n).getURI());
+                        }
+                    }
+                }
+            });
+        } catch (Exception e) {
+            throw new RDFServiceException("Unable to list graph URIs", e);
+        }
+        return graphURIs;
+    }
 
-	/**
-	 */
-	@Override
-	public void getGraphMetadata() throws RDFServiceException {
-	    throw new UnsupportedOperationException();
-	}
+    /**
+     */
+    @Override
+    public void getGraphMetadata() throws RDFServiceException {
+        throw new UnsupportedOperationException();
+    }
 
-	/**
-	 * Get the URI of the default write graph
-	 *
-	 * @return String URI of default write graph
-	 */
-	@Override
-	public String getDefaultWriteGraphURI() throws RDFServiceException {
-		return defaultWriteGraphURI;
-	}
+    /**
+     * Get the URI of the default write graph
+     *
+     * @return String URI of default write graph
+     */
+    @Override
+    public String getDefaultWriteGraphURI() throws RDFServiceException {
+        return defaultWriteGraphURI;
+    }
 
-	/**
-	 * Register a listener to listen to changes in any graph in
-	 * the RDF store.
-	 *
-	 */
-	@Override
-	public synchronized void registerListener(ChangeListener changeListener) throws RDFServiceException {
+    /**
+     * Register a listener to listen to changes in any graph in the RDF store.
+     *
+     */
+    @Override
+    public synchronized void registerListener(ChangeListener changeListener) throws RDFServiceException {
 
-		if (!registeredListeners.contains(changeListener)) {
-			registeredListeners.add(changeListener);
-		}
-	}
+        if (!registeredListeners.contains(changeListener)) {
+            registeredListeners.add(changeListener);
+        }
+    }
 
-	/**
-	 * Unregister a listener from listening to changes in any graph
-	 * in the RDF store.
-	 *
-	 */
-	@Override
-	public synchronized void unregisterListener(ChangeListener changeListener) throws RDFServiceException {
-		registeredListeners.remove(changeListener);
-	}
+    /**
+     * Unregister a listener from listening to changes in any graph in the RDF store.
+     *
+     */
+    @Override
+    public synchronized void unregisterListener(ChangeListener changeListener) throws RDFServiceException {
+        registeredListeners.remove(changeListener);
+    }
 
-	/**
-	 * Create a ChangeSet object
-	 *
-	 * @return a ChangeSet object
-	 */
-	@Override
-	public ChangeSet manufactureChangeSet() {
-		return new ChangeSetImpl();
-	}
+    /**
+     * Create a ChangeSet object
+     *
+     * @return a ChangeSet object
+     */
+    @Override
+    public ChangeSet manufactureChangeSet() {
+        return new ChangeSetImpl();
+    }
 
-	//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-	// Non-override methods below
-	//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-	protected String getReadEndpointURI() {
-		return readEndpointURI;
-	}
+    // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    // Non-override methods below
+    // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    protected String getReadEndpointURI() {
+        return readEndpointURI;
+    }
 
-	protected String getUpdateEndpointURI() {
-		return updateEndpointURI;
-	}
+    protected String getUpdateEndpointURI() {
+        return updateEndpointURI;
+    }
 
-	protected void executeUpdate(String updateString) throws RDFServiceException {
-		try {
-			HttpPost meth = new HttpPost(updateEndpointURI);
-			meth.addHeader("Content-Type", "application/x-www-form-urlencoded; charset="+Consts.UTF_8);
-			meth.setEntity(new UrlEncodedFormEntity(Arrays.asList(new BasicNameValuePair("update", updateString)),Consts.UTF_8));
-			HttpContext context = getContext(meth);
-			HttpResponse response = context != null ? httpClient.execute(meth, context) : httpClient.execute(meth);
-			try {
-				int statusCode = response.getStatusLine().getStatusCode();
-				if (statusCode > 399) {
-					log.error("response " + response.getStatusLine() + " to update. \n");
-					//log.debug("update string: \n" + updateString);
-					throw new RDFServiceException("Unable to perform SPARQL UPDATE");
-				}
-			} finally {
-				EntityUtils.consume(response.getEntity());
-			}
-		} catch (Exception e) {
-			log.debug("update string: \n" + updateString);
-			throw new RDFServiceException("Unable to perform change set update", e);
-		}
-	}
+    protected void executeUpdate(String updateString) throws RDFServiceException {
+        try {
+            HttpPost meth = new HttpPost(updateEndpointURI);
+            meth.addHeader("Content-Type", "application/x-www-form-urlencoded; charset=" + Consts.UTF_8);
+            meth.setEntity(new UrlEncodedFormEntity(Arrays.asList(new BasicNameValuePair("update", updateString)),
+                    Consts.UTF_8));
+            HttpContext context = getContext(meth);
+            HttpResponse response = context != null ? httpClient.execute(meth, context) : httpClient.execute(meth);
+            try {
+                int statusCode = response.getStatusLine().getStatusCode();
+                if (statusCode > 399) {
+                    log.error("response " + response.getStatusLine() + " to update. \n");
+                    // log.debug("update string: \n" + updateString);
+                    throw new RDFServiceException("Unable to perform SPARQL UPDATE");
+                }
+            } finally {
+                EntityUtils.consume(response.getEntity());
+            }
+        } catch (Exception e) {
+            log.debug("update string: \n" + updateString);
+            throw new RDFServiceException("Unable to perform change set update", e);
+        }
+    }
 
-	private void addModel(Model model, String graphURI) throws RDFServiceException {
-		try {
-		    long start = System.currentTimeMillis();
-			verbModel(model, graphURI, "INSERT");
-			log.info((System.currentTimeMillis() - start) + " ms to insert " + model.size() + " triples");
-		} finally {
-			rebuildGraphURICache = true;
-		}
-	}
+    private void addModel(Model model, String graphURI) throws RDFServiceException {
+        try {
+            long start = System.currentTimeMillis();
+            verbModel(model, graphURI, "INSERT");
+            log.info((System.currentTimeMillis() - start) + " ms to insert " + model.size() + " triples");
+        } finally {
+            rebuildGraphURICache = true;
+        }
+    }
 
-	private void deleteModel(Model model, String graphURI) throws RDFServiceException {
-		try {
-			verbModel(model, graphURI, "DELETE");
-		} finally {
-			rebuildGraphURICache = true;
-		}
-	}
+    private void deleteModel(Model model, String graphURI) throws RDFServiceException {
+        try {
+            verbModel(model, graphURI, "DELETE");
+        } finally {
+            rebuildGraphURICache = true;
+        }
+    }
 
-	private void verbModel(Model model, String graphURI, String verb) throws RDFServiceException {
-		Model m = ModelFactory.createDefaultModel();
-		StmtIterator stmtIt = model.listStatements();
-		int count = 0;
-		try {
-			while (stmtIt.hasNext()) {
-				count++;
-				m.add(stmtIt.nextStatement());
-				if (count % CHUNK_SIZE == 0 || !stmtIt.hasNext()) {
-					StringWriter sw = new StringWriter();
-					m.write(sw, "N-TRIPLE");
-					StringBuilder updateStringBuff = new StringBuilder();
-					updateStringBuff.append(verb).append(" DATA { ").append((graphURI != null) ? "GRAPH <" + graphURI + "> { " : "");
-					updateStringBuff.append(sw);
-					updateStringBuff.append((graphURI != null) ? " } " : "").append(" }");
+    private void verbModel(Model model, String graphURI, String verb) throws RDFServiceException {
+        Model m = ModelFactory.createDefaultModel();
+        StmtIterator stmtIt = model.listStatements();
+        int count = 0;
+        try {
+            while (stmtIt.hasNext()) {
+                count++;
+                m.add(stmtIt.nextStatement());
+                if (count % CHUNK_SIZE == 0 || !stmtIt.hasNext()) {
+                    StringWriter sw = new StringWriter();
+                    m.write(sw, "N-TRIPLE");
+                    StringBuilder updateStringBuff = new StringBuilder();
+                    updateStringBuff.append(verb).append(" DATA { ")
+                            .append((graphURI != null) ? "GRAPH <" + graphURI + "> { " : "");
+                    updateStringBuff.append(sw);
+                    updateStringBuff.append((graphURI != null) ? " } " : "").append(" }");
 
-					String updateString = updateStringBuff.toString();
+                    String updateString = updateStringBuff.toString();
 
-					executeUpdate(updateString);
+                    executeUpdate(updateString);
 
-					m.removeAll();
-				}
-			}
-		} finally {
-			stmtIt.close();
-		}
-	}
+                    m.removeAll();
+                }
+            }
+        } finally {
+            stmtIt.close();
+        }
+    }
 
-//	protected void addTriple(Triple t, String graphURI) throws RDFServiceException {
-//		try {
-//			StringBuffer updateString = new StringBuffer();
-//			updateString.append("INSERT DATA { ");
-//			updateString.append((graphURI != null) ? "GRAPH <" + graphURI + "> { " : "");
-//			updateString.append(sparqlNodeUpdate(t.getSubject(), ""));
-//			updateString.append(" ");
-//			updateString.append(sparqlNodeUpdate(t.getPredicate(), ""));
-//			updateString.append(" ");
-//			updateString.append(sparqlNodeUpdate(t.getObject(), ""));
-//			updateString.append(" }");
-//			updateString.append((graphURI != null) ? " } " : "");
+//    protected void addTriple(Triple t, String graphURI) throws RDFServiceException {
+//        try {
+//            StringBuffer updateString = new StringBuffer();
+//            updateString.append("INSERT DATA { ");
+//            updateString.append((graphURI != null) ? "GRAPH <" + graphURI + "> { " : "");
+//            updateString.append(sparqlNodeUpdate(t.getSubject(), ""));
+//            updateString.append(" ");
+//            updateString.append(sparqlNodeUpdate(t.getPredicate(), ""));
+//            updateString.append(" ");
+//            updateString.append(sparqlNodeUpdate(t.getObject(), ""));
+//            updateString.append(" }");
+//            updateString.append((graphURI != null) ? " } " : "");
 //
-//			executeUpdate(updateString.toString());
-//			notifyListeners(t, ModelChange.Operation.ADD, graphURI);
-//		} finally {
-//			rebuildGraphURICache = true;
-//		}
-//	}
+//            executeUpdate(updateString.toString());
+//            notifyListeners(t, ModelChange.Operation.ADD, graphURI);
+//        } finally {
+//            rebuildGraphURICache = true;
+//        }
+//    }
 //
-//	protected void removeTriple(Triple t, String graphURI) throws RDFServiceException {
-//		try {
-//			StringBuffer updateString = new StringBuffer();
-//			updateString.append("DELETE DATA { ");
-//			updateString.append((graphURI != null) ? "GRAPH <" + graphURI + "> { " : "");
-//			updateString.append(sparqlNodeUpdate(t.getSubject(), ""));
-//			updateString.append(" ");
-//			updateString.append(sparqlNodeUpdate(t.getPredicate(), ""));
-//			updateString.append(" ");
-//			updateString.append(sparqlNodeUpdate(t.getObject(), ""));
-//			updateString.append(" }");
-//			updateString.append((graphURI != null) ? " } " : "");
+//    protected void removeTriple(Triple t, String graphURI) throws RDFServiceException {
+//        try {
+//            StringBuffer updateString = new StringBuffer();
+//            updateString.append("DELETE DATA { ");
+//            updateString.append((graphURI != null) ? "GRAPH <" + graphURI + "> { " : "");
+//            updateString.append(sparqlNodeUpdate(t.getSubject(), ""));
+//            updateString.append(" ");
+//            updateString.append(sparqlNodeUpdate(t.getPredicate(), ""));
+//            updateString.append(" ");
+//            updateString.append(sparqlNodeUpdate(t.getObject(), ""));
+//            updateString.append(" }");
+//            updateString.append((graphURI != null) ? " } " : "");
 //
-//			executeUpdate(updateString.toString());
-//			notifyListeners(t, ModelChange.Operation.REMOVE, graphURI);
-//		} finally {
-//			rebuildGraphURICache = true;
-//		}
-//	}
+//            executeUpdate(updateString.toString());
+//            notifyListeners(t, ModelChange.Operation.REMOVE, graphURI);
+//        } finally {
+//            rebuildGraphURICache = true;
+//        }
+//    }
 
-	@Override
-	protected boolean isPreconditionSatisfied(String query,
-											  RDFService.SPARQLQueryType queryType)
-			throws RDFServiceException {
-		Model model = ModelFactory.createDefaultModel();
+    @Override
+    protected boolean isPreconditionSatisfied(String query, RDFService.SPARQLQueryType queryType)
+            throws RDFServiceException {
+        Model model = ModelFactory.createDefaultModel();
 
-		switch (queryType) {
-			case DESCRIBE:
-				model.read(sparqlDescribeQuery(query,RDFService.ModelSerializationFormat.N3), null);
-				return !model.isEmpty();
-			case CONSTRUCT:
-				model.read(sparqlConstructQuery(query,RDFService.ModelSerializationFormat.N3), null);
-				return !model.isEmpty();
-			case SELECT:
-				return sparqlSelectQueryHasResults(query);
-			case ASK:
-				return sparqlAskQuery(query);
-			default:
-				throw new RDFServiceException("unrecognized SPARQL query type");
-		}
-	}
+        switch (queryType) {
+            case DESCRIBE:
+                model.read(sparqlDescribeQuery(query, RDFService.ModelSerializationFormat.N3), null);
+                return !model.isEmpty();
+            case CONSTRUCT:
+                model.read(sparqlConstructQuery(query, RDFService.ModelSerializationFormat.N3), null);
+                return !model.isEmpty();
+            case SELECT:
+                return sparqlSelectQueryHasResults(query);
+            case ASK:
+                return sparqlAskQuery(query);
+            default:
+                throw new RDFServiceException("unrecognized SPARQL query type");
+        }
+    }
 
-	@Override
-	protected boolean sparqlSelectQueryHasResults(String queryStr) throws RDFServiceException {
+    @Override
+    protected boolean sparqlSelectQueryHasResults(String queryStr) throws RDFServiceException {
 
-		Query query = createQuery(queryStr);
-		QueryExecution qe = QueryExecutionFactory.sparqlService(readEndpointURI, query);
+        Query query = createQuery(queryStr);
+        QueryExecution qe = QueryExecutionFactory.sparqlService(readEndpointURI, query);
 
-		try {
-			ResultSet resultSet = qe.execSelect();
-			return resultSet.hasNext();
-		} finally {
-			qe.close();
-		}
-	}
+        try {
+            ResultSet resultSet = qe.execSelect();
+            return resultSet.hasNext();
+        } finally {
+            qe.close();
+        }
+    }
 
-	private void performChange(ModelChange modelChange) throws RDFServiceException {
-		Model model = parseModel(modelChange);
-		Model[] separatedModel = separateStatementsWithBlankNodes(model);
-		if (modelChange.getOperation() == ModelChange.Operation.ADD) {
-			addModel(separatedModel[1], modelChange.getGraphURI());
-			addBlankNodesWithSparqlUpdate(separatedModel[0], modelChange.getGraphURI());
-		} else if (modelChange.getOperation() == ModelChange.Operation.REMOVE) {
-			deleteModel(separatedModel[1], modelChange.getGraphURI());
-			removeBlankNodesWithSparqlUpdate(separatedModel[0], modelChange.getGraphURI());
-		} else {
-			log.error("unrecognized operation type");
-		}
-	}
+    private void performChange(ModelChange modelChange) throws RDFServiceException {
+        Model model = parseModel(modelChange);
+        Model[] separatedModel = separateStatementsWithBlankNodes(model);
+        if (modelChange.getOperation() == ModelChange.Operation.ADD) {
+            addModel(separatedModel[1], modelChange.getGraphURI());
+            addBlankNodesWithSparqlUpdate(separatedModel[0], modelChange.getGraphURI());
+        } else if (modelChange.getOperation() == ModelChange.Operation.REMOVE) {
+            deleteModel(separatedModel[1], modelChange.getGraphURI());
+            removeBlankNodesWithSparqlUpdate(separatedModel[0], modelChange.getGraphURI());
+        } else {
+            log.error("unrecognized operation type");
+        }
+    }
 
-	private void addBlankNodesWithSparqlUpdate(Model model, String graphURI)
-			throws RDFServiceException {
-		updateBlankNodesWithSparqlUpdate(model, graphURI, ADD);
-	}
+    private void addBlankNodesWithSparqlUpdate(Model model, String graphURI) throws RDFServiceException {
+        updateBlankNodesWithSparqlUpdate(model, graphURI, ADD);
+    }
 
-	private void removeBlankNodesWithSparqlUpdate(Model model, String graphURI)
-			throws RDFServiceException {
-		updateBlankNodesWithSparqlUpdate(model, graphURI, REMOVE);
-	}
+    private void removeBlankNodesWithSparqlUpdate(Model model, String graphURI) throws RDFServiceException {
+        updateBlankNodesWithSparqlUpdate(model, graphURI, REMOVE);
+    }
 
-	private static final boolean ADD = true;
-	private static final boolean REMOVE = false;
+    private static final boolean ADD = true;
+    private static final boolean REMOVE = false;
 
-	private void updateBlankNodesWithSparqlUpdate(Model model, String graphURI, boolean add)
-			throws RDFServiceException {
-		List<Statement> blankNodeStatements = new ArrayList<Statement>();
-		StmtIterator stmtIt = model.listStatements();
-		while (stmtIt.hasNext()) {
-			Statement stmt = stmtIt.nextStatement();
-			if (stmt.getSubject().isAnon() || stmt.getObject().isAnon()) {
-				blankNodeStatements.add(stmt);
-			}
-		}
+    private void updateBlankNodesWithSparqlUpdate(Model model, String graphURI, boolean add)
+            throws RDFServiceException {
+        List<Statement> blankNodeStatements = new ArrayList<Statement>();
+        StmtIterator stmtIt = model.listStatements();
+        while (stmtIt.hasNext()) {
+            Statement stmt = stmtIt.nextStatement();
+            if (stmt.getSubject().isAnon() || stmt.getObject().isAnon()) {
+                blankNodeStatements.add(stmt);
+            }
+        }
 
-		if(blankNodeStatements.size() == 0) {
-			return;
-		}
+        if (blankNodeStatements.size() == 0) {
+            return;
+        }
 
-		Model blankNodeModel = ModelFactory.createDefaultModel();
-		blankNodeModel.add(blankNodeStatements);
+        Model blankNodeModel = ModelFactory.createDefaultModel();
+        blankNodeModel.add(blankNodeStatements);
 
-		log.debug("update model size " + model.size());
-		log.debug("blank node model size " + blankNodeModel.size());
+        log.debug("update model size " + model.size());
+        log.debug("blank node model size " + blankNodeModel.size());
 
-		if (!add && blankNodeModel.size() == 1) {
-			log.warn("Deleting single triple with blank node: " + blankNodeModel);
-			log.warn("This likely indicates a problem; excessive data may be deleted.");
-		}
+        if (!add && blankNodeModel.size() == 1) {
+            log.warn("Deleting single triple with blank node: " + blankNodeModel);
+            log.warn("This likely indicates a problem; excessive data may be deleted.");
+        }
 
-		Query rootFinderQuery = QueryFactory.create(JenaModelUtils.BNODE_ROOT_QUERY);
-		QueryExecution qe = QueryExecutionFactory.create(rootFinderQuery, blankNodeModel);
-		try {
-			ResultSet rs = qe.execSelect();
-			while (rs.hasNext()) {
-				QuerySolution qs = rs.next();
-				org.apache.jena.rdf.model.Resource s = qs.getResource("s");
-				String treeFinder = makeDescribe(s);
-				Query treeFinderQuery = QueryFactory.create(treeFinder);
-				QueryExecution qee = QueryExecutionFactory.create(treeFinderQuery, blankNodeModel);
-				try {
-					Model tree = qee.execDescribe();
-					if (s.isAnon()) {
-						if (add) {
-							addModel(tree, graphURI);
-						} else {
-							removeUsingSparqlUpdate(tree, graphURI);
-						}
-					} else {
-						StmtIterator sit = tree.listStatements(s, null, (RDFNode) null);
-						while (sit.hasNext()) {
-							Statement stmt = sit.nextStatement();
-							RDFNode n = stmt.getObject();
-							Model m2 = ModelFactory.createDefaultModel();
-							if (n.isResource()) {
-								org.apache.jena.rdf.model.Resource s2 =
-										(org.apache.jena.rdf.model.Resource) n;
-								// now run yet another describe query
-								String smallerTree = makeDescribe(s2);
-								Query smallerTreeQuery = QueryFactory.create(smallerTree);
-								QueryExecution qe3 = QueryExecutionFactory.create(
-										smallerTreeQuery, tree);
-								try {
-									qe3.execDescribe(m2);
-								} finally {
-									qe3.close();
-								}
-							}
-							m2.add(stmt);
-							if (add) {
-								addModel(m2, graphURI);
-							} else {
-								removeUsingSparqlUpdate(m2, graphURI);
-							}
-						}
-					}
-				} finally {
-					qee.close();
-				}
-			}
-		} finally {
-			qe.close();
-		}
-	}
+        Query rootFinderQuery = QueryFactory.create(JenaModelUtils.BNODE_ROOT_QUERY);
+        QueryExecution qe = QueryExecutionFactory.create(rootFinderQuery, blankNodeModel);
+        try {
+            ResultSet rs = qe.execSelect();
+            while (rs.hasNext()) {
+                QuerySolution qs = rs.next();
+                org.apache.jena.rdf.model.Resource s = qs.getResource("s");
+                String treeFinder = makeDescribe(s);
+                Query treeFinderQuery = QueryFactory.create(treeFinder);
+                QueryExecution qee = QueryExecutionFactory.create(treeFinderQuery, blankNodeModel);
+                try {
+                    Model tree = qee.execDescribe();
+                    if (s.isAnon()) {
+                        if (add) {
+                            addModel(tree, graphURI);
+                        } else {
+                            removeUsingSparqlUpdate(tree, graphURI);
+                        }
+                    } else {
+                        StmtIterator sit = tree.listStatements(s, null, (RDFNode) null);
+                        while (sit.hasNext()) {
+                            Statement stmt = sit.nextStatement();
+                            RDFNode n = stmt.getObject();
+                            Model m2 = ModelFactory.createDefaultModel();
+                            if (n.isResource()) {
+                                org.apache.jena.rdf.model.Resource s2 = (org.apache.jena.rdf.model.Resource) n;
+                                // now run yet another describe query
+                                String smallerTree = makeDescribe(s2);
+                                Query smallerTreeQuery = QueryFactory.create(smallerTree);
+                                QueryExecution qe3 = QueryExecutionFactory.create(smallerTreeQuery, tree);
+                                try {
+                                    qe3.execDescribe(m2);
+                                } finally {
+                                    qe3.close();
+                                }
+                            }
+                            m2.add(stmt);
+                            if (add) {
+                                addModel(m2, graphURI);
+                            } else {
+                                removeUsingSparqlUpdate(m2, graphURI);
+                            }
+                        }
+                    }
+                } finally {
+                    qee.close();
+                }
+            }
+        } finally {
+            qe.close();
+        }
+    }
 
-	private void removeUsingSparqlUpdate(Model model, String graphURI)
-			throws RDFServiceException {
+    private void removeUsingSparqlUpdate(Model model, String graphURI) throws RDFServiceException {
 
-		StmtIterator stmtIt = model.listStatements();
+        StmtIterator stmtIt = model.listStatements();
 
-		if (!stmtIt.hasNext()) {
-			stmtIt.close();
-			return;
-		}
+        if (!stmtIt.hasNext()) {
+            stmtIt.close();
+            return;
+        }
 
-		StringBuffer queryBuff = new StringBuffer();
-		if (graphURI != null) {
-			queryBuff.append("WITH <").append(graphURI).append("> \n");
-		}
-		queryBuff.append("DELETE { \n");
-		List<Statement> stmts = stmtIt.toList();
-		sort(stmts);
-		addStatementPatterns(stmts, queryBuff, !WHERE_CLAUSE);
-		queryBuff.append("} WHERE { \n");
-		stmtIt = model.listStatements();
-		stmts = stmtIt.toList();
-		sort(stmts);
-		addStatementPatterns(stmts, queryBuff, WHERE_CLAUSE);
-		queryBuff.append("} \n");
+        StringBuffer queryBuff = new StringBuffer();
+        if (graphURI != null) {
+            queryBuff.append("WITH <").append(graphURI).append("> \n");
+        }
+        queryBuff.append("DELETE { \n");
+        List<Statement> stmts = stmtIt.toList();
+        sort(stmts);
+        addStatementPatterns(stmts, queryBuff, !WHERE_CLAUSE);
+        queryBuff.append("} WHERE { \n");
+        stmtIt = model.listStatements();
+        stmts = stmtIt.toList();
+        sort(stmts);
+        addStatementPatterns(stmts, queryBuff, WHERE_CLAUSE);
+        queryBuff.append("} \n");
 
-		if(log.isDebugEnabled()) {
-			log.debug(queryBuff.toString());
-		}
-		executeUpdate(queryBuff.toString());
-	}
+        if (log.isDebugEnabled()) {
+            log.debug(queryBuff.toString());
+        }
+        executeUpdate(queryBuff.toString());
+    }
 
-	private List<Statement> sort(List<Statement> stmts) {
-		List<Statement> output = new ArrayList<Statement>();
-		int originalSize = stmts.size();
-		if (originalSize == 1)
-			return stmts;
-		List <Statement> remaining = stmts;
-		ConcurrentLinkedQueue<org.apache.jena.rdf.model.Resource> subjQueue =
-				new ConcurrentLinkedQueue<org.apache.jena.rdf.model.Resource>();
-		for(Statement stmt : remaining) {
-			if(stmt.getSubject().isURIResource()) {
-				subjQueue.add(stmt.getSubject());
-				break;
-			}
-		}
-		if (subjQueue.isEmpty()) {
-			throw new RuntimeException("No named subject in statement patterns");
-		}
-		while(remaining.size() > 0) {
-			if(subjQueue.isEmpty()) {
-				subjQueue.add(remaining.get(0).getSubject());
-			}
-			while(!subjQueue.isEmpty()) {
-				org.apache.jena.rdf.model.Resource subj = subjQueue.poll();
-				List<Statement> temp = new ArrayList<Statement>();
-				for (Statement stmt : remaining) {
-					if(stmt.getSubject().equals(subj)) {
-						output.add(stmt);
-						if (stmt.getObject().isResource()) {
-							subjQueue.add((org.apache.jena.rdf.model.Resource) stmt.getObject());
-						}
-					} else {
-						temp.add(stmt);
-					}
-				}
-				remaining = temp;
-			}
-		}
-		if(output.size() != originalSize) {
-			throw new RuntimeException("original list size was " + originalSize +
-					" but sorted size is " + output.size());
-		}
-		return output;
-	}
+    private List<Statement> sort(List<Statement> stmts) {
+        List<Statement> output = new ArrayList<Statement>();
+        int originalSize = stmts.size();
+        if (originalSize == 1) {
+            return stmts;
+        }
+        List<Statement> remaining = stmts;
+        ConcurrentLinkedQueue<org.apache.jena.rdf.model.Resource> subjQueue =
+                new ConcurrentLinkedQueue<org.apache.jena.rdf.model.Resource>();
+        for (Statement stmt : remaining) {
+            if (stmt.getSubject().isURIResource()) {
+                subjQueue.add(stmt.getSubject());
+                break;
+            }
+        }
+        if (subjQueue.isEmpty()) {
+            throw new RuntimeException("No named subject in statement patterns");
+        }
+        while (remaining.size() > 0) {
+            if (subjQueue.isEmpty()) {
+                subjQueue.add(remaining.get(0).getSubject());
+            }
+            while (!subjQueue.isEmpty()) {
+                org.apache.jena.rdf.model.Resource subj = subjQueue.poll();
+                List<Statement> temp = new ArrayList<Statement>();
+                for (Statement stmt : remaining) {
+                    if (stmt.getSubject().equals(subj)) {
+                        output.add(stmt);
+                        if (stmt.getObject().isResource()) {
+                            subjQueue.add((org.apache.jena.rdf.model.Resource) stmt.getObject());
+                        }
+                    } else {
+                        temp.add(stmt);
+                    }
+                }
+                remaining = temp;
+            }
+        }
+        if (output.size() != originalSize) {
+            throw new RuntimeException(
+                    "original list size was " + originalSize + " but sorted size is " + output.size());
+        }
+        return output;
+    }
 
-	private static final boolean WHERE_CLAUSE = true;
+    private static final boolean WHERE_CLAUSE = true;
 
-	private void addStatementPatterns(List<Statement> stmts, StringBuffer patternBuff, boolean whereClause) {
-		for(Statement stmt : stmts) {
-			Triple t = stmt.asTriple();
-			patternBuff.append(SparqlGraph.sparqlNodeDelete(t.getSubject(), null));
-			patternBuff.append(" ");
-			patternBuff.append(SparqlGraph.sparqlNodeDelete(t.getPredicate(), null));
-			patternBuff.append(" ");
-			patternBuff.append(SparqlGraph.sparqlNodeDelete(t.getObject(), null));
-			patternBuff.append(" .\n");
-			if (whereClause) {
-				if (t.getSubject().isBlank()) {
-					patternBuff.append("    FILTER(isBlank(").append(SparqlGraph.sparqlNodeDelete(t.getSubject(), null)).append(")) \n");
-				}
-				if (t.getObject().isBlank()) {
-					patternBuff.append("    FILTER(isBlank(").append(SparqlGraph.sparqlNodeDelete(t.getObject(), null)).append(")) \n");
-				}
-			}
-		}
-	}
+    private void addStatementPatterns(List<Statement> stmts, StringBuffer patternBuff, boolean whereClause) {
+        for (Statement stmt : stmts) {
+            Triple t = stmt.asTriple();
+            patternBuff.append(SparqlGraph.sparqlNodeDelete(t.getSubject(), null));
+            patternBuff.append(" ");
+            patternBuff.append(SparqlGraph.sparqlNodeDelete(t.getPredicate(), null));
+            patternBuff.append(" ");
+            patternBuff.append(SparqlGraph.sparqlNodeDelete(t.getObject(), null));
+            patternBuff.append(" .\n");
+            if (whereClause) {
+                if (t.getSubject().isBlank()) {
+                    patternBuff.append("    FILTER(isBlank(").append(SparqlGraph.sparqlNodeDelete(t.getSubject(), null))
+                            .append(")) \n");
+                }
+                if (t.getObject().isBlank()) {
+                    patternBuff.append("    FILTER(isBlank(").append(SparqlGraph.sparqlNodeDelete(t.getObject(), null))
+                            .append(")) \n");
+                }
+            }
+        }
+    }
 
-	private String makeDescribe(org.apache.jena.rdf.model.Resource s) {
-		StringBuilder query = new StringBuilder("DESCRIBE <") ;
-		if (s.isAnon()) {
-			query.append("_:").append(s.getId().toString());
-		} else {
-			query.append(s.getURI());
-		}
-		query.append(">");
-		return query.toString();
-	}
+    private String makeDescribe(org.apache.jena.rdf.model.Resource s) {
+        StringBuilder query = new StringBuilder("DESCRIBE <");
+        if (s.isAnon()) {
+            query.append("_:").append(s.getId().toString());
+        } else {
+            query.append(s.getURI());
+        }
+        query.append(">");
+        return query.toString();
+    }
 
-	private Model parseModel(ModelChange modelChange) {
-		Model model = ModelFactory.createDefaultModel();
-		model.read(modelChange.getSerializedModel(), null,
-				getSerializationFormatString(modelChange.getSerializationFormat()));
-		return model;
-	}
+    private Model parseModel(ModelChange modelChange) {
+        Model model = ModelFactory.createDefaultModel();
+        model.read(modelChange.getSerializedModel(), null,
+                getSerializationFormatString(modelChange.getSerializationFormat()));
+        return model;
+    }
 
-	@Override
-	public void serializeAll(OutputStream outputStream)
-			throws RDFServiceException {
-		String query = "SELECT * WHERE { GRAPH ?g {?s ?p ?o}}";
-		serialize(outputStream, query);
-	}
+    @Override
+    public void serializeAll(OutputStream outputStream) throws RDFServiceException {
+        String query = "SELECT * WHERE { GRAPH ?g {?s ?p ?o}}";
+        serialize(outputStream, query);
+    }
 
-	@Override
-	public void serializeGraph(String graphURI, OutputStream outputStream)
-			throws RDFServiceException {
-		String query = "SELECT * WHERE { GRAPH <" + graphURI + "> {?s ?p ?o}}";
-		serialize(outputStream, query);
-	}
+    @Override
+    public void serializeGraph(String graphURI, OutputStream outputStream) throws RDFServiceException {
+        String query = "SELECT * WHERE { GRAPH <" + graphURI + "> {?s ?p ?o}}";
+        serialize(outputStream, query);
+    }
 
-	private void serialize(OutputStream outputStream, String query) throws RDFServiceException {
-		InputStream resultStream = sparqlSelectQuery(query, RDFService.ResultFormat.JSON);
-		ResultSet resultSet = ResultSetFactory.fromJSON(resultStream);
-		if (resultSet.getResultVars().contains("g")) {
-			Iterator<Quad> quads = new ResultSetQuadsIterator(resultSet);
-			RDFDataMgr.writeQuads(outputStream, quads);
-		} else {
-			Iterator<Triple> triples = new ResultSetTriplesIterator(resultSet);
-			RDFDataMgr.writeTriples(outputStream, triples);
-		}
-	}
+    private void serialize(OutputStream outputStream, String query) throws RDFServiceException {
+        InputStream resultStream = sparqlSelectQuery(query, RDFService.ResultFormat.JSON);
+        ResultSet resultSet = ResultSetFactory.fromJSON(resultStream);
+        if (resultSet.getResultVars().contains("g")) {
+            Iterator<Quad> quads = new ResultSetQuadsIterator(resultSet);
+            RDFDataMgr.writeQuads(outputStream, quads);
+        } else {
+            Iterator<Triple> triples = new ResultSetTriplesIterator(resultSet);
+            RDFDataMgr.writeTriples(outputStream, triples);
+        }
+    }
 
-	/**
-	 * The basic version. Parse the model from the file, read the model from the
-	 * tripleStore, and ask whether they are isomorphic.
-	 */
-	@Override
-	public boolean isEquivalentGraph(String graphURI, InputStream serializedGraph,
-									 ModelSerializationFormat serializationFormat) throws RDFServiceException {
-		Model fileModel = RDFServiceUtils.parseModel(serializedGraph, serializationFormat);
-		Model tripleStoreModel = new RDFServiceDataset(this).getNamedModel(graphURI);
-		Model fromTripleStoreModel = ModelFactory.createDefaultModel().add(tripleStoreModel);
-		return fileModel.isIsomorphicWith(fromTripleStoreModel);
-	}
+    /**
+     * The basic version. Parse the model from the file, read the model from the tripleStore, and ask whether they are
+     * isomorphic.
+     */
+    @Override
+    public boolean isEquivalentGraph(String graphURI, InputStream serializedGraph,
+            ModelSerializationFormat serializationFormat) throws RDFServiceException {
+        Model fileModel = RDFServiceUtils.parseModel(serializedGraph, serializationFormat);
+        Model tripleStoreModel = new RDFServiceDataset(this).getNamedModel(graphURI);
+        Model fromTripleStoreModel = ModelFactory.createDefaultModel().add(tripleStoreModel);
+        return fileModel.isIsomorphicWith(fromTripleStoreModel);
+    }
 
-	/**
-	 * The basic version. Parse the model from the file, read the model from the
-	 * tripleStore, and ask whether they are isomorphic.
-	 */
-	@Override
-	public boolean isEquivalentGraph(String graphURI, Model graph) throws RDFServiceException {
-		Model tripleStoreModel = new RDFServiceDataset(this).getNamedModel(graphURI);
-		Model fromTripleStoreModel = ModelFactory.createDefaultModel().add(tripleStoreModel);
-		return graph.isIsomorphicWith(fromTripleStoreModel);
-	}
+    /**
+     * The basic version. Parse the model from the file, read the model from the tripleStore, and ask whether they are
+     * isomorphic.
+     */
+    @Override
+    public boolean isEquivalentGraph(String graphURI, Model graph) throws RDFServiceException {
+        Model tripleStoreModel = new RDFServiceDataset(this).getNamedModel(graphURI);
+        Model fromTripleStoreModel = ModelFactory.createDefaultModel().add(tripleStoreModel);
+        return graph.isIsomorphicWith(fromTripleStoreModel);
+    }
 
-	@Override
-	public boolean preferPreciseOptionals() {
-		return false;
-	}
+    @Override
+    public boolean preferPreciseOptionals() {
+        return false;
+    }
 
-	protected HttpContext getContext(HttpRequestBase request) {
-		UsernamePasswordCredentials credentials = getCredentials();
-		if (credentials != null) {
-			try {
-				request.addHeader(new BasicScheme().authenticate(credentials, request, null));
+    protected HttpContext getContext(HttpRequestBase request) {
+        UsernamePasswordCredentials credentials = getCredentials();
+        if (credentials != null) {
+            try {
+                request.addHeader(new BasicScheme().authenticate(credentials, request, null));
 
-				CredentialsProvider provider = new BasicCredentialsProvider();
-				provider.setCredentials(AuthScope.ANY, getCredentials());
+                CredentialsProvider provider = new BasicCredentialsProvider();
+                provider.setCredentials(AuthScope.ANY, getCredentials());
 
-				BasicHttpContext context = new BasicHttpContext();
-				context.setAttribute(ClientContext.CREDS_PROVIDER, provider);
-				return context;
-			} catch (AuthenticationException e) {
-				log.error("Unable to set credentials");
-			}
-		}
+                BasicHttpContext context = new BasicHttpContext();
+                context.setAttribute(ClientContext.CREDS_PROVIDER, provider);
+                return context;
+            } catch (AuthenticationException e) {
+                log.error("Unable to set credentials");
+            }
+        }
 
-		return new BasicHttpContext();
-	}
+        return new BasicHttpContext();
+    }
 
-	protected UsernamePasswordCredentials getCredentials() {
-		return null;
-	}
+    protected UsernamePasswordCredentials getCredentials() {
+        return null;
+    }
 }

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/rdfservice/impl/sparql/RDFServiceSparql.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/rdfservice/impl/sparql/RDFServiceSparql.java
@@ -378,6 +378,7 @@ public class RDFServiceSparql extends RDFServiceImpl implements RDFService {
                     if (rebuildGraphURICache) {
                         try {
                             isRebuildGraphURICacheRunning = true;
+                            rebuildGraphURICache = false;
                             Set<String> newURIs = new HashSet<>();
                             try {
                                 String fastJenaQuery = "SELECT DISTINCT ?g WHERE { GRAPH ?g {} } ORDER BY ?g";
@@ -394,7 +395,6 @@ public class RDFServiceSparql extends RDFServiceImpl implements RDFService {
                             log.error(e, e);
                         } finally {
                             isRebuildGraphURICacheRunning = false;
-                            rebuildGraphURICache = false;
                         }
                     }
                 }

--- a/api/src/test/java/edu/cornell/mannlib/vitro/webapp/rdfservice/impl/RDFServiceImplTest.java
+++ b/api/src/test/java/edu/cornell/mannlib/vitro/webapp/rdfservice/impl/RDFServiceImplTest.java
@@ -1,4 +1,4 @@
-package edu.cornell.mannlib.vitro.webapp.rdfservice.impl.jena;
+package edu.cornell.mannlib.vitro.webapp.rdfservice.impl;
 
 import java.util.Iterator;
 import java.util.List;
@@ -11,7 +11,7 @@ import org.apache.jena.query.DatasetFactory;
 import org.apache.jena.rdf.model.Model;
 import org.junit.Test;
 
-public class RDFServiceJenaTest {
+public class RDFServiceImplTest {
 
     @Test
     public void getConcurrentGraphUrisTest() throws RDFServiceException, InterruptedException {
@@ -20,7 +20,7 @@ public class RDFServiceJenaTest {
         testDataSet.addNamedModel("test:init1", m1);
         Model m2 = VitroModelFactory.createModel();
         testDataSet.addNamedModel("test:init2", m2);
-        RDFServiceJena rdfService = new RDFServiceModel(testDataSet);
+        RDFServiceImpl rdfService = new RDFServiceModel(testDataSet);
         rdfService.getGraphURIs();
         long i = 0;
         while (rdfService.rebuildGraphURICache) {

--- a/checkstyle-suppressions.xml
+++ b/checkstyle-suppressions.xml
@@ -759,13 +759,10 @@
     <suppress files="src[\\/]main[\\/]java[\\/]edu[\\/]cornell[\\/]mannlib[\\/]vitro[\\/]webapp[\\/]rdfservice[\\/]filter[\\/]LanguageFilteringRDFService\.java" checks="."/>
     <suppress files="src[\\/]main[\\/]java[\\/]edu[\\/]cornell[\\/]mannlib[\\/]vitro[\\/]webapp[\\/]rdfservice[\\/]filter[\\/]LanguageFilteringUtils\.java" checks="."/>
     <suppress files="src[\\/]main[\\/]java[\\/]edu[\\/]cornell[\\/]mannlib[\\/]vitro[\\/]webapp[\\/]rdfservice[\\/]filter[\\/]LanguageFilterModel\.java" checks="."/>
-    <suppress files="src[\\/]main[\\/]java[\\/]edu[\\/]cornell[\\/]mannlib[\\/]vitro[\\/]webapp[\\/]rdfservice[\\/]filter[\\/]SameAsFilteringRDFServiceFactory\.java" checks="."/>
     <suppress files="src[\\/]main[\\/]java[\\/]edu[\\/]cornell[\\/]mannlib[\\/]vitro[\\/]webapp[\\/]rdfservice[\\/]impl[\\/]ChangeSetImpl\.java" checks="."/>
     <suppress files="src[\\/]main[\\/]java[\\/]edu[\\/]cornell[\\/]mannlib[\\/]vitro[\\/]webapp[\\/]rdfservice[\\/]impl[\\/]ModelChangeImpl\.java" checks="."/>
     <suppress files="src[\\/]main[\\/]java[\\/]edu[\\/]cornell[\\/]mannlib[\\/]vitro[\\/]webapp[\\/]rdfservice[\\/]impl[\\/]RDFServiceFactorySingle\.java" checks="."/>
-    <suppress files="src[\\/]main[\\/]java[\\/]edu[\\/]cornell[\\/]mannlib[\\/]vitro[\\/]webapp[\\/]rdfservice[\\/]impl[\\/]RDFServiceImpl\.java" checks="."/>
     <suppress files="src[\\/]main[\\/]java[\\/]edu[\\/]cornell[\\/]mannlib[\\/]vitro[\\/]webapp[\\/]rdfservice[\\/]impl[\\/]RDFServiceUtils\.java" checks="."/>
-    <suppress files="src[\\/]main[\\/]java[\\/]edu[\\/]cornell[\\/]mannlib[\\/]vitro[\\/]webapp[\\/]rdfservice[\\/]impl[\\/]jena[\\/]RDFServiceJena\.java" checks="."/>
     <suppress files="src[\\/]main[\\/]java[\\/]edu[\\/]cornell[\\/]mannlib[\\/]vitro[\\/]webapp[\\/]rdfservice[\\/]impl[\\/]jena[\\/]model[\\/]RDFServiceModel\.java" checks="."/>
     <suppress files="src[\\/]main[\\/]java[\\/]edu[\\/]cornell[\\/]mannlib[\\/]vitro[\\/]webapp[\\/]rdfservice[\\/]impl[\\/]jena[\\/]sdb[\\/]RDFServiceFactorySDB\.java" checks="."/>
     <suppress files="src[\\/]main[\\/]java[\\/]edu[\\/]cornell[\\/]mannlib[\\/]vitro[\\/]webapp[\\/]rdfservice[\\/]impl[\\/]jena[\\/]sdb[\\/]RDFServiceSDB\.java" checks="."/>
@@ -773,7 +770,6 @@
     <suppress files="src[\\/]main[\\/]java[\\/]edu[\\/]cornell[\\/]mannlib[\\/]vitro[\\/]webapp[\\/]rdfservice[\\/]impl[\\/]logging[\\/]LoggingRDFService\.java" checks="."/>
     <suppress files="src[\\/]main[\\/]java[\\/]edu[\\/]cornell[\\/]mannlib[\\/]vitro[\\/]webapp[\\/]rdfservice[\\/]impl[\\/]logging[\\/]LoggingRDFServiceFactory\.java" checks="."/>
     <suppress files="src[\\/]main[\\/]java[\\/]edu[\\/]cornell[\\/]mannlib[\\/]vitro[\\/]webapp[\\/]rdfservice[\\/]impl[\\/]logging[\\/]RDFServiceLogger\.java" checks="."/>
-    <suppress files="src[\\/]main[\\/]java[\\/]edu[\\/]cornell[\\/]mannlib[\\/]vitro[\\/]webapp[\\/]rdfservice[\\/]impl[\\/]sparql[\\/]RDFServiceSparql\.java" checks="."/>
     <suppress files="src[\\/]main[\\/]java[\\/]edu[\\/]cornell[\\/]mannlib[\\/]vitro[\\/]webapp[\\/]rdfservice[\\/]impl[\\/]sparql[\\/]RDFServiceSparqlHttp\.java" checks="."/>
     <suppress files="src[\\/]main[\\/]java[\\/]edu[\\/]cornell[\\/]mannlib[\\/]vitro[\\/]webapp[\\/]rdfservice[\\/]impl[\\/]virtuoso[\\/]RDFServiceVirtuoso\.java" checks="."/>
     <suppress files="src[\\/]main[\\/]java[\\/]edu[\\/]cornell[\\/]mannlib[\\/]vitro[\\/]webapp[\\/]reasoner[\\/]ABoxRecomputer\.java" checks="."/>


### PR DESCRIPTION
**[VIVO GitHub issue](https://github.com/vivo-project/VIVO/issues/3885)**

# What does this pull request do?
Run RdfServiceSparql graph uri update in a separate thread to avoid lock the same way it was previously implemented in RDFServiceJena.

# How should this be tested?
Test as in issue description:
* Configure VIVO to use ContentTripleSourceSPARQL
* Try adding/removing graph.

# Interested parties
@VIVO-project/vivo-committers @chenejac @brianjlowe 
