### PR TITLE
Apply role based search filters in existing endpoints

### DIFF
--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/freemarker/IndividualListController.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/freemarker/IndividualListController.java
@@ -28,6 +28,8 @@ import edu.cornell.mannlib.vitro.webapp.dao.IndividualDao;
 import edu.cornell.mannlib.vitro.webapp.i18n.I18n;
 import edu.cornell.mannlib.vitro.webapp.modules.searchEngine.SearchEngineException;
 import edu.cornell.mannlib.vitro.webapp.modules.searchEngine.SearchQuery;
+import edu.cornell.mannlib.vitro.webapp.search.controller.SearchFilter;
+import edu.cornell.mannlib.vitro.webapp.search.controller.SearchFiltering;
 import edu.cornell.mannlib.vitro.webapp.utils.searchengine.SearchQueryUtils;
 import edu.cornell.mannlib.vitro.webapp.web.templatemodels.individuallist.ListedIndividual;
 import edu.cornell.mannlib.vitro.webapp.web.templatemodels.individuallist.ListedIndividualBuilder;
@@ -188,7 +190,7 @@ public class IndividualListController extends FreemarkerHttpServlet {
 		boolean languageFilter = Boolean.valueOf(props.getProperty(LANGUAGE_FILTER_PROPERTY, "false"));
 		IndividualListQueryResults results = buildAndExecuteVClassQuery(classUris, alpha,
 				((languageFilter) ? vreq.getLocale() : null), page, pageSize,
-				vreq.getWebappDaoFactory().getIndividualDao());
+				vreq);
 		IndividualListResults indListResults = getResultsForVClassQuery(results, page, pageSize, alpha, vreq);
 		return indListResults;
 	}
