### PR TITLE
Fix/captcha repeater vulnerability

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -71,6 +71,11 @@
             <version>1.5</version>
         </dependency>
         <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>1.7.25</version>
+        </dependency>
+        <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>fluent-hc</artifactId>
             <version>4.5.6</version>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -66,6 +66,11 @@
             <version>2.11</version>
         </dependency>
         <dependency>
+            <groupId>net.logicsquad</groupId>
+            <artifactId>nanocaptcha</artifactId>
+            <version>1.5</version>
+        </dependency>
+        <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>fluent-hc</artifactId>
             <version>4.5.6</version>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -73,7 +73,7 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>1.7.25</version>
+            <version>1.7.36</version>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -76,6 +76,11 @@
             <version>1.7.25</version>
         </dependency>
         <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>30.1-jre</version>
+        </dependency>
+        <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>fluent-hc</artifactId>
             <version>4.5.6</version>

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/beans/AbstractCaptchaProvider.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/beans/AbstractCaptchaProvider.java
@@ -1,0 +1,20 @@
+package edu.cornell.mannlib.vitro.webapp.beans;
+
+import java.io.IOException;
+import java.util.Map;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+public abstract class AbstractCaptchaProvider {
+
+    protected static final Log log = LogFactory.getLog(AbstractCaptchaProvider.class.getName());
+
+    abstract CaptchaBundle generateRefreshChallenge() throws IOException;
+
+    abstract void addCaptchaRelatedFieldsToPageContext(Map<String, Object> context) throws IOException;
+
+    boolean validateCaptcha(String captchaInput, String challengeId) {
+        return false;
+    }
+}

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/beans/AbstractCaptchaProvider.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/beans/AbstractCaptchaProvider.java
@@ -6,14 +6,41 @@ import java.util.Map;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
+/**
+ * The AbstractCaptchaProvider is an abstract class providing a base structure for captcha providers.
+ * It includes methods for generating refresh challenges, adding captcha-related fields to page context,
+ * and validating user inputs against captcha challenges.
+ *
+ * @see CaptchaBundle
+ */
 public abstract class AbstractCaptchaProvider {
 
     protected static final Log log = LogFactory.getLog(AbstractCaptchaProvider.class.getName());
 
+    /**
+     * Generates a refresh challenge, typically used for updating the captcha displayed on the page.
+     * Returns empty CaptchaBundle in case of 3rd party implementations
+     *
+     * @return CaptchaBundle containing the refreshed captcha challenge.
+     * @throws IOException If there is an issue generating the refresh challenge.
+     */
     abstract CaptchaBundle generateRefreshChallenge() throws IOException;
 
+    /**
+     * Adds captcha-related fields to the provided page context, allowing integration with web pages.
+     *
+     * @param context The context map representing the page's variables.
+     * @throws IOException If there is an issue adding captcha-related fields to the page context.
+     */
     abstract void addCaptchaRelatedFieldsToPageContext(Map<String, Object> context) throws IOException;
 
+    /**
+     * Validates the user input against a captcha challenge identified by the provided challengeId.
+     *
+     * @param captchaInput The user's input to be validated.
+     * @param challengeId  The identifier of the captcha challenge (ignored in case of 3rd party implementations).
+     * @return True if the input is valid, false otherwise.
+     */
     boolean validateCaptcha(String captchaInput, String challengeId) {
         return false;
     }

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/beans/CaptchaBundle.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/beans/CaptchaBundle.java
@@ -1,3 +1,5 @@
+/* $This file is distributed under the terms of the license in LICENSE$ */
+
 package edu.cornell.mannlib.vitro.webapp.beans;
 
 import java.util.Objects;

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/beans/CaptchaBundle.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/beans/CaptchaBundle.java
@@ -1,0 +1,48 @@
+package edu.cornell.mannlib.vitro.webapp.beans;
+
+import java.util.Objects;
+
+public class CaptchaBundle {
+
+    private final String b64Image;
+
+    private final String code;
+
+    private final String challengeId;
+
+
+    public CaptchaBundle(String b64Image, String code, String challengeId) {
+        this.b64Image = b64Image;
+        this.code = code;
+        this.challengeId = challengeId;
+    }
+
+    public String getB64Image() {
+        return b64Image;
+    }
+
+    public String getCode() {
+        return code;
+    }
+
+    public String getCaptchaId() {
+        return challengeId;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        CaptchaBundle that = (CaptchaBundle) o;
+        return Objects.equals(code, that.code) && Objects.equals(challengeId, that.challengeId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(code, challengeId);
+    }
+}

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/beans/CaptchaBundle.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/beans/CaptchaBundle.java
@@ -2,6 +2,13 @@ package edu.cornell.mannlib.vitro.webapp.beans;
 
 import java.util.Objects;
 
+/**
+ * Represents a bundle containing a CAPTCHA image in Base64 format, the associated code,
+ * and a unique challenge identifier.
+ *
+ * @author Ivan Mrsulja
+ * @version 1.0
+ */
 public class CaptchaBundle {
 
     private final String b64Image;

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/beans/CaptchaDifficulty.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/beans/CaptchaDifficulty.java
@@ -1,0 +1,6 @@
+package edu.cornell.mannlib.vitro.webapp.beans;
+
+public enum CaptchaDifficulty {
+    EASY,
+    HARD
+}

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/beans/CaptchaImplementation.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/beans/CaptchaImplementation.java
@@ -1,7 +1,7 @@
 package edu.cornell.mannlib.vitro.webapp.beans;
 
 public enum CaptchaImplementation {
-    RECAPTCHAv2,
+    RECAPTCHAV2,
     NANOCAPTCHA,
-    NONE
+    NONE;
 }

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/beans/CaptchaImplementation.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/beans/CaptchaImplementation.java
@@ -1,0 +1,7 @@
+package edu.cornell.mannlib.vitro.webapp.beans;
+
+public enum CaptchaImplementation {
+    RECAPTCHAv2,
+    NANOCAPTCHA,
+    NONE
+}

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/beans/CaptchaServiceBean.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/beans/CaptchaServiceBean.java
@@ -1,3 +1,5 @@
+/* $This file is distributed under the terms of the license in LICENSE$ */
+
 package edu.cornell.mannlib.vitro.webapp.beans;
 
 import java.awt.Color;
@@ -6,7 +8,6 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.security.SecureRandom;
 import java.util.Base64;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
@@ -16,8 +17,6 @@ import javax.imageio.ImageIO;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
-import edu.cornell.mannlib.vitro.webapp.config.ConfigurationProperties;
-import edu.cornell.mannlib.vitro.webapp.controller.VitroRequest;
 import net.logicsquad.nanocaptcha.image.ImageCaptcha;
 import net.logicsquad.nanocaptcha.image.backgrounds.GradiatedBackgroundProducer;
 import net.logicsquad.nanocaptcha.image.filter.FishEyeImageFilter;
@@ -58,13 +57,10 @@ public class CaptchaServiceBean {
      * Validates a reCAPTCHA response using Google's reCAPTCHA API.
      *
      * @param recaptchaResponse The reCAPTCHA response to validate.
-     * @param vreq              The VitroRequest associated with the validation.
+     * @param secretKey         The secret key used for Google ReCaptcha validation.
      * @return True if the reCAPTCHA response is valid, false otherwise.
      */
-    public static boolean validateReCaptcha(String recaptchaResponse, VitroRequest vreq) {
-        String secretKey =
-            Objects.requireNonNull(ConfigurationProperties.getBean(vreq).getProperty("recaptcha.secretKey"),
-                "You have to provide a secret key through configuration file.");
+    public static boolean validateReCaptcha(String recaptchaResponse, String secretKey) {
         String verificationUrl =
             "https://www.google.com/recaptcha/api/siteverify?secret=" + secretKey + "&response=" + recaptchaResponse;
 

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/beans/CaptchaServiceBean.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/beans/CaptchaServiceBean.java
@@ -8,6 +8,8 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.security.SecureRandom;
 import java.util.Base64;
+import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
@@ -17,6 +19,7 @@ import javax.imageio.ImageIO;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
+import edu.cornell.mannlib.vitro.webapp.config.ConfigurationProperties;
 import net.logicsquad.nanocaptcha.image.ImageCaptcha;
 import net.logicsquad.nanocaptcha.image.backgrounds.GradiatedBackgroundProducer;
 import net.logicsquad.nanocaptcha.image.filter.FishEyeImageFilter;
@@ -57,10 +60,12 @@ public class CaptchaServiceBean {
      * Validates a reCAPTCHA response using Google's reCAPTCHA API.
      *
      * @param recaptchaResponse The reCAPTCHA response to validate.
-     * @param secretKey         The secret key used for Google ReCaptcha validation.
      * @return True if the reCAPTCHA response is valid, false otherwise.
      */
-    public static boolean validateReCaptcha(String recaptchaResponse, String secretKey) {
+    public static boolean validateReCaptcha(String recaptchaResponse) {
+        String secretKey =
+            Objects.requireNonNull(ConfigurationProperties.getInstance().getProperty("recaptcha.secretKey"),
+                "You have to provide a secret key through configuration file.");
         String verificationUrl =
             "https://www.google.com/recaptcha/api/siteverify?secret=" + secretKey + "&response=" + recaptchaResponse;
 
@@ -88,16 +93,23 @@ public class CaptchaServiceBean {
      * @throws IOException If an error occurs during image conversion.
      */
     public static CaptchaBundle generateChallenge() throws IOException {
-        ImageCaptcha imageCaptcha =
-            new ImageCaptcha.Builder(200, 75)
-                .addContent(random.nextInt(2) + 5)
-                .addBackground(new GradiatedBackgroundProducer())
+        String difficulty = getCaptchaDifficulty();
+        ImageCaptcha.Builder imageCaptchaBuilder = new ImageCaptcha.Builder(200, 75)
+            .addContent(random.nextInt(2) + 5)
+            .addBackground(new GradiatedBackgroundProducer())
+            .addNoise(new StraightLineNoiseProducer(getRandomColor(), 2))
+            .addFilter(new StretchImageFilter())
+            .addBorder();
+
+        if (difficulty.equals("hard")) {
+            imageCaptchaBuilder
                 .addNoise(new CurvedLineNoiseProducer(getRandomColor(), 2f))
-                .addNoise(new StraightLineNoiseProducer(getRandomColor(), 2))
                 .addFilter(new StretchImageFilter())
                 .addFilter(new FishEyeImageFilter())
-                .addBorder()
                 .build();
+        }
+
+        ImageCaptcha imageCaptcha = imageCaptchaBuilder.build();
         return new CaptchaBundle(convertToBase64(imageCaptcha.getImage()), imageCaptcha.getContent(),
             UUID.randomUUID().toString());
     }
@@ -146,6 +158,86 @@ public class CaptchaServiceBean {
     }
 
     /**
+     * Retrieves the configured captcha implementation based on the application's configuration properties.
+     * If captcha functionality is disabled, returns "NONE." If the captcha implementation is not specified,
+     * defaults to "NANOCAPTCHA."
+     *
+     * @return The selected captcha implementation ("NANOCAPTCHA," "RECAPTCHA," or "NONE").
+     */
+    public static String getCaptchaImpl() {
+        if (!Boolean.parseBoolean(ConfigurationProperties.getInstance().getProperty("captcha.enabled"))) {
+            return "NONE";
+        }
+
+        String captchaImpl =
+            ConfigurationProperties.getInstance().getProperty("captcha.implementation");
+        if (captchaImpl == null) {
+            captchaImpl = "NANOCAPTCHA";
+        }
+
+        return captchaImpl;
+    }
+
+    /**
+     * Adds captcha-related fields to the given page context map. The specific fields added depend on the
+     * configured captcha implementation.
+     *
+     * If the captcha implementation is "RECAPTCHA," the "siteKey" field is added to the context. If the
+     * implementation is "NANOCAPTCHA" or "NONE," a captcha challenge is generated, and "challenge" and
+     * "challengeId" fields are added to the context. Additionally, the "captchaToUse" field is added
+     * to the context, indicating the selected captcha implementation.
+     *
+     * @param context The page context map to which captcha-related fields are added.
+     * @throws IOException If there is an IO error during captcha challenge generation.
+     */
+    public static void addCaptchaRelatedFieldsToPageContext(Map<String, Object> context) throws IOException {
+        String captchaImpl = getCaptchaImpl();
+
+        if (captchaImpl.equals("RECAPTCHA")) {
+            context.put("siteKey",
+                Objects.requireNonNull(ConfigurationProperties.getInstance().getProperty("recaptcha.siteKey"),
+                    "You have to provide a site key through configuration file."));
+        } else {
+            CaptchaBundle captchaChallenge = generateChallenge();
+            CaptchaServiceBean.getCaptchaChallenges().put(captchaChallenge.getCaptchaId(), captchaChallenge);
+
+            context.put("challenge", captchaChallenge.getB64Image());
+            context.put("challengeId", captchaChallenge.getCaptchaId());
+        }
+
+        context.put("captchaToUse", captchaImpl);
+    }
+
+    /**
+     * Validates a user's captcha input against the stored captcha challenge.
+     *
+     * @param captchaInput The user's input for the captcha challenge.
+     * @param challengeId  The unique identifier for the captcha challenge.
+     * @return {@code true} if the captcha input is valid, {@code false} otherwise.
+     */
+    public static boolean validateCaptcha(String captchaInput, String challengeId) {
+        String captchaImpl = getCaptchaImpl();
+
+        switch (captchaImpl) {
+            case "RECAPTCHA":
+                if (CaptchaServiceBean.validateReCaptcha(captchaInput)) {
+                    return true;
+                }
+                break;
+            case "NANOCAPTCHA":
+                Optional<CaptchaBundle> optionalChallenge = CaptchaServiceBean.getChallenge(challengeId);
+                if (optionalChallenge.isPresent() && optionalChallenge.get().getCode().equals(captchaInput)) {
+                    return true;
+                }
+                break;
+            case "NONE":
+                return true;
+        }
+
+        return false;
+    }
+
+    /**
      * Generates a random Color object.
      *
      * @return A randomly generated Color object.
@@ -155,5 +247,19 @@ public class CaptchaServiceBean {
         int g = random.nextInt(256);
         int b = random.nextInt(256);
         return new Color(r, g, b);
+    }
+
+    /**
+     * Retrieves the configured difficulty level for generating captchas.
+     * If the difficulty level is not specified or is not "hard", the default difficulty is set to "easy".
+     *
+     * @return The difficulty level for captcha generation ("easy" or "hard").
+     */
+    private static String getCaptchaDifficulty() {
+        String difficulty = ConfigurationProperties.getInstance().getProperty("nanocaptcha.difficulty");
+        if (difficulty == null || !difficulty.equals("hard")) {
+            difficulty = "easy";
+        }
+        return difficulty;
     }
 }

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/beans/CaptchaServiceBean.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/beans/CaptchaServiceBean.java
@@ -26,8 +26,8 @@ import net.logicsquad.nanocaptcha.image.noise.StraightLineNoiseProducer;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.http.HttpResponse;
-import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
 import org.apache.http.util.EntityUtils;
 
@@ -64,11 +64,10 @@ public class CaptchaServiceBean {
         String verificationUrl =
             "https://www.google.com/recaptcha/api/siteverify?secret=" + secretKey + "&response=" + recaptchaResponse;
 
-        try {
-            HttpClient httpClient = HttpClients.createDefault();
+        try (CloseableHttpClient httpClient = HttpClients.createDefault()) {
             HttpGet verificationRequest = new HttpGet(verificationUrl);
-
             HttpResponse verificationResponse = httpClient.execute(verificationRequest);
+
             String responseBody = EntityUtils.toString(verificationResponse.getEntity());
             ObjectMapper objectMapper = new ObjectMapper();
             ReCaptchaResponse response = objectMapper.readValue(responseBody, ReCaptchaResponse.class);

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/beans/CaptchaServiceBean.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/beans/CaptchaServiceBean.java
@@ -2,38 +2,16 @@
 
 package edu.cornell.mannlib.vitro.webapp.beans;
 
-import java.awt.Color;
-import java.awt.image.BufferedImage;
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.security.SecureRandom;
-import java.util.Base64;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
-import javax.imageio.ImageIO;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Strings;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import edu.cornell.mannlib.vitro.webapp.config.ConfigurationProperties;
-import net.logicsquad.nanocaptcha.image.ImageCaptcha;
-import net.logicsquad.nanocaptcha.image.backgrounds.GradiatedBackgroundProducer;
-import net.logicsquad.nanocaptcha.image.filter.FishEyeImageFilter;
-import net.logicsquad.nanocaptcha.image.filter.StretchImageFilter;
-import net.logicsquad.nanocaptcha.image.noise.CurvedLineNoiseProducer;
-import net.logicsquad.nanocaptcha.image.noise.StraightLineNoiseProducer;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
-import org.apache.http.HttpResponse;
-import org.apache.http.client.methods.HttpGet;
-import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.impl.client.HttpClients;
-import org.apache.http.util.EntityUtils;
 
 
 /**
@@ -46,73 +24,38 @@ import org.apache.http.util.EntityUtils;
  */
 public class CaptchaServiceBean {
 
-    private static final SecureRandom random = new SecureRandom();
-
-    private static final Log log = LogFactory.getLog(CaptchaServiceBean.class.getName());
-
     private static final Cache<String, CaptchaBundle> captchaChallenges =
         CacheBuilder.newBuilder()
             .maximumSize(1000)
             .expireAfterWrite(5, TimeUnit.MINUTES)
             .build();
 
+    private static AbstractCaptchaProvider captchaProvider;
 
-    /**
-     * Validates a reCAPTCHA response using Google's reCAPTCHA API.
-     *
-     * @param recaptchaResponse The reCAPTCHA response to validate.
-     * @return True if the reCAPTCHA response is valid, false otherwise.
-     */
-    public static boolean validateReCaptcha(String recaptchaResponse) {
-        String secretKey =
-            Objects.requireNonNull(ConfigurationProperties.getInstance().getProperty("recaptcha.secretKey"),
-                "You have to provide a secret key through configuration file.");
-        String verificationUrl =
-            "https://www.google.com/recaptcha/api/siteverify?secret=" + secretKey + "&response=" + recaptchaResponse;
-
-        try (CloseableHttpClient httpClient = HttpClients.createDefault()) {
-            HttpGet verificationRequest = new HttpGet(verificationUrl);
-            HttpResponse verificationResponse = httpClient.execute(verificationRequest);
-
-            String responseBody = EntityUtils.toString(verificationResponse.getEntity());
-            ObjectMapper objectMapper = new ObjectMapper();
-            ReCaptchaResponse response = objectMapper.readValue(responseBody, ReCaptchaResponse.class);
-
-            return response.isSuccess();
-        } catch (IOException e) {
-            log.warn("ReCaptcha validation failed.");
+    static {
+        CaptchaImplementation captchaImplementation = getCaptchaImpl();
+        switch (captchaImplementation) {
+            case RECAPTCHAV2:
+                captchaProvider = new Recaptchav2Provider();
+                break;
+            case NANOCAPTCHA:
+                captchaProvider = new NanocaptchaProvider();
+                break;
+            case NONE:
+                captchaProvider = new DummyCaptchaProvider();
+                break;
         }
-
-        return false;
     }
 
     /**
-     * Generates a new CAPTCHA challenge using the nanocaptcha library.
+     * Generates a new CAPTCHA challenge (returns empty CaptchaBundle for 3rd party providers).
      *
      * @return A CaptchaBundle containing the CAPTCHA image in Base64 format, the content,
      * and a unique identifier.
      * @throws IOException If an error occurs during image conversion.
      */
-    public static CaptchaBundle generateChallenge() throws IOException {
-        CaptchaDifficulty difficulty = getCaptchaDifficulty();
-        ImageCaptcha.Builder imageCaptchaBuilder = new ImageCaptcha.Builder(220, 85)
-            .addContent(random.nextInt(2) + 5)
-            .addBackground(new GradiatedBackgroundProducer())
-            .addNoise(new StraightLineNoiseProducer(getRandomColor(), 2))
-            .addFilter(new StretchImageFilter())
-            .addBorder();
-
-        if (difficulty.equals(CaptchaDifficulty.HARD)) {
-            imageCaptchaBuilder
-                .addNoise(new CurvedLineNoiseProducer(getRandomColor(), 2f))
-                .addFilter(new StretchImageFilter())
-                .addFilter(new FishEyeImageFilter())
-                .build();
-        }
-
-        ImageCaptcha imageCaptcha = imageCaptchaBuilder.build();
-        return new CaptchaBundle(convertToBase64(imageCaptcha.getImage()), imageCaptcha.getContent(),
-            UUID.randomUUID().toString());
+    public static CaptchaBundle generateRefreshedChallenge() throws IOException {
+        return captchaProvider.generateRefreshChallenge();
     }
 
     /**
@@ -144,21 +87,6 @@ public class CaptchaServiceBean {
     }
 
     /**
-     * Converts a BufferedImage object to Base64 format.
-     *
-     * @param image The BufferedImage to convert.
-     * @return The Base64-encoded string representation of the image.
-     * @throws IOException If an error occurs during image conversion.
-     */
-    private static String convertToBase64(BufferedImage image) throws IOException {
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        ImageIO.write(image, "png", baos);
-        byte[] imageBytes = baos.toByteArray();
-
-        return Base64.getEncoder().encodeToString(imageBytes);
-    }
-
-    /**
      * Retrieves the configured captcha implementation based on the application's configuration properties.
      * If captcha functionality is disabled, returns NONE. If the captcha implementation is not specified,
      * defaults to NANOCAPTCHA.
@@ -174,8 +102,11 @@ public class CaptchaServiceBean {
 
         String captchaImplSetting =
             ConfigurationProperties.getInstance().getProperty("captcha.implementation");
-        if (Strings.isNullOrEmpty(captchaImplSetting)) {
-            captchaImplSetting = "NANOCAPTCHA";
+
+        if (Strings.isNullOrEmpty(captchaImplSetting) ||
+            (!captchaImplSetting.equalsIgnoreCase(CaptchaImplementation.RECAPTCHAV2.name()) &&
+                !captchaImplSetting.equalsIgnoreCase(CaptchaImplementation.NANOCAPTCHA.name()))) {
+            captchaImplSetting = CaptchaImplementation.NANOCAPTCHA.name();
         }
 
         return CaptchaImplementation.valueOf(captchaImplSetting.toUpperCase());
@@ -184,86 +115,24 @@ public class CaptchaServiceBean {
     /**
      * Adds captcha-related fields to the given page context map. The specific fields added depend on the
      * configured captcha implementation.
-     * <p>
-     * If the captcha implementation is "RECAPTCHA," the "siteKey" field is added to the context. If the
-     * implementation is "NANOCAPTCHA" or "NONE," a captcha challenge is generated, and "challenge" and
-     * "challengeId" fields are added to the context. Additionally, the "captchaToUse" field is added
-     * to the context, indicating the selected captcha implementation.
      *
      * @param context The page context map to which captcha-related fields are added.
      * @throws IOException If there is an IO error during captcha challenge generation.
      */
     public static void addCaptchaRelatedFieldsToPageContext(Map<String, Object> context) throws IOException {
         CaptchaImplementation captchaImpl = getCaptchaImpl();
-
-        if (captchaImpl.equals(CaptchaImplementation.RECAPTCHAV2)) {
-            context.put("siteKey",
-                Objects.requireNonNull(ConfigurationProperties.getInstance().getProperty("recaptcha.siteKey"),
-                    "You have to provide a site key through configuration file."));
-        } else {
-            CaptchaBundle captchaChallenge = generateChallenge();
-            CaptchaServiceBean.getCaptchaChallenges().put(captchaChallenge.getCaptchaId(), captchaChallenge);
-
-            context.put("challenge", captchaChallenge.getB64Image());
-            context.put("challengeId", captchaChallenge.getCaptchaId());
-        }
-
         context.put("captchaToUse", captchaImpl.name());
+        captchaProvider.addCaptchaRelatedFieldsToPageContext(context);
     }
 
     /**
-     * Validates a user's captcha input against the stored captcha challenge.
+     * Validates a user's captcha input.
      *
      * @param captchaInput The user's input for the captcha challenge.
-     * @param challengeId  The unique identifier for the captcha challenge.
+     * @param challengeId  The unique identifier for the challenge (if captcha is 3rd party, this param is ignored).
      * @return {@code true} if the captcha input is valid, {@code false} otherwise.
      */
     public static boolean validateCaptcha(String captchaInput, String challengeId) {
-        CaptchaImplementation captchaImpl = getCaptchaImpl();
-
-        switch (captchaImpl) {
-            case RECAPTCHAV2:
-                if (CaptchaServiceBean.validateReCaptcha(captchaInput)) {
-                    return true;
-                }
-                break;
-            case NANOCAPTCHA:
-                Optional<CaptchaBundle> optionalChallenge = CaptchaServiceBean.getChallenge(challengeId);
-                if (optionalChallenge.isPresent() && optionalChallenge.get().getCode().equals(captchaInput)) {
-                    return true;
-                }
-                break;
-            case NONE:
-                return true;
-        }
-
-        return false;
-    }
-
-    /**
-     * Generates a random Color object.
-     *
-     * @return A randomly generated Color object.
-     */
-    private static Color getRandomColor() {
-        int r = random.nextInt(256);
-        int g = random.nextInt(256);
-        int b = random.nextInt(256);
-        return new Color(r, g, b);
-    }
-
-    /**
-     * Retrieves the configured difficulty level for generating captchas.
-     * If the difficulty level is not specified or is not HARD, the default difficulty is set to EASY.
-     *
-     * @return The difficulty level for captcha generation (EASY or HARD).
-     */
-    private static CaptchaDifficulty getCaptchaDifficulty() {
-        String difficulty = ConfigurationProperties.getInstance().getProperty("nanocaptcha.difficulty");
-        try {
-            return CaptchaDifficulty.valueOf(difficulty.toUpperCase());
-        } catch (NullPointerException | IllegalArgumentException e) {
-            return CaptchaDifficulty.EASY;
-        }
+        return captchaProvider.validateCaptcha(captchaInput, challengeId);
     }
 }

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/beans/CaptchaServiceBean.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/beans/CaptchaServiceBean.java
@@ -1,0 +1,79 @@
+package edu.cornell.mannlib.vitro.webapp.beans;
+
+import java.awt.Color;
+import java.awt.Font;
+import java.awt.GraphicsEnvironment;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.security.SecureRandom;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.UUID;
+
+import javax.imageio.ImageIO;
+
+import net.logicsquad.nanocaptcha.image.ImageCaptcha;
+import net.logicsquad.nanocaptcha.image.backgrounds.GradiatedBackgroundProducer;
+import net.logicsquad.nanocaptcha.image.filter.FishEyeImageFilter;
+import net.logicsquad.nanocaptcha.image.filter.StretchImageFilter;
+import net.logicsquad.nanocaptcha.image.noise.CurvedLineNoiseProducer;
+import net.logicsquad.nanocaptcha.image.noise.StraightLineNoiseProducer;
+
+public class CaptchaServiceBean {
+
+    public static CaptchaBundle generateChallenge() throws IOException {
+        ImageCaptcha imageCaptcha =
+            new ImageCaptcha.Builder(200, 75)
+                .addContent(5)
+                .addBackground(new GradiatedBackgroundProducer())
+                .addNoise(new CurvedLineNoiseProducer(getRandomColor(), 2f))
+                .addNoise(new StraightLineNoiseProducer(getRandomColor(), 2))
+                .addFilter(new StretchImageFilter())
+                .addFilter(new FishEyeImageFilter())
+                .addBorder()
+                .build();
+        return new CaptchaBundle(convertToBase64(imageCaptcha.getImage()), imageCaptcha.getContent(),
+            UUID.randomUUID().toString());
+    }
+
+    private static String convertToBase64(BufferedImage image) throws IOException {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        ImageIO.write(image, "png", baos);
+        byte[] imageBytes = baos.toByteArray();
+
+        return Base64.getEncoder().encodeToString(imageBytes);
+    }
+
+    private static Color getRandomColor() {
+        SecureRandom random = new SecureRandom();
+        int r = random.nextInt(256);
+        int g = random.nextInt(256);
+        int b = random.nextInt(256);
+        return new Color(r, g, b);
+    }
+
+    private static ArrayList<Color> getRandomColors(int count) {
+        ArrayList<Color> randomFontList = new ArrayList<>();
+
+        for (int i = 0; i < count; i++) {
+            randomFontList.add(getRandomColor());
+        }
+
+        return randomFontList;
+    }
+
+    private static ArrayList<Font> getRandomFonts(int count) {
+        Font[] fonts = GraphicsEnvironment.getLocalGraphicsEnvironment().getAllFonts();
+
+        ArrayList<Font> randomFontList = new ArrayList<>();
+        SecureRandom random = new SecureRandom();
+
+        for (int i = 0; i < count; i++) {
+            int randomIndex = random.nextInt(fonts.length);
+            randomFontList.add(fonts[randomIndex]);
+        }
+
+        return randomFontList;
+    }
+}

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/beans/CaptchaServiceBean.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/beans/CaptchaServiceBean.java
@@ -94,7 +94,7 @@ public class CaptchaServiceBean {
      */
     public static CaptchaBundle generateChallenge() throws IOException {
         String difficulty = getCaptchaDifficulty();
-        ImageCaptcha.Builder imageCaptchaBuilder = new ImageCaptcha.Builder(200, 75)
+        ImageCaptcha.Builder imageCaptchaBuilder = new ImageCaptcha.Builder(220, 85)
             .addContent(random.nextInt(2) + 5)
             .addBackground(new GradiatedBackgroundProducer())
             .addNoise(new StraightLineNoiseProducer(getRandomColor(), 2))

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/beans/CaptchaServiceBean.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/beans/CaptchaServiceBean.java
@@ -1,13 +1,10 @@
 package edu.cornell.mannlib.vitro.webapp.beans;
 
 import java.awt.Color;
-import java.awt.Font;
-import java.awt.GraphicsEnvironment;
 import java.awt.image.BufferedImage;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.security.SecureRandom;
-import java.util.ArrayList;
 import java.util.Base64;
 import java.util.Objects;
 import java.util.Optional;
@@ -33,6 +30,15 @@ import org.apache.http.client.methods.HttpGet;
 import org.apache.http.impl.client.HttpClients;
 import org.apache.http.util.EntityUtils;
 
+
+/**
+ * This class provides services related to CAPTCHA challenges and reCAPTCHA validation.
+ * It includes methods for generating CAPTCHA challenges, validating reCAPTCHA responses,
+ * and managing CAPTCHA challenges for specific hosts.
+ *
+ * @author Ivan Mrsulja
+ * @version 1.0
+ */
 public class CaptchaServiceBean {
 
     private static final SecureRandom random = new SecureRandom();
@@ -42,6 +48,13 @@ public class CaptchaServiceBean {
     private static final ConcurrentHashMap<String, CaptchaBundle> captchaChallenges = new ConcurrentHashMap<>();
 
 
+    /**
+     * Validates a reCAPTCHA response using Google's reCAPTCHA API.
+     *
+     * @param recaptchaResponse The reCAPTCHA response to validate.
+     * @param vreq              The VitroRequest associated with the validation.
+     * @return True if the reCAPTCHA response is valid, false otherwise.
+     */
     public static boolean validateReCaptcha(String recaptchaResponse, VitroRequest vreq) {
         String secretKey =
             Objects.requireNonNull(ConfigurationProperties.getBean(vreq).getProperty("recaptcha.secretKey"),
@@ -66,6 +79,13 @@ public class CaptchaServiceBean {
         return false;
     }
 
+    /**
+     * Generates a new CAPTCHA challenge using the nanocaptcha library.
+     *
+     * @return A CaptchaBundle containing the CAPTCHA image in Base64 format, the content,
+     * and a unique identifier.
+     * @throws IOException If an error occurs during image conversion.
+     */
     public static CaptchaBundle generateChallenge() throws IOException {
         ImageCaptcha imageCaptcha =
             new ImageCaptcha.Builder(200, 75)
@@ -81,6 +101,15 @@ public class CaptchaServiceBean {
             UUID.randomUUID().toString());
     }
 
+    /**
+     * Retrieves a CAPTCHA challenge for a specific host based on the provided CAPTCHA ID
+     * and remote address. Removes the challenge from the storage after retrieval.
+     *
+     * @param captchaId     The CAPTCHA ID to match.
+     * @param remoteAddress The remote address associated with the host.
+     * @return An Optional containing the CaptchaBundle if a matching challenge is found,
+     * or an empty Optional otherwise.
+     */
     public static Optional<CaptchaBundle> getChallenge(String captchaId, String remoteAddress) {
         CaptchaBundle challengeForHost = captchaChallenges.getOrDefault(remoteAddress, new CaptchaBundle("", "", ""));
         captchaChallenges.remove(remoteAddress);
@@ -92,10 +121,22 @@ public class CaptchaServiceBean {
         return Optional.of(challengeForHost);
     }
 
+    /**
+     * Gets the map containing CAPTCHA challenges for different hosts.
+     *
+     * @return A ConcurrentHashMap with host addresses as keys and CaptchaBundle objects as values.
+     */
     public static ConcurrentHashMap<String, CaptchaBundle> getCaptchaChallenges() {
         return captchaChallenges;
     }
 
+    /**
+     * Converts a BufferedImage object to Base64 format.
+     *
+     * @param image The BufferedImage to convert.
+     * @return The Base64-encoded string representation of the image.
+     * @throws IOException If an error occurs during image conversion.
+     */
     private static String convertToBase64(BufferedImage image) throws IOException {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         ImageIO.write(image, "png", baos);
@@ -104,6 +145,11 @@ public class CaptchaServiceBean {
         return Base64.getEncoder().encodeToString(imageBytes);
     }
 
+    /**
+     * Generates a random Color object.
+     *
+     * @return A randomly generated Color object.
+     */
     private static Color getRandomColor() {
         int r = random.nextInt(256);
         int g = random.nextInt(256);

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/beans/CaptchaServiceBean.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/beans/CaptchaServiceBean.java
@@ -178,7 +178,7 @@ public class CaptchaServiceBean {
             captchaImplSetting = "NANOCAPTCHA";
         }
 
-        return CaptchaImplementation.valueOf(captchaImplSetting);
+        return CaptchaImplementation.valueOf(captchaImplSetting.toUpperCase());
     }
 
     /**
@@ -196,7 +196,7 @@ public class CaptchaServiceBean {
     public static void addCaptchaRelatedFieldsToPageContext(Map<String, Object> context) throws IOException {
         CaptchaImplementation captchaImpl = getCaptchaImpl();
 
-        if (captchaImpl.equals(CaptchaImplementation.RECAPTCHAv2)) {
+        if (captchaImpl.equals(CaptchaImplementation.RECAPTCHAV2)) {
             context.put("siteKey",
                 Objects.requireNonNull(ConfigurationProperties.getInstance().getProperty("recaptcha.siteKey"),
                     "You have to provide a site key through configuration file."));
@@ -222,7 +222,7 @@ public class CaptchaServiceBean {
         CaptchaImplementation captchaImpl = getCaptchaImpl();
 
         switch (captchaImpl) {
-            case RECAPTCHAv2:
+            case RECAPTCHAV2:
                 if (CaptchaServiceBean.validateReCaptcha(captchaInput)) {
                     return true;
                 }

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/beans/CaptchaServiceBean.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/beans/CaptchaServiceBean.java
@@ -15,8 +15,8 @@ import edu.cornell.mannlib.vitro.webapp.config.ConfigurationProperties;
 
 
 /**
- * This class provides services related to CAPTCHA challenges and reCAPTCHA validation.
- * It includes methods for generating CAPTCHA challenges, validating reCAPTCHA responses,
+ * This class provides services related to CAPTCHA challenges and validation.
+ * It includes method delegates for generating challenges, validating challenge responses,
  * and managing CAPTCHA challenges for specific hosts.
  *
  * @author Ivan Mrsulja

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/beans/CaptchaServiceBean.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/beans/CaptchaServiceBean.java
@@ -9,21 +9,62 @@ import java.io.IOException;
 import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.Base64;
+import java.util.Objects;
+import java.util.Optional;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 
 import javax.imageio.ImageIO;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import edu.cornell.mannlib.vitro.webapp.config.ConfigurationProperties;
+import edu.cornell.mannlib.vitro.webapp.controller.VitroRequest;
 import net.logicsquad.nanocaptcha.image.ImageCaptcha;
 import net.logicsquad.nanocaptcha.image.backgrounds.GradiatedBackgroundProducer;
 import net.logicsquad.nanocaptcha.image.filter.FishEyeImageFilter;
 import net.logicsquad.nanocaptcha.image.filter.StretchImageFilter;
 import net.logicsquad.nanocaptcha.image.noise.CurvedLineNoiseProducer;
 import net.logicsquad.nanocaptcha.image.noise.StraightLineNoiseProducer;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.util.EntityUtils;
 
 public class CaptchaServiceBean {
 
     private static final SecureRandom random = new SecureRandom();
 
+    private static final Log log = LogFactory.getLog(CaptchaServiceBean.class.getName());
+
+    private static final ConcurrentHashMap<String, CaptchaBundle> captchaChallenges = new ConcurrentHashMap<>();
+
+
+    public static boolean validateReCaptcha(String recaptchaResponse, VitroRequest vreq) {
+        String secretKey =
+            Objects.requireNonNull(ConfigurationProperties.getBean(vreq).getProperty("recaptcha.secretKey"),
+                "You have to provide a secret key through configuration file.");
+        String verificationUrl =
+            "https://www.google.com/recaptcha/api/siteverify?secret=" + secretKey + "&response=" + recaptchaResponse;
+
+        try {
+            HttpClient httpClient = HttpClients.createDefault();
+            HttpGet verificationRequest = new HttpGet(verificationUrl);
+
+            HttpResponse verificationResponse = httpClient.execute(verificationRequest);
+            String responseBody = EntityUtils.toString(verificationResponse.getEntity());
+            ObjectMapper objectMapper = new ObjectMapper();
+            ReCaptchaResponse response = objectMapper.readValue(responseBody, ReCaptchaResponse.class);
+
+            return response.isSuccess();
+        } catch (IOException e) {
+            log.warn("ReCaptcha validation failed.");
+        }
+
+        return false;
+    }
 
     public static CaptchaBundle generateChallenge() throws IOException {
         ImageCaptcha imageCaptcha =
@@ -40,6 +81,21 @@ public class CaptchaServiceBean {
             UUID.randomUUID().toString());
     }
 
+    public static Optional<CaptchaBundle> getChallenge(String captchaId, String remoteAddress) {
+        CaptchaBundle challengeForHost = captchaChallenges.getOrDefault(remoteAddress, new CaptchaBundle("", "", ""));
+        captchaChallenges.remove(remoteAddress);
+
+        if (!challengeForHost.getCaptchaId().equals(captchaId)) {
+            return Optional.empty();
+        }
+
+        return Optional.of(challengeForHost);
+    }
+
+    public static ConcurrentHashMap<String, CaptchaBundle> getCaptchaChallenges() {
+        return captchaChallenges;
+    }
+
     private static String convertToBase64(BufferedImage image) throws IOException {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         ImageIO.write(image, "png", baos);
@@ -53,27 +109,5 @@ public class CaptchaServiceBean {
         int g = random.nextInt(256);
         int b = random.nextInt(256);
         return new Color(r, g, b);
-    }
-
-    private static ArrayList<Color> getRandomColors(int count) {
-        ArrayList<Color> randomFontList = new ArrayList<>();
-
-        for (int i = 0; i < count; i++) {
-            randomFontList.add(getRandomColor());
-        }
-
-        return randomFontList;
-    }
-
-    private static ArrayList<Font> getRandomFonts(int count) {
-        Font[] fonts = GraphicsEnvironment.getLocalGraphicsEnvironment().getAllFonts();
-
-        ArrayList<Font> randomFontList = new ArrayList<>();
-        for (int i = 0; i < count; i++) {
-            int randomIndex = random.nextInt(fonts.length);
-            randomFontList.add(fonts[randomIndex]);
-        }
-
-        return randomFontList;
     }
 }

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/beans/CaptchaServiceBean.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/beans/CaptchaServiceBean.java
@@ -22,10 +22,13 @@ import net.logicsquad.nanocaptcha.image.noise.StraightLineNoiseProducer;
 
 public class CaptchaServiceBean {
 
+    private static final SecureRandom random = new SecureRandom();
+
+
     public static CaptchaBundle generateChallenge() throws IOException {
         ImageCaptcha imageCaptcha =
             new ImageCaptcha.Builder(200, 75)
-                .addContent(5)
+                .addContent(random.nextInt(2) + 5)
                 .addBackground(new GradiatedBackgroundProducer())
                 .addNoise(new CurvedLineNoiseProducer(getRandomColor(), 2f))
                 .addNoise(new StraightLineNoiseProducer(getRandomColor(), 2))
@@ -46,7 +49,6 @@ public class CaptchaServiceBean {
     }
 
     private static Color getRandomColor() {
-        SecureRandom random = new SecureRandom();
         int r = random.nextInt(256);
         int g = random.nextInt(256);
         int b = random.nextInt(256);
@@ -67,8 +69,6 @@ public class CaptchaServiceBean {
         Font[] fonts = GraphicsEnvironment.getLocalGraphicsEnvironment().getAllFonts();
 
         ArrayList<Font> randomFontList = new ArrayList<>();
-        SecureRandom random = new SecureRandom();
-
         for (int i = 0; i < count; i++) {
             int randomIndex = random.nextInt(fonts.length);
             randomFontList.add(fonts[randomIndex]);

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/beans/DummyCaptchaProvider.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/beans/DummyCaptchaProvider.java
@@ -2,6 +2,14 @@ package edu.cornell.mannlib.vitro.webapp.beans;
 
 import java.util.Map;
 
+/**
+ * DummyCaptchaProvider is a concrete implementation of AbstractCaptchaProvider,
+ * serving as a fallback when CAPTCHA is disabled. Validation will always pass,
+ * in order to fulfill validation logic.
+ *
+ * @see AbstractCaptchaProvider
+ * @see CaptchaBundle
+ */
 public class DummyCaptchaProvider extends AbstractCaptchaProvider {
 
     @Override

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/beans/DummyCaptchaProvider.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/beans/DummyCaptchaProvider.java
@@ -1,0 +1,21 @@
+package edu.cornell.mannlib.vitro.webapp.beans;
+
+import java.util.Map;
+
+public class DummyCaptchaProvider extends AbstractCaptchaProvider {
+
+    @Override
+    CaptchaBundle generateRefreshChallenge() {
+        return new CaptchaBundle("", "", ""); // No refresh challenges if there is no implementation
+    }
+
+    @Override
+    void addCaptchaRelatedFieldsToPageContext(Map<String, Object> context) {
+        // No added fields necessary if there is no implementation
+    }
+
+    @Override
+    boolean validateCaptcha(String captchaInput, String challengeId) {
+        return true; // validation always passes
+    }
+}

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/beans/NanocaptchaProvider.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/beans/NanocaptchaProvider.java
@@ -20,24 +20,18 @@ import net.logicsquad.nanocaptcha.image.filter.StretchImageFilter;
 import net.logicsquad.nanocaptcha.image.noise.CurvedLineNoiseProducer;
 import net.logicsquad.nanocaptcha.image.noise.StraightLineNoiseProducer;
 
+/**
+ * NanocaptchaProvider generates and manages captcha challenges using Nanocaptcha.
+ * This class extends AbstractCaptchaProvider and supports easy and hard difficulty levels.
+ *
+ * @see AbstractCaptchaProvider
+ * @see CaptchaBundle
+ * @see CaptchaServiceBean
+ * @see CaptchaDifficulty
+ */
 public class NanocaptchaProvider extends AbstractCaptchaProvider {
 
     private final SecureRandom random = new SecureRandom();
-
-    /**
-     * Converts a BufferedImage object to Base64 format.
-     *
-     * @param image The BufferedImage to convert.
-     * @return The Base64-encoded string representation of the image.
-     * @throws IOException If an error occurs during image conversion.
-     */
-    private static String convertToBase64(BufferedImage image) throws IOException {
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        ImageIO.write(image, "png", baos);
-        byte[] imageBytes = baos.toByteArray();
-
-        return Base64.getEncoder().encodeToString(imageBytes);
-    }
 
     @Override
     public CaptchaBundle generateRefreshChallenge() throws IOException {
@@ -59,6 +53,13 @@ public class NanocaptchaProvider extends AbstractCaptchaProvider {
         return optionalChallenge.isPresent() && optionalChallenge.get().getCode().equals(captchaInput);
     }
 
+    /**
+     * Generates a captcha challenge.
+     *
+     * @return CaptchaBundle containing the captcha image encoded in Base64,
+     *         captcha content, and a randomly generated UUID.
+     * @throws IOException If there is an issue generating the captcha.
+     */
     private CaptchaBundle generateChallenge() throws IOException {
         CaptchaDifficulty difficulty = getCaptchaDifficulty();
         ImageCaptcha.Builder imageCaptchaBuilder = new ImageCaptcha.Builder(220, 85)
@@ -79,6 +80,21 @@ public class NanocaptchaProvider extends AbstractCaptchaProvider {
         ImageCaptcha imageCaptcha = imageCaptchaBuilder.build();
         return new CaptchaBundle(convertToBase64(imageCaptcha.getImage()), imageCaptcha.getContent(),
             UUID.randomUUID().toString());
+    }
+
+    /**
+     * Converts a BufferedImage object to Base64 format.
+     *
+     * @param image The BufferedImage to convert.
+     * @return The Base64-encoded string representation of the image.
+     * @throws IOException If an error occurs during image conversion.
+     */
+    private String convertToBase64(BufferedImage image) throws IOException {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        ImageIO.write(image, "png", baos);
+        byte[] imageBytes = baos.toByteArray();
+
+        return Base64.getEncoder().encodeToString(imageBytes);
     }
 
     /**

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/beans/NanocaptchaProvider.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/beans/NanocaptchaProvider.java
@@ -1,0 +1,110 @@
+package edu.cornell.mannlib.vitro.webapp.beans;
+
+import java.awt.Color;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.security.SecureRandom;
+import java.util.Base64;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+import javax.imageio.ImageIO;
+
+import edu.cornell.mannlib.vitro.webapp.config.ConfigurationProperties;
+import net.logicsquad.nanocaptcha.image.ImageCaptcha;
+import net.logicsquad.nanocaptcha.image.backgrounds.GradiatedBackgroundProducer;
+import net.logicsquad.nanocaptcha.image.filter.FishEyeImageFilter;
+import net.logicsquad.nanocaptcha.image.filter.StretchImageFilter;
+import net.logicsquad.nanocaptcha.image.noise.CurvedLineNoiseProducer;
+import net.logicsquad.nanocaptcha.image.noise.StraightLineNoiseProducer;
+
+public class NanocaptchaProvider extends AbstractCaptchaProvider {
+
+    private final SecureRandom random = new SecureRandom();
+
+    /**
+     * Converts a BufferedImage object to Base64 format.
+     *
+     * @param image The BufferedImage to convert.
+     * @return The Base64-encoded string representation of the image.
+     * @throws IOException If an error occurs during image conversion.
+     */
+    private static String convertToBase64(BufferedImage image) throws IOException {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        ImageIO.write(image, "png", baos);
+        byte[] imageBytes = baos.toByteArray();
+
+        return Base64.getEncoder().encodeToString(imageBytes);
+    }
+
+    @Override
+    public CaptchaBundle generateRefreshChallenge() throws IOException {
+        return generateChallenge();
+    }
+
+    @Override
+    public void addCaptchaRelatedFieldsToPageContext(Map<String, Object> context) throws IOException {
+        CaptchaBundle captchaChallenge = generateChallenge();
+        CaptchaServiceBean.getCaptchaChallenges().put(captchaChallenge.getCaptchaId(), captchaChallenge);
+
+        context.put("challenge", captchaChallenge.getB64Image());
+        context.put("challengeId", captchaChallenge.getCaptchaId());
+    }
+
+    @Override
+    public boolean validateCaptcha(String captchaInput, String challengeId) {
+        Optional<CaptchaBundle> optionalChallenge = CaptchaServiceBean.getChallenge(challengeId);
+        return optionalChallenge.isPresent() && optionalChallenge.get().getCode().equals(captchaInput);
+    }
+
+    private CaptchaBundle generateChallenge() throws IOException {
+        CaptchaDifficulty difficulty = getCaptchaDifficulty();
+        ImageCaptcha.Builder imageCaptchaBuilder = new ImageCaptcha.Builder(220, 85)
+            .addContent(random.nextInt(2) + 5)
+            .addBackground(new GradiatedBackgroundProducer())
+            .addNoise(new StraightLineNoiseProducer(getRandomColor(), 2))
+            .addFilter(new StretchImageFilter())
+            .addBorder();
+
+        if (difficulty.equals(CaptchaDifficulty.HARD)) {
+            imageCaptchaBuilder
+                .addNoise(new CurvedLineNoiseProducer(getRandomColor(), 2f))
+                .addFilter(new StretchImageFilter())
+                .addFilter(new FishEyeImageFilter())
+                .build();
+        }
+
+        ImageCaptcha imageCaptcha = imageCaptchaBuilder.build();
+        return new CaptchaBundle(convertToBase64(imageCaptcha.getImage()), imageCaptcha.getContent(),
+            UUID.randomUUID().toString());
+    }
+
+    /**
+     * Retrieves the configured difficulty level for generating captchas.
+     * If the difficulty level is not specified or is not HARD, the default difficulty is set to EASY.
+     *
+     * @return The difficulty level for captcha generation (EASY or HARD).
+     */
+    private CaptchaDifficulty getCaptchaDifficulty() {
+        String difficulty = ConfigurationProperties.getInstance().getProperty("nanocaptcha.difficulty");
+        try {
+            return CaptchaDifficulty.valueOf(difficulty.toUpperCase());
+        } catch (NullPointerException | IllegalArgumentException e) {
+            return CaptchaDifficulty.EASY;
+        }
+    }
+
+    /**
+     * Generates a random Color object.
+     *
+     * @return A randomly generated Color object.
+     */
+    private Color getRandomColor() {
+        int r = random.nextInt(256);
+        int g = random.nextInt(256);
+        int b = random.nextInt(256);
+        return new Color(r, g, b);
+    }
+}

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/beans/ReCaptchaResponse.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/beans/ReCaptchaResponse.java
@@ -1,0 +1,54 @@
+package edu.cornell.mannlib.vitro.webapp.beans;
+
+import java.util.Date;
+
+public class ReCaptchaResponse {
+
+    private boolean success;
+
+    private Date challenge_ts;
+
+    private String hostname;
+
+    public ReCaptchaResponse() {
+    }
+
+    public ReCaptchaResponse(boolean success, Date challenge_ts, String hostname) {
+        this.success = success;
+        this.challenge_ts = challenge_ts;
+        this.hostname = hostname;
+    }
+
+    public boolean isSuccess() {
+        return success;
+    }
+
+    public void setSuccess(boolean success) {
+        this.success = success;
+    }
+
+    public Date getChallenge_ts() {
+        return challenge_ts;
+    }
+
+    public void setChallenge_ts(Date challenge_ts) {
+        this.challenge_ts = challenge_ts;
+    }
+
+    public String getHostname() {
+        return hostname;
+    }
+
+    public void setHostname(String hostname) {
+        this.hostname = hostname;
+    }
+
+    @Override
+    public String toString() {
+        return "ReCaptchaResponse{" +
+            "success=" + success +
+            ", challenge_ts=" + challenge_ts +
+            ", hostname='" + hostname + '\'' +
+            '}';
+    }
+}

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/beans/ReCaptchaResponse.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/beans/ReCaptchaResponse.java
@@ -1,3 +1,5 @@
+/* $This file is distributed under the terms of the license in LICENSE$ */
+
 package edu.cornell.mannlib.vitro.webapp.beans;
 
 import java.util.Date;

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/beans/ReCaptchaResponse.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/beans/ReCaptchaResponse.java
@@ -2,6 +2,14 @@ package edu.cornell.mannlib.vitro.webapp.beans;
 
 import java.util.Date;
 
+/**
+ * Represents the response from Google's reCAPTCHA API.
+ * It includes information about the success of the reCAPTCHA verification,
+ * the timestamp of the challenge, and the hostname associated with the verification.
+ *
+ * @author Ivan Mrsulja
+ * @version 1.0
+ */
 public class ReCaptchaResponse {
 
     private boolean success;

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/beans/Recaptchav2Provider.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/beans/Recaptchav2Provider.java
@@ -12,6 +12,13 @@ import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
 import org.apache.http.util.EntityUtils;
 
+/**
+ * Recaptchav2Provider generates and manages captcha challenges using Google RECAPTCHAv2.
+ * This class extends AbstractCaptchaProvider.
+ *
+ * @see AbstractCaptchaProvider
+ * @see CaptchaBundle
+ */
 public class Recaptchav2Provider extends AbstractCaptchaProvider {
 
     @Override

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/beans/Recaptchav2Provider.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/beans/Recaptchav2Provider.java
@@ -1,0 +1,62 @@
+package edu.cornell.mannlib.vitro.webapp.beans;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.Objects;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import edu.cornell.mannlib.vitro.webapp.config.ConfigurationProperties;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.util.EntityUtils;
+
+public class Recaptchav2Provider extends AbstractCaptchaProvider {
+
+    @Override
+    public CaptchaBundle generateRefreshChallenge() {
+        return new CaptchaBundle("", "", ""); // RECAPTCHAv2 does not generate refresh challenges on backend side
+    }
+
+    @Override
+    public void addCaptchaRelatedFieldsToPageContext(Map<String, Object> context) {
+        context.put("siteKey",
+            Objects.requireNonNull(ConfigurationProperties.getInstance().getProperty("recaptcha.siteKey"),
+                "You have to provide a site key through configuration file."));
+    }
+
+    @Override
+    public boolean validateCaptcha(String captchaInput, String challengeId) {
+        return validateReCaptcha(captchaInput);
+    }
+
+    /**
+     * Validates a reCAPTCHA response using Google's reCAPTCHA API.
+     *
+     * @param recaptchaResponse The reCAPTCHA response to validate.
+     * @return True if the reCAPTCHA response is valid, false otherwise.
+     */
+    public boolean validateReCaptcha(String recaptchaResponse) {
+        String secretKey =
+            Objects.requireNonNull(ConfigurationProperties.getInstance().getProperty("recaptcha.secretKey"),
+                "You have to provide a secret key through configuration file.");
+        String verificationUrl =
+            "https://www.google.com/recaptcha/api/siteverify?secret=" + secretKey + "&response=" + recaptchaResponse;
+
+        try (CloseableHttpClient httpClient = HttpClients.createDefault()) {
+            HttpGet verificationRequest = new HttpGet(verificationUrl);
+            HttpResponse verificationResponse = httpClient.execute(verificationRequest);
+
+            String responseBody = EntityUtils.toString(verificationResponse.getEntity());
+            ObjectMapper objectMapper = new ObjectMapper();
+            ReCaptchaResponse response = objectMapper.readValue(responseBody, ReCaptchaResponse.class);
+
+            return response.isSuccess();
+        } catch (IOException e) {
+            log.warn("ReCaptcha validation failed.");
+        }
+
+        return false;
+    }
+}

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/beans/RefreshCaptchaController.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/beans/RefreshCaptchaController.java
@@ -1,3 +1,5 @@
+/* $This file is distributed under the terms of the license in LICENSE$ */
+
 package edu.cornell.mannlib.vitro.webapp.beans;
 
 import java.io.IOException;

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/beans/RefreshCaptchaController.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/beans/RefreshCaptchaController.java
@@ -1,0 +1,31 @@
+package edu.cornell.mannlib.vitro.webapp.beans;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import com.twelvemonkeys.servlet.HttpServlet;
+
+@WebServlet(name = "refreshCaptcha", urlPatterns = {"/refreshCaptcha"}, loadOnStartup = 5)
+public class RefreshCaptchaController extends HttpServlet {
+
+    protected void doGet(HttpServletRequest request, HttpServletResponse response)
+        throws ServletException, IOException {
+        String oldChallengeId = request.getParameter("oldChallengeId");
+
+        response.setContentType("application/json");
+        PrintWriter out = response.getWriter();
+
+        CaptchaBundle newChallenge = CaptchaServiceBean.generateChallenge();
+        CaptchaServiceBean.getCaptchaChallenges().invalidate(oldChallengeId);
+        CaptchaServiceBean.getCaptchaChallenges().put(newChallenge.getCaptchaId(), newChallenge);
+
+        out.println("{\"challenge\": \"" + newChallenge.getB64Image() + "\", \"challengeId\": \"" +
+            newChallenge.getCaptchaId() + "\"}");
+    }
+
+}

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/beans/RefreshCaptchaController.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/beans/RefreshCaptchaController.java
@@ -22,7 +22,7 @@ public class RefreshCaptchaController extends HttpServlet {
         response.setContentType("application/json");
         PrintWriter out = response.getWriter();
 
-        CaptchaBundle newChallenge = CaptchaServiceBean.generateChallenge();
+        CaptchaBundle newChallenge = CaptchaServiceBean.generateRefreshedChallenge();
         CaptchaServiceBean.getCaptchaChallenges().invalidate(oldChallengeId);
         CaptchaServiceBean.getCaptchaChallenges().put(newChallenge.getCaptchaId(), newChallenge);
 

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/freemarker/ContactFormController.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/freemarker/ContactFormController.java
@@ -63,14 +63,14 @@ public class ContactFormController extends FreemarkerHttpServlet {
 
         else {
             String captchaImpl =
-                ConfigurationProperties.getBean(vreq).getProperty("captcha.implementation");
+                ConfigurationProperties.getInstance().getProperty("captcha.implementation");
             if (captchaImpl == null) {
                 captchaImpl = "";
             }
 
             if (captchaImpl.equals("RECAPTCHA")) {
                 body.put("siteKey",
-                    Objects.requireNonNull(ConfigurationProperties.getBean(vreq).getProperty("recaptcha.siteKey"),
+                    Objects.requireNonNull(ConfigurationProperties.getInstance().getProperty("recaptcha.siteKey"),
                         "You have to provide a site key through configuration file."));
             } else {
                 CaptchaBundle captchaChallenge = CaptchaServiceBean.generateChallenge();

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/freemarker/ContactFormController.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/freemarker/ContactFormController.java
@@ -74,7 +74,7 @@ public class ContactFormController extends FreemarkerHttpServlet {
                         "You have to provide a site key through configuration file."));
             } else {
                 CaptchaBundle captchaChallenge = CaptchaServiceBean.generateChallenge();
-                CaptchaServiceBean.getCaptchaChallenges().put(vreq.getRemoteAddr(), captchaChallenge);
+                CaptchaServiceBean.getCaptchaChallenges().put(captchaChallenge.getCaptchaId(), captchaChallenge);
 
                 body.put("challenge", captchaChallenge.getB64Image());
                 body.put("challengeId", captchaChallenge.getCaptchaId());

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/freemarker/ContactFormController.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/freemarker/ContactFormController.java
@@ -2,9 +2,13 @@
 
 package edu.cornell.mannlib.vitro.webapp.controller.freemarker;
 
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.UUID;
 
+import edu.cornell.mannlib.vitro.webapp.beans.CaptchaBundle;
+import edu.cornell.mannlib.vitro.webapp.beans.CaptchaServiceBean;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -36,7 +40,7 @@ public class ContactFormController extends FreemarkerHttpServlet {
     }
 
     @Override
-    protected ResponseValues processRequest(VitroRequest vreq) {
+    protected ResponseValues processRequest(VitroRequest vreq) throws IOException {
 
         ApplicationBean appBean = vreq.getAppBean();
 
@@ -59,6 +63,11 @@ public class ContactFormController extends FreemarkerHttpServlet {
 
         else {
 
+            CaptchaBundle captchaChallenge = CaptchaServiceBean.generateChallenge();
+            ContactMailController.getCaptchaChallenges().add(captchaChallenge);
+
+            body.put("challenge", captchaChallenge.getB64Image());
+            body.put("challengeId", captchaChallenge.getCaptchaId());
             body.put("formAction", "submitFeedback");
 
             if (vreq.getHeader("Referer") == null) {

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/freemarker/ContactFormController.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/freemarker/ContactFormController.java
@@ -80,6 +80,7 @@ public class ContactFormController extends FreemarkerHttpServlet {
                 body.put("challengeId", captchaChallenge.getCaptchaId());
             }
 
+            body.put("contextPath", vreq.getContextPath());
             body.put("formAction", "submitFeedback");
             body.put("captchaToUse", captchaImpl);
 

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/freemarker/ContactFormController.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/freemarker/ContactFormController.java
@@ -62,27 +62,10 @@ public class ContactFormController extends FreemarkerHttpServlet {
         }
 
         else {
-            String captchaImpl =
-                ConfigurationProperties.getInstance().getProperty("captcha.implementation");
-            if (captchaImpl == null) {
-                captchaImpl = "";
-            }
-
-            if (captchaImpl.equals("RECAPTCHA")) {
-                body.put("siteKey",
-                    Objects.requireNonNull(ConfigurationProperties.getInstance().getProperty("recaptcha.siteKey"),
-                        "You have to provide a site key through configuration file."));
-            } else {
-                CaptchaBundle captchaChallenge = CaptchaServiceBean.generateChallenge();
-                CaptchaServiceBean.getCaptchaChallenges().put(captchaChallenge.getCaptchaId(), captchaChallenge);
-
-                body.put("challenge", captchaChallenge.getB64Image());
-                body.put("challengeId", captchaChallenge.getCaptchaId());
-            }
+            CaptchaServiceBean.addCaptchaRelatedFieldsToPageContext(body);
 
             body.put("contextPath", vreq.getContextPath());
             body.put("formAction", "submitFeedback");
-            body.put("captchaToUse", captchaImpl);
 
             if (vreq.getHeader("Referer") == null) {
                 vreq.getSession().setAttribute("contactFormReferer","none");

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/freemarker/ContactMailController.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/freemarker/ContactMailController.java
@@ -81,7 +81,7 @@ public class ContactMailController extends FreemarkerHttpServlet {
             return errorNoRecipients();
         }
 
-        captchaImpl = ConfigurationProperties.getBean(vreq).getProperty("captcha.implementation");
+        captchaImpl = ConfigurationProperties.getInstance().getProperty("captcha.implementation");
         if (captchaImpl == null) {
             captchaImpl = "";
         }
@@ -107,7 +107,7 @@ public class ContactMailController extends FreemarkerHttpServlet {
 
         if (errorMsg != null) {
             String siteKey =
-                Objects.requireNonNull(ConfigurationProperties.getBean(vreq).getProperty("recaptcha.siteKey"),
+                Objects.requireNonNull(ConfigurationProperties.getInstance().getProperty("recaptcha.siteKey"),
                     "You have to provide a site key through configuration file.");
             return errorParametersNotValid(errorMsg, webusername, webuseremail, comments, vreq.getContextPath(),
                 siteKey);
@@ -352,7 +352,7 @@ public class ContactMailController extends FreemarkerHttpServlet {
         switch (captchaImpl) {
             case "RECAPTCHA":
                 String secretKey =
-                    Objects.requireNonNull(ConfigurationProperties.getBean(vreq).getProperty("recaptcha.secretKey"),
+                    Objects.requireNonNull(ConfigurationProperties.getInstance().getProperty("recaptcha.secretKey"),
                         "You have to provide a secret key through configuration file.");
                 if (CaptchaServiceBean.validateReCaptcha(captchaInput, secretKey)) {
                     return null;

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/freemarker/ContactMailController.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/freemarker/ContactMailController.java
@@ -421,6 +421,7 @@ public class ContactMailController extends FreemarkerHttpServlet {
         body.put("webuseremail", webuseremail);
         body.put("comments", comments);
         body.put("captchaToUse", captchaImpl);
+        body.put("contextPath", vreq.getContextPath());
 
         if (!captchaImpl.equals("RECAPTCHA")) {
             CaptchaBundle captchaChallenge = CaptchaServiceBean.generateChallenge();

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/freemarker/ContactMailController.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/freemarker/ContactMailController.java
@@ -7,10 +7,14 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.UnsupportedEncodingException;
+import java.util.ArrayList;
 import java.util.Calendar;
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import javax.mail.Address;
 import javax.mail.Message;
@@ -24,28 +28,29 @@ import javax.mail.internet.MimeMessage;
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServletRequest;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
-
 import edu.cornell.mannlib.vitro.webapp.application.ApplicationUtils;
 import edu.cornell.mannlib.vitro.webapp.beans.ApplicationBean;
+import edu.cornell.mannlib.vitro.webapp.beans.CaptchaBundle;
+import edu.cornell.mannlib.vitro.webapp.beans.CaptchaServiceBean;
 import edu.cornell.mannlib.vitro.webapp.controller.VitroRequest;
 import edu.cornell.mannlib.vitro.webapp.controller.freemarker.TemplateProcessingHelper.TemplateProcessingException;
 import edu.cornell.mannlib.vitro.webapp.controller.freemarker.responsevalues.ResponseValues;
 import edu.cornell.mannlib.vitro.webapp.controller.freemarker.responsevalues.TemplateResponseValues;
 import edu.cornell.mannlib.vitro.webapp.email.FreemarkerEmailFactory;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 
 @WebServlet(name = "sendMail", urlPatterns = {"/submitFeedback"}, loadOnStartup = 5)
 public class ContactMailController extends FreemarkerHttpServlet {
-	private static final Log log = LogFactory
-			.getLog(ContactMailController.class);
+    private static final Log log = LogFactory
+        .getLog(ContactMailController.class);
     private static final long serialVersionUID = 1L;
 
-    private final static String SPAM_MESSAGE        = "Your message was flagged as spam.";
+    private final static String SPAM_MESSAGE = "Your message was flagged as spam.";
 
-    private final static String WEB_USERNAME_PARAM  = "webusername";
+    private final static String WEB_USERNAME_PARAM = "webusername";
     private final static String WEB_USEREMAIL_PARAM = "webuseremail";
-    private final static String COMMENTS_PARAM      = "s34gfd88p9x1";
+    private final static String COMMENTS_PARAM = "s34gfd88p9x1";
 
     private final static String TEMPLATE_CONFIRMATION = "contactForm-confirmation.ftl";
     private final static String TEMPLATE_EMAIL = "contactForm-email.ftl";
@@ -53,135 +58,136 @@ public class ContactMailController extends FreemarkerHttpServlet {
     private final static String TEMPLATE_ERROR = "contactForm-error.ftl";
     private final static String TEMPLATE_FORM = "contactForm-form.ftl";
 
-	private static final String EMAIL_JOURNAL_FILE_DIR = "emailJournal";
-	private static final String EMAIL_JOURNAL_FILE_NAME = "contactFormEmails.html";
+    private static final String EMAIL_JOURNAL_FILE_DIR = "emailJournal";
+    private static final String EMAIL_JOURNAL_FILE_NAME = "contactFormEmails.html";
 
-	@Override
+    private static List<CaptchaBundle> captchaChallenges = Collections.synchronizedList(new ArrayList<>());
+
+    @Override
     protected String getTitle(String siteName, VitroRequest vreq) {
         return siteName + " Feedback Form";
     }
 
 
     @Override
-	protected ResponseValues processRequest(VitroRequest vreq) {
-    	if (!FreemarkerEmailFactory.isConfigured(vreq)) {
-			return errorNoSmtpServer();
-		}
+    protected ResponseValues processRequest(VitroRequest vreq) throws IOException {
+        if (!FreemarkerEmailFactory.isConfigured(vreq)) {
+            return errorNoSmtpServer();
+        }
 
-		String[] recipients = figureRecipients(vreq);
-		if (recipients.length == 0) {
-			return errorNoRecipients();
-		}
+        String[] recipients = figureRecipients(vreq);
+        if (recipients.length == 0) {
+            return errorNoRecipients();
+        }
 
-		String webusername = nonNullAndTrim(vreq, WEB_USERNAME_PARAM);
-		String webuseremail = nonNullAndTrim(vreq, WEB_USEREMAIL_PARAM);
-		String comments = nonNullAndTrim(vreq, COMMENTS_PARAM);
-	    String formType = nonNullAndTrim(vreq, "DeliveryType");
-	    String captchaInput = nonNullAndTrim(vreq, "defaultReal");
-	    String captchaDisplay = nonNullAndTrim(vreq, "defaultRealHash");
+        String webusername = nonNullAndTrim(vreq, WEB_USERNAME_PARAM);
+        String webuseremail = nonNullAndTrim(vreq, WEB_USEREMAIL_PARAM);
+        String comments = nonNullAndTrim(vreq, COMMENTS_PARAM);
+        String formType = nonNullAndTrim(vreq, "DeliveryType");
+        String captchaInput = nonNullAndTrim(vreq, "userSolution");
+        String captchaId = nonNullAndTrim(vreq, "challengeId");
 
-	    String errorMsg = validateInput(webusername, webuseremail, comments, captchaInput, captchaDisplay);
+        String errorMsg = validateInput(webusername, webuseremail, comments, captchaInput, captchaId);
 
-		if ( errorMsg != null) {
-			return errorParametersNotValid(errorMsg, webusername, webuseremail, comments);
-		}
+        if (errorMsg != null) {
+            return errorParametersNotValid(errorMsg, webusername, webuseremail, comments);
+        }
 
-		String spamReason = checkForSpam(comments, formType);
-		if (spamReason != null) {
-			return errorSpam();
-		}
+        String spamReason = checkForSpam(comments, formType);
+        if (spamReason != null) {
+            return errorSpam();
+        }
 
-		return processValidRequest(vreq, webusername, webuseremail, recipients, comments);
-	}
+        return processValidRequest(vreq, webusername, webuseremail, recipients, comments);
+    }
 
-	private String[] figureRecipients(VitroRequest vreq) {
-		String contactMailAddresses = vreq.getAppBean().getContactMail().trim();
-		if ((contactMailAddresses == null) || contactMailAddresses.isEmpty()) {
-			return new String[0];
-		}
+    private String[] figureRecipients(VitroRequest vreq) {
+        String contactMailAddresses = vreq.getAppBean().getContactMail().trim();
+        if ((contactMailAddresses == null) || contactMailAddresses.isEmpty()) {
+            return new String[0];
+        }
 
-		return contactMailAddresses.split(",");
-	}
+        return contactMailAddresses.split(",");
+    }
 
-	private ResponseValues processValidRequest(VitroRequest vreq,
-			String webusername, String webuseremail, String[] recipients,
-			String comments) throws Error {
-		String statusMsg = null; // holds the error status
+    private ResponseValues processValidRequest(VitroRequest vreq,
+                                               String webusername, String webuseremail, String[] recipients,
+                                               String comments) throws Error {
+        String statusMsg = null; // holds the error status
 
-		ApplicationBean appBean = vreq.getAppBean();
-		String deliveryfrom = "Message from the " + appBean.getApplicationName() + " Contact Form";
+        ApplicationBean appBean = vreq.getAppBean();
+        String deliveryfrom = "Message from the " + appBean.getApplicationName() + " Contact Form";
 
-	    String originalReferer = getOriginalRefererFromSession(vreq);
+        String originalReferer = getOriginalRefererFromSession(vreq);
 
-	    String msgText = composeEmail(webusername, webuseremail, comments,
-	    		deliveryfrom, originalReferer, vreq.getRemoteAddr(), vreq);
+        String msgText = composeEmail(webusername, webuseremail, comments,
+            deliveryfrom, originalReferer, vreq.getRemoteAddr(), vreq);
 
-	    try {
-	    	// Write the message to the journal file
-	    	FileWriter fw = new FileWriter(locateTheJournalFile(), true);
-	        PrintWriter outFile = new PrintWriter(fw);
-	        writeBackupCopy(outFile, msgText, vreq);
+        try {
+            // Write the message to the journal file
+            FileWriter fw = new FileWriter(locateTheJournalFile(), true);
+            PrintWriter outFile = new PrintWriter(fw);
+            writeBackupCopy(outFile, msgText, vreq);
 
-	        try {
-	        	// Send the message
-	        	Session s = FreemarkerEmailFactory.getEmailSession(vreq);
-	        	sendMessage(s, webuseremail, webusername, recipients, deliveryfrom, msgText);
-	        } catch (AddressException e) {
-	            statusMsg = "Please supply a valid email address.";
-	            outFile.println( statusMsg );
-	            outFile.println( e.getMessage() );
-	        } catch (SendFailedException e) {
-	            statusMsg = "The system was unable to deliver your mail.  Please try again later.  [SEND FAILED]";
-	            outFile.println( statusMsg );
-	            outFile.println( e.getMessage() );
-	        } catch (MessagingException e) {
-	            statusMsg = "The system was unable to deliver your mail.  Please try again later.  [MESSAGING]";
-	            outFile.println( statusMsg );
-	            outFile.println( e.getMessage() );
-	            e.printStackTrace();
-	        }
+            try {
+                // Send the message
+                Session s = FreemarkerEmailFactory.getEmailSession(vreq);
+                sendMessage(s, webuseremail, webusername, recipients, deliveryfrom, msgText);
+            } catch (AddressException e) {
+                statusMsg = "Please supply a valid email address.";
+                outFile.println(statusMsg);
+                outFile.println(e.getMessage());
+            } catch (SendFailedException e) {
+                statusMsg = "The system was unable to deliver your mail.  Please try again later.  [SEND FAILED]";
+                outFile.println(statusMsg);
+                outFile.println(e.getMessage());
+            } catch (MessagingException e) {
+                statusMsg = "The system was unable to deliver your mail.  Please try again later.  [MESSAGING]";
+                outFile.println(statusMsg);
+                outFile.println(e.getMessage());
+                e.printStackTrace();
+            }
 
-	        outFile.close();
-	    }
-	    catch (IOException e){
-	    	log.error("Can't open file to write email backup");
-	    }
+            outFile.close();
+        } catch (IOException e) {
+            log.error("Can't open file to write email backup");
+        }
 
-	    if (statusMsg == null) {
-	    	// Message was sent successfully
-	    	return new TemplateResponseValues(TEMPLATE_CONFIRMATION);
-	    } else {
-	    	Map<String, Object> body = new HashMap<String, Object>();
-	        body.put("errorMessage", statusMsg);
-			return new TemplateResponseValues(TEMPLATE_ERROR, body);
-	    }
-	}
+        if (statusMsg == null) {
+            // Message was sent successfully
+            return new TemplateResponseValues(TEMPLATE_CONFIRMATION);
+        } else {
+            Map<String, Object> body = new HashMap<String, Object>();
+            body.put("errorMessage", statusMsg);
+            return new TemplateResponseValues(TEMPLATE_ERROR, body);
+        }
+    }
 
-	/**
-	 * The journal file belongs in a sub-directory of the Vitro home directory.
-	 * If the sub-directory doesn't exist, create it.
-	 */
-	private File locateTheJournalFile() {
-		File homeDir = ApplicationUtils.instance().getHomeDirectory().getPath().toFile();
-		File journalDir = new File(homeDir, EMAIL_JOURNAL_FILE_DIR);
-		if (!journalDir.exists()) {
-			boolean created = journalDir.mkdir();
-			if (!created) {
-				throw new IllegalStateException(
-						"Unable to create email journal directory at '"
-								+ journalDir + "'");
-			}
-		}
+    /**
+     * The journal file belongs in a sub-directory of the Vitro home directory.
+     * If the sub-directory doesn't exist, create it.
+     */
+    private File locateTheJournalFile() {
+        File homeDir = ApplicationUtils.instance().getHomeDirectory().getPath().toFile();
+        File journalDir = new File(homeDir, EMAIL_JOURNAL_FILE_DIR);
+        if (!journalDir.exists()) {
+            boolean created = journalDir.mkdir();
+            if (!created) {
+                throw new IllegalStateException(
+                    "Unable to create email journal directory at '"
+                        + journalDir + "'");
+            }
+        }
 
-		File journalFile = new File(journalDir, EMAIL_JOURNAL_FILE_NAME);
-		return journalFile;
-	}
+        File journalFile = new File(journalDir, EMAIL_JOURNAL_FILE_NAME);
+        return journalFile;
+    }
 
 
-	private String getOriginalRefererFromSession(VitroRequest vreq) {
-		String originalReferer = (String) vreq.getSession().getAttribute("contactFormReferer");
-	    if (originalReferer != null) {
-	    	vreq.getSession().removeAttribute("contactFormReferer");
+    private String getOriginalRefererFromSession(VitroRequest vreq) {
+        String originalReferer = (String) vreq.getSession().getAttribute("contactFormReferer");
+        if (originalReferer != null) {
+            vreq.getSession().removeAttribute("contactFormReferer");
 	    	/* does not support legitimate clients that don't send the Referer header
 	    	  String referer = request.getHeader("Referer");
 	          if (referer == null ||
@@ -192,25 +198,28 @@ public class ContactMailController extends FreemarkerHttpServlet {
 	              statusMsg = SPAM_MESSAGE;
 	          }
 	        */
-	    } else {
-	        originalReferer = "none";
-	    }
-		return originalReferer;
-	}
+        } else {
+            originalReferer = "none";
+        }
+        return originalReferer;
+    }
 
-    /** Intended to mangle url so it can get through spam filtering
-     *    http://host/dir/servlet?param=value -&gt;  host: dir/servlet?param=value */
-    public String stripProtocol( String in ){
-        if( in == null )
+    /**
+     * Intended to mangle url so it can get through spam filtering
+     * http://host/dir/servlet?param=value -&gt;  host: dir/servlet?param=value
+     */
+    public String stripProtocol(String in) {
+        if (in == null) {
             return "";
-        else
-            return in.replaceAll("http://", "host: " );
+        } else {
+            return in.replaceAll("http://", "host: ");
+        }
     }
 
     private String composeEmail(String webusername, String webuseremail,
-    							String comments, String deliveryfrom,
-    							String originalReferer, String ipAddr,
-    							HttpServletRequest request) {
+                                String comments, String deliveryfrom,
+                                String originalReferer, String ipAddr,
+                                HttpServletRequest request) {
 
         Map<String, Object> email = new HashMap<String, Object>();
         String template = TEMPLATE_EMAIL;
@@ -220,7 +229,7 @@ public class ContactMailController extends FreemarkerHttpServlet {
         email.put("emailAddress", webuseremail);
         email.put("comments", comments);
         email.put("ip", ipAddr);
-        if ( !(originalReferer == null || originalReferer.equals("none")) ) {
+        if (!(originalReferer == null || originalReferer.equals("none"))) {
             email.put("referrer", UrlBuilder.urlDecode(originalReferer));
         }
 
@@ -233,13 +242,13 @@ public class ContactMailController extends FreemarkerHttpServlet {
     }
 
     private void writeBackupCopy(PrintWriter outFile, String msgText,
-    		HttpServletRequest request) {
+                                 HttpServletRequest request) {
 
         Map<String, Object> backup = new HashMap<String, Object>();
         String template = TEMPLATE_BACKUP;
 
-    	Calendar cal = Calendar.getInstance();
-    	backup.put("datetime", cal.getTime().toString());
+        Calendar cal = Calendar.getInstance();
+        backup.put("datetime", cal.getTime().toString());
         backup.put("msgText", msgText);
 
         try {
@@ -253,61 +262,61 @@ public class ContactMailController extends FreemarkerHttpServlet {
     }
 
     private void sendMessage(Session s, String webuseremail, String webusername,
-    		String[] recipients, String deliveryfrom, String msgText)
-    		throws AddressException, SendFailedException, MessagingException {
+                             String[] recipients, String deliveryfrom, String msgText)
+        throws MessagingException {
         // Construct the message
-        MimeMessage msg = new MimeMessage( s );
+        MimeMessage msg = new MimeMessage(s);
         //System.out.println("trying to send message from servlet");
 
         // Set the reply address
         try {
-            msg.setReplyTo( new Address[] { new InternetAddress( webuseremail, webusername ) } );
+            msg.setReplyTo(new Address[] {new InternetAddress(webuseremail, webusername)});
         } catch (UnsupportedEncodingException e) {
-        	log.error("Can't set message reply with personal name " + webusername +
-        			" due to UnsupportedEncodingException");
+            log.error("Can't set message reply with personal name " + webusername +
+                " due to UnsupportedEncodingException");
 //            msg.setFrom( new InternetAddress( webuseremail ) );
         }
 
         // Set the recipient address
-        InternetAddress[] address=new InternetAddress[recipients.length];
-        for (int i=0; i<recipients.length; i++){
+        InternetAddress[] address = new InternetAddress[recipients.length];
+        for (int i = 0; i < recipients.length; i++) {
             address[i] = new InternetAddress(recipients[i]);
         }
-        msg.setRecipients( Message.RecipientType.TO, address );
+        msg.setRecipients(Message.RecipientType.TO, address);
 
-		// Set the from address
-		if (address != null && address.length > 0) {
-			msg.setFrom(address[0]);
-		} else {
-            msg.setFrom( new InternetAddress( webuseremail ) );
-		}
+        // Set the from address
+        if (address != null && address.length > 0) {
+            msg.setFrom(address[0]);
+        } else {
+            msg.setFrom(new InternetAddress(webuseremail));
+        }
 
         // Set the subject and text
-        msg.setSubject( deliveryfrom );
+        msg.setSubject(deliveryfrom);
 
         // add the multipart to the message
-        msg.setContent(msgText,"text/html; charset=UTF-8");
+        msg.setContent(msgText, "text/html; charset=UTF-8");
 
         // set the Date: header
-        msg.setSentDate( new Date() );
+        msg.setSentDate(new Date());
 
-        Transport.send( msg ); // try to send the message via smtp - catch error exceptions
+        Transport.send(msg); // try to send the message via smtp - catch error exceptions
 
     }
 
-	private String nonNullAndTrim(HttpServletRequest req, String key) {
-		String value = req.getParameter(key);
-		return (value == null) ? "" : value.trim();
-	}
+    private String nonNullAndTrim(HttpServletRequest req, String key) {
+        String value = req.getParameter(key);
+        return (value == null) ? "" : value.trim();
+    }
 
     private String validateInput(String webusername, String webuseremail,
-    							 String comments, String captchaInput, String captchaDisplay) {
+                                 String comments, String captchaInput, String challengeId) {
 
-        if( webusername.isEmpty() ){
+        if (webusername.isEmpty()) {
             return "Please enter a value in the Full name field.";
         }
 
-        if( webuseremail.isEmpty() ){
+        if (webuseremail.isEmpty()) {
             return "Please enter a valid email address.";
         }
 
@@ -319,11 +328,12 @@ public class ContactMailController extends FreemarkerHttpServlet {
             return "Please enter the contents of the gray box in the security field provided.";
         }
 
-		if ( !captchaHash(captchaInput).equals(captchaDisplay) ) {
-			return "The value you entered in the security field did not match the letters displayed in the gray box.";
-		}
+        Optional<CaptchaBundle> optionalChallenge = getChallenge(challengeId);
+        if (optionalChallenge.isPresent() && optionalChallenge.get().getCode().equals(captchaInput)) {
+            return null;
+        }
 
-        return null;
+        return "The value you entered in the security field did not match the letters displayed in the gray box.";
     }
 
     /**
@@ -331,22 +341,22 @@ public class ContactMailController extends FreemarkerHttpServlet {
      * containing the reason the message was flagged as spam.
      */
     private String checkForSpam(String comments, String formType) {
-    	/* If the form doesn't specify a delivery type, treat as spam. */
-	    if (!"contact".equals(formType)) {
-	        return "The form specifies no delivery type.";
-	    }
+        /* If the form doesn't specify a delivery type, treat as spam. */
+        if (!"contact".equals(formType)) {
+            return "The form specifies no delivery type.";
+        }
 
         /* if this blog markup is found, treat comment as blog spam */
         if (
             (comments.indexOf("[/url]") > -1
-            || comments.indexOf("[/URL]") > -1
-            || comments.indexOf("[url=") > -1
-            || comments.indexOf("[URL=") > -1)) {
+                || comments.indexOf("[/URL]") > -1
+                || comments.indexOf("[url=") > -1
+                || comments.indexOf("[URL=") > -1)) {
             return "The message contained blog link markup.";
         }
 
         /* if message is absurdly short, treat as blog spam */
-        if (comments.length()<15) {
+        if (comments.length() < 15) {
             return "The message was too short.";
         }
 
@@ -354,45 +364,65 @@ public class ContactMailController extends FreemarkerHttpServlet {
 
     }
 
-	private String captchaHash(String value) {
-		int hash = 5381;
-		value = value.toUpperCase();
-		for(int i = 0; i < value.length(); i++) {
-			hash = ((hash << 5) + hash) + value.charAt(i);
-		}
-		return String.valueOf(hash);
-	}
+    private String captchaHash(String value) {
+        int hash = 5381;
+        value = value.toUpperCase();
+        for (int i = 0; i < value.length(); i++) {
+            hash = ((hash << 5) + hash) + value.charAt(i);
+        }
+        return String.valueOf(hash);
+    }
 
-	private ResponseValues errorNoSmtpServer() {
+    private ResponseValues errorNoSmtpServer() {
         Map<String, Object> body = new HashMap<String, Object>();
         body.put("errorMessage",
-                "This application has not yet been configured to send mail. " +
+            "This application has not yet been configured to send mail. " +
                 "Email properties must be specified in the configuration properties file.");
-		return new TemplateResponseValues(TEMPLATE_ERROR, body);
-	}
+        return new TemplateResponseValues(TEMPLATE_ERROR, body);
+    }
 
-	private ResponseValues errorNoRecipients() {
-		Map<String, Object> body = new HashMap<String, Object>();
-		body.put("errorMessage", "To establish the Contact Us mail capability "
-				+ "the system administrators must specify "
-				+ "at least one email address.");
-		return new TemplateResponseValues(TEMPLATE_ERROR, body);
-	}
-
-	private ResponseValues errorParametersNotValid(String errorMsg, String webusername, String webuseremail, String comments) {
+    private ResponseValues errorNoRecipients() {
         Map<String, Object> body = new HashMap<String, Object>();
-		body.put("errorMessage", errorMsg);
-		body.put("formAction", "submitFeedback");
-		body.put("webusername", webusername);
-		body.put("webuseremail", webuseremail);
-		body.put("comments", comments);
-		return new TemplateResponseValues(TEMPLATE_FORM, body);
-	}
+        body.put("errorMessage", "To establish the Contact Us mail capability "
+            + "the system administrators must specify "
+            + "at least one email address.");
+        return new TemplateResponseValues(TEMPLATE_ERROR, body);
+    }
 
-	private ResponseValues errorSpam() {
-		Map<String, Object> body = new HashMap<String, Object>();
-		body.put("errorMessage", SPAM_MESSAGE);
-		return new TemplateResponseValues(TEMPLATE_ERROR, body);
-	}
+    private ResponseValues errorParametersNotValid(String errorMsg, String webusername, String webuseremail,
+                                                   String comments) throws IOException {
+        Map<String, Object> body = new HashMap<String, Object>();
+        body.put("errorMessage", errorMsg);
+        body.put("formAction", "submitFeedback");
+        body.put("webusername", webusername);
+        body.put("webuseremail", webuseremail);
+        body.put("comments", comments);
 
+        CaptchaBundle captchaChallenge = CaptchaServiceBean.generateChallenge();
+        ContactMailController.getCaptchaChallenges().add(captchaChallenge);
+        body.put("challenge", captchaChallenge.getB64Image());
+        body.put("challengeId", captchaChallenge.getCaptchaId());
+
+        return new TemplateResponseValues(TEMPLATE_FORM, body);
+    }
+
+    private ResponseValues errorSpam() {
+        Map<String, Object> body = new HashMap<String, Object>();
+        body.put("errorMessage", SPAM_MESSAGE);
+        return new TemplateResponseValues(TEMPLATE_ERROR, body);
+    }
+
+    private Optional<CaptchaBundle> getChallenge(String captchaId) {
+        for (CaptchaBundle challenge : captchaChallenges) {
+            if (challenge.getCaptchaId().equals(captchaId)) {
+                captchaChallenges.remove(challenge);
+                return Optional.of(challenge);
+            }
+        }
+        return Optional.empty();
+    }
+
+    public static List<CaptchaBundle> getCaptchaChallenges() {
+        return captchaChallenges;
+    }
 }

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/freemarker/ContactMailController.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/freemarker/ContactMailController.java
@@ -36,6 +36,8 @@ import edu.cornell.mannlib.vitro.webapp.controller.freemarker.TemplateProcessing
 import edu.cornell.mannlib.vitro.webapp.controller.freemarker.responsevalues.ResponseValues;
 import edu.cornell.mannlib.vitro.webapp.controller.freemarker.responsevalues.TemplateResponseValues;
 import edu.cornell.mannlib.vitro.webapp.email.FreemarkerEmailFactory;
+import edu.cornell.mannlib.vitro.webapp.i18n.I18n;
+import edu.cornell.mannlib.vitro.webapp.i18n.I18nBundle;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
@@ -325,21 +327,22 @@ public class ContactMailController extends FreemarkerHttpServlet {
 
     private String validateInput(String webusername, String webuseremail,
                                  String comments, String captchaInput, String challengeId, VitroRequest vreq) {
+        I18nBundle i18nBundle = I18n.bundle(vreq);
 
         if (webusername.isEmpty()) {
-            return "Please enter a value in the Full name field.";
+            return i18nBundle.text("full_name_empty");
         }
 
         if (webuseremail.isEmpty()) {
-            return "Please enter a valid email address.";
+            return i18nBundle.text("email_address_empty");
         }
 
         if (comments.isEmpty()) {
-            return "Please enter your comments or questions in the space provided.";
+            return i18nBundle.text("comments_empty");
         }
 
         if (captchaInput.isEmpty()) {
-            return "Please enter the contents of the gray box in the security field provided.";
+            return i18nBundle.text("captcha_user_sol_empty");
         }
 
         switch(captchaImpl) {
@@ -356,7 +359,7 @@ public class ContactMailController extends FreemarkerHttpServlet {
         }
 
 
-        return "The value you entered in the security field did not match the letters displayed in the gray box.";
+        return i18nBundle.text("captcha_user_sol_invalid");
     }
 
     /**

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/freemarker/ContactMailController.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/freemarker/ContactMailController.java
@@ -28,9 +28,8 @@ import javax.servlet.http.HttpServletRequest;
 
 import edu.cornell.mannlib.vitro.webapp.application.ApplicationUtils;
 import edu.cornell.mannlib.vitro.webapp.beans.ApplicationBean;
-import edu.cornell.mannlib.vitro.webapp.beans.CaptchaBundle;
+import edu.cornell.mannlib.vitro.webapp.beans.CaptchaImplementation;
 import edu.cornell.mannlib.vitro.webapp.beans.CaptchaServiceBean;
-import edu.cornell.mannlib.vitro.webapp.config.ConfigurationProperties;
 import edu.cornell.mannlib.vitro.webapp.controller.VitroRequest;
 import edu.cornell.mannlib.vitro.webapp.controller.freemarker.TemplateProcessingHelper.TemplateProcessingException;
 import edu.cornell.mannlib.vitro.webapp.controller.freemarker.responsevalues.ResponseValues;
@@ -62,7 +61,7 @@ public class ContactMailController extends FreemarkerHttpServlet {
     private static final String EMAIL_JOURNAL_FILE_DIR = "emailJournal";
     private static final String EMAIL_JOURNAL_FILE_NAME = "contactFormEmails.html";
 
-    private String captchaImpl;
+    private CaptchaImplementation captchaImpl;
 
     @Override
     protected String getTitle(String siteName, VitroRequest vreq) {
@@ -91,10 +90,10 @@ public class ContactMailController extends FreemarkerHttpServlet {
         String captchaInput;
         String captchaId = "";
         switch (captchaImpl) {
-            case "RECAPTCHA":
+            case RECAPTCHAv2:
                 captchaInput = nonNullAndTrim(vreq, "g-recaptcha-response");
                 break;
-            case "NANOCAPTCHA":
+            case NANOCAPTCHA:
             default:
                 captchaInput = nonNullAndTrim(vreq, "userSolution");
                 captchaId = nonNullAndTrim(vreq, "challengeId");
@@ -338,7 +337,7 @@ public class ContactMailController extends FreemarkerHttpServlet {
             return i18nBundle.text("comments_empty");
         }
 
-        if (!captchaImpl.equals("NONE") && captchaInput.isEmpty()) {
+        if (!captchaImpl.equals(CaptchaImplementation.NONE) && captchaInput.isEmpty()) {
             return i18nBundle.text("captcha_user_sol_empty");
         }
 

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/freemarker/ContactMailController.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/freemarker/ContactMailController.java
@@ -90,7 +90,7 @@ public class ContactMailController extends FreemarkerHttpServlet {
         String captchaInput;
         String captchaId = "";
         switch (captchaImpl) {
-            case RECAPTCHAv2:
+            case RECAPTCHAV2:
                 captchaInput = nonNullAndTrim(vreq, "g-recaptcha-response");
                 break;
             case NANOCAPTCHA:

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/freemarker/ContactMailController.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/freemarker/ContactMailController.java
@@ -349,7 +349,7 @@ public class ContactMailController extends FreemarkerHttpServlet {
                 }
             case "DEFAULT":
             default:
-                Optional<CaptchaBundle> optionalChallenge = CaptchaServiceBean.getChallenge(challengeId, vreq.getRemoteAddr());
+                Optional<CaptchaBundle> optionalChallenge = CaptchaServiceBean.getChallenge(challengeId);
                 if (optionalChallenge.isPresent() && optionalChallenge.get().getCode().equals(captchaInput)) {
                     return null;
                 }
@@ -424,7 +424,7 @@ public class ContactMailController extends FreemarkerHttpServlet {
 
         if (!captchaImpl.equals("RECAPTCHA")) {
             CaptchaBundle captchaChallenge = CaptchaServiceBean.generateChallenge();
-            CaptchaServiceBean.getCaptchaChallenges().put(vreq.getRemoteAddr(), captchaChallenge);
+            CaptchaServiceBean.getCaptchaChallenges().put(captchaChallenge.getCaptchaId(), captchaChallenge);
             body.put("challenge", captchaChallenge.getB64Image());
             body.put("challengeId", captchaChallenge.getCaptchaId());
         } else {

--- a/api/src/test/java/edu/cornell/mannlib/vitro/webapp/service/CaptchaServiceBeanTest.java
+++ b/api/src/test/java/edu/cornell/mannlib/vitro/webapp/service/CaptchaServiceBeanTest.java
@@ -14,7 +14,7 @@ import com.google.common.cache.Cache;
 import edu.cornell.mannlib.vitro.testing.AbstractTestClass;
 import edu.cornell.mannlib.vitro.webapp.beans.CaptchaBundle;
 import edu.cornell.mannlib.vitro.webapp.beans.CaptchaServiceBean;
-import edu.cornell.mannlib.vitro.webapp.controller.VitroRequest;
+import edu.cornell.mannlib.vitro.webapp.config.ConfigurationProperties;
 import org.junit.Before;
 import org.junit.Test;
 import stubs.edu.cornell.mannlib.vitro.webapp.config.ConfigurationPropertiesStub;
@@ -33,7 +33,7 @@ public class CaptchaServiceBeanTest extends AbstractTestClass {
         props.setProperty("recaptcha.secretKey", "secretKey");
 
         ServletContextStub ctx = new ServletContextStub();
-        props.setBean(ctx);
+        ConfigurationProperties.setInstance(props);
 
         HttpSessionStub session = new HttpSessionStub();
         session.setServletContext(ctx);

--- a/api/src/test/java/edu/cornell/mannlib/vitro/webapp/service/CaptchaServiceBeanTest.java
+++ b/api/src/test/java/edu/cornell/mannlib/vitro/webapp/service/CaptchaServiceBeanTest.java
@@ -1,0 +1,95 @@
+package edu.cornell.mannlib.vitro.webapp.service;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.Optional;
+
+import edu.cornell.mannlib.vitro.testing.AbstractTestClass;
+import edu.cornell.mannlib.vitro.webapp.beans.CaptchaBundle;
+import edu.cornell.mannlib.vitro.webapp.beans.CaptchaServiceBean;
+import edu.cornell.mannlib.vitro.webapp.controller.VitroRequest;
+import org.junit.Before;
+import org.junit.Test;
+import stubs.edu.cornell.mannlib.vitro.webapp.config.ConfigurationPropertiesStub;
+import stubs.javax.servlet.ServletContextStub;
+import stubs.javax.servlet.http.HttpServletRequestStub;
+import stubs.javax.servlet.http.HttpSessionStub;
+
+public class CaptchaServiceBeanTest extends AbstractTestClass {
+
+    HttpServletRequestStub httpServletRequest;
+
+
+    @Before
+    public void createConfigurationProperties() throws Exception {
+        ConfigurationPropertiesStub props = new ConfigurationPropertiesStub();
+        props.setProperty("recaptcha.secretKey", "secretKey");
+
+        ServletContextStub ctx = new ServletContextStub();
+        props.setBean(ctx);
+
+        HttpSessionStub session = new HttpSessionStub();
+        session.setServletContext(ctx);
+
+        httpServletRequest = new HttpServletRequestStub();
+        httpServletRequest.setSession(session);
+    }
+
+    @Test
+    public void validateReCaptcha_InvalidResponse_ReturnsFalse() throws IOException {
+        // Given
+        VitroRequest vitroRequest = new VitroRequest(httpServletRequest);
+
+        // When
+        boolean result = CaptchaServiceBean.validateReCaptcha("invalidResponse", vitroRequest);
+
+        // Then
+        assertFalse(result);
+    }
+
+    @Test
+    public void generateChallenge_ValidChallengeGenerated() throws IOException {
+        // When
+        CaptchaBundle captchaBundle = CaptchaServiceBean.generateChallenge();
+
+        // Then
+        assertNotNull(captchaBundle);
+        assertNotNull(captchaBundle.getB64Image());
+        assertNotNull(captchaBundle.getCode());
+        assertNotNull(captchaBundle.getCaptchaId());
+    }
+
+    @Test
+    public void getChallenge_MatchingCaptchaIdAndRemoteAddress_ReturnsCaptchaBundle() {
+        // Given
+        String captchaId = "sampleCaptchaId";
+        String remoteAddress = "sampleRemoteAddress";
+        CaptchaBundle sampleChallenge = new CaptchaBundle("sampleB64Image", "sampleCode", captchaId);
+        CaptchaServiceBean.getCaptchaChallenges().put(remoteAddress, sampleChallenge);
+
+        // When
+        Map<String, CaptchaBundle> captchaChallenges = CaptchaServiceBean.getCaptchaChallenges();
+        Optional<CaptchaBundle> result = CaptchaServiceBean.getChallenge(captchaId, remoteAddress);
+
+        // Then
+        assertTrue(result.isPresent());
+        assertEquals(sampleChallenge, result.get());
+        assertTrue(captchaChallenges.isEmpty()); // Ensure the challenge is removed from the map
+    }
+
+    @Test
+    public void getChallenge_NonMatchingCaptchaIdAndRemoteAddress_ReturnsEmptyOptional() {
+        // When
+        Map<String, CaptchaBundle> captchaChallenges = CaptchaServiceBean.getCaptchaChallenges();
+        Optional<CaptchaBundle> result = CaptchaServiceBean.getChallenge("nonMatchingId", "nonMatchingAddress");
+
+        // Then
+        assertFalse(result.isPresent());
+        assertTrue(captchaChallenges.isEmpty()); // Ensure the map remains empty
+    }
+}

--- a/api/src/test/java/edu/cornell/mannlib/vitro/webapp/service/CaptchaServiceBeanTest.java
+++ b/api/src/test/java/edu/cornell/mannlib/vitro/webapp/service/CaptchaServiceBeanTest.java
@@ -6,9 +6,9 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
-import java.util.Map;
 import java.util.Optional;
 
+import com.google.common.cache.Cache;
 import edu.cornell.mannlib.vitro.testing.AbstractTestClass;
 import edu.cornell.mannlib.vitro.webapp.beans.CaptchaBundle;
 import edu.cornell.mannlib.vitro.webapp.beans.CaptchaServiceBean;
@@ -68,28 +68,27 @@ public class CaptchaServiceBeanTest extends AbstractTestClass {
     public void getChallenge_MatchingCaptchaIdAndRemoteAddress_ReturnsCaptchaBundle() {
         // Given
         String captchaId = "sampleCaptchaId";
-        String remoteAddress = "sampleRemoteAddress";
         CaptchaBundle sampleChallenge = new CaptchaBundle("sampleB64Image", "sampleCode", captchaId);
-        CaptchaServiceBean.getCaptchaChallenges().put(remoteAddress, sampleChallenge);
+        CaptchaServiceBean.getCaptchaChallenges().put(captchaId, sampleChallenge);
 
         // When
-        Map<String, CaptchaBundle> captchaChallenges = CaptchaServiceBean.getCaptchaChallenges();
-        Optional<CaptchaBundle> result = CaptchaServiceBean.getChallenge(captchaId, remoteAddress);
+        Cache<String, CaptchaBundle> captchaChallenges = CaptchaServiceBean.getCaptchaChallenges();
+        Optional<CaptchaBundle> result = CaptchaServiceBean.getChallenge(captchaId);
 
         // Then
         assertTrue(result.isPresent());
         assertEquals(sampleChallenge, result.get());
-        assertTrue(captchaChallenges.isEmpty()); // Ensure the challenge is removed from the map
+        assertEquals(0, captchaChallenges.size());
     }
 
     @Test
     public void getChallenge_NonMatchingCaptchaIdAndRemoteAddress_ReturnsEmptyOptional() {
         // When
-        Map<String, CaptchaBundle> captchaChallenges = CaptchaServiceBean.getCaptchaChallenges();
-        Optional<CaptchaBundle> result = CaptchaServiceBean.getChallenge("nonMatchingId", "nonMatchingAddress");
+        Cache<String, CaptchaBundle> captchaChallenges = CaptchaServiceBean.getCaptchaChallenges();
+        Optional<CaptchaBundle> result = CaptchaServiceBean.getChallenge("nonMatchingId");
 
         // Then
         assertFalse(result.isPresent());
-        assertTrue(captchaChallenges.isEmpty()); // Ensure the map remains empty
+        assertEquals(0, captchaChallenges.size());
     }
 }

--- a/api/src/test/java/edu/cornell/mannlib/vitro/webapp/service/CaptchaServiceBeanTest.java
+++ b/api/src/test/java/edu/cornell/mannlib/vitro/webapp/service/CaptchaServiceBeanTest.java
@@ -1,3 +1,5 @@
+/* $This file is distributed under the terms of the license in LICENSE$ */
+
 package edu.cornell.mannlib.vitro.webapp.service;
 
 import static org.junit.Assert.assertEquals;
@@ -43,10 +45,10 @@ public class CaptchaServiceBeanTest extends AbstractTestClass {
     @Test
     public void validateReCaptcha_InvalidResponse_ReturnsFalse() throws IOException {
         // Given
-        VitroRequest vitroRequest = new VitroRequest(httpServletRequest);
+        String secretKey = "WRONG_SECRET_KEY";
 
         // When
-        boolean result = CaptchaServiceBean.validateReCaptcha("invalidResponse", vitroRequest);
+        boolean result = CaptchaServiceBean.validateReCaptcha("invalidResponse", secretKey);
 
         // Then
         assertFalse(result);

--- a/api/src/test/java/edu/cornell/mannlib/vitro/webapp/service/CaptchaServiceBeanTest.java
+++ b/api/src/test/java/edu/cornell/mannlib/vitro/webapp/service/CaptchaServiceBeanTest.java
@@ -15,6 +15,7 @@ import java.util.Optional;
 
 import edu.cornell.mannlib.vitro.testing.AbstractTestClass;
 import edu.cornell.mannlib.vitro.webapp.beans.CaptchaBundle;
+import edu.cornell.mannlib.vitro.webapp.beans.CaptchaImplementation;
 import edu.cornell.mannlib.vitro.webapp.beans.CaptchaServiceBean;
 import edu.cornell.mannlib.vitro.webapp.config.ConfigurationProperties;
 import org.junit.Before;
@@ -140,7 +141,7 @@ public class CaptchaServiceBeanTest extends AbstractTestClass {
     @Test
     public void addCaptchaRelatedFieldsToPageContext_RecaptchaImpl() throws IOException {
         // Given
-        props.setProperty("captcha.implementation", "RECAPTCHA");
+        props.setProperty("captcha.implementation", "RECAPTCHAv2");
         props.setProperty("recaptcha.siteKey", "SITE_KEY");
         Map<String, Object> context = new HashMap<>();
 
@@ -151,7 +152,7 @@ public class CaptchaServiceBeanTest extends AbstractTestClass {
         assertNotNull(context.get("siteKey"));
         assertNull(context.get("challenge"));
         assertNull(context.get("challengeId"));
-        assertEquals("RECAPTCHA", context.get("captchaToUse"));
+        assertEquals("RECAPTCHAv2", context.get("captchaToUse"));
     }
 
     @Test
@@ -174,13 +175,13 @@ public class CaptchaServiceBeanTest extends AbstractTestClass {
     public void getCaptchaImpl_EnabledCaptcha() {
         // Given
         props.setProperty("captcha.enabled", "true");
-        props.setProperty("captcha.implementation", "RECAPTCHA");
+        props.setProperty("captcha.implementation", "RECAPTCHAv2");
 
-        // Act
-        String captchaImpl = CaptchaServiceBean.getCaptchaImpl();
+        // When
+        CaptchaImplementation captchaImpl = CaptchaServiceBean.getCaptchaImpl();
 
-        // Assert
-        assertEquals("RECAPTCHA", captchaImpl);
+        // Then
+        assertEquals(CaptchaImplementation.RECAPTCHAv2, captchaImpl);
     }
 
     @Test
@@ -188,11 +189,11 @@ public class CaptchaServiceBeanTest extends AbstractTestClass {
         // Given
         props.setProperty("captcha.enabled", "false");
 
-        // Act
-        String captchaImpl = CaptchaServiceBean.getCaptchaImpl();
+        // When
+        CaptchaImplementation captchaImpl = CaptchaServiceBean.getCaptchaImpl();
 
-        // Assert
-        assertEquals("NONE", captchaImpl);
+        // Then
+        assertEquals(CaptchaImplementation.NONE, captchaImpl);
     }
 
     @Test
@@ -201,11 +202,11 @@ public class CaptchaServiceBeanTest extends AbstractTestClass {
         props.setProperty("captcha.enabled", "true");
         props.setProperty("captcha.implementation", null);
 
-        // Act
-        String captchaImpl = CaptchaServiceBean.getCaptchaImpl();
+        // When
+        CaptchaImplementation captchaImpl = CaptchaServiceBean.getCaptchaImpl();
 
-        // Assert
-        assertEquals("NANOCAPTCHA", captchaImpl);
+        // Then
+        assertEquals(CaptchaImplementation.NANOCAPTCHA, captchaImpl);
     }
 
     @Test

--- a/api/src/test/java/edu/cornell/mannlib/vitro/webapp/service/CaptchaServiceBeanTest.java
+++ b/api/src/test/java/edu/cornell/mannlib/vitro/webapp/service/CaptchaServiceBeanTest.java
@@ -152,7 +152,7 @@ public class CaptchaServiceBeanTest extends AbstractTestClass {
         assertNotNull(context.get("siteKey"));
         assertNull(context.get("challenge"));
         assertNull(context.get("challengeId"));
-        assertEquals("RECAPTCHAv2", context.get("captchaToUse"));
+        assertEquals("RECAPTCHAV2", context.get("captchaToUse"));
     }
 
     @Test
@@ -181,7 +181,7 @@ public class CaptchaServiceBeanTest extends AbstractTestClass {
         CaptchaImplementation captchaImpl = CaptchaServiceBean.getCaptchaImpl();
 
         // Then
-        assertEquals(CaptchaImplementation.RECAPTCHAv2, captchaImpl);
+        assertEquals(CaptchaImplementation.RECAPTCHAV2, captchaImpl);
     }
 
     @Test

--- a/api/src/test/java/edu/cornell/mannlib/vitro/webapp/service/CaptchaServiceBeanTest.java
+++ b/api/src/test/java/edu/cornell/mannlib/vitro/webapp/service/CaptchaServiceBeanTest.java
@@ -4,8 +4,6 @@ package edu.cornell.mannlib.vitro.webapp.service;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
@@ -43,78 +41,6 @@ public class CaptchaServiceBeanTest extends AbstractTestClass {
     }
 
     @Test
-    public void validateReCaptcha_InvalidResponse_ReturnsFalse() {
-        // Given
-        props.setProperty("recaptcha.secretKey", "WRONG_SECRET_KEY");
-
-        // When
-        boolean result = CaptchaServiceBean.validateReCaptcha("invalidResponse");
-
-        // Then
-        assertFalse(result);
-    }
-
-    @Test
-    public void generateChallenge_ValidEasyChallengeGenerated() throws IOException {
-        // Given
-        props.setProperty("nanocaptcha.difficulty", "easy");
-
-        // When
-        CaptchaBundle captchaBundle = CaptchaServiceBean.generateChallenge();
-
-        // Then
-        assertNotNull(captchaBundle);
-        assertNotNull(captchaBundle.getB64Image());
-        assertNotNull(captchaBundle.getCode());
-        assertNotNull(captchaBundle.getCaptchaId());
-    }
-
-    @Test
-    public void generateChallenge_ValidEmptyChallengeGenerated() throws IOException {
-        // Given
-        props.setProperty("nanocaptcha.difficulty", "");
-
-        // When
-        CaptchaBundle captchaBundle = CaptchaServiceBean.generateChallenge();
-
-        // Then
-        assertNotNull(captchaBundle);
-        assertNotNull(captchaBundle.getB64Image());
-        assertNotNull(captchaBundle.getCode());
-        assertNotNull(captchaBundle.getCaptchaId());
-    }
-
-    @Test
-    public void generateChallenge_ValidInvalidDifficultyChallengeGenerated() throws IOException {
-        // Given
-        props.setProperty("nanocaptcha.difficulty", "asdasdasd");
-
-        // When
-        CaptchaBundle captchaBundle = CaptchaServiceBean.generateChallenge();
-
-        // Then
-        assertNotNull(captchaBundle);
-        assertNotNull(captchaBundle.getB64Image());
-        assertNotNull(captchaBundle.getCode());
-        assertNotNull(captchaBundle.getCaptchaId());
-    }
-
-    @Test
-    public void generateChallenge_ValidHardChallengeGenerated() throws IOException {
-        // Given
-        props.setProperty("nanocaptcha.difficulty", "hard");
-
-        // When
-        CaptchaBundle captchaBundle = CaptchaServiceBean.generateChallenge();
-
-        // Then
-        assertNotNull(captchaBundle);
-        assertNotNull(captchaBundle.getB64Image());
-        assertNotNull(captchaBundle.getCode());
-        assertNotNull(captchaBundle.getCaptchaId());
-    }
-
-    @Test
     public void getChallenge_MatchingCaptchaIdAndRemoteAddress_ReturnsCaptchaBundle() {
         // Given
         String captchaId = "sampleCaptchaId";
@@ -139,24 +65,20 @@ public class CaptchaServiceBeanTest extends AbstractTestClass {
     }
 
     @Test
-    public void addCaptchaRelatedFieldsToPageContext_RecaptchaImpl() throws IOException {
+    public void addCaptchaRelatedFieldsToPageContext_recaptchaImpl() throws IOException {
         // Given
         props.setProperty("captcha.implementation", "RECAPTCHAv2");
-        props.setProperty("recaptcha.siteKey", "SITE_KEY");
         Map<String, Object> context = new HashMap<>();
 
         // When
         CaptchaServiceBean.addCaptchaRelatedFieldsToPageContext(context);
 
-        // Assert
-        assertNotNull(context.get("siteKey"));
-        assertNull(context.get("challenge"));
-        assertNull(context.get("challengeId"));
+        // Then
         assertEquals("RECAPTCHAV2", context.get("captchaToUse"));
     }
 
     @Test
-    public void addCaptchaRelatedFieldsToPageContext_NanocaptchaImpl() throws IOException {
+    public void addCaptchaRelatedFieldsToPageContext_nanocaptchaImpl() throws IOException {
         // Given
         props.setProperty("captcha.implementation", "NANOCAPTCHA");
         Map<String, Object> context = new HashMap<>();
@@ -164,10 +86,7 @@ public class CaptchaServiceBeanTest extends AbstractTestClass {
         // When
         CaptchaServiceBean.addCaptchaRelatedFieldsToPageContext(context);
 
-        // Assert
-        assertNull(context.get("siteKey"));
-        assertNotNull(context.get("challenge"));
-        assertNotNull(context.get("challengeId"));
+        // Then
         assertEquals("NANOCAPTCHA", context.get("captchaToUse"));
     }
 
@@ -210,20 +129,6 @@ public class CaptchaServiceBeanTest extends AbstractTestClass {
     }
 
     @Test
-    public void validateCaptcha_NanoCaptchaValid() {
-        // Given
-        CaptchaBundle sampleChallenge = new CaptchaBundle("sampleB64Image", "validCode", "challengeId");
-        CaptchaServiceBean.getCaptchaChallenges().put("challengeId", sampleChallenge);
-        props.setProperty("captcha.implementation", "NANOCAPTCHA");
-
-        // Act
-        boolean result = CaptchaServiceBean.validateCaptcha("validCode", "challengeId");
-
-        // Assert
-        assertTrue(result);
-    }
-
-    @Test
     public void validateCaptcha_NoneValid() {
         // Given
         props.setProperty("captcha.enabled", "false");
@@ -231,7 +136,7 @@ public class CaptchaServiceBeanTest extends AbstractTestClass {
         // Act
         boolean result = CaptchaServiceBean.validateCaptcha("anyInput", "anyChallengeId");
 
-        // Assert
+        // Then
         assertTrue(result);
     }
 }

--- a/api/src/test/java/edu/cornell/mannlib/vitro/webapp/service/NanocaptchaProviderTest.java
+++ b/api/src/test/java/edu/cornell/mannlib/vitro/webapp/service/NanocaptchaProviderTest.java
@@ -1,0 +1,129 @@
+package edu.cornell.mannlib.vitro.webapp.service;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import edu.cornell.mannlib.vitro.webapp.beans.CaptchaBundle;
+import edu.cornell.mannlib.vitro.webapp.beans.CaptchaServiceBean;
+import edu.cornell.mannlib.vitro.webapp.beans.NanocaptchaProvider;
+import edu.cornell.mannlib.vitro.webapp.config.ConfigurationProperties;
+import org.junit.Before;
+import org.junit.Test;
+import stubs.edu.cornell.mannlib.vitro.webapp.config.ConfigurationPropertiesStub;
+import stubs.javax.servlet.ServletContextStub;
+import stubs.javax.servlet.http.HttpServletRequestStub;
+import stubs.javax.servlet.http.HttpSessionStub;
+
+public class NanocaptchaProviderTest {
+
+    private final ConfigurationPropertiesStub props = new ConfigurationPropertiesStub();
+
+    private final NanocaptchaProvider provider = new NanocaptchaProvider();
+
+
+    @Before
+    public void createConfigurationProperties() {
+        props.setProperty("captcha.enabled", "true");
+        ServletContextStub ctx = new ServletContextStub();
+        ConfigurationProperties.setInstance(props);
+
+        HttpSessionStub session = new HttpSessionStub();
+        session.setServletContext(ctx);
+
+        HttpServletRequestStub httpServletRequest = new HttpServletRequestStub();
+        httpServletRequest.setSession(session);
+    }
+
+    @Test
+    public void generateChallenge_ValidEasyChallengeGenerated() throws IOException {
+        // Given
+        props.setProperty("nanocaptcha.difficulty", "easy");
+
+        // When
+        CaptchaBundle captchaBundle = provider.generateRefreshChallenge();
+
+        // Then
+        assertNotNull(captchaBundle);
+        assertNotNull(captchaBundle.getB64Image());
+        assertNotNull(captchaBundle.getCode());
+        assertNotNull(captchaBundle.getCaptchaId());
+    }
+
+    @Test
+    public void generateChallenge_ValidEmptyChallengeGenerated() throws IOException {
+        // Given
+        props.setProperty("nanocaptcha.difficulty", "");
+
+        // When
+        CaptchaBundle captchaBundle = provider.generateRefreshChallenge();
+
+        // Then
+        assertNotNull(captchaBundle);
+        assertNotNull(captchaBundle.getB64Image());
+        assertNotNull(captchaBundle.getCode());
+        assertNotNull(captchaBundle.getCaptchaId());
+    }
+
+    @Test
+    public void generateChallenge_ValidInvalidDifficultyChallengeGenerated() throws IOException {
+        // Given
+        props.setProperty("nanocaptcha.difficulty", "asdasdasd");
+
+        // When
+        CaptchaBundle captchaBundle = provider.generateRefreshChallenge();
+
+        // Then
+        assertNotNull(captchaBundle);
+        assertNotNull(captchaBundle.getB64Image());
+        assertNotNull(captchaBundle.getCode());
+        assertNotNull(captchaBundle.getCaptchaId());
+    }
+
+    @Test
+    public void generateChallenge_ValidHardChallengeGenerated() throws IOException {
+        // Given
+        props.setProperty("nanocaptcha.difficulty", "hard");
+
+        // When
+        CaptchaBundle captchaBundle = provider.generateRefreshChallenge();
+
+        // Then
+        assertNotNull(captchaBundle);
+        assertNotNull(captchaBundle.getB64Image());
+        assertNotNull(captchaBundle.getCode());
+        assertNotNull(captchaBundle.getCaptchaId());
+    }
+
+    @Test
+    public void validateCaptcha_NanoCaptchaValid() {
+        // Given
+        CaptchaBundle sampleChallenge = new CaptchaBundle("sampleB64Image", "validCode", "challengeId");
+        CaptchaServiceBean.getCaptchaChallenges().put("challengeId", sampleChallenge);
+        props.setProperty("captcha.implementation", "NANOCAPTCHA");
+
+        // Act
+        boolean result = provider.validateCaptcha("validCode", "challengeId");
+
+        // Assert
+        assertTrue(result);
+    }
+
+    @Test
+    public void addCaptchaRelatedFieldsToPageContext_NanocaptchaImpl() throws IOException {
+        // Given
+        Map<String, Object> context = new HashMap<>();
+
+        // When
+        provider.addCaptchaRelatedFieldsToPageContext(context);
+
+        // Assert
+        assertNull(context.get("siteKey"));
+        assertNotNull(context.get("challenge"));
+        assertNotNull(context.get("challengeId"));
+    }
+}

--- a/api/src/test/java/edu/cornell/mannlib/vitro/webapp/service/Recaptchav2ProviderTest.java
+++ b/api/src/test/java/edu/cornell/mannlib/vitro/webapp/service/Recaptchav2ProviderTest.java
@@ -1,0 +1,67 @@
+package edu.cornell.mannlib.vitro.webapp.service;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import edu.cornell.mannlib.vitro.testing.AbstractTestClass;
+import edu.cornell.mannlib.vitro.webapp.beans.Recaptchav2Provider;
+import edu.cornell.mannlib.vitro.webapp.config.ConfigurationProperties;
+import org.junit.Before;
+import org.junit.Test;
+import stubs.edu.cornell.mannlib.vitro.webapp.config.ConfigurationPropertiesStub;
+import stubs.javax.servlet.ServletContextStub;
+import stubs.javax.servlet.http.HttpServletRequestStub;
+import stubs.javax.servlet.http.HttpSessionStub;
+
+public class Recaptchav2ProviderTest extends AbstractTestClass {
+
+    private final ConfigurationPropertiesStub props = new ConfigurationPropertiesStub();
+
+    private final Recaptchav2Provider provider = new Recaptchav2Provider();
+
+
+    @Before
+    public void createConfigurationProperties() {
+        props.setProperty("captcha.enabled", "true");
+        ServletContextStub ctx = new ServletContextStub();
+        ConfigurationProperties.setInstance(props);
+
+        HttpSessionStub session = new HttpSessionStub();
+        session.setServletContext(ctx);
+
+        HttpServletRequestStub httpServletRequest = new HttpServletRequestStub();
+        httpServletRequest.setSession(session);
+    }
+
+    @Test
+    public void validateReCaptcha_InvalidResponse_ReturnsFalse() {
+        // Given
+        props.setProperty("recaptcha.secretKey", "WRONG_SECRET_KEY");
+
+        // When
+        boolean result = provider.validateReCaptcha("invalidResponse");
+
+        // Then
+        assertFalse(result);
+    }
+
+    @Test
+    public void addCaptchaRelatedFieldsToPageContext_RecaptchaImpl() throws IOException {
+        // Given
+        props.setProperty("recaptcha.siteKey", "SITE_KEY");
+        Map<String, Object> context = new HashMap<>();
+
+        // When
+        provider.addCaptchaRelatedFieldsToPageContext(context);
+
+        // Assert
+        assertNotNull(context.get("siteKey"));
+        assertNull(context.get("challenge"));
+        assertNull(context.get("challengeId"));
+    }
+}

--- a/home/src/main/resources/config/example.runtime.properties
+++ b/home/src/main/resources/config/example.runtime.properties
@@ -194,3 +194,11 @@ proxy.eligibleTypeList = http://www.w3.org/2002/07/owl#Thing
 #fileUpload.maxFileSize = 10485760
 #comma separated list of mime types allowed for upload
 #fileUpload.allowedMIMETypes = image/png, application/pdf
+
+# Captcha configuration. Available implementations are: DEFAULT (text-based) and RECAPTCHA
+# If captcha.implementation property is not provided, system will fall back to DEFAULT implementation
+# For RECAPTCHA method, you have to provide siteKey and secretKey.
+# More information on siteKey and secretKey is available on: https://www.google.com/recaptcha
+captcha.implementation = DEFAULT
+#recaptcha.siteKey =
+#recaptcha.secretKey =

--- a/home/src/main/resources/config/example.runtime.properties
+++ b/home/src/main/resources/config/example.runtime.properties
@@ -195,15 +195,15 @@ proxy.eligibleTypeList = http://www.w3.org/2002/07/owl#Thing
 #comma separated list of mime types allowed for upload
 #fileUpload.allowedMIMETypes = image/png, application/pdf
 
-# Captcha configuration. Available implementations are: NANOCAPTCHA (text-based) and RECAPTCHAv2
-# NANOCAPTCHA is available in 2 difficulties (easy and hard)
-# If captcha.implementation property is not provided, system will fall back to NANOCAPTCHA implementation
+# Captcha configuration. Available implementations are: nanocaptcha (text-based) and recaptchav2
+# nanocaptcha is available in 2 difficulties (easy and hard)
+# If captcha.implementation property is not provided, system will fall back to nanocaptcha implementation
 # with easy diffuculty (if captcha is enabled)
-# For RECAPTCHAv2 method, you have to provide siteKey and secretKey.
+# For recaptchav2 method, you have to provide siteKey and secretKey.
 # More information on siteKey and secretKey is available on: https://www.google.com/recaptcha
-# Only RECAPTCHAv2 implementation is supported
+# Only recaptchav2 implementation is supported
 captcha.enabled = true
-captcha.implementation = NANOCAPTCHA
+captcha.implementation = nanocaptcha
 nanocaptcha.difficulty = hard
 #recaptcha.siteKey =
 #recaptcha.secretKey =

--- a/home/src/main/resources/config/example.runtime.properties
+++ b/home/src/main/resources/config/example.runtime.properties
@@ -195,10 +195,14 @@ proxy.eligibleTypeList = http://www.w3.org/2002/07/owl#Thing
 #comma separated list of mime types allowed for upload
 #fileUpload.allowedMIMETypes = image/png, application/pdf
 
-# Captcha configuration. Available implementations are: DEFAULT (text-based) and RECAPTCHA
-# If captcha.implementation property is not provided, system will fall back to DEFAULT implementation
+# Captcha configuration. Available implementations are: NANOCAPTCHA (text-based) and RECAPTCHA
+# NANOCAPTCHA is available in 2 difficulties ('easy' and 'hard')
+# If captcha.implementation property is not provided, system will fall back to NANOCAPTCHA implementation
+# with easy diffuculty (if captcha is enabled)
 # For RECAPTCHA method, you have to provide siteKey and secretKey.
 # More information on siteKey and secretKey is available on: https://www.google.com/recaptcha
-captcha.implementation = DEFAULT
+captcha.enabled = true
+captcha.implementation = NANOCAPTCHA
+nanocaptcha.difficulty = hard
 #recaptcha.siteKey =
 #recaptcha.secretKey =

--- a/home/src/main/resources/config/example.runtime.properties
+++ b/home/src/main/resources/config/example.runtime.properties
@@ -195,11 +195,11 @@ proxy.eligibleTypeList = http://www.w3.org/2002/07/owl#Thing
 #comma separated list of mime types allowed for upload
 #fileUpload.allowedMIMETypes = image/png, application/pdf
 
-# Captcha configuration. Available implementations are: NANOCAPTCHA (text-based) and RECAPTCHA
-# NANOCAPTCHA is available in 2 difficulties ('easy' and 'hard')
+# Captcha configuration. Available implementations are: NANOCAPTCHA (text-based) and RECAPTCHAv2
+# NANOCAPTCHA is available in 2 difficulties (easy and hard)
 # If captcha.implementation property is not provided, system will fall back to NANOCAPTCHA implementation
 # with easy diffuculty (if captcha is enabled)
-# For RECAPTCHA method, you have to provide siteKey and secretKey.
+# For RECAPTCHAv2 method, you have to provide siteKey and secretKey.
 # More information on siteKey and secretKey is available on: https://www.google.com/recaptcha
 # Only RECAPTCHAv2 implementation is supported
 captcha.enabled = true

--- a/home/src/main/resources/config/example.runtime.properties
+++ b/home/src/main/resources/config/example.runtime.properties
@@ -201,6 +201,7 @@ proxy.eligibleTypeList = http://www.w3.org/2002/07/owl#Thing
 # with easy diffuculty (if captcha is enabled)
 # For RECAPTCHA method, you have to provide siteKey and secretKey.
 # More information on siteKey and secretKey is available on: https://www.google.com/recaptcha
+# Only RECAPTCHAv2 implementation is supported
 captcha.enabled = true
 captcha.implementation = NANOCAPTCHA
 nanocaptcha.difficulty = hard

--- a/home/src/main/resources/config/example.runtime.properties
+++ b/home/src/main/resources/config/example.runtime.properties
@@ -204,6 +204,6 @@ proxy.eligibleTypeList = http://www.w3.org/2002/07/owl#Thing
 # Only recaptchav2 implementation is supported
 captcha.enabled = true
 captcha.implementation = nanocaptcha
-nanocaptcha.difficulty = hard
+nanocaptcha.difficulty = easy
 #recaptcha.siteKey =
 #recaptcha.secretKey =

--- a/home/src/main/resources/rdf/i18n/de_DE/interface-i18n/firsttime/vitro_UiLabel.ttl
+++ b/home/src/main/resources/rdf/i18n/de_DE/interface-i18n/firsttime/vitro_UiLabel.ttl
@@ -6273,7 +6273,7 @@ uil-data:no_individual_associated_with_id.Vitro
 uil-data:full_name_empty.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;
-        rdfs:label       "Bitte geben Sie einen Wert im Feld Vollständiger Name ein."@de-DE ;
+        rdfs:label       "Bitte geben Sie ihren vollständigen Namen an."@de-DE ;
         uil:hasApp      "Vitro" ;
         uil:hasKey      "full_name_empty" ;
         uil:hasPackage  "Vitro-languages" .

--- a/home/src/main/resources/rdf/i18n/de_DE/interface-i18n/firsttime/vitro_UiLabel.ttl
+++ b/home/src/main/resources/rdf/i18n/de_DE/interface-i18n/firsttime/vitro_UiLabel.ttl
@@ -6269,3 +6269,43 @@ uil-data:no_individual_associated_with_id.Vitro
         uil:hasApp      "Vitro" ;
         uil:hasKey      "no_individual_associated_with_id" ;
         uil:hasPackage  "Vitro-languages" .
+
+uil-data:full_name_empty.Vitro
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         uil:UILabel ;
+        rdfs:label       "Bitte geben Sie einen Wert im Feld Vollständiger Name ein."@de-DE ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "full_name_empty" ;
+        uil:hasPackage  "Vitro-languages" .
+
+uil-data:email_address_empty.Vitro
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         uil:UILabel ;
+        rdfs:label       "Bitte geben Sie eine gültige E-Mail-Adresse ein."@de-DE ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "email_address_empty" ;
+        uil:hasPackage  "Vitro-languages" .
+
+uil-data:comments_empty.Vitro
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         uil:UILabel ;
+        rdfs:label       "Bitte geben Sie Ihre Kommentare oder Fragen in das bereitgestellte Feld ein."@de-DE ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "comments_empty" ;
+        uil:hasPackage  "Vitro-languages" .
+
+uil-data:captcha_user_sol_empty.Vitro
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         uil:UILabel ;
+        rdfs:label       "Bitte lösen Sie die CAPTCHA-Herausforderung im bereitgestellten Sicherheitsfeld."@de-DE ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "captcha_user_sol_empty" ;
+        uil:hasPackage  "Vitro-languages" .
+
+uil-data:captcha_user_sol_invalid.Vitro
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         uil:UILabel ;
+        rdfs:label       "Ungültige CAPTCHA-Lösung, bitte versuchen Sie es erneut."@de-DE ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "captcha_user_sol_invalid" ;
+        uil:hasPackage  "Vitro-languages" .

--- a/home/src/main/resources/rdf/i18n/en_CA/interface-i18n/firsttime/vitro_UiLabel.ttl
+++ b/home/src/main/resources/rdf/i18n/en_CA/interface-i18n/firsttime/vitro_UiLabel.ttl
@@ -6269,3 +6269,43 @@ uil-data:no_individual_associated_with_id.Vitro
         uil:hasApp      "Vitro" ;
         uil:hasKey      "no_individual_associated_with_id" ;
         uil:hasPackage  "Vitro-languages" .
+
+uil-data:full_name_empty.Vitro
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         uil:UILabel ;
+        rdfs:label       "Please enter a value in the Full name field."@en-CA ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "full_name_empty" ;
+        uil:hasPackage  "Vitro-languages" .
+
+uil-data:email_address_empty.Vitro
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         uil:UILabel ;
+        rdfs:label       "Please enter a valid email address."@en-CA ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "email_address_empty" ;
+        uil:hasPackage  "Vitro-languages" .
+
+uil-data:comments_empty.Vitro
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         uil:UILabel ;
+        rdfs:label       "Please enter your comments or questions in the space provided."@en-CA ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "comments_empty" ;
+        uil:hasPackage  "Vitro-languages" .
+
+uil-data:captcha_user_sol_empty.Vitro
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         uil:UILabel ;
+        rdfs:label       "Please solve CAPTCHA challenge in the security field provided."@en-CA ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "captcha_user_sol_empty" ;
+        uil:hasPackage  "Vitro-languages" .
+
+uil-data:captcha_user_sol_invalid.Vitro
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         uil:UILabel ;
+        rdfs:label       "Invalid CAPTCHA solution, please try again."@en-CA ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "captcha_user_sol_invalid" ;
+        uil:hasPackage  "Vitro-languages" .

--- a/home/src/main/resources/rdf/i18n/en_US/interface-i18n/firsttime/vitro_UiLabel.ttl
+++ b/home/src/main/resources/rdf/i18n/en_US/interface-i18n/firsttime/vitro_UiLabel.ttl
@@ -6269,3 +6269,43 @@ uil-data:no_individual_associated_with_id.Vitro
         uil:hasApp      "Vitro" ;
         uil:hasKey      "no_individual_associated_with_id" ;
         uil:hasPackage  "Vitro-languages" .
+
+uil-data:full_name_empty.Vitro
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         uil:UILabel ;
+        rdfs:label       "Please enter a value in the Full name field."@en-US ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "full_name_empty" ;
+        uil:hasPackage  "Vitro-languages" .
+
+uil-data:email_address_empty.Vitro
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         uil:UILabel ;
+        rdfs:label       "Please enter a valid email address."@en-US ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "email_address_empty" ;
+        uil:hasPackage  "Vitro-languages" .
+
+uil-data:comments_empty.Vitro
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         uil:UILabel ;
+        rdfs:label       "Please enter your comments or questions in the space provided."@en-US ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "comments_empty" ;
+        uil:hasPackage  "Vitro-languages" .
+
+uil-data:captcha_user_sol_empty.Vitro
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         uil:UILabel ;
+        rdfs:label       "Please solve CAPTCHA challenge in the security field provided."@en-US ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "captcha_user_sol_empty" ;
+        uil:hasPackage  "Vitro-languages" .
+
+uil-data:captcha_user_sol_invalid.Vitro
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         uil:UILabel ;
+        rdfs:label       "Invalid CAPTCHA solution, please try again."@en-US ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "captcha_user_sol_invalid" ;
+        uil:hasPackage  "Vitro-languages" .

--- a/home/src/main/resources/rdf/i18n/es/interface-i18n/firsttime/vitro_UiLabel.ttl
+++ b/home/src/main/resources/rdf/i18n/es/interface-i18n/firsttime/vitro_UiLabel.ttl
@@ -6273,7 +6273,7 @@ uil-data:no_individual_associated_with_id.Vitro
 uil-data:full_name_empty.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;
-        rdfs:label       "Por favor, ingrese un valor en el campo de nombre completo."@es ;
+        rdfs:label       "Por favor, introduzca un valor en el campo de nombre completo."@es ;
         uil:hasApp      "Vitro" ;
         uil:hasKey      "full_name_empty" ;
         uil:hasPackage  "Vitro-languages" .
@@ -6281,7 +6281,7 @@ uil-data:full_name_empty.Vitro
 uil-data:email_address_empty.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;
-        rdfs:label       "Por favor, ingrese una dirección de correo electrónico válida."@es ;
+        rdfs:label       "Por favor, introduzca una dirección de correo electrónico válida."@es ;
         uil:hasApp      "Vitro" ;
         uil:hasKey      "email_address_empty" ;
         uil:hasPackage  "Vitro-languages" .
@@ -6289,7 +6289,7 @@ uil-data:email_address_empty.Vitro
 uil-data:comments_empty.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;
-        rdfs:label       "Por favor, ingrese sus comentarios o preguntas en el espacio proporcionado."@es ;
+        rdfs:label       "Por favor, introduzca sus comentarios o preguntas en el espacio proporcionado."@es ;
         uil:hasApp      "Vitro" ;
         uil:hasKey      "comments_empty" ;
         uil:hasPackage  "Vitro-languages" .
@@ -6305,7 +6305,7 @@ uil-data:captcha_user_sol_empty.Vitro
 uil-data:captcha_user_sol_invalid.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;
-        rdfs:label       "Solución CAPTCHA no válida, por favor, inténtelo nuevamente."@es ;
+        rdfs:label       "Solución CAPTCHA no válida, por favor, inténtelo de nuevo."@es ;
         uil:hasApp      "Vitro" ;
         uil:hasKey      "captcha_user_sol_invalid" ;
         uil:hasPackage  "Vitro-languages" .

--- a/home/src/main/resources/rdf/i18n/es/interface-i18n/firsttime/vitro_UiLabel.ttl
+++ b/home/src/main/resources/rdf/i18n/es/interface-i18n/firsttime/vitro_UiLabel.ttl
@@ -6269,3 +6269,43 @@ uil-data:no_individual_associated_with_id.Vitro
         uil:hasApp      "Vitro" ;
         uil:hasKey      "no_individual_associated_with_id" ;
         uil:hasPackage  "Vitro-languages" .
+
+uil-data:full_name_empty.Vitro
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         uil:UILabel ;
+        rdfs:label       "Por favor, ingrese un valor en el campo de nombre completo."@es ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "full_name_empty" ;
+        uil:hasPackage  "Vitro-languages" .
+
+uil-data:email_address_empty.Vitro
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         uil:UILabel ;
+        rdfs:label       "Por favor, ingrese una dirección de correo electrónico válida."@es ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "email_address_empty" ;
+        uil:hasPackage  "Vitro-languages" .
+
+uil-data:comments_empty.Vitro
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         uil:UILabel ;
+        rdfs:label       "Por favor, ingrese sus comentarios o preguntas en el espacio proporcionado."@es ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "comments_empty" ;
+        uil:hasPackage  "Vitro-languages" .
+
+uil-data:captcha_user_sol_empty.Vitro
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         uil:UILabel ;
+        rdfs:label       "Por favor, resuelva el desafío CAPTCHA en el campo de seguridad proporcionado."@es ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "captcha_user_sol_empty" ;
+        uil:hasPackage  "Vitro-languages" .
+
+uil-data:captcha_user_sol_invalid.Vitro
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         uil:UILabel ;
+        rdfs:label       "Solución CAPTCHA no válida, por favor, inténtelo nuevamente."@es ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "captcha_user_sol_invalid" ;
+        uil:hasPackage  "Vitro-languages" .

--- a/home/src/main/resources/rdf/i18n/fr_CA/interface-i18n/firsttime/vitro_UiLabel.ttl
+++ b/home/src/main/resources/rdf/i18n/fr_CA/interface-i18n/firsttime/vitro_UiLabel.ttl
@@ -6269,3 +6269,43 @@ uil-data:no_individual_associated_with_id.Vitro
         uil:hasApp      "Vitro" ;
         uil:hasKey      "no_individual_associated_with_id" ;
         uil:hasPackage  "Vitro-languages" .
+
+uil-data:full_name_empty.Vitro
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         uil:UILabel ;
+        rdfs:label       "Veuillez entrer une valeur dans le champ du nom complet."@fr-CA ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "full_name_empty" ;
+        uil:hasPackage  "Vitro-languages" .
+
+uil-data:email_address_empty.Vitro
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         uil:UILabel ;
+        rdfs:label       "Veuillez entrer une adresse e-mail valide."@fr-CA ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "email_address_empty" ;
+        uil:hasPackage  "Vitro-languages" .
+
+uil-data:comments_empty.Vitro
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         uil:UILabel ;
+        rdfs:label       "Veuillez entrer vos commentaires ou questions dans l'espace prévu."@fr-CA ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "comments_empty" ;
+        uil:hasPackage  "Vitro-languages" .
+
+uil-data:captcha_user_sol_empty.Vitro
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         uil:UILabel ;
+        rdfs:label       "Veuillez résoudre le défi CAPTCHA dans le champ de sécurité fourni."@fr-CA ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "captcha_user_sol_empty" ;
+        uil:hasPackage  "Vitro-languages" .
+
+uil-data:captcha_user_sol_invalid.Vitro
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         uil:UILabel ;
+        rdfs:label       "Solution CAPTCHA invalide, veuillez réessayer."@fr-CA ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "captcha_user_sol_invalid" ;
+        uil:hasPackage  "Vitro-languages" .

--- a/home/src/main/resources/rdf/i18n/fr_CA/interface-i18n/firsttime/vitro_UiLabel.ttl
+++ b/home/src/main/resources/rdf/i18n/fr_CA/interface-i18n/firsttime/vitro_UiLabel.ttl
@@ -6281,7 +6281,7 @@ uil-data:full_name_empty.Vitro
 uil-data:email_address_empty.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;
-        rdfs:label       "Veuillez entrer une adresse e-mail valide."@fr-CA ;
+        rdfs:label       "Veuillez entrer une adresse courriel valide."@fr-CA ;
         uil:hasApp      "Vitro" ;
         uil:hasKey      "email_address_empty" ;
         uil:hasPackage  "Vitro-languages" .

--- a/home/src/main/resources/rdf/i18n/pt_BR/interface-i18n/firsttime/vitro_UiLabel.ttl
+++ b/home/src/main/resources/rdf/i18n/pt_BR/interface-i18n/firsttime/vitro_UiLabel.ttl
@@ -6269,3 +6269,43 @@ uil-data:no_individual_associated_with_id.Vitro
         uil:hasApp      "Vitro" ;
         uil:hasKey      "no_individual_associated_with_id" ;
         uil:hasPackage  "Vitro-languages" .
+
+uil-data:full_name_empty.Vitro
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         uil:UILabel ;
+        rdfs:label       "Por favor, insira um valor no campo de nome completo."@pt-BR ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "full_name_empty" ;
+        uil:hasPackage  "Vitro-languages" .
+
+uil-data:email_address_empty.Vitro
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         uil:UILabel ;
+        rdfs:label       "Por favor, insira um endereço de e-mail válido."@pt-BR ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "email_address_empty" ;
+        uil:hasPackage  "Vitro-languages" .
+
+uil-data:comments_empty.Vitro
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         uil:UILabel ;
+        rdfs:label       "Por favor, insira seus comentários ou perguntas no espaço fornecido."@pt-BR ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "comments_empty" ;
+        uil:hasPackage  "Vitro-languages" .
+
+uil-data:captcha_user_sol_empty.Vitro
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         uil:UILabel ;
+        rdfs:label       "Por favor, resolva o desafio CAPTCHA no campo de segurança fornecido."@pt-BR ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "captcha_user_sol_empty" ;
+        uil:hasPackage  "Vitro-languages" .
+
+uil-data:captcha_user_sol_invalid.Vitro
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         uil:UILabel ;
+        rdfs:label       "Solução CAPTCHA inválida, por favor, tente novamente."@pt-BR ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "captcha_user_sol_invalid" ;
+        uil:hasPackage  "Vitro-languages" .

--- a/home/src/main/resources/rdf/i18n/pt_BR/interface-i18n/firsttime/vitro_UiLabel.ttl
+++ b/home/src/main/resources/rdf/i18n/pt_BR/interface-i18n/firsttime/vitro_UiLabel.ttl
@@ -6273,7 +6273,7 @@ uil-data:no_individual_associated_with_id.Vitro
 uil-data:full_name_empty.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;
-        rdfs:label       "Por favor, insira um valor no campo de nome completo."@pt-BR ;
+        rdfs:label       "Por favor, insira um valor no campo, nome completo."@pt-BR ;
         uil:hasApp      "Vitro" ;
         uil:hasKey      "full_name_empty" ;
         uil:hasPackage  "Vitro-languages" .

--- a/home/src/main/resources/rdf/i18n/pt_BR/interface-i18n/firsttime/vitro_UiLabel.ttl
+++ b/home/src/main/resources/rdf/i18n/pt_BR/interface-i18n/firsttime/vitro_UiLabel.ttl
@@ -6305,7 +6305,7 @@ uil-data:captcha_user_sol_empty.Vitro
 uil-data:captcha_user_sol_invalid.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;
-        rdfs:label       "Solução CAPTCHA inválida, por favor, tente novamente."@pt-BR ;
+        rdfs:label       "A solução do CAPTCHA informada está inválida, por favor, tente novamente."@pt-BR ;
         uil:hasApp      "Vitro" ;
         uil:hasKey      "captcha_user_sol_invalid" ;
         uil:hasPackage  "Vitro-languages" .

--- a/home/src/main/resources/rdf/i18n/ru_RU/interface-i18n/firsttime/vitro_UiLabel.ttl
+++ b/home/src/main/resources/rdf/i18n/ru_RU/interface-i18n/firsttime/vitro_UiLabel.ttl
@@ -6297,7 +6297,7 @@ uil-data:comments_empty.Vitro
 uil-data:captcha_user_sol_empty.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;
-        rdfs:label       "Пожалуйста, решите задачу CAPTCHA в предоставленном поле безопасности."@ru-RU ;
+        rdfs:label       "Пожалуйста, выполните полностью автоматизированный тест Тьюринга для различения компьютеров и людей."@ru-RU ;
         uil:hasApp      "Vitro" ;
         uil:hasKey      "captcha_user_sol_empty" ;
         uil:hasPackage  "Vitro-languages" .

--- a/home/src/main/resources/rdf/i18n/ru_RU/interface-i18n/firsttime/vitro_UiLabel.ttl
+++ b/home/src/main/resources/rdf/i18n/ru_RU/interface-i18n/firsttime/vitro_UiLabel.ttl
@@ -6273,7 +6273,7 @@ uil-data:no_individual_associated_with_id.Vitro
 uil-data:full_name_empty.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;
-        rdfs:label       "Пожалуйста, введите значение в поле ФИО."@ru-RU ;
+        rdfs:label       "Пожалуйста, введите Ваше имя."@ru-RU ;
         uil:hasApp      "Vitro" ;
         uil:hasKey      "full_name_empty" ;
         uil:hasPackage  "Vitro-languages" .

--- a/home/src/main/resources/rdf/i18n/ru_RU/interface-i18n/firsttime/vitro_UiLabel.ttl
+++ b/home/src/main/resources/rdf/i18n/ru_RU/interface-i18n/firsttime/vitro_UiLabel.ttl
@@ -6269,3 +6269,43 @@ uil-data:no_individual_associated_with_id.Vitro
         uil:hasApp      "Vitro" ;
         uil:hasKey      "no_individual_associated_with_id" ;
         uil:hasPackage  "Vitro-languages" .
+
+uil-data:full_name_empty.Vitro
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         uil:UILabel ;
+        rdfs:label       "Пожалуйста, введите значение в поле ФИО."@ru-RU ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "full_name_empty" ;
+        uil:hasPackage  "Vitro-languages" .
+
+uil-data:email_address_empty.Vitro
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         uil:UILabel ;
+        rdfs:label       "Пожалуйста, введите действительный адрес электронной почты."@ru-RU ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "email_address_empty" ;
+        uil:hasPackage  "Vitro-languages" .
+
+uil-data:comments_empty.Vitro
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         uil:UILabel ;
+        rdfs:label       "Пожалуйста, введите свои комментарии или вопросы в предоставленное поле."@ru-RU ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "comments_empty" ;
+        uil:hasPackage  "Vitro-languages" .
+
+uil-data:captcha_user_sol_empty.Vitro
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         uil:UILabel ;
+        rdfs:label       "Пожалуйста, решите задачу CAPTCHA в предоставленном поле безопасности."@ru-RU ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "captcha_user_sol_empty" ;
+        uil:hasPackage  "Vitro-languages" .
+
+uil-data:captcha_user_sol_invalid.Vitro
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         uil:UILabel ;
+        rdfs:label       "Недопустимое решение CAPTCHA, пожалуйста, попробуйте снова."@ru-RU ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "captcha_user_sol_invalid" ;
+        uil:hasPackage  "Vitro-languages" .

--- a/home/src/main/resources/rdf/i18n/ru_RU/interface-i18n/firsttime/vitro_UiLabel.ttl
+++ b/home/src/main/resources/rdf/i18n/ru_RU/interface-i18n/firsttime/vitro_UiLabel.ttl
@@ -6289,7 +6289,7 @@ uil-data:email_address_empty.Vitro
 uil-data:comments_empty.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;
-        rdfs:label       "Пожалуйста, введите свои комментарии или вопросы в предоставленное поле."@ru-RU ;
+        rdfs:label       "Пожалуйста, заполните поле для комментариев, вопросов и предложений."@ru-RU ;
         uil:hasApp      "Vitro" ;
         uil:hasKey      "comments_empty" ;
         uil:hasPackage  "Vitro-languages" .

--- a/home/src/main/resources/rdf/i18n/ru_RU/interface-i18n/firsttime/vitro_UiLabel.ttl
+++ b/home/src/main/resources/rdf/i18n/ru_RU/interface-i18n/firsttime/vitro_UiLabel.ttl
@@ -6305,7 +6305,7 @@ uil-data:captcha_user_sol_empty.Vitro
 uil-data:captcha_user_sol_invalid.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;
-        rdfs:label       "Недопустимое решение CAPTCHA, пожалуйста, попробуйте снова."@ru-RU ;
+        rdfs:label       "Недопустимое решение теста Тьюринга для различения компьютеров и людей. Пожалуйста, попробуйте снова."@ru-RU ;
         uil:hasApp      "Vitro" ;
         uil:hasKey      "captcha_user_sol_invalid" ;
         uil:hasPackage  "Vitro-languages" .

--- a/home/src/main/resources/rdf/i18n/sr_Latn_RS/interface-i18n/firsttime/vitro_UiLabel.ttl
+++ b/home/src/main/resources/rdf/i18n/sr_Latn_RS/interface-i18n/firsttime/vitro_UiLabel.ttl
@@ -6269,3 +6269,43 @@ uil-data:no_individual_associated_with_id.Vitro
         uil:hasApp      "Vitro" ;
         uil:hasKey      "no_individual_associated_with_id" ;
         uil:hasPackage  "Vitro-languages" .
+
+uil-data:full_name_empty.Vitro
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         uil:UILabel ;
+        rdfs:label       "Molimo vas da unesete vrednost u polje za puno ime."@sr-Latn-RS ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "full_name_empty" ;
+        uil:hasPackage  "Vitro-languages" .
+
+uil-data:email_address_empty.Vitro
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         uil:UILabel ;
+        rdfs:label       "Molimo vas da unesete ispravnu email adresu."@sr-Latn-RS ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "email_address_empty" ;
+        uil:hasPackage  "Vitro-languages" .
+
+uil-data:comments_empty.Vitro
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         uil:UILabel ;
+        rdfs:label       "Molimo vas da unesete vaše komentare ili pitanja u predviđeno polje."@sr-Latn-RS ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "comments_empty" ;
+        uil:hasPackage  "Vitro-languages" .
+
+uil-data:captcha_user_sol_empty.Vitro
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         uil:UILabel ;
+        rdfs:label       "Molimo vas da rešite CAPTCHA izazov u predviđenom sigurnosnom polju."@sr-Latn-RS ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "captcha_user_sol_empty" ;
+        uil:hasPackage  "Vitro-languages" .
+
+uil-data:captcha_user_sol_invalid.Vitro
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         uil:UILabel ;
+        rdfs:label       "Pogrešno rešenje CAPTCHA izazova, molimo vas da pokušate ponovo."@sr-Latn-RS ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "captcha_user_sol_invalid" ;
+        uil:hasPackage  "Vitro-languages" .

--- a/webapp/src/main/webapp/templates/freemarker/body/contactForm/contactForm-form.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/body/contactForm/contactForm-form.ftl
@@ -14,20 +14,26 @@
     <p>${i18n().interest_thanks(siteName)}</p>
 
     <form name="contact_form" id="contact_form" class="customForm" action="${formAction!}" method="post" onSubmit="return ValidateForm('contact_form');" role="contact form">
-        <input type="hidden" name="RequiredFields" value="webusername,webuseremail,s34gfd88p9x1" />
-        <input type="hidden" name="RequiredFieldsNames" value="Name,Email address,Comments" />
-        <input type="hidden" name="EmailFields" value="webuseremail" />
-        <input type="hidden" name="EmailFieldsNames" value="emailaddress" />
-        <input type="hidden" name="DeliveryType" value="contact" />
+        <div>
+          <input type="hidden" name="RequiredFields" value="webusername,webuseremail,s34gfd88p9x1" />
+          <input type="hidden" name="RequiredFieldsNames" value="Name,Email address,Comments" />
+          <input type="hidden" name="EmailFields" value="webuseremail" />
+          <input type="hidden" name="EmailFieldsNames" value="emailaddress" />
+          <input type="hidden" name="DeliveryType" value="contact" />
 
-        <label for="webusername">${i18n().full_name} <span class="requiredHint"> *</span></label>
-        <input type="text" name="webusername" value="${webusername!}"/>
+          <label for="webusername">${i18n().full_name} <span class="requiredHint"> *</span></label><br/>
+          <input type="text" name="webusername" value="${webusername!}"/>
+        </div>
 
-        <label for="webuseremail">${i18n().email_address} <span class="requiredHint"> *</span></label>
-        <input type="text" name="webuseremail"  value="${webuseremail!}"/>
+        <div>
+          <label for="webuseremail">${i18n().email_address} <span class="requiredHint"> *</span></label><br/>
+          <input type="text" name="webuseremail"  value="${webuseremail!}"/>
+        </div>
 
-        <label>${i18n().comments_questions} <span class="requiredHint"> *</span></label>
-        <textarea name="s34gfd88p9x1" rows="10" cols="90">${comments!}</textarea>
+        <div>
+          <label>${i18n().comments_questions} <span class="requiredHint"> *</span></label><br/>
+          <textarea name="s34gfd88p9x1" rows="10" cols="90">${comments!}</textarea>
+        </div>
 
 
         <#if captchaToUse == "RECAPTCHA">

--- a/webapp/src/main/webapp/templates/freemarker/body/contactForm/contactForm-form.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/body/contactForm/contactForm-form.ftl
@@ -36,7 +36,7 @@
         </div>
 
 
-        <#if captchaToUse == "RECAPTCHAv2">
+        <#if captchaToUse == "RECAPTCHAV2">
             <div class="g-recaptcha" data-sitekey="${siteKey!}"></div>
             <input type="hidden" id="g-recaptcha-response" name="g-recaptcha-response" />
         <#elseif captchaToUse == "NANOCAPTCHA">
@@ -72,7 +72,7 @@ ${stylesheets.add('<link rel="stylesheet" href="${urls.base}/templates/freemarke
 ${scripts.add('<script type="text/javascript" src="${urls.base}/js/commentForm.js"></script>',
               '<script type="text/javascript" src="${urls.base}/js/jquery-ui/js/jquery-ui-1.12.1.min.js"></script>')}
 
-<#if captchaToUse == "RECAPTCHAv2">
+<#if captchaToUse == "RECAPTCHAV2">
     <script src="https://www.google.com/recaptcha/api.js" async defer></script>
     <script>
         document.getElementById('contact_form').addEventListener('submit', function() {

--- a/webapp/src/main/webapp/templates/freemarker/body/contactForm/contactForm-form.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/body/contactForm/contactForm-form.ftl
@@ -29,10 +29,12 @@
         <label>${i18n().comments_questions} <span class="requiredHint"> *</span></label>
         <textarea name="s34gfd88p9x1" rows="10" cols="90">${comments!}</textarea>
 
-
-    	<p><label class="realpersonLabel">${i18n().enter_in_security_field}:<span class="requiredHint"> *</span></label>
-
-    		<input type="text" id="defaultReal" name="defaultReal"></p>
+    	<p>
+            <label class="realpersonLabel">${i18n().enter_in_security_field}:<span class="requiredHint"> *</span></label>
+            <img src="data:image/png;base64,${challenge!}" alt="Refresh page if not displayed..." style="vertical-align: middle;">
+            <span><input type="text" id="userSolution" name="userSolution" style="vertical-align: middle;"></span>
+            <input type="text" id="challengeId" name="challengeId" value="${challengeId!}" style="display: none;">
+        </p>
 
         <div class="buttons">
             <br /><input id="submit" type="submit" value="${i18n().send_mail}" />
@@ -51,10 +53,4 @@
 ${stylesheets.add('<link rel="stylesheet" href="${urls.base}/templates/freemarker/edit/forms/css/customForm.css" />',
                   '<link rel="stylesheet" href="${urls.base}/css/jquery_plugins/jquery.realperson.css" />')}
 ${scripts.add('<script type="text/javascript" src="${urls.base}/js/commentForm.js"></script>',
-              '<script type="text/javascript" src="${urls.base}/js/jquery_plugins/jquery.realperson.js"></script>',
               '<script type="text/javascript" src="${urls.base}/js/jquery-ui/js/jquery-ui-1.12.1.min.js"></script>')}
-<script type="text/javascript">
-  $(function() {
-    $('#defaultReal').realperson();
-  });
-</script>

--- a/webapp/src/main/webapp/templates/freemarker/body/contactForm/contactForm-form.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/body/contactForm/contactForm-form.ftl
@@ -29,12 +29,19 @@
         <label>${i18n().comments_questions} <span class="requiredHint"> *</span></label>
         <textarea name="s34gfd88p9x1" rows="10" cols="90">${comments!}</textarea>
 
-    	<p>
-            <label class="realpersonLabel">${i18n().enter_in_security_field}:<span class="requiredHint"> *</span></label>
-            <img src="data:image/png;base64,${challenge!}" alt="Refresh page if not displayed..." style="vertical-align: middle;">
-            <span><input type="text" id="userSolution" name="userSolution" style="vertical-align: middle;"></span>
-            <input type="text" id="challengeId" name="challengeId" value="${challengeId!}" style="display: none;">
-        </p>
+
+        <#if captchaToUse == "RECAPTCHA">
+            <div class="g-recaptcha" data-sitekey="${siteKey!}"></div>
+            <input type="hidden" id="g-recaptcha-response" name="g-recaptcha-response" />
+        <#else>
+            <!-- Your custom captcha implementation -->
+            <p>
+                <label class="realpersonLabel">${i18n().enter_in_security_field}:<span class="requiredHint"> *</span></label>
+                <img src="data:image/png;base64,${challenge!}" alt="Refresh page if not displayed..." style="vertical-align: middle;">
+                <span><input type="text" id="userSolution" name="userSolution" style="vertical-align: middle;"></span>
+                <input type="text" id="challengeId" name="challengeId" value="${challengeId!}" style="display: none;">
+            </p>
+        </#if>
 
         <div class="buttons">
             <br /><input id="submit" type="submit" value="${i18n().send_mail}" />
@@ -54,3 +61,14 @@ ${stylesheets.add('<link rel="stylesheet" href="${urls.base}/templates/freemarke
                   '<link rel="stylesheet" href="${urls.base}/css/jquery_plugins/jquery.realperson.css" />')}
 ${scripts.add('<script type="text/javascript" src="${urls.base}/js/commentForm.js"></script>',
               '<script type="text/javascript" src="${urls.base}/js/jquery-ui/js/jquery-ui-1.12.1.min.js"></script>')}
+
+<#if captchaToUse == "RECAPTCHA">
+    <script src="https://www.google.com/recaptcha/api.js" async defer></script>
+    <script>
+        document.getElementById('contact_form').addEventListener('submit', function() {
+            var recaptchaResponse = grecaptcha.getResponse();
+            console.log(recaptchaResponse);
+            document.getElementById('g-recaptcha-response').value = recaptchaResponse;
+        });
+    </script>
+</#if>

--- a/webapp/src/main/webapp/templates/freemarker/body/contactForm/contactForm-form.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/body/contactForm/contactForm-form.ftl
@@ -36,7 +36,7 @@
         </div>
 
 
-        <#if captchaToUse == "RECAPTCHA">
+        <#if captchaToUse == "RECAPTCHAv2">
             <div class="g-recaptcha" data-sitekey="${siteKey!}"></div>
             <input type="hidden" id="g-recaptcha-response" name="g-recaptcha-response" />
         <#elseif captchaToUse == "NANOCAPTCHA">
@@ -72,7 +72,7 @@ ${stylesheets.add('<link rel="stylesheet" href="${urls.base}/templates/freemarke
 ${scripts.add('<script type="text/javascript" src="${urls.base}/js/commentForm.js"></script>',
               '<script type="text/javascript" src="${urls.base}/js/jquery-ui/js/jquery-ui-1.12.1.min.js"></script>')}
 
-<#if captchaToUse == "RECAPTCHA">
+<#if captchaToUse == "RECAPTCHAv2">
     <script src="https://www.google.com/recaptcha/api.js" async defer></script>
     <script>
         document.getElementById('contact_form').addEventListener('submit', function() {

--- a/webapp/src/main/webapp/templates/freemarker/body/contactForm/contactForm-form.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/body/contactForm/contactForm-form.ftl
@@ -37,7 +37,11 @@
             <!-- Your custom captcha implementation -->
             <p>
                 <label class="realpersonLabel">${i18n().enter_in_security_field}:<span class="requiredHint"> *</span></label>
-                <img src="data:image/png;base64,${challenge!}" alt="Refresh page if not displayed..." style="vertical-align: middle;">
+                <div class="captcha-container">
+                    <span><input id="refresh" type="button" value="↻" /></span>
+                    <img id="captchaImage" src="data:image/png;base64,${challenge!}" alt="Refresh page if not displayed..." style="vertical-align: middle;">
+                </div>
+                <br />
                 <span><input type="text" id="userSolution" name="userSolution" style="vertical-align: middle;"></span>
                 <input type="text" id="challengeId" name="challengeId" value="${challengeId!}" style="display: none;">
             </p>
@@ -69,6 +73,29 @@ ${scripts.add('<script type="text/javascript" src="${urls.base}/js/commentForm.j
             var recaptchaResponse = grecaptcha.getResponse();
             console.log(recaptchaResponse);
             document.getElementById('g-recaptcha-response').value = recaptchaResponse;
+        });
+    </script>
+<#else>
+    <script>
+        $(document).ready(function () {
+            $('#refresh').click(function () {
+                var oldChallengeId = $('#challengeId').val();
+
+                $.ajax({
+                    url: '${contextPath}/refreshCaptcha',
+                    type: 'GET',
+                    dataType: 'json',
+                    data: { oldChallengeId: oldChallengeId },
+                    success: function (data) {
+                        $('#userSolution').val('');
+                        $('#challengeId').val(data.challengeId);
+                        $('#captchaImage').attr('src', 'data:image/png;base64,' + data.challenge);
+                    },
+                    error: function () {
+                        console.error('Error while refreshing captcha');
+                    }
+                });
+            });
         });
     </script>
 </#if>

--- a/webapp/src/main/webapp/templates/freemarker/body/contactForm/contactForm-form.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/body/contactForm/contactForm-form.ftl
@@ -39,7 +39,7 @@
         <#if captchaToUse == "RECAPTCHA">
             <div class="g-recaptcha" data-sitekey="${siteKey!}"></div>
             <input type="hidden" id="g-recaptcha-response" name="g-recaptcha-response" />
-        <#else>
+        <#elseif captchaToUse == "NANOCAPTCHA">
             <!-- Your custom captcha implementation -->
             <p>
                 <label class="realpersonLabel">${i18n().enter_in_security_field}:<span class="requiredHint"> *</span></label>
@@ -81,7 +81,7 @@ ${scripts.add('<script type="text/javascript" src="${urls.base}/js/commentForm.j
             document.getElementById('g-recaptcha-response').value = recaptchaResponse;
         });
     </script>
-<#else>
+<#elseif captchaToUse == "NANOCAPTCHA">
     <script>
         $(document).ready(function () {
             $('#refresh').click(function () {

--- a/webapp/src/main/webapp/templates/freemarker/edit/forms/css/customForm.css
+++ b/webapp/src/main/webapp/templates/freemarker/edit/forms/css/customForm.css
@@ -113,6 +113,28 @@ form.customForm label.dateTime {
 fieldset.dateTime select {
     margin-top: 0;
 }
+
+.captcha-container {
+    position: relative;
+    display: inline-block;
+}
+
+.captcha-container span {
+    position: absolute;
+    top: 0;
+    right: 0;
+    background: #ffffffeb;
+    color: #595b5b;
+    border: 1px solid #595b5b;
+    font-size: 0.8em;
+    padding: 0 8px;
+}
+
+.captcha-container span input {
+    border: 0;
+    background: transparent;
+}
+
 /* ---------------------------------- */
 /* ----- FOR MANAGE PUBLICATIONS ---- */
 /* ---------------------------------- */


### PR DESCRIPTION
**[VIVO GitHub issue](https://github.com/vivo-project/VIVO/issues)**: [Mitigate vulnerability of Captcha feature](https://github.com/vivo-project/VIVO/issues/3918)
[VIVO PR](https://github.com/vivo-project/VIVO/pull/3920)

# What does this pull request do?
This PR mitigates vulnerability of captcha feature by introducing new methods of challenge generation: nanocaptcha and Google reCAPTCHA.

# What's new?
A CaptrchaServiceBean is created which can both provide and validate text-based challenges as well as provide validation services for Google reCaptcha through Google API. I also included a configuration for which captcha method is used so you can use both methods interchangeably (just change configuration options).

# How should this be tested?
Unit tests for CaptchaServiceBean are created. If you want to test manually, simply run the application and follow instructions on how to configure each captcha method (instructions are available in example.runtime.properties file).
Captcha is currently only used on `/contact` page. Keep in mind that you have to setup SMTP properties as well as default contact email for feedback form to be accessible.

# Interested parties
@litvinovg @chenejac @brianjlowe 
