### PR TITLE
Converted hard-coded search results sort option "by relevance" to configuration individual.

### DIFF
--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/search/controller/PagedSearchController.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/search/controller/PagedSearchController.java
@@ -462,11 +462,28 @@ public class PagedSearchController extends FreemarkerHttpServlet {
 
     private void addSortRules(VitroRequest vreq, SearchQuery query, Map<String, SortConfiguration> sortOptions) {
         String sortType = getSortType(vreq);
+        if (sortOptions.isEmpty()) {
+            return;
+        }
         if (!StringUtils.isBlank(sortType) && sortOptions.containsKey(sortType)) {
             SortConfiguration conf = sortOptions.get(sortType);
-            query.addSortField(conf.getField(vreq.getLocale()), conf.getSortOrder());
+            String field = conf.getField(vreq.getLocale());
+            if (!StringUtils.isBlank(field)) {
+                query.addSortField(field, conf.getSortOrder());
+            }
             conf.setSelected(true);
+            return;
         }
+        boolean textQueryIsEmpty = StringUtils.isBlank(getQueryText(vreq));
+        // If text field is empty, apply the first sort option
+        if (textQueryIsEmpty) {
+            SortConfiguration conf = sortOptions.entrySet().iterator().next().getValue();
+            String field = conf.getField(vreq.getLocale());
+            if (!StringUtils.isBlank(field)) {
+                query.addSortField(field, conf.getSortOrder());
+            }
+        }
+        // If text field is not empty, sort by relevance (no need to add sort field)
     }
 
     private String getSortType(VitroRequest vreq) {

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/search/controller/SearchFiltering.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/search/controller/SearchFiltering.java
@@ -125,12 +125,16 @@ public class SearchFiltering {
             + "WHERE {\n"
             + "    ?sort rdf:type search:Sort . \n"
             + "    ?sort rdfs:label ?sort_label .\n"
-            + "    ?sort search:sortField ?field .\n"
-            + "    ?sort search:id ?id .\n"
-            + "    ?field search:indexField ?searchField  .\n"
             + "    OPTIONAL {\n"
-            + "        ?field search:isLanguageSpecific ?f_multilingual  .\n"
-            + "        BIND(?f_multilingual as ?bind_multilingual) .\n"
+            + "        ?sort search:sortField ?field .\n"
+            + "        ?field search:indexField ?searchField  .\n"
+            + "        OPTIONAL {\n"
+            + "            ?field search:isLanguageSpecific ?f_multilingual  .\n"
+            + "            BIND(?f_multilingual as ?bind_multilingual) .\n"
+            + "        }\n"
+            + "    }\n"
+            + "    OPTIONAL {\n"
+            + "        ?sort search:id ?id .\n"
             + "    }\n"
             + "    OPTIONAL {\n"
             + "        ?sort search:isAscending ?f_ord  .\n"
@@ -340,12 +344,13 @@ public class SearchFiltering {
             ResultSet results = qexec.execSelect();
             while (results.hasNext()) {
                 QuerySolution solution = results.nextSolution();
-                if (solution.get("label") == null || solution.get("id") == null
-                        || solution.get("searchField") == null) {
+                RDFNode searchFieldNode = solution.get("searchField");
+                RDFNode idNode = solution.get("id");
+                if (solution.get("label") == null) {
                     continue;
                 }
-                String field = solution.get("searchField").toString();
-                String id = solution.get("id").toString();
+                String field = searchFieldNode == null ? "" : searchFieldNode.toString();
+                String id = idNode == null ? "" : idNode.toString();
                 String label = solution.get("label").toString();
 
                 SortConfiguration config = null;

--- a/home/src/main/resources/rdf/display/firsttime/search_individuals_vitro.n3
+++ b/home/src/main/resources/rdf/display/firsttime/search_individuals_vitro.n3
@@ -44,6 +44,9 @@
         vitro-search:order         30 ;
         vitro-search:id            "titleasc" .
 
+:sort_by_relevance a                vitro-search:Sort ;
+        vitro-search:id            "relevance" .
+
 :field_label_sort
         a                          vitro-search:SearchField ;
         vitro-search:isLanguageSpecific true ;

--- a/home/src/main/resources/rdf/i18n/de_DE/display/firsttime/search_individuals_vitro.n3
+++ b/home/src/main/resources/rdf/i18n/de_DE/display/firsttime/search_individuals_vitro.n3
@@ -8,7 +8,7 @@
 :sort_title_asc rdfs:label "Titel A-Z"@de-DE .
 :sort_by_relevance rdfs:label "Relevanz"@de-DE .
 :field_label_sort rdfs:label "Etikettensortierfeld"@de-DE .
-:field_category rdfs:label "KlasseGruppe"@de-DE .
+:field_category rdfs:label "Klassengruppe"@de-DE .
 :field_type rdfs:label "Typ"@de-DE .
 :filter_querytext rdfs:label "Text"@de-DE .
 :field_querytext rdfs:label "Standardfeld"@de-DE .

--- a/home/src/main/resources/rdf/i18n/de_DE/display/firsttime/search_individuals_vitro.n3
+++ b/home/src/main/resources/rdf/i18n/de_DE/display/firsttime/search_individuals_vitro.n3
@@ -1,0 +1,14 @@
+@prefix : <https://vivoweb.org/ontology/vitro-search-individual/> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+
+:filter_group_search_filters rdfs:label "Suchfilter"@de-DE .
+:filter_type rdfs:label "Typ"@de-DE .
+:filter_category rdfs:label "Kategorie"@de-DE .
+:sort_title_desc rdfs:label "Titel Z-A"@de-DE .
+:sort_title_asc rdfs:label "Titel A-Z"@de-DE .
+:sort_by_relevance rdfs:label "Relevanz"@de-DE .
+:field_label_sort rdfs:label "Etikettensortierfeld"@de-DE .
+:field_category rdfs:label "KlasseGruppe"@de-DE .
+:field_type rdfs:label "Typ"@de-DE .
+:filter_querytext rdfs:label "Text"@de-DE .
+:field_querytext rdfs:label "Standardfeld"@de-DE .

--- a/home/src/main/resources/rdf/i18n/de_DE/interface-i18n/firsttime/vitro_extended_search.ttl
+++ b/home/src/main/resources/rdf/i18n/de_DE/interface-i18n/firsttime/vitro_extended_search.ttl
@@ -9,7 +9,7 @@
 uil-data:search_results_sort_by.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:PropertyKey ;
-        rdfs:label       "Sort by {0}"@en-US ;
+        rdfs:label       "Sortieren nach {0}"@de-DE ;
         uil:hasApp       "Vitro" ;
         uil:hasKey       "search_results_sort_by" ;
         uil:hasPackage   "Vitro-languages" .
@@ -17,7 +17,7 @@ uil-data:search_results_sort_by.Vitro
 uil-data:search_results_per_page.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:PropertyKey ;
-        rdfs:label       "{0} Results per page"@en-US ;
+        rdfs:label       "{0} Ergebnisse pro Seite"@de-DE ;
         uil:hasApp       "Vitro" ;
         uil:hasKey       "search_results_per_page" ;
         uil:hasPackage   "Vitro-languages" .
@@ -25,7 +25,7 @@ uil-data:search_results_per_page.Vitro
 uil-data:search_field_placeholder.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:PropertyKey ;
-        rdfs:label       "Enter search term"@en-US ;
+        rdfs:label       "Suchbegriff eingeben"@de-DE ;
         uil:hasApp       "Vitro" ;
         uil:hasKey       "search_field_placeholder" ;
         uil:hasPackage   "Vitro-languages" .
@@ -33,7 +33,7 @@ uil-data:search_field_placeholder.Vitro
 uil-data:results_found.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:PropertyKey ;
-        rdfs:label       "{0} results found"@en-US ;
+        rdfs:label       "{0} Ergebnisse gefunden"@de-DE ;
         uil:hasApp       "Vitro" ;
         uil:hasKey       "results_found" ;
         uil:hasPackage   "Vitro-languages" .

--- a/home/src/main/resources/rdf/i18n/en_CA/display/firsttime/search_individuals_vitro.n3
+++ b/home/src/main/resources/rdf/i18n/en_CA/display/firsttime/search_individuals_vitro.n3
@@ -1,0 +1,14 @@
+@prefix : <https://vivoweb.org/ontology/vitro-search-individual/> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+
+:filter_group_search_filters rdfs:label "Filters"@en-CA .
+:filter_type rdfs:label "Type"@en-CA .
+:filter_category rdfs:label "Category"@en-CA .
+:sort_title_desc rdfs:label "Title Z-A"@en-CA .
+:sort_title_asc rdfs:label "Title A-Z"@en-CA .
+:sort_by_relevance rdfs:label "Relevance"@en-CA .
+:field_label_sort rdfs:label "Label sort field"@en-CA .
+:field_category rdfs:label "ClassGroup"@en-CA .
+:field_type rdfs:label "Type"@en-CA .
+:filter_querytext rdfs:label "Text"@en-CA .
+:field_querytext rdfs:label "Default field"@en-CA .

--- a/home/src/main/resources/rdf/i18n/en_CA/interface-i18n/firsttime/vitro_extended_search.ttl
+++ b/home/src/main/resources/rdf/i18n/en_CA/interface-i18n/firsttime/vitro_extended_search.ttl
@@ -9,7 +9,7 @@
 uil-data:search_results_sort_by.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:PropertyKey ;
-        rdfs:label       "Sort by {0}"@en-US ;
+        rdfs:label       "Sort by {0}"@en-CA ;
         uil:hasApp       "Vitro" ;
         uil:hasKey       "search_results_sort_by" ;
         uil:hasPackage   "Vitro-languages" .
@@ -17,7 +17,7 @@ uil-data:search_results_sort_by.Vitro
 uil-data:search_results_per_page.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:PropertyKey ;
-        rdfs:label       "{0} Results per page"@en-US ;
+        rdfs:label       "{0} results per page"@en-CA ;
         uil:hasApp       "Vitro" ;
         uil:hasKey       "search_results_per_page" ;
         uil:hasPackage   "Vitro-languages" .
@@ -25,7 +25,7 @@ uil-data:search_results_per_page.Vitro
 uil-data:search_field_placeholder.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:PropertyKey ;
-        rdfs:label       "Enter search term"@en-US ;
+        rdfs:label       "Enter search term"@en-CA ;
         uil:hasApp       "Vitro" ;
         uil:hasKey       "search_field_placeholder" ;
         uil:hasPackage   "Vitro-languages" .
@@ -33,7 +33,7 @@ uil-data:search_field_placeholder.Vitro
 uil-data:results_found.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:PropertyKey ;
-        rdfs:label       "{0} results found"@en-US ;
+        rdfs:label       "{0} results found"@en-CA ;
         uil:hasApp       "Vitro" ;
         uil:hasKey       "results_found" ;
         uil:hasPackage   "Vitro-languages" .

--- a/home/src/main/resources/rdf/i18n/en_US/display/firsttime/search_individuals_vitro.n3
+++ b/home/src/main/resources/rdf/i18n/en_US/display/firsttime/search_individuals_vitro.n3
@@ -6,6 +6,7 @@
 :filter_category rdfs:label "Category"@en-US .
 :sort_title_desc rdfs:label "Title Z-A"@en-US .
 :sort_title_asc rdfs:label "Title A-Z"@en-US .
+:sort_by_relevance rdfs:label "Relevance"@en-US .
 :field_label_sort rdfs:label "Label sort field"@en-US .
 :field_category rdfs:label "ClassGroup"@en-US .
 :field_type rdfs:label "Type"@en-US .

--- a/home/src/main/resources/rdf/i18n/en_US/display/firsttime/search_individuals_vitro.n3
+++ b/home/src/main/resources/rdf/i18n/en_US/display/firsttime/search_individuals_vitro.n3
@@ -1,7 +1,7 @@
 @prefix : <https://vivoweb.org/ontology/vitro-search-individual/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-:filter_group_search_filters rdfs:label "Search filters"@en-US .
+:filter_group_search_filters rdfs:label "Filters"@en-US .
 :filter_type rdfs:label "Type"@en-US .
 :filter_category rdfs:label "Category"@en-US .
 :sort_title_desc rdfs:label "Title Z-A"@en-US .

--- a/home/src/main/resources/rdf/i18n/en_US/interface-i18n/firsttime/vitro_extended_search.ttl
+++ b/home/src/main/resources/rdf/i18n/en_US/interface-i18n/firsttime/vitro_extended_search.ttl
@@ -6,14 +6,6 @@
 @prefix skos:  <http://www.w3.org/2004/02/skos/core#> .
 @prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> .
 
-uil-data:search_results_relevance.Vitro
-        rdf:type         owl:NamedIndividual ;
-        rdf:type         uil:PropertyKey ;
-        rdfs:label       "Relevance"@en-US ;
-        uil:hasApp      "Vitro" ;
-        uil:hasKey      "search_results_relevance" ;
-        uil:hasPackage  "Vitro-languages" .
-
 uil-data:search_results_sort_by.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:PropertyKey ;

--- a/home/src/main/resources/rdf/i18n/es/display/firsttime/search_individuals_vitro.n3
+++ b/home/src/main/resources/rdf/i18n/es/display/firsttime/search_individuals_vitro.n3
@@ -1,0 +1,14 @@
+@prefix : <https://vivoweb.org/ontology/vitro-search-individual/> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+
+:filter_group_search_filters rdfs:label "Filtros de búsqueda"@es .
+:filter_type rdfs:label "Tipo"@es .
+:filter_category rdfs:label "Categoría"@es .
+:sort_title_desc rdfs:label "Título Z-A"@es .
+:sort_title_asc rdfs:label "Título A-Z"@es .
+:sort_by_relevance rdfs:label "Relevancia"@es .
+:field_label_sort rdfs:label "Campo de clasificación de etiquetas"@es .
+:field_category rdfs:label "Grupo de clase"@es .
+:field_type rdfs:label "Tipo"@es .
+:filter_querytext rdfs:label "Texto"@es .
+:field_querytext rdfs:label "Campo predeterminado"@es .

--- a/home/src/main/resources/rdf/i18n/es/interface-i18n/firsttime/vitro_extended_search.ttl
+++ b/home/src/main/resources/rdf/i18n/es/interface-i18n/firsttime/vitro_extended_search.ttl
@@ -9,7 +9,7 @@
 uil-data:search_results_sort_by.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:PropertyKey ;
-        rdfs:label       "Sort by {0}"@en-US ;
+        rdfs:label       "Ordenar por {0}"@es ;
         uil:hasApp       "Vitro" ;
         uil:hasKey       "search_results_sort_by" ;
         uil:hasPackage   "Vitro-languages" .
@@ -17,7 +17,7 @@ uil-data:search_results_sort_by.Vitro
 uil-data:search_results_per_page.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:PropertyKey ;
-        rdfs:label       "{0} Results per page"@en-US ;
+        rdfs:label       "{0} resultados por página"@es ;
         uil:hasApp       "Vitro" ;
         uil:hasKey       "search_results_per_page" ;
         uil:hasPackage   "Vitro-languages" .
@@ -25,7 +25,7 @@ uil-data:search_results_per_page.Vitro
 uil-data:search_field_placeholder.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:PropertyKey ;
-        rdfs:label       "Enter search term"@en-US ;
+        rdfs:label       "Introduzca el término de búsqueda"@es ;
         uil:hasApp       "Vitro" ;
         uil:hasKey       "search_field_placeholder" ;
         uil:hasPackage   "Vitro-languages" .
@@ -33,7 +33,7 @@ uil-data:search_field_placeholder.Vitro
 uil-data:results_found.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:PropertyKey ;
-        rdfs:label       "{0} results found"@en-US ;
+        rdfs:label       "{0} resultados encontrados"@es ;
         uil:hasApp       "Vitro" ;
         uil:hasKey       "results_found" ;
         uil:hasPackage   "Vitro-languages" .

--- a/home/src/main/resources/rdf/i18n/fr_CA/display/firsttime/search_individuals_vitro.n3
+++ b/home/src/main/resources/rdf/i18n/fr_CA/display/firsttime/search_individuals_vitro.n3
@@ -1,0 +1,14 @@
+@prefix : <https://vivoweb.org/ontology/vitro-search-individual/> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+
+:filter_group_search_filters rdfs:label "Filtres"@fr-CA .
+:filter_type rdfs:label "Taper"@fr-CA .
+:filter_category rdfs:label "Catégorie"@fr-CA .
+:sort_title_desc rdfs:label "Titre Z-A"@fr-CA .
+:sort_title_asc rdfs:label "Titre A-Z"@fr-CA .
+:sort_by_relevance rdfs:label "Pertinence"@fr-CA .
+:field_label_sort rdfs:label "Champ de tri des étiquettes"@fr-CA .
+:field_category rdfs:label "Groupe de classe"@fr-CA .
+:field_type rdfs:label "Taper"@fr-CA .
+:filter_querytext rdfs:label "Texte"@fr-CA .
+:field_querytext rdfs:label "Champ par défaut"@fr-CA .

--- a/home/src/main/resources/rdf/i18n/fr_CA/interface-i18n/firsttime/vitro_extended_search.ttl
+++ b/home/src/main/resources/rdf/i18n/fr_CA/interface-i18n/firsttime/vitro_extended_search.ttl
@@ -9,7 +9,7 @@
 uil-data:search_results_sort_by.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:PropertyKey ;
-        rdfs:label       "Sort by {0}"@en-US ;
+        rdfs:label       "Trier par {0}"@fr-CA ;
         uil:hasApp       "Vitro" ;
         uil:hasKey       "search_results_sort_by" ;
         uil:hasPackage   "Vitro-languages" .
@@ -17,7 +17,7 @@ uil-data:search_results_sort_by.Vitro
 uil-data:search_results_per_page.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:PropertyKey ;
-        rdfs:label       "{0} Results per page"@en-US ;
+        rdfs:label       "{0} résultats par page"@fr-CA ;
         uil:hasApp       "Vitro" ;
         uil:hasKey       "search_results_per_page" ;
         uil:hasPackage   "Vitro-languages" .
@@ -25,7 +25,7 @@ uil-data:search_results_per_page.Vitro
 uil-data:search_field_placeholder.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:PropertyKey ;
-        rdfs:label       "Enter search term"@en-US ;
+        rdfs:label       "Entrez le terme de recherche"@fr-CA ;
         uil:hasApp       "Vitro" ;
         uil:hasKey       "search_field_placeholder" ;
         uil:hasPackage   "Vitro-languages" .
@@ -33,7 +33,7 @@ uil-data:search_field_placeholder.Vitro
 uil-data:results_found.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:PropertyKey ;
-        rdfs:label       "{0} results found"@en-US ;
+        rdfs:label       "{0} résultats trouvés"@fr-CA ;
         uil:hasApp       "Vitro" ;
         uil:hasKey       "results_found" ;
         uil:hasPackage   "Vitro-languages" .

--- a/home/src/main/resources/rdf/i18n/pt_BR/display/firsttime/search_individuals_vitro.n3
+++ b/home/src/main/resources/rdf/i18n/pt_BR/display/firsttime/search_individuals_vitro.n3
@@ -1,0 +1,14 @@
+@prefix : <https://vivoweb.org/ontology/vitro-search-individual/> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+
+:filter_group_search_filters rdfs:label "Filtros"@pt-BR .
+:filter_type rdfs:label "Tipo"@pt-BR .
+:filter_category rdfs:label "Categoria"@pt-BR .
+:sort_title_desc rdfs:label "Título Z-A"@pt-BR .
+:sort_title_asc rdfs:label "Título A-Z"@pt-BR .
+:sort_by_relevance rdfs:label "Relevância"@pt-BR .
+:field_label_sort rdfs:label "Campo de classificação de rótulo"@pt-BR .
+:field_category rdfs:label "Grupo de Classe"@pt-BR .
+:field_type rdfs:label "Tipo"@pt-BR .
+:filter_querytext rdfs:label "Texto"@pt-BR .
+:field_querytext rdfs:label "Campo padrão"@pt-BR .

--- a/home/src/main/resources/rdf/i18n/pt_BR/display/firsttime/search_individuals_vitro.n3
+++ b/home/src/main/resources/rdf/i18n/pt_BR/display/firsttime/search_individuals_vitro.n3
@@ -7,7 +7,7 @@
 :sort_title_desc rdfs:label "Título Z-A"@pt-BR .
 :sort_title_asc rdfs:label "Título A-Z"@pt-BR .
 :sort_by_relevance rdfs:label "Relevância"@pt-BR .
-:field_label_sort rdfs:label "Campo de classificação de rótulo"@pt-BR .
+:field_label_sort rdfs:label "Campo de ordenação por rótulo"@pt-BR .
 :field_category rdfs:label "Grupo de Classe"@pt-BR .
 :field_type rdfs:label "Tipo"@pt-BR .
 :filter_querytext rdfs:label "Texto"@pt-BR .

--- a/home/src/main/resources/rdf/i18n/pt_BR/interface-i18n/firsttime/vitro_extended_search.ttl
+++ b/home/src/main/resources/rdf/i18n/pt_BR/interface-i18n/firsttime/vitro_extended_search.ttl
@@ -9,7 +9,7 @@
 uil-data:search_results_sort_by.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:PropertyKey ;
-        rdfs:label       "Sort by {0}"@en-US ;
+        rdfs:label       "Ordenar por {0}"@pt-BR ;
         uil:hasApp       "Vitro" ;
         uil:hasKey       "search_results_sort_by" ;
         uil:hasPackage   "Vitro-languages" .
@@ -17,7 +17,7 @@ uil-data:search_results_sort_by.Vitro
 uil-data:search_results_per_page.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:PropertyKey ;
-        rdfs:label       "{0} Results per page"@en-US ;
+        rdfs:label       "{0} resultados por página"@pt-BR ;
         uil:hasApp       "Vitro" ;
         uil:hasKey       "search_results_per_page" ;
         uil:hasPackage   "Vitro-languages" .
@@ -25,7 +25,7 @@ uil-data:search_results_per_page.Vitro
 uil-data:search_field_placeholder.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:PropertyKey ;
-        rdfs:label       "Enter search term"@en-US ;
+        rdfs:label       "Insira o termo de pesquisa"@pt-BR ;
         uil:hasApp       "Vitro" ;
         uil:hasKey       "search_field_placeholder" ;
         uil:hasPackage   "Vitro-languages" .
@@ -33,7 +33,7 @@ uil-data:search_field_placeholder.Vitro
 uil-data:results_found.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:PropertyKey ;
-        rdfs:label       "{0} results found"@en-US ;
+        rdfs:label       "{0} resultados encontrados"@pt-BR ;
         uil:hasApp       "Vitro" ;
         uil:hasKey       "results_found" ;
         uil:hasPackage   "Vitro-languages" .

--- a/home/src/main/resources/rdf/i18n/ru_RU/display/firsttime/search_individuals_vitro.n3
+++ b/home/src/main/resources/rdf/i18n/ru_RU/display/firsttime/search_individuals_vitro.n3
@@ -1,0 +1,14 @@
+@prefix : <https://vivoweb.org/ontology/vitro-search-individual/> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+
+:filter_group_search_filters rdfs:label "Фильтры"@ru-RU .
+:filter_type rdfs:label "Тип"@ru-RU .
+:filter_category rdfs:label "Категория"@ru-RU .
+:sort_title_desc rdfs:label "названию Я-А"@ru-RU .
+:sort_title_asc rdfs:label "названию А-Я"@ru-RU .
+:sort_by_relevance rdfs:label "релевантности"@ru-RU .
+:field_label_sort rdfs:label "Поле сортировки по названию"@ru-RU .
+:field_category rdfs:label "Поле категория"@ru-RU .
+:field_type rdfs:label "Поле тип"@ru-RU .
+:filter_querytext rdfs:label "Текст"@ru-RU .
+:field_querytext rdfs:label "Поле фильтра по умолчанию"@ru-RU .

--- a/home/src/main/resources/rdf/i18n/ru_RU/interface-i18n/firsttime/vitro_extended_search.ttl
+++ b/home/src/main/resources/rdf/i18n/ru_RU/interface-i18n/firsttime/vitro_extended_search.ttl
@@ -9,7 +9,7 @@
 uil-data:search_results_sort_by.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:PropertyKey ;
-        rdfs:label       "Sort by {0}"@en-US ;
+        rdfs:label       "Сортировка по {0}"@ru-RU ;
         uil:hasApp       "Vitro" ;
         uil:hasKey       "search_results_sort_by" ;
         uil:hasPackage   "Vitro-languages" .
@@ -17,7 +17,7 @@ uil-data:search_results_sort_by.Vitro
 uil-data:search_results_per_page.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:PropertyKey ;
-        rdfs:label       "{0} Results per page"@en-US ;
+        rdfs:label       "по {0} результатов на странице"@ru-RU ;
         uil:hasApp       "Vitro" ;
         uil:hasKey       "search_results_per_page" ;
         uil:hasPackage   "Vitro-languages" .
@@ -25,7 +25,7 @@ uil-data:search_results_per_page.Vitro
 uil-data:search_field_placeholder.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:PropertyKey ;
-        rdfs:label       "Enter search term"@en-US ;
+        rdfs:label       "Введите текст"@ru-RU ;
         uil:hasApp       "Vitro" ;
         uil:hasKey       "search_field_placeholder" ;
         uil:hasPackage   "Vitro-languages" .
@@ -33,7 +33,7 @@ uil-data:search_field_placeholder.Vitro
 uil-data:results_found.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:PropertyKey ;
-        rdfs:label       "{0} results found"@en-US ;
+        rdfs:label       "{0} результатов найдено"@ru-RU ;
         uil:hasApp       "Vitro" ;
         uil:hasKey       "results_found" ;
         uil:hasPackage   "Vitro-languages" .

--- a/home/src/main/resources/rdf/i18n/sr_Latn_RS/display/firsttime/search_individuals_vitro.n3
+++ b/home/src/main/resources/rdf/i18n/sr_Latn_RS/display/firsttime/search_individuals_vitro.n3
@@ -1,0 +1,14 @@
+@prefix : <https://vivoweb.org/ontology/vitro-search-individual/> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+
+:filter_group_search_filters rdfs:label "Filteri za pretragu"@sr-Latn-RS .
+:filter_type rdfs:label "Tip"@sr-Latn-RS .
+:filter_category rdfs:label "Kategorija"@sr-Latn-RS .
+:sort_title_desc rdfs:label "Naslov Z-A"@sr-Latn-RS .
+:sort_title_asc rdfs:label "Naslov A-Z"@sr-Latn-RS .
+:sort_by_relevance rdfs:label "Relevantnost"@sr-Latn-RS .
+:field_label_sort rdfs:label "Polje za sortiranje oznaka"@sr-Latn-RS .
+:field_category rdfs:label "Odeljenska grupa"@sr-Latn-RS .
+:field_type rdfs:label "Tip"@sr-Latn-RS .
+:filter_querytext rdfs:label "Tekst"@sr-Latn-RS .
+:field_querytext rdfs:label "Podrazumevano polje"@sr-Latn-RS .

--- a/home/src/main/resources/rdf/i18n/sr_Latn_RS/interface-i18n/firsttime/vitro_extended_search.ttl
+++ b/home/src/main/resources/rdf/i18n/sr_Latn_RS/interface-i18n/firsttime/vitro_extended_search.ttl
@@ -9,7 +9,7 @@
 uil-data:search_results_sort_by.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:PropertyKey ;
-        rdfs:label       "Sort by {0}"@en-US ;
+        rdfs:label       "Sortiraj po {0}"@sr-Latn-RS ;
         uil:hasApp       "Vitro" ;
         uil:hasKey       "search_results_sort_by" ;
         uil:hasPackage   "Vitro-languages" .
@@ -17,7 +17,7 @@ uil-data:search_results_sort_by.Vitro
 uil-data:search_results_per_page.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:PropertyKey ;
-        rdfs:label       "{0} Results per page"@en-US ;
+        rdfs:label       "{0} rezultati po strani"@sr-Latn-RS ;
         uil:hasApp       "Vitro" ;
         uil:hasKey       "search_results_per_page" ;
         uil:hasPackage   "Vitro-languages" .
@@ -25,7 +25,7 @@ uil-data:search_results_per_page.Vitro
 uil-data:search_field_placeholder.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:PropertyKey ;
-        rdfs:label       "Enter search term"@en-US ;
+        rdfs:label       "Unesite termin za pretragu"@sr-Latn-RS ;
         uil:hasApp       "Vitro" ;
         uil:hasKey       "search_field_placeholder" ;
         uil:hasPackage   "Vitro-languages" .
@@ -33,7 +33,7 @@ uil-data:search_field_placeholder.Vitro
 uil-data:results_found.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:PropertyKey ;
-        rdfs:label       "{0} results found"@en-US ;
+        rdfs:label       "{0} pronađeni rezultati"@sr-Latn-RS ;
         uil:hasApp       "Vitro" ;
         uil:hasKey       "results_found" ;
         uil:hasPackage   "Vitro-languages" .

--- a/webapp/src/main/webapp/templates/freemarker/body/search/search-pagedResults.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/body/search/search-pagedResults.ftl
@@ -266,14 +266,18 @@ ${headScripts.add('<script type="text/javascript" src="${urls.base}/bootstrap-5.
 	<#if sorting?has_content>
 		<div>
 			<select form="search-form" name="sort" id="search-form-sort" onchange="this.form.submit()" >
-				<option value="">${i18n().search_results_sort_by} ${i18n().search_results_relevance}</option>
+			    <#assign addDefaultOption = true>
 				<#list sorting as option>
 					<#if option.selected>
 						<option value="${option.id}" selected="selected">${i18n().search_results_sort_by} ${option.label}</option>
+						<#assign addDefaultOption = false>
 					<#else>
 						<option value="${option.id}" >${i18n().search_results_sort_by} ${option.label}</option>
 					</#if>
 				</#list>
+				<#if addDefaultOption>
+					<option disabled selected value="" style="display:none">${i18n().search_results_sort_by}</option>
+				</#if>
 			</select>
 		</div>
 	</#if>

--- a/webapp/src/main/webapp/templates/freemarker/body/search/search-pagedResults.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/body/search/search-pagedResults.ftl
@@ -47,7 +47,7 @@ ${headScripts.add('<script type="text/javascript" src="${urls.base}/bootstrap-5.
 <#macro printResultNumbers>
 	<h2 class="searchResultsHeader">
 	<#escape x as x?html>
-	    ${hitCount} ${i18n().results_found} 
+	    ${i18n().results_found(hitCount)} 
 	</#escape>
 	<script type="text/javascript">
 		var url = window.location.toString();
@@ -269,14 +269,14 @@ ${headScripts.add('<script type="text/javascript" src="${urls.base}/bootstrap-5.
 			    <#assign addDefaultOption = true>
 				<#list sorting as option>
 					<#if option.selected>
-						<option value="${option.id}" selected="selected">${i18n().search_results_sort_by} ${option.label}</option>
+						<option value="${option.id}" selected="selected">${i18n().search_results_sort_by(option.label)}</option>
 						<#assign addDefaultOption = false>
 					<#else>
-						<option value="${option.id}" >${i18n().search_results_sort_by} ${option.label}</option>
+						<option value="${option.id}" >${i18n().search_results_sort_by(option.label)}</option>
 					</#if>
 				</#list>
 				<#if addDefaultOption>
-					<option disabled selected value="" style="display:none">${i18n().search_results_sort_by}</option>
+					<option disabled selected value="" style="display:none">${i18n().search_results_sort_by('')}</option>
 				</#if>
 			</select>
 		</div>
@@ -288,9 +288,9 @@ ${headScripts.add('<script type="text/javascript" src="${urls.base}/bootstrap-5.
 	<select form="search-form" name="hitsPerPage" id="search-form-hits-per-page" onchange="this.form.submit()">
 		<#list hitsPerPageOptions as option>
 			<#if option == hitsPerPage>
-				<option value="${option}" selected="selected">${option} ${i18n().search_results_per_page}</option>
+				<option value="${option}" selected="selected">${i18n().search_results_per_page(option)}</option>
 			<#else>
-				<option value="${option}">${option} ${i18n().search_results_per_page}</option>
+				<option value="${option}">${i18n().search_results_per_page(option)}</option>
 			</#if>
 		</#list>
 	</select>


### PR DESCRIPTION
[Related VIVO PR](https://github.com/vivo-project/VIVO/pull/3928)
# What does this pull request do?
Converted hard-coded search results sort option "by relevance" to configuration individual.
Without that there is no way to change order of sort options on search results page.
Apply first sort option if no query text was provided and no sort option was explicitly set.

# Interested parties
@VIVO-project/vivo-committers