@@ -196,7 +198,7 @@ public class IndividualListController extends FreemarkerHttpServlet {
     public static IndividualListResults getRandomResultsForVClass(String vclassURI, int page, int pageSize, VitroRequest vreq) {
    	 	try{
             List<String> classUris = Collections.singletonList(vclassURI);
-			IndividualListQueryResults results = buildAndExecuteRandomVClassQuery(classUris, page, pageSize, vreq.getWebappDaoFactory().getIndividualDao());
+			IndividualListQueryResults results = buildAndExecuteRandomVClassQuery(classUris, page, pageSize, vreq);
 	        return getResultsForVClassQuery(results, page, pageSize, "", vreq);
    	 	} catch(Throwable th) {
 	   		log.error("An error occurred retrieving random results for vclass query", th);
@@ -216,9 +218,12 @@ public class IndividualListController extends FreemarkerHttpServlet {
 
     private static IndividualListQueryResults buildAndExecuteVClassQuery(
 			List<String> vclassURIs, String alpha, Locale locale, int page,
-			int pageSize, IndividualDao indDao)
+			int pageSize, VitroRequest vreq)
 			throws SearchEngineException {
+		 IndividualDao indDao = vreq.getWebappDaoFactory().getIndividualDao();
 		 SearchQuery query = SearchQueryUtils.getQuery(vclassURIs, alpha, locale, page, pageSize);
+		 Map<String, SearchFilter> filtersByField = SearchFiltering.readFilterConfigurations(vreq);
+		 SearchFiltering.addPreconfiguredFiltersToQuery(query, filtersByField.values());
 		 IndividualListQueryResults results = IndividualListQueryResults.runQuery(query, indDao);
 		 log.debug("Executed search query for " + vclassURIs);
 		 if (results.getIndividuals().isEmpty()) {
@@ -228,9 +233,12 @@ public class IndividualListController extends FreemarkerHttpServlet {
 	}
 
     private static IndividualListQueryResults buildAndExecuteRandomVClassQuery(
-			List<String> vclassURIs, int page, int pageSize, IndividualDao indDao)
+			List<String> vclassURIs, int page, int pageSize, VitroRequest vreq)
 			throws SearchEngineException {
+		 IndividualDao indDao = vreq.getWebappDaoFactory().getIndividualDao();
 		 SearchQuery query = SearchQueryUtils.getRandomQuery(vclassURIs, page, pageSize);
+		 Map<String, SearchFilter> filtersByField = SearchFiltering.readFilterConfigurations(vreq);
+		 SearchFiltering.addPreconfiguredFiltersToQuery( query, filtersByField.values());
 		 IndividualListQueryResults results = IndividualListQueryResults.runQuery(query, indDao);
 		 log.debug("Executed search query for " + vclassURIs);
 		 if (results.getIndividuals().isEmpty()) {

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/freemarker/IndividualListController.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/freemarker/IndividualListController.java
@@ -8,6 +8,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.servlet.annotation.WebServlet;
 
@@ -222,8 +223,8 @@ public class IndividualListController extends FreemarkerHttpServlet {
 			throws SearchEngineException {
 		 IndividualDao indDao = vreq.getWebappDaoFactory().getIndividualDao();
 		 SearchQuery query = SearchQueryUtils.getQuery(vclassURIs, alpha, locale, page, pageSize);
-		 Map<String, SearchFilter> filtersByField = SearchFiltering.readFilterConfigurations(vreq);
-		 SearchFiltering.addPreconfiguredFiltersToQuery(query, filtersByField.values());
+		 Set<String> currentRoles = SearchFiltering.getCurrentUserRoles(vreq);
+		 SearchFiltering.addDefaultFilters(query, currentRoles);
 		 IndividualListQueryResults results = IndividualListQueryResults.runQuery(query, indDao);
 		 log.debug("Executed search query for " + vclassURIs);
 		 if (results.getIndividuals().isEmpty()) {
@@ -237,8 +238,8 @@ public class IndividualListController extends FreemarkerHttpServlet {
 			throws SearchEngineException {
 		 IndividualDao indDao = vreq.getWebappDaoFactory().getIndividualDao();
 		 SearchQuery query = SearchQueryUtils.getRandomQuery(vclassURIs, page, pageSize);
-		 Map<String, SearchFilter> filtersByField = SearchFiltering.readFilterConfigurations(vreq);
-		 SearchFiltering.addPreconfiguredFiltersToQuery( query, filtersByField.values());
+		 Set<String> currentRoles = SearchFiltering.getCurrentUserRoles(vreq);
+		 SearchFiltering.addDefaultFilters(query, currentRoles);
 		 IndividualListQueryResults results = IndividualListQueryResults.runQuery(query, indDao);
 		 log.debug("Executed search query for " + vclassURIs);
 		 if (results.getIndividuals().isEmpty()) {

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/DefaultObjectPropertyFormGenerator.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/DefaultObjectPropertyFormGenerator.java
@@ -2,8 +2,6 @@
 
 package edu.cornell.mannlib.vitro.webapp.edit.n3editing.configuration.generators;
 
-import static edu.cornell.mannlib.vitro.webapp.modelaccess.ModelAccess.LANGUAGE_NEUTRAL;
-import static edu.cornell.mannlib.vitro.webapp.modelaccess.ModelAccess.POLICY_NEUTRAL;
 import static edu.cornell.mannlib.vitro.webapp.modelaccess.ModelNames.DISPLAY;
 
 import java.util.ArrayList;

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/DefaultObjectPropertyFormGenerator.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/DefaultObjectPropertyFormGenerator.java
@@ -11,6 +11,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import javax.servlet.http.HttpSession;
 
@@ -45,6 +46,7 @@ import edu.cornell.mannlib.vitro.webapp.modules.searchEngine.SearchQuery;
 import edu.cornell.mannlib.vitro.webapp.modules.searchEngine.SearchResponse;
 import edu.cornell.mannlib.vitro.webapp.modules.searchEngine.SearchResultDocumentList;
 import edu.cornell.mannlib.vitro.webapp.search.VitroSearchTermNames;
+import edu.cornell.mannlib.vitro.webapp.search.controller.SearchFiltering;
 import edu.cornell.mannlib.vitro.webapp.utils.FrontEndEditingUtils;
 import edu.cornell.mannlib.vitro.webapp.utils.FrontEndEditingUtils.EditMode;
 
@@ -187,7 +189,7 @@ public class DefaultObjectPropertyFormGenerator implements EditConfigurationGene
     	if(types.size() == 0 ){
     		types.add(VitroVocabulary.OWL_THING);
     	}
-
+    	Set<String> currentRoles = SearchFiltering.getCurrentUserRoles(vreq);
     	long count = 0;
     	for( String type:types){
     		//search query for type count.
@@ -198,6 +200,7 @@ public class DefaultObjectPropertyFormGenerator implements EditConfigurationGene
     			query.setQuery( VitroSearchTermNames.RDFTYPE + ":" + type);
     		}
     		query.setRows(0);
+    		SearchFiltering.addDefaultFilters(query, currentRoles);
     		SearchResponse rsp = searchEngine.query(query);
     		SearchResultDocumentList docs = rsp.getResults();
     		long found = docs.getNumFound();
@@ -549,9 +552,9 @@ public class DefaultObjectPropertyFormGenerator implements EditConfigurationGene
 			String objectLabel = EditConfigurationUtils.getObjectIndividual(vreq).getName();
 			formSpecificData.put("objectLabel", objectLabel);
 		}
-
+		Set<String> currentRoles = SearchFiltering.getCurrentUserRoles(vreq);
 		//TODO: find out if there are any individuals in the classes of objectTypes
-		formSpecificData.put("rangeIndividualsExist", rangeIndividualsExist(types) );
+		formSpecificData.put("rangeIndividualsExist", rangeIndividualsExist(types, currentRoles) );
 
 		formSpecificData.put("sparqlForAcFilter", getSparqlForAcFilter(vreq));
 		if(customErrorMessages != null && !customErrorMessages.isEmpty()) {
@@ -561,7 +564,7 @@ public class DefaultObjectPropertyFormGenerator implements EditConfigurationGene
 		editConfiguration.setFormSpecificData(formSpecificData);
 	}
 
-	private Object rangeIndividualsExist(List<VClass> types) throws SearchEngineException {
+	private Object rangeIndividualsExist(List<VClass> types, Set<String> currentRoles) throws SearchEngineException {
 		SearchEngine searchEngine = ApplicationUtils.instance().getSearchEngine();
 
     	boolean rangeIndividualsFound = false;
@@ -570,6 +573,7 @@ public class DefaultObjectPropertyFormGenerator implements EditConfigurationGene
     		SearchQuery query = searchEngine.createQuery();
     		query.setQuery( VitroSearchTermNames.RDFTYPE + ":" + type.getURI());
     		query.setRows(0);
+    		SearchFiltering.addDefaultFilters(query, currentRoles);
 
     		SearchResponse rsp = searchEngine.query(query);
     		SearchResultDocumentList docs = rsp.getResults();

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/search/controller/AutocompleteController.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/search/controller/AutocompleteController.java
@@ -8,6 +8,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 import javax.servlet.ServletException;
 import javax.servlet.annotation.WebServlet;
@@ -99,6 +100,9 @@ public class AutocompleteController extends VitroAjaxController {
                 return;
             }
             log.debug("query for '" + qtxt +"' is " + query.toString());
+
+            Map<String, SearchFilter> filtersByField = SearchFiltering.readFilterConfigurations(vreq);
+            SearchFiltering.addPreconfiguredFiltersToQuery( query, filtersByField.values());
 
 			SearchEngine search = ApplicationUtils.instance().getSearchEngine();
             SearchResponse queryResponse = search.query(query);

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/search/controller/AutocompleteController.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/search/controller/AutocompleteController.java
@@ -9,6 +9,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import javax.servlet.ServletException;
 import javax.servlet.annotation.WebServlet;
@@ -100,9 +101,8 @@ public class AutocompleteController extends VitroAjaxController {
                 return;
             }
             log.debug("query for '" + qtxt +"' is " + query.toString());
-
-            Map<String, SearchFilter> filtersByField = SearchFiltering.readFilterConfigurations(vreq);
-            SearchFiltering.addPreconfiguredFiltersToQuery( query, filtersByField.values());
+            Set<String> currentRoles = SearchFiltering.getCurrentUserRoles(vreq);
+            SearchFiltering.addDefaultFilters( query, currentRoles);
 
 			SearchEngine search = ApplicationUtils.instance().getSearchEngine();
             SearchResponse queryResponse = search.query(query);

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/search/controller/PagedSearchController.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/search/controller/PagedSearchController.java
@@ -171,7 +171,7 @@ public class PagedSearchController extends FreemarkerHttpServlet {
                 log.debug(getSpentTime(startTime) + "ms spent before read filter configurations.");
             }
             Set<String> currentRoles = SearchFiltering.getCurrentUserRoles(vreq);
-            Map<String, SearchFilter> filterConfigurationsByField = SearchFiltering.readFilterConfigurations(currentRoles);
+            Map<String, SearchFilter> filterConfigurationsByField = SearchFiltering.readFilterConfigurations(currentRoles, vreq);
             if (log.isDebugEnabled()) {
                 log.debug(getSpentTime(startTime) + "ms spent before get sort configurations.");
             }
@@ -187,7 +187,7 @@ public class PagedSearchController extends FreemarkerHttpServlet {
             if (log.isDebugEnabled()) {
                 log.debug(getSpentTime(startTime) + "ms spent after setSelectedFilters.");
             }
-            Map<String, SortConfiguration> sortConfigurations = SearchFiltering.getSortConfigurations();
+            Map<String, SortConfiguration> sortConfigurations = SearchFiltering.getSortConfigurations(vreq);
             if (log.isDebugEnabled()) {
                 log.debug(getSpentTime(startTime) + "ms spent before get query configurations.");
             }
@@ -270,7 +270,7 @@ public class PagedSearchController extends FreemarkerHttpServlet {
                 Map<String, SearchFilter> filtersForTemplateById =
                         SearchFiltering.getFiltersForTemplate(filterConfigurationsByField);
                 body.put("filters", filtersForTemplateById);
-                body.put("filterGroups", SearchFiltering.readFilterGroupsConfigurations(filtersForTemplateById));
+                body.put("filterGroups", SearchFiltering.readFilterGroupsConfigurations(vreq, filtersForTemplateById));
                 body.put("sorting", sortConfigurations.values());
                 body.put("emptySearch", isEmptySearchFilters(filterConfigurationsByField));
             }
@@ -365,7 +365,7 @@ public class PagedSearchController extends FreemarkerHttpServlet {
                     }
                 }
                 if (searchFilter.isLocalizationRequired() && StringUtils.isBlank(filterValue.getName())) {
-                    String label = SearchFiltering.getUriLabel(value.getName());
+                    String label = SearchFiltering.getUriLabel(value.getName(), vreq);
                     if (!StringUtils.isBlank(label)) {
                         filterValue.setName(label);
                     }

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/search/controller/PagedSearchController.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/search/controller/PagedSearchController.java
@@ -170,11 +170,24 @@ public class PagedSearchController extends FreemarkerHttpServlet {
             if (log.isDebugEnabled()) {
                 log.debug(getSpentTime(startTime) + "ms spent before read filter configurations.");
             }
-            Map<String, SearchFilter> filterConfigurationsByField = SearchFiltering.readFilterConfigurations(vreq);
+            Set<String> currentRoles = SearchFiltering.getCurrentUserRoles(vreq);
+            Map<String, SearchFilter> filterConfigurationsByField = SearchFiltering.readFilterConfigurations(currentRoles);
             if (log.isDebugEnabled()) {
                 log.debug(getSpentTime(startTime) + "ms spent before get sort configurations.");
             }
-            Map<String, SortConfiguration> sortConfigurations = SearchFiltering.getSortConfigurations(vreq);
+            for (SearchFilter filter: filterConfigurationsByField.values()) {
+                filter.setInputText(SearchFiltering.getFilterInputText(vreq, filter.getId()));
+                filter.setRangeValues(SearchFiltering.getFilterRangeText(vreq, filter.getId()));
+            }
+            Map<String, List<String>> requestFilters = SearchFiltering.getRequestFilters(vreq);
+            if (log.isDebugEnabled()) {
+                log.debug(getSpentTime(startTime) + "ms spent after getRequestFilters.");
+            }
+            SearchFiltering.setSelectedFilters(filterConfigurationsByField, requestFilters);
+            if (log.isDebugEnabled()) {
+                log.debug(getSpentTime(startTime) + "ms spent after setSelectedFilters.");
+            }
+            Map<String, SortConfiguration> sortConfigurations = SearchFiltering.getSortConfigurations();
             if (log.isDebugEnabled()) {
                 log.debug(getSpentTime(startTime) + "ms spent before get query configurations.");
             }
@@ -257,7 +270,7 @@ public class PagedSearchController extends FreemarkerHttpServlet {
                 Map<String, SearchFilter> filtersForTemplateById =
                         SearchFiltering.getFiltersForTemplate(filterConfigurationsByField);
                 body.put("filters", filtersForTemplateById);
-                body.put("filterGroups", SearchFiltering.readFilterGroupsConfigurations(vreq, filtersForTemplateById));
+                body.put("filterGroups", SearchFiltering.readFilterGroupsConfigurations(filtersForTemplateById));
                 body.put("sorting", sortConfigurations.values());
                 body.put("emptySearch", isEmptySearchFilters(filterConfigurationsByField));
             }
@@ -352,7 +365,7 @@ public class PagedSearchController extends FreemarkerHttpServlet {
                     }
                 }
                 if (searchFilter.isLocalizationRequired() && StringUtils.isBlank(filterValue.getName())) {
-                    String label = SearchFiltering.getUriLabel(value.getName(), vreq);
+                    String label = SearchFiltering.getUriLabel(value.getName());
                     if (!StringUtils.isBlank(label)) {
                         filterValue.setName(label);
                     }

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/search/controller/SearchFiltering.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/search/controller/SearchFiltering.java
@@ -222,11 +222,16 @@ public class SearchFiltering {
         return requestFilters;
     }
 
-    public static Map<String, SearchFilter> readFilterConfigurations(Set<String> currentRoles) {
+    public static Map<String, SearchFilter> readFilterConfigurations(Set<String> currentRoles, VitroRequest vreq) {
         long startTime = System.nanoTime();
 
         Map<String, SearchFilter> filtersByField = new LinkedHashMap<>();
-        Model model = ModelAccess.getInstance().getOntModelSelector().getDisplayModel();
+        Model model;
+        if (vreq != null) {
+            model = ModelAccess.on(vreq).getOntModelSelector().getDisplayModel();
+        } else {
+            model = ModelAccess.getInstance().getOntModelSelector().getDisplayModel();
+        }
         if (model == null) {
             return filtersByField;
         }
@@ -281,7 +286,7 @@ public class SearchFiltering {
     }
 
     public static void addDefaultFilters(SearchQuery query, Set<String> currentRoles) {
-        Map<String, SearchFilter> filtersByField = SearchFiltering.readFilterConfigurations(currentRoles);
+        Map<String, SearchFilter> filtersByField = SearchFiltering.readFilterConfigurations(currentRoles, null);
         SearchFiltering.addPreconfiguredFiltersToQuery( query, filtersByField.values());
     }
 
@@ -305,9 +310,10 @@ public class SearchFiltering {
         }
     }
 
-    public static List<SearchFilterGroup> readFilterGroupsConfigurations(Map<String, SearchFilter> filtersById) {
+    public static List<SearchFilterGroup> readFilterGroupsConfigurations(VitroRequest vreq,
+            Map<String, SearchFilter> filtersById) {
         Map<String, SearchFilterGroup> groups = new LinkedHashMap<>();
-        Model model = ModelAccess.getInstance().getOntModelSelector().getDisplayModel();
+        Model model = ModelAccess.on(vreq).getOntModelSelector().getDisplayModel();
         model.enterCriticalSection(Lock.READ);
         try {
             Query facetQuery = QueryFactory.create(FILTER_GROUPS_QUERY);
@@ -345,9 +351,9 @@ public class SearchFiltering {
         return new LinkedList<SearchFilterGroup>(groups.values());
     }
 
-    public static Map<String, SortConfiguration> getSortConfigurations() {
+    public static Map<String, SortConfiguration> getSortConfigurations(VitroRequest vreq) {
         Map<String, SortConfiguration> sortConfigurations = new LinkedHashMap<>();
-        Model model = ModelAccess.getInstance().getOntModelSelector().getDisplayModel();
+        Model model = ModelAccess.on(vreq).getOntModelSelector().getDisplayModel();
         model.enterCriticalSection(Lock.READ);
         try {
             Query facetQuery = QueryFactory.create(SORT_QUERY);
@@ -521,9 +527,9 @@ public class SearchFiltering {
         return true;
     }
 
-    static String getUriLabel(String uri) {
+    static String getUriLabel(String uri, VitroRequest vreq) {
         String result = "";
-        Model model = ModelAccess.getInstance().getOntModelSelector().getFullModel();
+        Model model = ModelAccess.on(vreq).getOntModelSelector().getFullModel();
         model.enterCriticalSection(Lock.READ);
         try {
             QuerySolutionMap initialBindings = new QuerySolutionMap();

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/search/controller/SearchFiltering.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/search/controller/SearchFiltering.java
@@ -222,15 +222,14 @@ public class SearchFiltering {
         return requestFilters;
     }
 
-    public static Map<String, SearchFilter> readFilterConfigurations(VitroRequest vreq) {
+    public static Map<String, SearchFilter> readFilterConfigurations(Set<String> currentRoles) {
         long startTime = System.nanoTime();
 
         Map<String, SearchFilter> filtersByField = new LinkedHashMap<>();
-        Model model = ModelAccess.on(vreq).getOntModelSelector().getDisplayModel();
+        Model model = ModelAccess.getInstance().getOntModelSelector().getDisplayModel();
         if (model == null) {
             return filtersByField;
         }
-        Set<String> currentRoles = getCurrentUserRoles(vreq);
         model.enterCriticalSection(Lock.READ);
         try {
             Query facetQuery = QueryFactory.create(FILTER_QUERY);
@@ -249,7 +248,7 @@ public class SearchFiltering {
                 if (filtersByField.containsKey(resultFieldName)) {
                     filter = filtersByField.get(resultFieldName);
                 } else {
-                    filter = createSearchFilter(vreq, filtersByField, solution, resultFilterId, resultFieldName);
+                    filter = createSearchFilter(filtersByField, solution, resultFilterId, resultFieldName);
                 }
                 if (solution.get("value_id") == null) {
                     continue;
@@ -278,15 +277,12 @@ public class SearchFiltering {
         if (log.isDebugEnabled()) {
             log.debug(getSpentTime(startTime) + "ms spent after FILTER QUERY request.");
         }
-        Map<String, List<String>> requestFilters = getRequestFilters(vreq);
-        if (log.isDebugEnabled()) {
-            log.debug(getSpentTime(startTime) + "ms spent after getRequestFilters.");
-        }
-        setSelectedFilters(filtersByField, requestFilters);
-        if (log.isDebugEnabled()) {
-            log.debug(getSpentTime(startTime) + "ms spent after setSelectedFilters.");
-        }
         return sortFilters(filtersByField);
+    }
+
+    public static void addDefaultFilters(SearchQuery query, Set<String> currentRoles) {
+        Map<String, SearchFilter> filtersByField = SearchFiltering.readFilterConfigurations(currentRoles);
+        SearchFiltering.addPreconfiguredFiltersToQuery( query, filtersByField.values());
     }
 
     public static Map<String, SearchFilter> sortFilters(Map<String, SearchFilter> filters) {
@@ -309,10 +305,9 @@ public class SearchFiltering {
         }
     }
 
-    public static List<SearchFilterGroup> readFilterGroupsConfigurations(VitroRequest vreq,
-            Map<String, SearchFilter> filtersById) {
+    public static List<SearchFilterGroup> readFilterGroupsConfigurations(Map<String, SearchFilter> filtersById) {
         Map<String, SearchFilterGroup> groups = new LinkedHashMap<>();
-        Model model = ModelAccess.on(vreq).getOntModelSelector().getDisplayModel();
+        Model model = ModelAccess.getInstance().getOntModelSelector().getDisplayModel();
         model.enterCriticalSection(Lock.READ);
         try {
             Query facetQuery = QueryFactory.create(FILTER_GROUPS_QUERY);
@@ -350,9 +345,9 @@ public class SearchFiltering {
         return new LinkedList<SearchFilterGroup>(groups.values());
     }
 
-    public static Map<String, SortConfiguration> getSortConfigurations(VitroRequest vreq) {
+    public static Map<String, SortConfiguration> getSortConfigurations() {
         Map<String, SortConfiguration> sortConfigurations = new LinkedHashMap<>();
-        Model model = ModelAccess.on(vreq).getOntModelSelector().getDisplayModel();
+        Model model = ModelAccess.getInstance().getOntModelSelector().getDisplayModel();
         model.enterCriticalSection(Lock.READ);
         try {
             Query facetQuery = QueryFactory.create(SORT_QUERY);
@@ -397,7 +392,7 @@ public class SearchFiltering {
         return sortConfigurations;
     }
 
-    private static SearchFilter createSearchFilter(VitroRequest vreq, Map<String, SearchFilter> filtersByField,
+    private static SearchFilter createSearchFilter(Map<String, SearchFilter> filtersByField,
             QuerySolution solution, String resultFilterId, String resultFieldName) {
         SearchFilter filter;
         filter = new SearchFilter(resultFilterId);
@@ -444,10 +439,6 @@ public class SearchFiltering {
         if (moreLimit != null && moreLimit.isLiteral()) {
             filter.setMoreLimit(moreLimit.asLiteral().getInt());
         }
-
-        filter.setInputText(getFilterInputText(vreq, resultFilterId));
-        filter.setRangeValues(getFilterRangeText(vreq, resultFilterId));
-
         return filter;
     }
 
@@ -473,7 +464,7 @@ public class SearchFiltering {
         }
     }
 
-    private static String getFilterInputText(VitroRequest vreq, String name) {
+    static String getFilterInputText(VitroRequest vreq, String name) {
         if (PagedSearchController.PARAM_QUERY_TEXT.equals(name)) {
             return PagedSearchController.getQueryText(vreq);
         }
@@ -484,7 +475,7 @@ public class SearchFiltering {
         return "";
     }
 
-    private static String getFilterRangeText(VitroRequest vreq, String name) {
+    static String getFilterRangeText(VitroRequest vreq, String name) {
         String[] values = vreq.getParameterValues(SearchFiltering.FILTER_RANGE + name);
         if (values != null && values.length > 0) {
             return values[0];
@@ -492,7 +483,7 @@ public class SearchFiltering {
         return "";
     }
 
-    private static void setSelectedFilters(Map<String, SearchFilter> filtersByField,
+    public static void setSelectedFilters(Map<String, SearchFilter> filtersByField,
             Map<String, List<String>> requestFilters) {
         for (SearchFilter filter : filtersByField.values()) {
             if (requestFilters.containsKey(filter.getId())) {
@@ -510,7 +501,7 @@ public class SearchFiltering {
         }
     }
 
-    private static Set<String> getCurrentUserRoles(VitroRequest vreq) {
+    public static Set<String> getCurrentUserRoles(VitroRequest vreq) {
         UserAccount user = LoginStatusBean.getCurrentUser(vreq);
         if (user == null) {
             return Collections.singleton(ROLE_PUBLIC_URI);
@@ -530,9 +521,9 @@ public class SearchFiltering {
         return true;
     }
 
-    static String getUriLabel(String uri, VitroRequest vreq) {
+    static String getUriLabel(String uri) {
         String result = "";
-        Model model = ModelAccess.on(vreq).getOntModelSelector().getFullModel();
+        Model model = ModelAccess.getInstance().getOntModelSelector().getFullModel();
         model.enterCriticalSection(Lock.READ);
         try {
             QuerySolutionMap initialBindings = new QuerySolutionMap();

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/search/controller/SearchFiltering.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/search/controller/SearchFiltering.java
@@ -3,6 +3,7 @@ package edu.cornell.mannlib.vitro.webapp.search.controller;
 import static edu.cornell.mannlib.vitro.webapp.dao.VitroVocabulary.ROLE_PUBLIC_URI;
 
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.Enumeration;
@@ -151,7 +152,8 @@ public class SearchFiltering {
             + "    BIND(COALESCE(?bind_multilingual, false) as ?multilingual)\n"
             + "} ORDER BY ?sort_order ?label ";
 
-    public static void addFiltersToQuery(VitroRequest vreq, SearchQuery query, Map<String, SearchFilter> filterById) {
+    protected static void addFiltersToQuery(VitroRequest vreq, SearchQuery query,
+            Map<String, SearchFilter> filterById) {
         Enumeration<String> paramNames = vreq.getParameterNames();
         while (paramNames.hasMoreElements()) {
             String paramFilterName = paramNames.nextElement();
@@ -174,8 +176,11 @@ public class SearchFiltering {
 
             }
         }
-        for (String filterId : filterById.keySet()) {
-            SearchFilter searchFilter = filterById.get(filterId);
+        addPreconfiguredFiltersToQuery(query, filterById.values());
+    }
+
+    public static void addPreconfiguredFiltersToQuery(SearchQuery query, Collection<SearchFilter> collection) {
+        for (SearchFilter searchFilter : collection) {
             if (searchFilter.isInput()) {
                 SearchFiltering.addInputFilter(query, searchFilter);
             } else if (searchFilter.isRange()) {
@@ -222,6 +227,10 @@ public class SearchFiltering {
 
         Map<String, SearchFilter> filtersByField = new LinkedHashMap<>();
         Model model = ModelAccess.on(vreq).getOntModelSelector().getDisplayModel();
+        if (model == null) {
+            return filtersByField;
+        }
+        Set<String> currentRoles = getCurrentUserRoles(vreq);
         model.enterCriticalSection(Lock.READ);
         try {
             Query facetQuery = QueryFactory.create(FILTER_QUERY);
@@ -258,7 +267,6 @@ public class SearchFiltering {
                 RDFNode role = solution.get("role");
                 if (role != null && role.isResource()) {
                     String roleUri = role.asResource().getURI();
-                    Set<String> currentRoles = getCurrentUserRoles(vreq);
                     if (currentRoles.contains(roleUri)) {
                         value.setDefault(true);
                     }
@@ -557,7 +565,7 @@ public class SearchFiltering {
         }
     }
 
-    static Map<String, SearchFilter> getFiltersById(Map<String, SearchFilter> filtersByField) {
+    public static Map<String, SearchFilter> getFiltersById(Map<String, SearchFilter> filtersByField) {
         Map<String, SearchFilter> filtersById =
                 filtersByField.values().stream().collect(Collectors.toMap(SearchFilter::getId, Function.identity()));
         return filtersById;

--- a/api/src/test/java/stubs/edu/cornell/mannlib/vitro/webapp/modelaccess/RequestModelAccessStub.java
+++ b/api/src/test/java/stubs/edu/cornell/mannlib/vitro/webapp/modelaccess/RequestModelAccessStub.java
@@ -10,6 +10,7 @@ import org.apache.jena.query.Dataset;
 
 import edu.cornell.mannlib.vitro.webapp.dao.WebappDaoFactory;
 import edu.cornell.mannlib.vitro.webapp.dao.jena.OntModelSelector;
+import edu.cornell.mannlib.vitro.webapp.dao.jena.SimpleOntModelSelector;
 import edu.cornell.mannlib.vitro.webapp.modelaccess.ModelAccess.DatasetOption;
 import edu.cornell.mannlib.vitro.webapp.modelaccess.ModelAccess.LanguageOption;
 import edu.cornell.mannlib.vitro.webapp.modelaccess.ModelAccess.OntModelSelectorOption;
@@ -91,8 +92,7 @@ public class RequestModelAccessStub implements RequestModelAccess {
 	@Override
 	public OntModelSelector getOntModelSelector(
 			OntModelSelectorOption... options) {
-		throw new RuntimeException(
-				"RequestModelAccessStub.getOntModelSelector() not implemented.");
+	    return new SimpleOntModelSelector();
 	}
 
 	@Override


### PR DESCRIPTION
# What does this pull request do?
A follow-up PR for recently merged [PR-433](https://github.com/vivo-project/Vitro/pull/433) and [PR-434](https://github.com/vivo-project/Vitro/pull/434)
to apply role based search filters in existing endpoints.

# What's new?
Applied search filters in IndividualListController, AutocompleteController
Fixed unsafe DataAutoCompleteController, perform authorization checks for each returned result.
Refactored SearchFiltering methods to remove dependency on not needed VitroRequest parameter
Applied search filters to DefaultObjectPropertyFormGeneratory
Removed unused import in DefaultObjectPropertyFormGenerator

# How should this be tested?
A description of what steps someone could take to:
* Apply test data provided in PR https://github.com/vivo-project/Vitro/pull/434
* Try IndividualListController, Autocompletecontroller, DataAutoComplete controllers, DefaultObjectPropertyFormGenerator


# Interested parties
@VIVO-project/vivo-committers
