### PR TITLE
fix: added a check that the data set key is empty to prevent incorrec…

### DIFF
--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/auth/attributes/AttributeValueKey.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/auth/attributes/AttributeValueKey.java
@@ -56,6 +56,10 @@ public class AttributeValueKey {
         return new AttributeValueKey(ao, aot, role, type);
     }
 
+    public boolean isEmpty() {
+        return ao == null && aot == null && role == null && type == null;
+    }
+
     @Override
     public boolean equals(Object object) {
         if (!(object instanceof AttributeValueKey)) {

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/auth/attributes/ValueSetFactory.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/auth/attributes/ValueSetFactory.java
@@ -8,7 +8,7 @@ public class ValueSetFactory {
 
     public static AttributeValueSet create(String value, QuerySolution qs, AttributeValueKey dataSetKey) {
         Optional<String> type = getSetElementsType(qs);
-        if (!type.isPresent() || dataSetKey == null) {
+        if (!type.isPresent() || dataSetKey == null || dataSetKey.isEmpty()) {
             return new MutableAttributeValueSet(value);
         } else {
             AttributeValueKey avcKey = getAttributeValueSetKey(dataSetKey, type.get());

--- a/api/src/test/java/edu/cornell/mannlib/vitro/webapp/auth/attributes/ValueSetFactoryTest.java
+++ b/api/src/test/java/edu/cornell/mannlib/vitro/webapp/auth/attributes/ValueSetFactoryTest.java
@@ -1,0 +1,24 @@
+package edu.cornell.mannlib.vitro.webapp.auth.attributes;
+
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.apache.jena.query.QuerySolutionMap;
+import org.apache.jena.rdf.model.ResourceFactory;
+import org.junit.Test;
+
+public class ValueSetFactoryTest {
+
+    @Test
+    public void testCreate() {
+        QuerySolutionMap qs = new QuerySolutionMap();
+        qs.add("setElementsType", ResourceFactory.createPlainLiteral("some type"));
+        AttributeValueKey key = new AttributeValueKey();
+        String oldValue = "value";
+        AttributeValueSet valueSet1 = ValueSetFactory.create(oldValue, qs, key);
+        assertTrue(valueSet1.contains(oldValue));
+        String newValue = "new value";
+        AttributeValueSet valueSet2 = ValueSetFactory.create(newValue, qs, key);
+        assertNotEquals(valueSet1, valueSet2);
+    }
+}


### PR DESCRIPTION
**[VIVO GitHub issue](https://github.com/vivo-project/VIVO/issues/3923)**

# What does this pull request do?
Avoid reuse of value sets by checking that the data set key is empty.

# How should this be tested?
* Test was created
* Try migration from ARM with multiple custom roles.

# Interested parties
@chenejac @matthiasluehr 
