### PR TITLE
Fix for collated faux object properties display

### DIFF
--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/auth/policy/PolicyDecisionPoint.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/auth/policy/PolicyDecisionPoint.java
@@ -40,8 +40,8 @@ public class PolicyDecisionPoint {
             }
         }
 
-        pd = new BasicPolicyDecision(DecisionResult.INCONCLUSIVE,
-                "No policy returned a conclusive decision on " + ar.getAccessObject());
+        pd = new BasicPolicyDecision(DecisionResult.INCONCLUSIVE, String.format(
+                "No policy returned a conclusive decision on %s of %s", ar.getAccessOperation(), ar.getAccessObject()));
         logger.logNoDecision(pd);
         return pd;
     }

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/dao/filtering/filters/HideFromDisplayByPolicyFilter.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/dao/filtering/filters/HideFromDisplayByPolicyFilter.java
@@ -80,7 +80,7 @@ public class HideFromDisplayByPolicyFilter extends VitroFiltersImpl {
 			ObjectProperty predicate = getOrCreateProperty(ops);
 			String objectUri = ops.getObjectURI();
 			return checkAuthorization(new ObjectPropertyStatementAccessObject(
-					ModelAccess.getInstance().getOntModel(), subjectUri, predicate, objectUri));
+					null, subjectUri, predicate, objectUri));
 		}
 
 		/**

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/dao/filtering/filters/HideFromDisplayByPolicyFilter.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/dao/filtering/filters/HideFromDisplayByPolicyFilter.java
@@ -80,7 +80,7 @@ public class HideFromDisplayByPolicyFilter extends VitroFiltersImpl {
 			ObjectProperty predicate = getOrCreateProperty(ops);
 			String objectUri = ops.getObjectURI();
 			return checkAuthorization(new ObjectPropertyStatementAccessObject(
-					null, subjectUri, predicate, objectUri));
+					ModelAccess.getInstance().getOntModel(), subjectUri, predicate, objectUri));
 		}
 
 		/**

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/web/templatemodels/individual/CollatedObjectPropertyTemplateModel.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/web/templatemodels/individual/CollatedObjectPropertyTemplateModel.java
@@ -57,8 +57,12 @@ public class CollatedObjectPropertyTemplateModel extends
 					+ op.getURI());
 
 			/* Get the data */
-			List<Map<String, String>> statementData = getStatementData();
-
+			List<Map<String, String>> statementData;
+			if (op instanceof FauxPropertyWrapper) {
+				statementData = getUnfilteredStatementData();
+			} else {
+				statementData = getStatementData(); 
+			}
 			/* Apply post-processing */
 			postprocess(statementData);
 


### PR DESCRIPTION
**[VIVO GitHub issue](https://github.com/vivo-project/VIVO/issues/3946)**

* Other Relevant Links (Mailing list discussion, related pull requests, etc.)

# What does this pull request do?
Fix for the issue linked above.
Use unfiltered statement data for faux object properties the same way it is used in [UncollatedObjectPropertyTemplateModel](https://github.com/vivo-project/Vitro/blob/03517df59ab02108f81f19d8ff383e20f9c556ca/api/src/main/java/edu/cornell/mannlib/vitro/webapp/web/templatemodels/individual/UncollatedObjectPropertyTemplateModel.java#L35) to prevent faux object property statements from being filtered out from display.

# How should this be tested?
A description of what steps someone could take to:
* Reproduce the problem in the issue
* Test that the pull request fixes it.

# Additional Notes:
Included operation name for inconclusive decision log entries.

# Interested parties
@chenejac 
