### PR TITLE
Freemarker dataGetter directive

### DIFF
--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/dao/DisplayVocabulary.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/dao/DisplayVocabulary.java
@@ -126,6 +126,14 @@ public class DisplayVocabulary {
     public static final String SAVE_TO_VAR = DISPLAY_NS + "saveToVar" ;
     public static final String QUERY_MODEL = DISPLAY_NS + "queryModel";
     public static final String QUERY = DISPLAY_NS + "query";
+    public static final String DISPLAY_URI_PARAM = DISPLAY_NS + "uri";
+    public static final String DISPLAY_STRING_PARAM = DISPLAY_NS + "string";
+    public static final String DISPLAY_INT_PARAM = DISPLAY_NS + "int";
+    public static final String DISPLAY_LONG_PARAM = DISPLAY_NS + "long";
+    public static final String DISPLAY_FLOAT_PARAM = DISPLAY_NS + "float";
+    public static final String DISPLAY_DOUBLE_PARAM = DISPLAY_NS + "double";
+    public static final String DISPLAY_BOOLEAN_PARAM = DISPLAY_NS + "boolean";
+
 
     /* URI of property for Fixed HTML Generator */
     public static final String FIXED_HTML_VALUE = DISPLAY_NS + "htmlValue";

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/freemarker/config/FreemarkerConfiguration.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/freemarker/config/FreemarkerConfiguration.java
@@ -28,6 +28,7 @@ import edu.cornell.mannlib.vitro.webapp.i18n.freemarker.I18nMethodModel;
 import edu.cornell.mannlib.vitro.webapp.startup.StartupStatus;
 import edu.cornell.mannlib.vitro.webapp.utils.developer.DeveloperSettings;
 import edu.cornell.mannlib.vitro.webapp.utils.developer.Key;
+import edu.cornell.mannlib.vitro.webapp.web.directives.DataGetterDirective;
 import edu.cornell.mannlib.vitro.webapp.web.directives.IndividualShortViewDirective;
 import edu.cornell.mannlib.vitro.webapp.web.directives.UrlDirective;
 import edu.cornell.mannlib.vitro.webapp.web.directives.WidgetDirective;
@@ -263,6 +264,7 @@ public abstract class FreemarkerConfiguration {
 			c.setSharedVariable("shortView", new IndividualShortViewDirective());
 			c.setSharedVariable("url", new UrlDirective());
 			c.setSharedVariable("widget", new WidgetDirective());
+			c.setSharedVariable("dataGetter", new DataGetterDirective());
 		}
 
 		private void addMethods(FreemarkerConfigurationImpl c) {

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/utils/dataGetter/DataGetterBase.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/utils/dataGetter/DataGetterBase.java
@@ -3,8 +3,6 @@ package edu.cornell.mannlib.vitro.webapp.utils.dataGetter;
 
 import static edu.cornell.mannlib.vitro.webapp.modelaccess.ModelNames.DISPLAY;
 
-import javax.servlet.ServletContext;
-
 import org.apache.commons.lang3.StringUtils;
 
 import org.apache.jena.rdf.model.Model;
@@ -18,7 +16,7 @@ public abstract class DataGetterBase implements DataGetter {
     /**
      * Get the model to use based on a model URI.
      */
-    protected Model getModel(ServletContext context, VitroRequest vreq , String modelName) {
+    protected Model getModel(VitroRequest vreq , String modelName) {
         //if not set use jenaOntModel from the request
         if( StringUtils.isEmpty(modelName) ){
             return vreq.getJenaOntModel();
@@ -27,16 +25,13 @@ public abstract class DataGetterBase implements DataGetter {
         }else if( REQUEST_JENA_ONT_MODEL.equals(modelName)){
             return vreq.getJenaOntModel();
         }else if( CONTEXT_DISPLAY_MODEL.equals(modelName)){
-        	return ModelAccess.on(context).getOntModel(DISPLAY);
-        }else if( ! StringUtils.isEmpty( modelName)){
+        	return ModelAccess.getInstance().getOntModel(DISPLAY);
+        }else{
             Model model = JenaIngestController.getModel( modelName, vreq);
             if( model == null )
                 throw new IllegalAccessError("Cannot get model <" + modelName +"> for DataGetter.");
             else
                 return model;
-        }else{
-            //default is just the JeanOntModel from the vreq.
-            return vreq.getJenaOntModel();
         }
     }
 

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/web/directives/BaseTemplateDirectiveModel.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/web/directives/BaseTemplateDirectiveModel.java
@@ -4,6 +4,8 @@ package edu.cornell.mannlib.vitro.webapp.web.directives;
 
 import java.io.IOException;
 import java.io.StringWriter;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 
 import org.apache.commons.logging.Log;
@@ -14,7 +16,11 @@ import freemarker.template.SimpleScalar;
 import freemarker.template.Template;
 import freemarker.template.TemplateDirectiveModel;
 import freemarker.template.TemplateException;
+import freemarker.template.TemplateHashModel;
+import freemarker.template.TemplateHashModelEx;
+import freemarker.template.TemplateModel;
 import freemarker.template.TemplateModelException;
+import freemarker.template.TemplateModelIterator;
 
 public abstract class BaseTemplateDirectiveModel implements TemplateDirectiveModel {
 
@@ -83,4 +89,23 @@ public abstract class BaseTemplateDirectiveModel implements TemplateDirectiveMod
 		return o.toString();
 	}
 
+    protected Map<String, Object> getOptionalHashModelParameter(Map<?, ?> params, String name) throws TemplateModelException {
+        Object object = params.get(name);
+        if (object == null) {
+            return Collections.emptyMap();
+        }
+        if (!(object instanceof TemplateHashModelEx)) {
+            throw new TemplateModelException(String.format("The %s parameter must be a string value.", name));
+        }
+        TemplateHashModelEx hashModel = (TemplateHashModelEx) object;
+        Map<String, Object> map = new HashMap<>();
+
+        TemplateModelIterator it = hashModel.keys().iterator();
+        while (it.hasNext()) {
+            TemplateModel key = it.next();
+            TemplateModel value = hashModel.get(key.toString());
+            map.put(key.toString(), value);
+        }
+        return map;
+    }
 }

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/web/directives/DataGetterDirective.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/web/directives/DataGetterDirective.java
@@ -82,7 +82,7 @@ public class DataGetterDirective extends BaseTemplateDirectiveModel {
      * 
      * @param env - Freemarker environment
      * @param overriddenVariable - overridden name of Freemarker variable
-     * @param dataGetterVariableName - default variable name specified in DataGetter configuration
+     * @param defaultVariable - default variable name specified in DataGetter configuration
      * @param value - value of data returned by DataGetter
      * 
      */

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/web/directives/DataGetterDirective.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/web/directives/DataGetterDirective.java
@@ -40,17 +40,15 @@ public class DataGetterDirective extends BaseTemplateDirectiveModel {
         String variableName = getOptionalSimpleScalarParameter(params, "var");
         HttpServletRequest req = (HttpServletRequest) env.getCustomAttribute("request");
         VitroRequest vreq = new VitroRequest(req);
-        debug(getTimeSince(startTime) + "ms .1");
         try {
-            debug(getTimeSince(startTime) + "ms .2");
             OntModel model = vreq.getDisplayModel();
-            debug(getTimeSince(startTime) + "ms .3");
+            debug(getTimeSince(startTime) + "ms spent before DataGetter retrieval.");
             DataGetter dataGetter = DataGetterUtils.dataGetterForURI(vreq, model, dataGetterUri);
-            debug(getTimeSince(startTime) + "ms .4");
+            debug(getTimeSince(startTime) + "ms spent after DataGetter retrieval.");
             Map<String, Object> parameters = getOptionalHashModelParameter(params, "parameters");
-            debug(getTimeSince(startTime) + "ms .5");
+            debug(getTimeSince(startTime) + "ms spent before DataGetter execution.");
             applyDataGetter(dataGetter, env, parameters, variableName);
-            debug(getTimeSince(startTime) + "ms .6");
+            debug(getTimeSince(startTime) + "ms spent after DataGetter execution.");
         } catch (Exception e) {
             handleException(dataGetterUri, "Could not process data getter '%s'", e);
         }
@@ -79,23 +77,26 @@ public class DataGetterDirective extends BaseTemplateDirectiveModel {
     }
 
     /**
-     * Wrap DataGetter results and assign it to Freemarker environment variable.
+     * Decide under which variable store the data, wrap DataGetter results
+     * and assign it to Freemarker environment variable.
      * 
      * @param env - Freemarker environment
-     * @param overrideVariableName - name of Freemarker variable
-     * @param key - name of data returned by DataGetter
+     * @param overriddenVariable - overridden name of Freemarker variable
+     * @param dataGetterVariableName - default variable name specified in DataGetter configuration
      * @param value - value of data returned by DataGetter
      * 
      */
-    private static void setVariable(Environment env, String overrideVariableName, String key, Object value)
+    private static void setVariable(Environment env, String overriddenVariable, String defaultVariable, Object value)
             throws TemplateModelException {
         ObjectWrapper wrapper = env.getObjectWrapper();
-        if (!StringUtils.isBlank(overrideVariableName)) {
-            env.setVariable(overrideVariableName, wrapper.wrap(value));
-            debug(String.format("Stored in environment: '%s' = '%s'", overrideVariableName, value));
+        if (!StringUtils.isBlank(overriddenVariable)) {
+            env.setVariable(overriddenVariable, wrapper.wrap(value));
+            debug(String.format("Stored overridden variable in Freemarker environment: '%s' = '%s'", overriddenVariable,
+                    value));
         } else {
-            env.setVariable(key, wrapper.wrap(value));
-            debug(String.format("Stored in environment: '%s' = '%s'", key, value));
+            env.setVariable(defaultVariable, wrapper.wrap(value));
+            debug(String.format("Stored default variable in Freemarker environment: '%s' = '%s'", defaultVariable,
+                    value));
         }
     }
 

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/web/directives/DataGetterDirective.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/web/directives/DataGetterDirective.java
@@ -1,0 +1,139 @@
+/* $This file is distributed under the terms of the license in LICENSE$ */
+
+package edu.cornell.mannlib.vitro.webapp.web.directives;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.servlet.http.HttpServletRequest;
+
+import edu.cornell.mannlib.vitro.webapp.controller.VitroRequest;
+import edu.cornell.mannlib.vitro.webapp.utils.dataGetter.DataGetter;
+import edu.cornell.mannlib.vitro.webapp.utils.dataGetter.DataGetterUtils;
+import freemarker.core.Environment;
+import freemarker.template.ObjectWrapper;
+import freemarker.template.TemplateDirectiveBody;
+import freemarker.template.TemplateException;
+import freemarker.template.TemplateModel;
+import freemarker.template.TemplateModelException;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.jena.ontology.OntModel;
+
+/**
+ * Freemarker directive to make substitutions in DataGetter and return the data
+ * in variable.
+ */
+public class DataGetterDirective extends BaseTemplateDirectiveModel {
+    private static final Log log = LogFactory.getLog(DataGetterDirective.class);
+
+    @Override
+    public void execute(Environment env, Map params, TemplateModel[] loopVars, TemplateDirectiveBody body)
+            throws TemplateException, IOException {
+        long startTime = System.nanoTime();
+        String dataGetterUri = getRequiredSimpleScalarParameter(params, "uri");
+        String variableName = getOptionalSimpleScalarParameter(params, "var");
+        HttpServletRequest req = (HttpServletRequest) env.getCustomAttribute("request");
+        VitroRequest vreq = new VitroRequest(req);
+        debug(getTimeSince(startTime) + "ms .1");
+        try {
+            debug(getTimeSince(startTime) + "ms .2");
+            OntModel model = vreq.getDisplayModel();
+            debug(getTimeSince(startTime) + "ms .3");
+            DataGetter dataGetter = DataGetterUtils.dataGetterForURI(vreq, model, dataGetterUri);
+            debug(getTimeSince(startTime) + "ms .4");
+            Map<String, Object> parameters = getOptionalHashModelParameter(params, "parameters");
+            debug(getTimeSince(startTime) + "ms .5");
+            applyDataGetter(dataGetter, env, parameters, variableName);
+            debug(getTimeSince(startTime) + "ms .6");
+        } catch (Exception e) {
+            handleException(dataGetterUri, "Could not process data getter '%s'", e);
+        }
+    }
+
+    /**
+     * Get the data from a DataGetter, provide variable values for substitution and
+     * store results in Freemarker environment variable.
+     * 
+     * @param dataGetter - DataGetter to execute
+     * @param env - Freemarker environment
+     * @param parameters - parameters to substitute in DataGetter
+     * @param overrideVariableName - name of Freemarker variable
+     * 
+     */
+    private static void applyDataGetter(DataGetter dataGetter, Environment env, Map<String, Object> parameters,
+            String overrideVariableName) throws TemplateModelException {
+        Map<String, Object> data = dataGetter.getData(parameters);
+        if (data != null) {
+            Object key = data.get("variableName");
+            if (key != null) {
+                Object value = data.get(key.toString());
+                setVariable(env, overrideVariableName, key.toString(), value);
+            }
+        }
+    }
+
+    /**
+     * Wrap DataGetter results and assign it to Freemarker environment variable.
+     * 
+     * @param env - Freemarker environment
+     * @param overrideVariableName - name of Freemarker variable
+     * @param key - name of data returned by DataGetter
+     * @param value - value of data returned by DataGetter
+     * 
+     */
+    private static void setVariable(Environment env, String overrideVariableName, String key, Object value)
+            throws TemplateModelException {
+        ObjectWrapper wrapper = env.getObjectWrapper();
+        if (!StringUtils.isBlank(overrideVariableName)) {
+            env.setVariable(overrideVariableName, wrapper.wrap(value));
+            debug(String.format("Stored in environment: '%s' = '%s'", overrideVariableName, value));
+        } else {
+            env.setVariable(key, wrapper.wrap(value));
+            debug(String.format("Stored in environment: '%s' = '%s'", key, value));
+        }
+    }
+
+    /**
+     * Handle exceptions that could happen during DataGetter execution
+     */
+    private void handleException(String templateName, String messageTemplate, Exception e) {
+        log.error(String.format(messageTemplate, templateName));
+        log.error(e, e);
+    }
+
+    @Override
+    public Map<String, Object> help(String name) {
+        Map<String, Object> map = new LinkedHashMap<String, Object>();
+        map.put("effect", "Find the freemarker template and optional DataGetters. "
+                + "Apply parameter substitutions in DataGetters." + "Execute the DataGetters and render the template.");
+        map.put("comments", "");
+        Map<String, String> params = new HashMap<String, String>();
+        params.put("template", "Freemarker template file name");
+        params.put("parameters", "Map of parameters and values");
+        map.put("parameters", params);
+
+        List<String> examples = new ArrayList<String>();
+        examples.add("<@dataGetter uri = \"http://dataGetterUri\" \n" + "var = \"foobar\" \n"
+                + "parameters = { \"object\": \"http://objUri\", \"property\": \"http://propUri\" } />");
+        map.put("examples", examples);
+
+        return map;
+    }
+
+    private static long getTimeSince(long previousTime) {
+        return (System.nanoTime() - previousTime) / 1000000;
+    }
+
+    private static void debug(String message) {
+        if (log.isDebugEnabled()) {
+            log.debug(message);
+        }
+    }
+
+}

--- a/api/src/test/java/edu/cornell/mannlib/vitro/webapp/controller/VitroRequestStub.java
+++ b/api/src/test/java/edu/cornell/mannlib/vitro/webapp/controller/VitroRequestStub.java
@@ -1,0 +1,23 @@
+package edu.cornell.mannlib.vitro.webapp.controller;
+
+import javax.servlet.http.HttpServletRequest;
+
+import edu.cornell.mannlib.vitro.webapp.rdfservice.RDFService;
+
+public class VitroRequestStub extends VitroRequest {
+
+    private RDFService defaultRdfService;
+
+    public VitroRequestStub(HttpServletRequest _req) {
+        super(_req);
+    }
+
+    @Override
+    public RDFService getRDFService() {
+        return defaultRdfService;
+    }
+
+    public void setRDFService(RDFService rdfService) {
+        this.defaultRdfService = rdfService;
+    }
+}

--- a/api/src/test/java/edu/cornell/mannlib/vitro/webapp/utils/dataGetter/SparqlQueryDataGetterTest.java
+++ b/api/src/test/java/edu/cornell/mannlib/vitro/webapp/utils/dataGetter/SparqlQueryDataGetterTest.java
@@ -3,85 +3,176 @@ package edu.cornell.mannlib.vitro.webapp.utils.dataGetter;
 
 import java.io.InputStream;
 import java.lang.reflect.InvocationTargetException;
-import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import edu.cornell.mannlib.vitro.testing.AbstractTestClass;
+import edu.cornell.mannlib.vitro.webapp.controller.VitroRequestStub;
+import edu.cornell.mannlib.vitro.webapp.dao.WebappDaoFactory;
+import edu.cornell.mannlib.vitro.webapp.dao.jena.SimpleOntModelSelector;
+import edu.cornell.mannlib.vitro.webapp.dao.jena.WebappDaoFactoryJena;
+import edu.cornell.mannlib.vitro.webapp.rdfservice.adapters.VitroModelFactory;
+import edu.cornell.mannlib.vitro.webapp.rdfservice.impl.jena.model.RDFServiceModel;
+import org.apache.jena.ontology.OntModel;
+import org.apache.jena.ontology.OntModelSpec;
+import org.apache.jena.rdf.model.ModelFactory;
+import org.apache.jena.rdf.model.Resource;
+import org.apache.jena.rdf.model.ResourceFactory;
+import org.apache.jena.rdf.model.impl.PropertyImpl;
+import org.apache.jena.rdf.model.impl.RDFDefaultErrorHandler;
+import org.apache.jena.vocabulary.RDF;
 import org.apache.log4j.Level;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-
 import stubs.javax.servlet.http.HttpServletRequestStub;
 
-import org.apache.jena.ontology.OntModel;
-import org.apache.jena.ontology.OntModelSpec;
-import org.apache.jena.rdf.model.Model;
-import org.apache.jena.rdf.model.ModelFactory;
-import org.apache.jena.rdf.model.ResourceFactory;
-import org.apache.jena.rdf.model.impl.RDFDefaultErrorHandler;
-import org.apache.jena.vocabulary.RDF;
+public class SparqlQueryDataGetterTest extends AbstractTestClass {
 
-import edu.cornell.mannlib.vitro.testing.AbstractTestClass;
-import edu.cornell.mannlib.vitro.webapp.controller.VitroRequest;
-import edu.cornell.mannlib.vitro.webapp.dao.WebappDaoFactory;
-import edu.cornell.mannlib.vitro.webapp.dao.jena.SimpleOntModelSelector;
-import edu.cornell.mannlib.vitro.webapp.dao.jena.WebappDaoFactoryJena;
-
-public class SparqlQueryDataGetterTest extends AbstractTestClass{
+    private static final PropertyImpl HAS_ID = new PropertyImpl("test:has-id");
+    private static final String VAR_PARAM = "param";
+    private static final String PERSON_TYPE = "http://xmlns.com/foaf/0.1/Person";
+    private static final String PREFIX = "http://vitro.mannlib.cornell.edu/ontologies/display/1.1#";
+    private static final String BOB_URI = "http://example.com/p/bob";
+    private static final Resource BOB = ResourceFactory.createResource(BOB_URI);
+    private static final String ALICE_URI = "http://example.com/p/alice";
+    private static final Resource ALICE = ResourceFactory.createResource(ALICE_URI);
 
     OntModel displayModel;
-    String testDataGetterURI_1 = "http://vitro.mannlib.cornell.edu/ontologies/display/1.1#query1data";
+    String testDataGetterURI_1 = "query1data";
     WebappDaoFactory wdf;
-    VitroRequest vreq;
+    VitroRequestStub vreq;
+    private Map<String, Object> params;
+    private OntModel dataModel;
 
     @Before
     public void setUp() {
         // Suppress error logging.
         setLoggerLevel(RDFDefaultErrorHandler.class, Level.OFF);
 
-        OntModel model = ModelFactory.createOntologyModel( OntModelSpec.OWL_MEM);
+        OntModel model = ModelFactory.createOntologyModel(OntModelSpec.OWL_MEM);
         InputStream in = SparqlQueryDataGetterTest.class.getResourceAsStream("resources/dataGetterTest.n3");
-        model.read(in,"","N3");
-        displayModel = ModelFactory.createOntologyModel(OntModelSpec.OWL_DL_MEM,model);
+        model.read(in, "", "N3");
+        displayModel = ModelFactory.createOntologyModel(OntModelSpec.OWL_DL_MEM, model);
 
-        SimpleOntModelSelector sos = new SimpleOntModelSelector( ModelFactory.createOntologyModel(OntModelSpec.OWL_DL_MEM));
+        SimpleOntModelSelector sos =
+                new SimpleOntModelSelector(ModelFactory.createOntologyModel(OntModelSpec.OWL_DL_MEM));
         sos.setDisplayModel(displayModel);
         wdf = new WebappDaoFactoryJena(sos);
-
-        vreq = new VitroRequest(new HttpServletRequestStub());
+        vreq = new VitroRequestStub(new HttpServletRequestStub());
+        params = new HashMap<>();
+        dataModel = VitroModelFactory.createOntologyModel();
     }
 
     @Test
-    public void testBasicGetData() throws IllegalArgumentException, SecurityException, InstantiationException, IllegalAccessException, ClassNotFoundException, InvocationTargetException, NoSuchMethodException {
-        DataGetter dg = DataGetterUtils.dataGetterForURI(vreq, displayModel, testDataGetterURI_1);
-        Assert.assertNotNull(dg);
-        Assert.assertTrue(
-                "DataGetter should be of type " + SparqlQueryDataGetter.class.getName(),
-                dg instanceof SparqlQueryDataGetter);
-
-        SparqlQueryDataGetter sdg = (SparqlQueryDataGetter)dg;
-
-
-        Model dataModel = ModelFactory.createDefaultModel();
-        String bobURI = "http://example.com/p/bob";
-        dataModel.add(ResourceFactory.createResource(bobURI), RDF.type, ResourceFactory.createResource("http://xmlns.com/foaf/0.1/Person"));
-
-        Map<String, String> params = Collections.emptyMap();
-
-        Map<String,Object> mapOut = sdg.doQueryOnModel(sdg.queryText, dataModel);
-
-        Assert.assertNotNull(mapOut);
-        Assert.assertTrue("should contain key people" , mapOut.containsKey("people"));
-
-        Object obj = mapOut.get("people");
-        Assert.assertTrue("people should be a List, it is " + obj.getClass().getName(), obj instanceof List);
-        List people = (List)obj;
-
-        Assert.assertEquals(1, people.size());
-
-        Map<String,String> first = (Map<String, String>) people.get(0);
-        Assert.assertEquals(bobURI, first.get("uri"));
+    public void testBasicGetData() throws Exception {
+        SparqlQueryDataGetter sdg = getDataGetter(testDataGetterURI_1);
+        dataModel.add(BOB, RDF.type, ResourceFactory.createResource(PERSON_TYPE));
+        Map<String, Object> data = sdg.doQueryOnModel(sdg.queryText, dataModel);
+        checkData(data);
     }
 
+    @Test
+    public void testDataGetterWithUriParam() throws Exception {
+        SparqlQueryDataGetter sdg = getDataGetter("dataGetterUriParam");
+        dataModel.add(BOB, RDF.type, ResourceFactory.createResource(PERSON_TYPE));
+        dataModel.add(ALICE, RDF.type, ResourceFactory.createResource("http://xmlns.com/foaf/0.1/Agent"));
+        vreq.setRDFService(new RDFServiceModel(dataModel));
+        params.put(VAR_PARAM, PERSON_TYPE);
+        Map<String, Object> data = sdg.getData(params);
+        checkData(data);
+    }
+
+    @Test
+    public void testDataGetterWithStringParam() throws Exception {
+        SparqlQueryDataGetter sdg = getDataGetter("dataGetterStringParam");
+        dataModel.add(BOB, HAS_ID, dataModel.createTypedLiteral("profile"));
+        dataModel.add(ALICE, HAS_ID, dataModel.createTypedLiteral("car"));
+        vreq.setRDFService(new RDFServiceModel(dataModel));
+        params.put(VAR_PARAM, "profile");
+        Map<String, Object> data = sdg.getData(params);
+        checkData(data);
+    }
+
+    @Test
+    public void testDataGetterWithIntParam() throws Exception {
+        SparqlQueryDataGetter sdg = getDataGetter("dataGetterIntParam");
+        dataModel.add(BOB, HAS_ID, dataModel.createTypedLiteral(1));
+        dataModel.add(ALICE, HAS_ID, dataModel.createTypedLiteral(2));
+        vreq.setRDFService(new RDFServiceModel(dataModel));
+        params.put(VAR_PARAM, "1");
+        Map<String, Object> data = sdg.getData(params);
+        checkData(data);
+    }
+
+    @Test
+    public void testDataGetterWithLongParam() throws Exception {
+        SparqlQueryDataGetter sdg = getDataGetter("dataGetterLongParam");
+        dataModel.add(BOB, HAS_ID, dataModel.createTypedLiteral(1L));
+        dataModel.add(ALICE, HAS_ID, dataModel.createTypedLiteral(2L));
+        vreq.setRDFService(new RDFServiceModel(dataModel));
+        params.put(VAR_PARAM, "1");
+        Map<String, Object> data = sdg.getData(params);
+        checkData(data);
+    }
+
+    @Test
+    public void testDataGetterWithFloatParam() throws Exception {
+        SparqlQueryDataGetter sdg = getDataGetter("dataGetterFloatParam");
+        Float value = 1.1f;
+        dataModel.add(BOB, HAS_ID, dataModel.createTypedLiteral(value));
+        dataModel.add(ALICE, HAS_ID, dataModel.createTypedLiteral(1.2f));
+        vreq.setRDFService(new RDFServiceModel(dataModel));
+        params.put(VAR_PARAM, value.toString());
+        Map<String, Object> data = sdg.getData(params);
+        checkData(data);
+    }
+
+    @Test
+    public void testDataGetterWithDoubleParam() throws Exception {
+        SparqlQueryDataGetter sdg = getDataGetter("dataGetterDoubleParam");
+        Double value = 1.1d;
+        dataModel.add(BOB, HAS_ID, dataModel.createTypedLiteral(value));
+        dataModel.add(ALICE, HAS_ID, dataModel.createTypedLiteral(1.2d));
+        vreq.setRDFService(new RDFServiceModel(dataModel));
+        params.put(VAR_PARAM, value.toString());
+        Map<String, Object> data = sdg.getData(params);
+        checkData(data);
+    }
+
+    @Test
+    public void testDataGetterWithBooleanParam() throws Exception {
+        SparqlQueryDataGetter sdg = getDataGetter("dataGetterBooleanParam");
+        Boolean value = true;
+        dataModel.add(BOB, HAS_ID, dataModel.createTypedLiteral(value));
+        dataModel.add(ALICE, HAS_ID, dataModel.createTypedLiteral(!value));
+        vreq.setRDFService(new RDFServiceModel(dataModel));
+        params.put(VAR_PARAM, value.toString());
+        Map<String, Object> data = sdg.getData(params);
+        checkData(data);
+    }
+
+    private SparqlQueryDataGetter getDataGetter(String dataGetterName)
+            throws InstantiationException, IllegalAccessException, ClassNotFoundException, InvocationTargetException {
+        DataGetter dg = DataGetterUtils.dataGetterForURI(vreq, displayModel, PREFIX + dataGetterName);
+        Assert.assertNotNull(dg);
+        Assert.assertTrue("DataGetter should be of type " + SparqlQueryDataGetter.class.getName(),
+                dg instanceof SparqlQueryDataGetter);
+        SparqlQueryDataGetter sdg = (SparqlQueryDataGetter) dg;
+        return sdg;
+    }
+
+    private void checkData(Map<String, Object> data) {
+        Assert.assertNotNull(data);
+        Assert.assertTrue("should contain key people", data.containsKey("people"));
+        Object obj = data.get("people");
+        Assert.assertTrue("people should be a List, it is " + obj.getClass().getName(), obj instanceof List);
+        @SuppressWarnings("rawtypes")
+        List people = (List) obj;
+        Assert.assertEquals(1, people.size());
+        @SuppressWarnings("unchecked")
+        Map<String, String> first = (Map<String, String>) people.get(0);
+        Assert.assertEquals(BOB_URI, first.get("uri"));
+    }
 }

--- a/api/src/test/resources/edu/cornell/mannlib/vitro/webapp/utils/dataGetter/resources/dataGetterTest.n3
+++ b/api/src/test/resources/edu/cornell/mannlib/vitro/webapp/utils/dataGetter/resources/dataGetterTest.n3
@@ -19,6 +19,44 @@ display:query1data
     display:query "SELECT * WHERE { ?uri a <http://xmlns.com/foaf/0.1/Person> } " ;
     display:saveToVar "people" .
 
+display:dataGetterUriParam
+    a <java:edu.cornell.mannlib.vitro.webapp.utils.dataGetter.SparqlQueryDataGetter>;
+    display:uri "param" ;
+    display:query "SELECT * WHERE { ?uri a ?param } " ;
+    display:saveToVar "people" .
+    
+display:dataGetterStringParam
+    a <java:edu.cornell.mannlib.vitro.webapp.utils.dataGetter.SparqlQueryDataGetter>;
+    display:string "param" ;
+    display:query "SELECT * WHERE { ?uri <test:has-id> ?param } " ;
+    display:saveToVar "people" .
+    
+display:dataGetterIntParam
+    a <java:edu.cornell.mannlib.vitro.webapp.utils.dataGetter.SparqlQueryDataGetter>;
+    display:int "param" ;
+    display:query "SELECT * WHERE { ?uri <test:has-id> ?param } " ;
+    display:saveToVar "people" .
+    
+display:dataGetterLongParam
+    a <java:edu.cornell.mannlib.vitro.webapp.utils.dataGetter.SparqlQueryDataGetter>;
+    display:long "param" ;
+    display:query "SELECT * WHERE { ?uri <test:has-id> ?param } " ;
+    display:saveToVar "people" .
 
+display:dataGetterFloatParam
+    a <java:edu.cornell.mannlib.vitro.webapp.utils.dataGetter.SparqlQueryDataGetter>;
+    display:float "param" ;
+    display:query "SELECT * WHERE { ?uri <test:has-id> ?param } " ;
+    display:saveToVar "people" .
+    
+display:dataGetterDoubleParam
+    a <java:edu.cornell.mannlib.vitro.webapp.utils.dataGetter.SparqlQueryDataGetter>;
+    display:double "param" ;
+    display:query "SELECT * WHERE { ?uri <test:has-id> ?param } " ;
+    display:saveToVar "people" .
 
-
+display:dataGetterBooleanParam
+    a <java:edu.cornell.mannlib.vitro.webapp.utils.dataGetter.SparqlQueryDataGetter>;
+    display:boolean "param" ;
+    display:query "SELECT * WHERE { ?uri <test:has-id> ?param } " ;
+    display:saveToVar "people" .

--- a/checkstyle-suppressions.xml
+++ b/checkstyle-suppressions.xml
@@ -1237,7 +1237,6 @@
     <suppress files="src[\\/]test[\\/]java[\\/]edu[\\/]cornell[\\/]mannlib[\\/]vitro[\\/]webapp[\\/]utils[\\/]configuration[\\/]ConfigurationBeanLoader_PropertyTest\.java" checks="."/>
     <suppress files="src[\\/]test[\\/]java[\\/]edu[\\/]cornell[\\/]mannlib[\\/]vitro[\\/]webapp[\\/]utils[\\/]configuration[\\/]ConfigurationBeanLoader_ValidationTest\.java" checks="."/>
     <suppress files="src[\\/]test[\\/]java[\\/]edu[\\/]cornell[\\/]mannlib[\\/]vitro[\\/]webapp[\\/]utils[\\/]dataGetter[\\/]DataGetterUtilsTest\.java" checks="."/>
-    <suppress files="src[\\/]test[\\/]java[\\/]edu[\\/]cornell[\\/]mannlib[\\/]vitro[\\/]webapp[\\/]utils[\\/]dataGetter[\\/]SparqlQueryDataGetterTest\.java" checks="."/>
     <suppress files="src[\\/]test[\\/]java[\\/]edu[\\/]cornell[\\/]mannlib[\\/]vitro[\\/]webapp[\\/]utils[\\/]http[\\/]ContentTypeUtilTest\.java" checks="."/>
     <suppress files="src[\\/]test[\\/]java[\\/]edu[\\/]cornell[\\/]mannlib[\\/]vitro[\\/]webapp[\\/]utils[\\/]ingest[\\/]JenaIngestUtilsTest\.java" checks="."/>
     <suppress files="src[\\/]test[\\/]java[\\/]edu[\\/]cornell[\\/]mannlib[\\/]vitro[\\/]webapp[\\/]utils[\\/]jena[\\/]JenaIngestUtilsTest\.java" checks="."/>

--- a/home/src/main/resources/rdf/displayTbox/everytime/displayTBOX.n3
+++ b/home/src/main/resources/rdf/displayTbox/everytime/displayTBOX.n3
@@ -135,6 +135,27 @@ display:htmlValue
 display:cannotDeletePage
     a owl:DatatypeProperty.
 
+display:uri
+    a owl:DatatypeProperty.
+
+display:string
+    a owl:DatatypeProperty.
+
+display:int
+    a owl:DatatypeProperty.
+
+display:long
+    a owl:DatatypeProperty.
+
+display:float
+    a owl:DatatypeProperty.
+
+display:double
+    a owl:DatatypeProperty.
+
+display:boolean
+    a owl:DatatypeProperty.
+
 ######### Object Properties#########
 ###Basic
 rdfs:range


### PR DESCRIPTION
Mentioned in **[VIVO GitHub issue](https://github.com/vivo-project/VIVO/issues/2832)**

# What does this pull request do?
Adds new Freemarker directive to execute DataGetters with provided parameters and save results as Freemarker variables.

# What's new?

- Added new directive to FreemarkerConfiguration
- Fixed substitutions in SparqlQueryDataGetter
- New data properties to specify types of substituted variables
- Added more tests for SparqlQueryDataGetter
- Removed unreachable case in DataGetterBase
- Removed SparqlQueryDataGetterTest.java from checkstyle suppressions

# How should this be tested?
SparqlQueryDataGetter improvements covered by tests.
New directive could be tested by calling test data getter in Freemarker template:
```
<@dataGetter uri = "test:dataGetter" var = "labels" parameters = {"object": "http://purl.org/ontology/bibo/AcademicArticle"} />
<#if labels?has_content><p>Label returned by data getter: ${labels[0].label}</p></#if>
```
Data getter configuration:
```
<test:dataGetter>
    a <java:edu.cornell.mannlib.vitro.webapp.utils.dataGetter.SparqlQueryDataGetter> ;
    display:saveToVar "result" ;
    display:uri "object";
    display:query """
    PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
    SELECT ?label
        WHERE {
          ?object rdfs:label ?label .
        } LIMIT 1
     """ .
```

# Interested parties
@VIVO-project/vivo-committers
