### PR TITLE
Support self editor profile matching by using External Auth ID

### DIFF
--- a/api/src/main/java/edu/cornell/mannlib/vedit/beans/LoginStatusBean.java
+++ b/api/src/main/java/edu/cornell/mannlib/vedit/beans/LoginStatusBean.java
@@ -2,7 +2,6 @@
 
 package edu.cornell.mannlib.vedit.beans;
 
-import javax.servlet.ServletContext;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpSession;
 
@@ -100,9 +99,7 @@ public class LoginStatusBean {
 		if (!getBean(session).isLoggedIn()) {
 			return null;
 		}
-
-		ServletContext ctx = session.getServletContext();
-		WebappDaoFactory wadf = ModelAccess.on(ctx).getWebappDaoFactory();
+		WebappDaoFactory wadf = ModelAccess.getInstance().getWebappDaoFactory();
 		UserAccountsDao userAccountsDao = wadf.getUserAccountsDao();
 		if (userAccountsDao == null) {
 			log.error("No UserAccountsDao");

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/auth/checks/SparqlSelectQueryResultsChecker.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/auth/checks/SparqlSelectQueryResultsChecker.java
@@ -27,21 +27,22 @@ import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.RDFNode;
 
 public class SparqlSelectQueryResultsChecker {
-    private static final String VAR_PROFILE_URI = "profileUri";
-    private static final String VAR_EXTERNAL_AUTH_ID = "externalAuthId";
-    private static final String VAR_MATCHING_PROPERTY_URI = "matchingPropertyUri";
-    private static final String VAR_OBJECT_URI = "objectUri";
+    private static final String PROFILE_URI = "profileUri";
+    private static final String EXTERNAL_AUTH_ID = "externalAuthId";
+    private static final String MATCHING_PROPERTY_URI = "matchingPropertyUri";
+    private static final String OBJECT_URI = "objectUri";
     private static final Log log = LogFactory.getLog(SparqlSelectQueryResultsChecker.class);
 
     public static boolean sparqlSelectQueryResultsContain(Check check, AuthorizationRequest ar, String[] inputValues) {
         String query = check.getConfiguration();
         if (StringUtils.isBlank(query)) {
             query = check.getValues().getSingleValue();
+            if (StringUtils.isBlank(query)) {
+                log.error("Sparql query is empty.");
+                return false;
+            }
         }
-        if (StringUtils.isBlank(query)) {
-            log.error("Sparql query is empty.");
-            return false;
-        }
+
         AccessObject ao = ar.getAccessObject();
         Model m = ao.getModel();
         if (m == null) {
@@ -61,13 +62,13 @@ public class SparqlSelectQueryResultsChecker {
             return makeProfileUriMatchQuery(ar, query, m, comparedValues);
         }
 
-        if (query.contains("?" + VAR_EXTERNAL_AUTH_ID) && externalAuthIdIsNotAvailable(ar)) {
-            logVariableNotAvailable(VAR_EXTERNAL_AUTH_ID);
+        if (query.contains("?" + EXTERNAL_AUTH_ID) && externalAuthIdIsNotAvailable(ar)) {
+            logVariableNotAvailable(EXTERNAL_AUTH_ID);
             return false;
         }
 
-        if (query.contains("?" + VAR_MATCHING_PROPERTY_URI) && matchingPropertyUriIsNotAvailable()) {
-            logVariableNotAvailable(VAR_MATCHING_PROPERTY_URI);
+        if (query.contains("?" + MATCHING_PROPERTY_URI) && matchingPropertyUriIsNotAvailable()) {
+            logVariableNotAvailable(MATCHING_PROPERTY_URI);
             return false;
         }
 
@@ -145,19 +146,19 @@ public class SparqlSelectQueryResultsChecker {
     }
 
     private static void setVariables(String profileUri, AuthorizationRequest ar, ParameterizedSparqlString pss) {
-        pss.setIri(VAR_PROFILE_URI, profileUri);
+        pss.setIri(PROFILE_URI, profileUri);
         AccessObject object = ar.getAccessObject();
         Optional<String> uri = object.getUri();
         if (uri.isPresent()) {
-            pss.setIri(VAR_OBJECT_URI, uri.get());
+            pss.setIri(OBJECT_URI, uri.get());
         }
         String externalAuthId = ar.getExternalAuthId();
         if (!StringUtils.isBlank(externalAuthId)) {
-            pss.setLiteral(VAR_EXTERNAL_AUTH_ID, externalAuthId);
+            pss.setLiteral(EXTERNAL_AUTH_ID, externalAuthId);
         }
         String matchingPropertyUri = SelfEditingConfiguration.getInstance().getMatchingPropertyUri();
         if (!StringUtils.isBlank(matchingPropertyUri)) {
-            pss.setIri(VAR_MATCHING_PROPERTY_URI, matchingPropertyUri);
+            pss.setIri(MATCHING_PROPERTY_URI, matchingPropertyUri);
         }
     }
 
@@ -182,7 +183,7 @@ public class SparqlSelectQueryResultsChecker {
 
     private static String createQueryMapKey(String profileUri, String queryTemplate, AuthorizationRequest ar) {
         String mapKey = queryTemplate + "." + profileUri;
-        if (queryTemplate.contains("?" + VAR_OBJECT_URI)) {
+        if (queryTemplate.contains("?" + OBJECT_URI)) {
             AccessObject object = ar.getAccessObject();
             Optional<String> uri = object.getUri();
             if (uri.isPresent()) {
@@ -207,7 +208,7 @@ public class SparqlSelectQueryResultsChecker {
     }
 
     private static boolean isProfileUriRelatedQuery(String queryTemplate) {
-        return queryTemplate.contains("?" + VAR_PROFILE_URI);
+        return queryTemplate.contains("?" + PROFILE_URI);
     }
 
 }

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/auth/checks/SubjectRoleCheck.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/auth/checks/SubjectRoleCheck.java
@@ -2,11 +2,13 @@
 
 package edu.cornell.mannlib.vitro.webapp.auth.checks;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import edu.cornell.mannlib.vitro.webapp.auth.attributes.Attribute;
 import edu.cornell.mannlib.vitro.webapp.auth.attributes.AttributeValueSet;
 import edu.cornell.mannlib.vitro.webapp.auth.requestedAction.AuthorizationRequest;
+import edu.cornell.mannlib.vitro.webapp.dao.VitroVocabulary;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
@@ -20,7 +22,10 @@ public class SubjectRoleCheck extends AbstractCheck {
 
     @Override
     public boolean check(AuthorizationRequest ar) {
-        final List<String> inputValues = ar.getRoleUris();
+        List<String> inputValues = new ArrayList<String>(ar.getRoleUris());
+        if (inputValues.isEmpty()) {
+            inputValues.add(VitroVocabulary.ROLE_PUBLIC_URI);
+        }
         if (AttributeValueChecker.test(this, ar, inputValues.toArray(new String[0]))) {
             log.debug("Attribute match requested '" + inputValues + "'");
             return true;

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/auth/checks/SubjectTypeCheck.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/auth/checks/SubjectTypeCheck.java
@@ -4,8 +4,6 @@ package edu.cornell.mannlib.vitro.webapp.auth.checks;
 
 import edu.cornell.mannlib.vitro.webapp.auth.attributes.Attribute;
 import edu.cornell.mannlib.vitro.webapp.auth.attributes.AttributeValueSet;
-import edu.cornell.mannlib.vitro.webapp.auth.identifier.IdentifierBundle;
-import edu.cornell.mannlib.vitro.webapp.auth.identifier.common.IsRootUser;
 import edu.cornell.mannlib.vitro.webapp.auth.requestedAction.AuthorizationRequest;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -20,8 +18,7 @@ public class SubjectTypeCheck extends AbstractCheck {
 
     @Override
     public boolean check(AuthorizationRequest ar) {
-        IdentifierBundle ac_subject = ar.getIds();
-        String inputValue = IsRootUser.isRootUser(ac_subject) ? "ROOT_USER" : "";
+        String inputValue = ar.isRootUser() ? "ROOT_USER" : "";
         if (AttributeValueChecker.test(this, ar, inputValue)) {
             log.debug("Attribute subject type match requested object type '");
             return true;

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/auth/requestedAction/AndAuthorizationRequest.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/auth/requestedAction/AndAuthorizationRequest.java
@@ -6,7 +6,6 @@ import java.util.Arrays;
 import java.util.List;
 
 import edu.cornell.mannlib.vitro.webapp.auth.attributes.AccessOperation;
-import edu.cornell.mannlib.vitro.webapp.auth.identifier.IdentifierBundle;
 import edu.cornell.mannlib.vitro.webapp.auth.objects.AccessObject;
 
 public class AndAuthorizationRequest extends AuthorizationRequest {
@@ -40,11 +39,6 @@ public class AndAuthorizationRequest extends AuthorizationRequest {
 
     @Override
     public AccessOperation getAccessOperation() {
-        return null;
-    }
-
-    @Override
-    public IdentifierBundle getIds() {
         return null;
     }
 

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/auth/requestedAction/AuthorizationRequest.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/auth/requestedAction/AuthorizationRequest.java
@@ -4,11 +4,12 @@ package edu.cornell.mannlib.vitro.webapp.auth.requestedAction;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 
 import edu.cornell.mannlib.vitro.webapp.auth.attributes.AccessOperation;
-import edu.cornell.mannlib.vitro.webapp.auth.identifier.IdentifierBundle;
 import edu.cornell.mannlib.vitro.webapp.auth.objects.AccessObject;
 import edu.cornell.mannlib.vitro.webapp.auth.policy.ifaces.DecisionResult;
+import edu.cornell.mannlib.vitro.webapp.beans.UserAccount;
 
 public abstract class AuthorizationRequest {
 
@@ -17,14 +18,7 @@ public abstract class AuthorizationRequest {
     
     public static enum WRAP_TYPE { AND , OR } ; 
     
-    IdentifierBundle ids;
-    private List<String> editorUris = Collections.emptyList();
-    List<String> roleUris = Collections.emptyList();
-
-    
-    public void setRoleUris(List<String> roleUris) {
-        this.roleUris = roleUris;
-    }
+    private UserAccount userAccount;
 
     public WRAP_TYPE getWrapType() {
         return null;
@@ -42,24 +36,20 @@ public abstract class AuthorizationRequest {
     
     public abstract AccessOperation getAccessOperation();
 
-    public IdentifierBundle getIds() {
-        return ids;
-    }
-    
-    public List<String> getRoleUris() {
-        return roleUris;
-    }
-    
-    public void setIds(IdentifierBundle ids) {
-        this.ids = ids;
+    public Set<String> getRoleUris() {
+        return userAccount.getPermissionSetUris();
     }
 
-    public void setEditorUris(List<String> list) {
-        editorUris = list;
+    public void setUserAccount(UserAccount userAccount) {
+        this.userAccount = userAccount;
+    }
+    
+    public UserAccount getUserAccount() {
+        return userAccount;
     }
 
-    public List<String> getEditorUris(){
-        return editorUris;
+    public Set<String> getEditorUris() {
+        return userAccount.getProxiedIndividualUris();
     }
 
     public static AuthorizationRequest or(AuthorizationRequest fist, AuthorizationRequest second) {
@@ -79,14 +69,13 @@ public abstract class AuthorizationRequest {
     @Override
     public String toString() {
         String result = "";
-        if (!getRoleUris().isEmpty()) {
-            result += String.format("User with roles '%s' ", getRoleUris().toString());
-        }
-        if (!getEditorUris().isEmpty()) {
-            result += String.format(" profile uris '%s' ", getEditorUris().toString());
-        }
         result += String.format(" requested '%s' ", getAccessOperation());
         result += String.format(" on '%s' ", getAccessObject());
         return result;
     }
+
+    public boolean isRootUser() {
+        return userAccount.isRootUser();
+    }
+
 }

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/auth/requestedAction/AuthorizationRequest.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/auth/requestedAction/AuthorizationRequest.java
@@ -51,6 +51,10 @@ public abstract class AuthorizationRequest {
     public Set<String> getEditorUris() {
         return userAccount.getProxiedIndividualUris();
     }
+    
+    public String getExternalAuthId() {
+        return userAccount.getExternalAuthId();
+    }
 
     public static AuthorizationRequest or(AuthorizationRequest fist, AuthorizationRequest second) {
         if (fist == null) {

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/auth/requestedAction/ForbiddenAuthorizationRequest.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/auth/requestedAction/ForbiddenAuthorizationRequest.java
@@ -3,7 +3,6 @@
 package edu.cornell.mannlib.vitro.webapp.auth.requestedAction;
 
 import edu.cornell.mannlib.vitro.webapp.auth.attributes.AccessOperation;
-import edu.cornell.mannlib.vitro.webapp.auth.identifier.IdentifierBundle;
 import edu.cornell.mannlib.vitro.webapp.auth.objects.AccessObject;
 import edu.cornell.mannlib.vitro.webapp.auth.policy.ifaces.DecisionResult;
 
@@ -30,8 +29,4 @@ public class ForbiddenAuthorizationRequest extends AuthorizationRequest {
         return null;
     }
 
-    @Override
-    public IdentifierBundle getIds() {
-        return null;
-    }
 }

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/auth/requestedAction/OrAuthorizationRequest.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/auth/requestedAction/OrAuthorizationRequest.java
@@ -6,7 +6,6 @@ import java.util.Arrays;
 import java.util.List;
 
 import edu.cornell.mannlib.vitro.webapp.auth.attributes.AccessOperation;
-import edu.cornell.mannlib.vitro.webapp.auth.identifier.IdentifierBundle;
 import edu.cornell.mannlib.vitro.webapp.auth.objects.AccessObject;
 
 public class OrAuthorizationRequest extends AuthorizationRequest {
@@ -40,11 +39,6 @@ public class OrAuthorizationRequest extends AuthorizationRequest {
 
     @Override
     public AccessOperation getAccessOperation() {
-        return null;
-    }
-
-    @Override
-    public IdentifierBundle getIds() {
         return null;
     }
 

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/authenticate/RestrictedAuthenticator.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/authenticate/RestrictedAuthenticator.java
@@ -7,8 +7,6 @@ import java.util.List;
 import javax.servlet.http.HttpServletRequest;
 
 import edu.cornell.mannlib.vedit.beans.LoginStatusBean.AuthenticationSource;
-import edu.cornell.mannlib.vitro.webapp.auth.identifier.ArrayIdentifierBundle;
-import edu.cornell.mannlib.vitro.webapp.auth.identifier.RequestIdentifiers;
 import edu.cornell.mannlib.vitro.webapp.auth.permissions.SimplePermission;
 import edu.cornell.mannlib.vitro.webapp.auth.policy.PolicyHelper;
 import edu.cornell.mannlib.vitro.webapp.beans.UserAccount;
@@ -47,11 +45,7 @@ public class RestrictedAuthenticator extends Authenticator {
 			return false;
 		}
 
-		ArrayIdentifierBundle ids = new ArrayIdentifierBundle();
-		ids.addAll(getIdsForUserAccount(userAccount));
-		ids.addAll(RequestIdentifiers.getIdBundleForRequest(req));
-
-		return PolicyHelper.isAuthorizedForActions(ids, SimplePermission.LOGIN_DURING_MAINTENANCE.ACTION);
+		return PolicyHelper.isAuthorizedForActions(userAccount, SimplePermission.LOGIN_DURING_MAINTENANCE.ACTION);
 	}
 
 	@Override

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/dao/filtering/filters/FilterByDisplayPermission.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/dao/filtering/filters/FilterByDisplayPermission.java
@@ -5,8 +5,6 @@ package edu.cornell.mannlib.vitro.webapp.dao.filtering.filters;
 import static edu.cornell.mannlib.vitro.webapp.auth.objects.AccessObject.SOME_URI;
 
 import edu.cornell.mannlib.vitro.webapp.auth.attributes.AccessOperation;
-import edu.cornell.mannlib.vitro.webapp.auth.identifier.ActiveIdentifierBundleFactories;
-import edu.cornell.mannlib.vitro.webapp.auth.identifier.IdentifierBundle;
 import edu.cornell.mannlib.vitro.webapp.auth.objects.AccessObject;
 import edu.cornell.mannlib.vitro.webapp.auth.objects.DataPropertyAccessObject;
 import edu.cornell.mannlib.vitro.webapp.auth.objects.DataPropertyStatementAccessObject;
@@ -17,6 +15,7 @@ import edu.cornell.mannlib.vitro.webapp.beans.DataProperty;
 import edu.cornell.mannlib.vitro.webapp.beans.DataPropertyStatement;
 import edu.cornell.mannlib.vitro.webapp.beans.ObjectProperty;
 import edu.cornell.mannlib.vitro.webapp.beans.ObjectPropertyStatement;
+import edu.cornell.mannlib.vitro.webapp.beans.UserAccount;
 import net.sf.jga.fn.UnaryFunctor;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -27,7 +26,7 @@ import org.apache.commons.logging.LogFactory;
  */
 public class FilterByDisplayPermission extends VitroFiltersImpl {
     private static final Log log = LogFactory.getLog(FilterByDisplayPermission.class);
-    IdentifierBundle accessSubject = ActiveIdentifierBundleFactories.getUserIdentifierBundle(null);
+    UserAccount userAccount = PolicyHelper.getUserAccount(null);
 
     public FilterByDisplayPermission() {
         setDataPropertyFilter(new DataPropertyFilterByPolicy());
@@ -37,7 +36,7 @@ public class FilterByDisplayPermission extends VitroFiltersImpl {
     }
 
     boolean checkAuthorization(AccessObject accessObject) {
-        boolean decision = PolicyHelper.isAuthorizedForActions(accessSubject, accessObject, AccessOperation.DISPLAY);
+        boolean decision = PolicyHelper.isAuthorizedForActions(userAccount, accessObject, AccessOperation.DISPLAY);
         log.debug("decision is " + decision);
         return decision;
     }

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/dao/filtering/filters/HideFromDisplayByPolicyFilter.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/dao/filtering/filters/HideFromDisplayByPolicyFilter.java
@@ -3,14 +3,12 @@
 package edu.cornell.mannlib.vitro.webapp.dao.filtering.filters;
 
 import net.sf.jga.fn.UnaryFunctor;
-
-import static edu.cornell.mannlib.vitro.webapp.auth.objects.AccessObject.SOME_URI;
-
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
+import static edu.cornell.mannlib.vitro.webapp.auth.objects.AccessObject.SOME_URI;
+
 import edu.cornell.mannlib.vitro.webapp.auth.attributes.AccessOperation;
-import edu.cornell.mannlib.vitro.webapp.auth.identifier.IdentifierBundle;
 import edu.cornell.mannlib.vitro.webapp.auth.objects.AccessObject;
 import edu.cornell.mannlib.vitro.webapp.auth.objects.DataPropertyAccessObject;
 import edu.cornell.mannlib.vitro.webapp.auth.objects.DataPropertyStatementAccessObject;
@@ -22,21 +20,23 @@ import edu.cornell.mannlib.vitro.webapp.beans.DataPropertyStatement;
 import edu.cornell.mannlib.vitro.webapp.beans.ObjectProperty;
 import edu.cornell.mannlib.vitro.webapp.beans.ObjectPropertyStatement;
 import edu.cornell.mannlib.vitro.webapp.modelaccess.ModelAccess;
+import edu.cornell.mannlib.vitro.webapp.beans.UserAccount;
 
 /**
  * Ask the current policies whether we can show these things to the user.
  */
 public class HideFromDisplayByPolicyFilter extends VitroFiltersImpl {
-	private static final Log log = LogFactory
-			.getLog(HideFromDisplayByPolicyFilter.class);
 
-	private final IdentifierBundle idBundle;
+    private static final Log log = LogFactory.getLog(HideFromDisplayByPolicyFilter.class);
 
-	public HideFromDisplayByPolicyFilter(IdentifierBundle idBundle) {
-		if (idBundle == null) {
-			throw new NullPointerException("idBundle may not be null.");
+	private final UserAccount userAccount;
+
+	public HideFromDisplayByPolicyFilter(UserAccount userAccount) {
+		if (userAccount == null) {
+		    log.debug("UserAccount provided for PolicyFilter is null. Fall back to default user account.");
+			userAccount = PolicyHelper.getUserAccount(null);
 		}
-		this.idBundle = idBundle;
+		this.userAccount = userAccount;
 
 		setDataPropertyFilter(new DataPropertyFilterByPolicy());
 		setObjectPropertyFilter(new ObjectPropertyFilterByPolicy());
@@ -45,7 +45,7 @@ public class HideFromDisplayByPolicyFilter extends VitroFiltersImpl {
 	}
 
 	boolean checkAuthorization(AccessObject whatToAuth) {
-	    return PolicyHelper.isAuthorizedForActions(idBundle, whatToAuth, AccessOperation.DISPLAY);
+	    return PolicyHelper.isAuthorizedForActions(userAccount, whatToAuth, AccessOperation.DISPLAY);
 	}
 
 	private class DataPropertyFilterByPolicy extends

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/modelaccess/impl/RequestModelAccessImpl.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/modelaccess/impl/RequestModelAccessImpl.java
@@ -21,7 +21,7 @@ import org.apache.commons.logging.LogFactory;
 
 import org.apache.jena.ontology.OntModel;
 import org.apache.jena.query.Dataset;
-
+import edu.cornell.mannlib.vedit.beans.LoginStatusBean;
 import edu.cornell.mannlib.vitro.webapp.auth.identifier.RequestIdentifiers;
 import edu.cornell.mannlib.vitro.webapp.auth.policy.PolicyStore;
 import edu.cornell.mannlib.vitro.webapp.config.ConfigurationProperties;
@@ -340,7 +340,7 @@ public class RequestModelAccessImpl implements RequestModelAccess {
 
 	private WebappDaoFactory addPolicyAwareness(WebappDaoFactory unaware) {
 		HideFromDisplayByPolicyFilter filter = new HideFromDisplayByPolicyFilter(
-				RequestIdentifiers.getIdBundleForRequest(req));
+				LoginStatusBean.getCurrentUser(req));
 		return new WebappDaoFactoryFiltering(unaware, filter);
 	}
 

--- a/api/src/test/java/edu/cornell/mannlib/vitro/webapp/auth/policy/AllowDisplayIndividualPagePolicyTest.java
+++ b/api/src/test/java/edu/cornell/mannlib/vitro/webapp/auth/policy/AllowDisplayIndividualPagePolicyTest.java
@@ -15,7 +15,7 @@ import java.util.Set;
 import edu.cornell.mannlib.vitro.webapp.auth.objects.AccessObject;
 import edu.cornell.mannlib.vitro.webapp.auth.objects.IndividualAccessObject;
 import edu.cornell.mannlib.vitro.webapp.auth.objects.NamedAccessObject;
-import edu.cornell.mannlib.vitro.webapp.auth.requestedAction.SimpleAuthorizationRequest;
+import edu.cornell.mannlib.vitro.webapp.auth.requestedAction.TestAuthorizationRequest;
 import org.junit.Test;
 
 public class AllowDisplayIndividualPagePolicyTest extends PolicyTest {
@@ -33,13 +33,13 @@ public class AllowDisplayIndividualPagePolicyTest extends PolicyTest {
         assertEquals(1000, policy.getPriority());
         countRulesAndAttributes(policy, 1, Collections.singleton(2));
         AccessObject ao = new IndividualAccessObject("https://test-individual");
-        SimpleAuthorizationRequest ar = new SimpleAuthorizationRequest(ao, DISPLAY);
+        TestAuthorizationRequest ar = new TestAuthorizationRequest(ao, DISPLAY);
         ar.setRoleUris(Arrays.asList(PUBLIC));
         assertEquals(AUTHORIZED, policy.decide(ar).getDecisionResult());
-        ar = new SimpleAuthorizationRequest(ao, ADD);
+        ar = new TestAuthorizationRequest(ao, ADD);
         assertEquals(INCONCLUSIVE, policy.decide(ar).getDecisionResult());
         ao = new NamedAccessObject("https://test-individual");
-        ar = new SimpleAuthorizationRequest(ao, DISPLAY);
+        ar = new TestAuthorizationRequest(ao, DISPLAY);
         assertEquals(INCONCLUSIVE, policy.decide(ar).getDecisionResult());
     }
 }

--- a/api/src/test/java/edu/cornell/mannlib/vitro/webapp/auth/policy/EditablePagesPolicyTest.java
+++ b/api/src/test/java/edu/cornell/mannlib/vitro/webapp/auth/policy/EditablePagesPolicyTest.java
@@ -13,7 +13,7 @@ import java.util.Set;
 import edu.cornell.mannlib.vitro.webapp.auth.attributes.AccessOperation;
 import edu.cornell.mannlib.vitro.webapp.auth.objects.ObjectPropertyStatementAccessObject;
 import edu.cornell.mannlib.vitro.webapp.auth.policy.ifaces.DecisionResult;
-import edu.cornell.mannlib.vitro.webapp.auth.requestedAction.SimpleAuthorizationRequest;
+import edu.cornell.mannlib.vitro.webapp.auth.requestedAction.TestAuthorizationRequest;
 import edu.cornell.mannlib.vitro.webapp.auth.rules.AccessRule;
 import org.junit.Test;
 
@@ -49,7 +49,7 @@ public class EditablePagesPolicyTest extends PolicyTest {
         AccessOperation operation = AccessOperation.EDIT;
         ObjectPropertyStatementAccessObject object =
                 new ObjectPropertyStatementAccessObject(null, "test://uri", SOME_PREDICATE, SOME_URI);
-        SimpleAuthorizationRequest ar = new SimpleAuthorizationRequest(object, operation);
+        TestAuthorizationRequest ar = new TestAuthorizationRequest(object, operation);
         ar.setRoleUris(Arrays.asList(CURATOR));
         assertEquals(DecisionResult.INCONCLUSIVE, policy.decide(ar).getDecisionResult());
         ar.setRoleUris(Arrays.asList(ADMIN));
@@ -70,7 +70,7 @@ public class EditablePagesPolicyTest extends PolicyTest {
         AccessOperation operation = AccessOperation.EDIT;
         ObjectPropertyStatementAccessObject object =
                 new ObjectPropertyStatementAccessObject(null, "test://uri", SOME_PREDICATE, SOME_URI);
-        SimpleAuthorizationRequest ar = new SimpleAuthorizationRequest(object, operation);
+        TestAuthorizationRequest ar = new TestAuthorizationRequest(object, operation);
         ar.setRoleUris(Arrays.asList(ADMIN));
         assertEquals(DecisionResult.INCONCLUSIVE, policy.decide(ar).getDecisionResult());
         ar.setRoleUris(Arrays.asList(CURATOR));
@@ -91,7 +91,7 @@ public class EditablePagesPolicyTest extends PolicyTest {
         AccessOperation operation = AccessOperation.EDIT;
         ObjectPropertyStatementAccessObject object =
                 new ObjectPropertyStatementAccessObject(null, "test://uri", SOME_PREDICATE, SOME_URI);
-        SimpleAuthorizationRequest ar = new SimpleAuthorizationRequest(object, operation);
+        TestAuthorizationRequest ar = new TestAuthorizationRequest(object, operation);
         ar.setRoleUris(Arrays.asList(ADMIN));
         assertEquals(DecisionResult.INCONCLUSIVE, policy.decide(ar).getDecisionResult());
         ar.setRoleUris(Arrays.asList(EDITOR));
@@ -118,7 +118,7 @@ public class EditablePagesPolicyTest extends PolicyTest {
         AccessOperation operation = AccessOperation.EDIT;
         ObjectPropertyStatementAccessObject object =
                 new ObjectPropertyStatementAccessObject(null, "test://uri", SOME_PREDICATE, SOME_URI);
-        SimpleAuthorizationRequest ar = new SimpleAuthorizationRequest(object, operation);
+        TestAuthorizationRequest ar = new TestAuthorizationRequest(object, operation);
         ar.setRoleUris(Arrays.asList(PUBLIC));
         assertEquals(DecisionResult.INCONCLUSIVE, policy.decide(ar).getDecisionResult());
         ar.setRoleUris(Arrays.asList(CUSTOM));

--- a/api/src/test/java/edu/cornell/mannlib/vitro/webapp/auth/policy/EditablePagesPolicyTest.java
+++ b/api/src/test/java/edu/cornell/mannlib/vitro/webapp/auth/policy/EditablePagesPolicyTest.java
@@ -32,7 +32,7 @@ public class EditablePagesPolicyTest extends PolicyTest {
         assertEquals(1, policies.size());
         DynamicPolicy policy = policies.iterator().next();
         assertTrue(policy != null);
-        countRulesAndAttributes(policy, 1, new HashSet<>(Arrays.asList(6)));
+        countRulesAndAttributes(policy, 2, new HashSet<>(Arrays.asList(6)));
     }
 
     @Test

--- a/api/src/test/java/edu/cornell/mannlib/vitro/webapp/auth/policy/ProximityTest.java
+++ b/api/src/test/java/edu/cornell/mannlib/vitro/webapp/auth/policy/ProximityTest.java
@@ -4,13 +4,14 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.Set;
 
 import edu.cornell.mannlib.vitro.webapp.auth.attributes.AccessOperation;
 import edu.cornell.mannlib.vitro.webapp.auth.objects.AccessObject;
 import edu.cornell.mannlib.vitro.webapp.auth.objects.ObjectPropertyStatementAccessObject;
 import edu.cornell.mannlib.vitro.webapp.auth.policy.ifaces.DecisionResult;
-import edu.cornell.mannlib.vitro.webapp.auth.requestedAction.SimpleAuthorizationRequest;
+import edu.cornell.mannlib.vitro.webapp.auth.requestedAction.TestAuthorizationRequest;
 import edu.cornell.mannlib.vitro.webapp.auth.rules.AccessRule;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
@@ -43,12 +44,12 @@ public class ProximityTest extends PolicyTest {
             targetModel.leaveCriticalSection();
         }
         AccessObject ao = new ObjectPropertyStatementAccessObject(targetModel, "test:publication", null, null);
-        SimpleAuthorizationRequest ar = new SimpleAuthorizationRequest(ao, AccessOperation.EDIT);
-        ar.setEditorUris(Arrays.asList("test:bob"));
+        TestAuthorizationRequest ar = new TestAuthorizationRequest(ao, AccessOperation.EDIT);
+        ar.setEditorUris(new HashSet(Arrays.asList("test:bob")));
         assertEquals(DecisionResult.INCONCLUSIVE, policy.decide(ar).getDecisionResult());
-        ar = new SimpleAuthorizationRequest(ao, AccessOperation.EDIT);
-        ar.setEditorUris(Arrays.asList("test:alice"));
+        ar = new TestAuthorizationRequest(ao, AccessOperation.EDIT);
+        ar.setEditorUris(new HashSet(Arrays.asList("test:alice")));
         assertEquals(DecisionResult.AUTHORIZED, policy.decide(ar).getDecisionResult());
-        ar = new SimpleAuthorizationRequest(ao, AccessOperation.EDIT);
+        ar = new TestAuthorizationRequest(ao, AccessOperation.EDIT);
     }
 }

--- a/api/src/test/java/edu/cornell/mannlib/vitro/webapp/auth/policy/SimplePermissionTemplateTest.java
+++ b/api/src/test/java/edu/cornell/mannlib/vitro/webapp/auth/policy/SimplePermissionTemplateTest.java
@@ -9,7 +9,7 @@ import edu.cornell.mannlib.vitro.webapp.auth.attributes.AccessObjectType;
 import edu.cornell.mannlib.vitro.webapp.auth.attributes.AccessOperation;
 import edu.cornell.mannlib.vitro.webapp.auth.permissions.SimplePermission;
 import edu.cornell.mannlib.vitro.webapp.auth.policy.ifaces.DecisionResult;
-import edu.cornell.mannlib.vitro.webapp.auth.requestedAction.SimpleAuthorizationRequest;
+import edu.cornell.mannlib.vitro.webapp.auth.requestedAction.TestAuthorizationRequest;
 import edu.cornell.mannlib.vitro.webapp.auth.rules.AccessRule;
 import org.junit.Test;
 
@@ -36,7 +36,7 @@ public class SimplePermissionTemplateTest extends PolicyTest {
         assertEquals(true, rule.isAllowMatched());
         assertEquals(4, rule.getChecksCount());
 
-        SimpleAuthorizationRequest ar = new SimpleAuthorizationRequest(SimplePermission.NS + "SeeSiteAdminPage");
+        TestAuthorizationRequest ar = new TestAuthorizationRequest(SimplePermission.NS + "SeeSiteAdminPage");
         ar.setRoleUris(Arrays.asList(CURATOR));
         assertEquals(DecisionResult.INCONCLUSIVE, policy.decide(ar).getDecisionResult());
         ar.setRoleUris(Arrays.asList(ADMIN));
@@ -57,7 +57,7 @@ public class SimplePermissionTemplateTest extends PolicyTest {
         assertEquals(true, rule.isAllowMatched());
         assertEquals(4, rule.getChecksCount());
 
-        SimpleAuthorizationRequest ar = new SimpleAuthorizationRequest(SimplePermission.NS + "EditOntology");
+        TestAuthorizationRequest ar = new TestAuthorizationRequest(SimplePermission.NS + "EditOntology");
         ar.setRoleUris(Arrays.asList(EDITOR));
         assertEquals(DecisionResult.INCONCLUSIVE, policy.decide(ar).getDecisionResult());
         ar.setRoleUris(Arrays.asList(CURATOR));
@@ -78,7 +78,7 @@ public class SimplePermissionTemplateTest extends PolicyTest {
         assertEquals(true, rule.isAllowMatched());
         assertEquals(4, rule.getChecksCount());
 
-        SimpleAuthorizationRequest ar = new SimpleAuthorizationRequest(SimplePermission.NS + "DoBackEndEditing");
+        TestAuthorizationRequest ar = new TestAuthorizationRequest(SimplePermission.NS + "DoBackEndEditing");
         ar.setRoleUris(Arrays.asList(SELF_EDITOR));
         assertEquals(DecisionResult.INCONCLUSIVE, policy.decide(ar).getDecisionResult());
         ar.setRoleUris(Arrays.asList(EDITOR));
@@ -99,7 +99,7 @@ public class SimplePermissionTemplateTest extends PolicyTest {
         assertEquals(true, rule.isAllowMatched());
         assertEquals(4, rule.getChecksCount());
 
-        SimpleAuthorizationRequest ar = new SimpleAuthorizationRequest(SimplePermission.NS + "DoFrontEndEditing");
+        TestAuthorizationRequest ar = new TestAuthorizationRequest(SimplePermission.NS + "DoFrontEndEditing");
         ar.setRoleUris(Arrays.asList(PUBLIC));
         assertEquals(DecisionResult.INCONCLUSIVE, policy.decide(ar).getDecisionResult());
         ar.setRoleUris(Arrays.asList(SELF_EDITOR));
@@ -120,7 +120,7 @@ public class SimplePermissionTemplateTest extends PolicyTest {
         assertEquals(true, rule.isAllowMatched());
         assertEquals(4, rule.getChecksCount());
 
-        SimpleAuthorizationRequest ar = new SimpleAuthorizationRequest(SimplePermission.NS + "QueryFullModel");
+        TestAuthorizationRequest ar = new TestAuthorizationRequest(SimplePermission.NS + "QueryFullModel");
         ar.setRoleUris(Arrays.asList(""));
         assertEquals(DecisionResult.INCONCLUSIVE, policy.decide(ar).getDecisionResult());
         ar.setRoleUris(Arrays.asList(PUBLIC));
@@ -146,7 +146,7 @@ public class SimplePermissionTemplateTest extends PolicyTest {
         assertEquals(true, rule.isAllowMatched());
         assertEquals(4, rule.getChecksCount());
 
-        SimpleAuthorizationRequest ar = new SimpleAuthorizationRequest(SimplePermission.NS + "QueryFullModel");
+        TestAuthorizationRequest ar = new TestAuthorizationRequest(SimplePermission.NS + "QueryFullModel");
         ar.setRoleUris(Arrays.asList(PUBLIC));
         assertEquals(DecisionResult.INCONCLUSIVE, policy.decide(ar).getDecisionResult());
         ar.setRoleUris(Arrays.asList(CUSTOM));

--- a/api/src/test/java/edu/cornell/mannlib/vitro/webapp/auth/policy/SuppressDisplayIndividualPageByUriTemplateTest.java
+++ b/api/src/test/java/edu/cornell/mannlib/vitro/webapp/auth/policy/SuppressDisplayIndividualPageByUriTemplateTest.java
@@ -19,7 +19,7 @@ import edu.cornell.mannlib.vitro.webapp.auth.attributes.AccessOperation;
 import edu.cornell.mannlib.vitro.webapp.auth.objects.AccessObject;
 import edu.cornell.mannlib.vitro.webapp.auth.objects.IndividualAccessObject;
 import edu.cornell.mannlib.vitro.webapp.auth.objects.NamedAccessObject;
-import edu.cornell.mannlib.vitro.webapp.auth.requestedAction.SimpleAuthorizationRequest;
+import edu.cornell.mannlib.vitro.webapp.auth.requestedAction.TestAuthorizationRequest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -73,35 +73,35 @@ public class SuppressDisplayIndividualPageByUriTemplateTest extends PolicyTest {
 
     private void policyNotAffectsOtherRoles(DynamicPolicy policy) {
         AccessObject object = new IndividualAccessObject(TEST_ENTITY);
-        SimpleAuthorizationRequest ar = new SimpleAuthorizationRequest(object, ao);
+        TestAuthorizationRequest ar = new TestAuthorizationRequest(object, ao);
         ar.setRoleUris(Arrays.asList(roleUri + "_NOT_EXISTS"));
         assertEquals(INCONCLUSIVE, policy.decide(ar).getDecisionResult());
     }
 
     private void policyNotAffectsOtherEntities(DynamicPolicy policy) {
         AccessObject object = new IndividualAccessObject("test:anothe_entity");
-        SimpleAuthorizationRequest ar = new SimpleAuthorizationRequest(object, ao);
+        TestAuthorizationRequest ar = new TestAuthorizationRequest(object, ao);
         ar.setRoleUris(Arrays.asList(roleUri));
         assertEquals(INCONCLUSIVE, policy.decide(ar).getDecisionResult());
     }
 
     private void policyNotAffectsOtherOperations(DynamicPolicy policy) {
         AccessObject object = new IndividualAccessObject(TEST_ENTITY);
-        SimpleAuthorizationRequest ar = new SimpleAuthorizationRequest(object, AccessOperation.ADD);
+        TestAuthorizationRequest ar = new TestAuthorizationRequest(object, AccessOperation.ADD);
         ar.setRoleUris(Arrays.asList(roleUri));
         assertEquals(INCONCLUSIVE, policy.decide(ar).getDecisionResult());
     }
 
     private void policyNotAffectsOtherTypes(DynamicPolicy policy) {
         AccessObject object = new NamedAccessObject(TEST_ENTITY);
-        SimpleAuthorizationRequest ar = new SimpleAuthorizationRequest(object, ao);
+        TestAuthorizationRequest ar = new TestAuthorizationRequest(object, ao);
         ar.setRoleUris(Arrays.asList(roleUri));
         assertEquals(INCONCLUSIVE, policy.decide(ar).getDecisionResult());
     }
 
     private void policyDeniesAccess(DynamicPolicy policy) {
         AccessObject object = new IndividualAccessObject(TEST_ENTITY);
-        SimpleAuthorizationRequest ar = new SimpleAuthorizationRequest(object, ao);
+        TestAuthorizationRequest ar = new TestAuthorizationRequest(object, ao);
         ar.setRoleUris(Arrays.asList(roleUri));
         assertEquals(UNAUTHORIZED, policy.decide(ar).getDecisionResult());
     }

--- a/api/src/test/java/edu/cornell/mannlib/vitro/webapp/auth/policy/SuppressDisplayIndividualPageTypeTemplateTest.java
+++ b/api/src/test/java/edu/cornell/mannlib/vitro/webapp/auth/policy/SuppressDisplayIndividualPageTypeTemplateTest.java
@@ -20,7 +20,7 @@ import edu.cornell.mannlib.vitro.webapp.auth.attributes.NamedKeyComponent;
 import edu.cornell.mannlib.vitro.webapp.auth.objects.AccessObject;
 import edu.cornell.mannlib.vitro.webapp.auth.objects.IndividualAccessObject;
 import edu.cornell.mannlib.vitro.webapp.auth.objects.NamedAccessObject;
-import edu.cornell.mannlib.vitro.webapp.auth.requestedAction.SimpleAuthorizationRequest;
+import edu.cornell.mannlib.vitro.webapp.auth.requestedAction.TestAuthorizationRequest;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
 import org.apache.jena.shared.Lock;
@@ -89,7 +89,7 @@ public class SuppressDisplayIndividualPageTypeTemplateTest extends PolicyTest {
     private void policyNotAffectsOtherRoles(DynamicPolicy policy, Model targetModel) {
         AccessObject object = new IndividualAccessObject(TEST_ENTITY);
         object.setModel(targetModel);
-        SimpleAuthorizationRequest ar = new SimpleAuthorizationRequest(object, AccessOperation.DISPLAY);
+        TestAuthorizationRequest ar = new TestAuthorizationRequest(object, AccessOperation.DISPLAY);
         ar.setRoleUris(Arrays.asList(roleUri + "_NOT_EXISTS"));
         assertEquals(INCONCLUSIVE, policy.decide(ar).getDecisionResult());
     }
@@ -97,7 +97,7 @@ public class SuppressDisplayIndividualPageTypeTemplateTest extends PolicyTest {
     private void policyNotAffectsOtherEntities(DynamicPolicy policy, Model targetModel) {
         AccessObject object = new IndividualAccessObject("test:another_entity");
         object.setModel(targetModel);
-        SimpleAuthorizationRequest ar = new SimpleAuthorizationRequest(object, ao);
+        TestAuthorizationRequest ar = new TestAuthorizationRequest(object, ao);
         ar.setRoleUris(Arrays.asList(roleUri));
         assertEquals(INCONCLUSIVE, policy.decide(ar).getDecisionResult());
     }
@@ -105,7 +105,7 @@ public class SuppressDisplayIndividualPageTypeTemplateTest extends PolicyTest {
     private void policyNotAffectsOtherOperations(DynamicPolicy policy, Model targetModel) {
         AccessObject object = new IndividualAccessObject(TEST_ENTITY);
         object.setModel(targetModel);
-        SimpleAuthorizationRequest ar = new SimpleAuthorizationRequest(object, AccessOperation.ADD);
+        TestAuthorizationRequest ar = new TestAuthorizationRequest(object, AccessOperation.ADD);
         ar.setRoleUris(Arrays.asList(roleUri));
         assertEquals(INCONCLUSIVE, policy.decide(ar).getDecisionResult());
     }
@@ -113,7 +113,7 @@ public class SuppressDisplayIndividualPageTypeTemplateTest extends PolicyTest {
     private void policyNotAffectsOtherTypes(DynamicPolicy policy, Model targetModel) {
         AccessObject object = new NamedAccessObject(TEST_ENTITY);
         object.setModel(targetModel);
-        SimpleAuthorizationRequest ar = new SimpleAuthorizationRequest(object, ao);
+        TestAuthorizationRequest ar = new TestAuthorizationRequest(object, ao);
         ar.setRoleUris(Arrays.asList(roleUri));
         assertEquals(INCONCLUSIVE, policy.decide(ar).getDecisionResult());
     }
@@ -121,7 +121,7 @@ public class SuppressDisplayIndividualPageTypeTemplateTest extends PolicyTest {
     private void policyDeniesAccess(DynamicPolicy policy, Model targetModel) {
         AccessObject object = new IndividualAccessObject(TEST_ENTITY);
         object.setModel(targetModel);
-        SimpleAuthorizationRequest ar = new SimpleAuthorizationRequest(object, ao);
+        TestAuthorizationRequest ar = new TestAuthorizationRequest(object, ao);
         ar.setRoleUris(Arrays.asList(roleUri));
         assertEquals(UNAUTHORIZED, policy.decide(ar).getDecisionResult());
     }

--- a/api/src/test/java/edu/cornell/mannlib/vitro/webapp/auth/policy/SuppressDisplayNotRelatedIndividualPageByTypeTemplateTest.java
+++ b/api/src/test/java/edu/cornell/mannlib/vitro/webapp/auth/policy/SuppressDisplayNotRelatedIndividualPageByTypeTemplateTest.java
@@ -13,6 +13,7 @@ import static org.junit.Assert.assertTrue;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.Set;
 
 import edu.cornell.mannlib.vitro.webapp.auth.attributes.AccessObjectType;
@@ -20,7 +21,7 @@ import edu.cornell.mannlib.vitro.webapp.auth.attributes.AccessOperation;
 import edu.cornell.mannlib.vitro.webapp.auth.objects.AccessObject;
 import edu.cornell.mannlib.vitro.webapp.auth.objects.IndividualAccessObject;
 import edu.cornell.mannlib.vitro.webapp.auth.objects.NamedAccessObject;
-import edu.cornell.mannlib.vitro.webapp.auth.requestedAction.SimpleAuthorizationRequest;
+import edu.cornell.mannlib.vitro.webapp.auth.requestedAction.TestAuthorizationRequest;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
 import org.apache.jena.shared.Lock;
@@ -89,7 +90,7 @@ public class SuppressDisplayNotRelatedIndividualPageByTypeTemplateTest extends P
     private void policyNotAffectsOtherRoles(DynamicPolicy policy, Model targetModel) {
         AccessObject object = new IndividualAccessObject(TEST_ENTITY);
         object.setModel(targetModel);
-        SimpleAuthorizationRequest ar = new SimpleAuthorizationRequest(object, AccessOperation.DISPLAY);
+        TestAuthorizationRequest ar = new TestAuthorizationRequest(object, AccessOperation.DISPLAY);
         ar.setRoleUris(Arrays.asList(roleUri + "_NOT_EXISTS"));
         assertEquals(INCONCLUSIVE, policy.decide(ar).getDecisionResult());
     }
@@ -97,7 +98,7 @@ public class SuppressDisplayNotRelatedIndividualPageByTypeTemplateTest extends P
     private void policyNotAffectsOtherEntities(DynamicPolicy policy, Model targetModel) {
         AccessObject object = new IndividualAccessObject("test:another_entity");
         object.setModel(targetModel);
-        SimpleAuthorizationRequest ar = new SimpleAuthorizationRequest(object, ao);
+        TestAuthorizationRequest ar = new TestAuthorizationRequest(object, ao);
         ar.setRoleUris(Arrays.asList(roleUri));
         assertEquals(INCONCLUSIVE, policy.decide(ar).getDecisionResult());
     }
@@ -105,7 +106,7 @@ public class SuppressDisplayNotRelatedIndividualPageByTypeTemplateTest extends P
     private void policyNotAffectsOtherOperations(DynamicPolicy policy, Model targetModel) {
         AccessObject object = new IndividualAccessObject(TEST_ENTITY);
         object.setModel(targetModel);
-        SimpleAuthorizationRequest ar = new SimpleAuthorizationRequest(object, AccessOperation.ADD);
+        TestAuthorizationRequest ar = new TestAuthorizationRequest(object, AccessOperation.ADD);
         ar.setRoleUris(Arrays.asList(roleUri));
         assertEquals(INCONCLUSIVE, policy.decide(ar).getDecisionResult());
     }
@@ -113,7 +114,7 @@ public class SuppressDisplayNotRelatedIndividualPageByTypeTemplateTest extends P
     private void policyNotAffectsOtherTypes(DynamicPolicy policy, Model targetModel) {
         AccessObject object = new NamedAccessObject(TEST_ENTITY);
         object.setModel(targetModel);
-        SimpleAuthorizationRequest ar = new SimpleAuthorizationRequest(object, ao);
+        TestAuthorizationRequest ar = new TestAuthorizationRequest(object, ao);
         ar.setRoleUris(Arrays.asList(roleUri));
         assertEquals(INCONCLUSIVE, policy.decide(ar).getDecisionResult());
     }
@@ -121,16 +122,16 @@ public class SuppressDisplayNotRelatedIndividualPageByTypeTemplateTest extends P
     private void policyNotAffectsRelatedIndividuals(DynamicPolicy policy, Model targetModel) {
         AccessObject object = new IndividualAccessObject(TEST_ENTITY);
         object.setModel(targetModel);
-        SimpleAuthorizationRequest ar = new SimpleAuthorizationRequest(object, ao);
+        TestAuthorizationRequest ar = new TestAuthorizationRequest(object, ao);
         ar.setRoleUris(Arrays.asList(roleUri));
-        ar.setEditorUris(Arrays.asList(TEST_ENTITY));
+        ar.setEditorUris(new HashSet(Arrays.asList(TEST_ENTITY)));
         assertEquals(INCONCLUSIVE, policy.decide(ar).getDecisionResult());
     }
 
     private void policyDeniesAccess(DynamicPolicy policy, Model targetModel) {
         AccessObject object = new IndividualAccessObject(TEST_ENTITY);
         object.setModel(targetModel);
-        SimpleAuthorizationRequest ar = new SimpleAuthorizationRequest(object, ao);
+        TestAuthorizationRequest ar = new TestAuthorizationRequest(object, ao);
         ar.setRoleUris(Arrays.asList(roleUri));
         assertEquals(UNAUTHORIZED, policy.decide(ar).getDecisionResult());
     }

--- a/api/src/test/java/edu/cornell/mannlib/vitro/webapp/auth/policy/SuppressDisplayNotRelatedIndividualPageByTypeTemplateTest.java
+++ b/api/src/test/java/edu/cornell/mannlib/vitro/webapp/auth/policy/SuppressDisplayNotRelatedIndividualPageByTypeTemplateTest.java
@@ -76,7 +76,7 @@ public class SuppressDisplayNotRelatedIndividualPageByTypeTemplateTest extends P
         DynamicPolicy policy = loader.loadPolicyFromTemplateDataSet(dataSetUri);
         assertTrue(policy != null);
         assertEquals(1500, policy.getPriority());
-        countRulesAndAttributes(policy, 1, Collections.singleton(5));
+        countRulesAndAttributes(policy, 1, Collections.singleton(6));
         policyDeniesAccess(policy, dataModel);
 
         policyNotAffectsOtherTypes(policy, dataModel);
@@ -124,7 +124,7 @@ public class SuppressDisplayNotRelatedIndividualPageByTypeTemplateTest extends P
         object.setModel(targetModel);
         TestAuthorizationRequest ar = new TestAuthorizationRequest(object, ao);
         ar.setRoleUris(Arrays.asList(roleUri));
-        ar.setEditorUris(new HashSet(Arrays.asList(TEST_ENTITY)));
+        ar.setEditorUris(new HashSet<String>(Arrays.asList(TEST_ENTITY)));
         assertEquals(INCONCLUSIVE, policy.decide(ar).getDecisionResult());
     }
 

--- a/api/src/test/java/edu/cornell/mannlib/vitro/webapp/auth/policy/SuppressDisplayNotRelatedPropertyByUriTemplateTest.java
+++ b/api/src/test/java/edu/cornell/mannlib/vitro/webapp/auth/policy/SuppressDisplayNotRelatedPropertyByUriTemplateTest.java
@@ -16,6 +16,7 @@ import static org.junit.Assert.assertTrue;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.Set;
 
 import edu.cornell.mannlib.vitro.webapp.auth.attributes.AccessObjectType;
@@ -25,7 +26,7 @@ import edu.cornell.mannlib.vitro.webapp.auth.objects.DataPropertyStatementAccess
 import edu.cornell.mannlib.vitro.webapp.auth.objects.FauxDataPropertyStatementAccessObject;
 import edu.cornell.mannlib.vitro.webapp.auth.objects.FauxObjectPropertyStatementAccessObject;
 import edu.cornell.mannlib.vitro.webapp.auth.objects.ObjectPropertyStatementAccessObject;
-import edu.cornell.mannlib.vitro.webapp.auth.requestedAction.SimpleAuthorizationRequest;
+import edu.cornell.mannlib.vitro.webapp.auth.requestedAction.TestAuthorizationRequest;
 import edu.cornell.mannlib.vitro.webapp.beans.FauxProperty;
 import edu.cornell.mannlib.vitro.webapp.beans.Property;
 import edu.cornell.mannlib.vitro.webapp.rdfservice.adapters.VitroModelFactory;
@@ -90,43 +91,43 @@ public class SuppressDisplayNotRelatedPropertyByUriTemplateTest extends PolicyTe
 
     private void policyNotAffectsRelatedIndividuals(DynamicPolicy policy, OntModel targetModel) {
         AccessObject object = getAccessObject(targetModel, TEST_PROPERTY);
-        SimpleAuthorizationRequest ar = new SimpleAuthorizationRequest(object, ao);
+        TestAuthorizationRequest ar = new TestAuthorizationRequest(object, ao);
         ar.setRoleUris(Arrays.asList(roleUri));
-        ar.setEditorUris(Arrays.asList(TEST_ENTITY));
+        ar.setEditorUris(new HashSet(Arrays.asList(TEST_ENTITY)));
         assertEquals(INCONCLUSIVE, policy.decide(ar).getDecisionResult());
     }
 
     private void policyNotAffectsOtherRoles(DynamicPolicy policy, OntModel targetModel) {
         AccessObject object = getAccessObject(targetModel, TEST_PROPERTY);
-        SimpleAuthorizationRequest ar = new SimpleAuthorizationRequest(object, ao);
+        TestAuthorizationRequest ar = new TestAuthorizationRequest(object, ao);
         ar.setRoleUris(Arrays.asList(ADMIN));
         assertEquals(INCONCLUSIVE, policy.decide(ar).getDecisionResult());
     }
 
     private void policyNotAffectsOtherOperations(DynamicPolicy policy, OntModel targetModel) {
         AccessObject object = getAccessObject(targetModel, TEST_PROPERTY);
-        SimpleAuthorizationRequest ar = new SimpleAuthorizationRequest(object, PUBLISH);
+        TestAuthorizationRequest ar = new TestAuthorizationRequest(object, PUBLISH);
         ar.setRoleUris(Arrays.asList(roleUri));
         assertEquals(INCONCLUSIVE, policy.decide(ar).getDecisionResult());
     }
 
     private void policyNotAffectsOtherEntities(DynamicPolicy policy, OntModel targetModel) {
         AccessObject object = getAccessObject(targetModel, OTHER_PROPERTY);
-        SimpleAuthorizationRequest ar = new SimpleAuthorizationRequest(object, ao);
+        TestAuthorizationRequest ar = new TestAuthorizationRequest(object, ao);
         ar.setRoleUris(Arrays.asList(roleUri));
         assertEquals(INCONCLUSIVE, policy.decide(ar).getDecisionResult());
     }
 
     private void policyNotAffectsOtherTypes(DynamicPolicy policy, OntModel targetModel) {
         AccessObject object = getWrongAccessObject(targetModel);
-        SimpleAuthorizationRequest ar = new SimpleAuthorizationRequest(object, ao);
+        TestAuthorizationRequest ar = new TestAuthorizationRequest(object, ao);
         ar.setRoleUris(Arrays.asList(roleUri));
         assertEquals(INCONCLUSIVE, policy.decide(ar).getDecisionResult());
     }
 
     private void policyDeniesAccess(DynamicPolicy policy, OntModel targetModel) {
         AccessObject object = getAccessObject(targetModel, TEST_PROPERTY);
-        SimpleAuthorizationRequest ar = new SimpleAuthorizationRequest(object, ao);
+        TestAuthorizationRequest ar = new TestAuthorizationRequest(object, ao);
         ar.setRoleUris(Arrays.asList(roleUri));
         assertEquals(UNAUTHORIZED, policy.decide(ar).getDecisionResult());
     }

--- a/api/src/test/java/edu/cornell/mannlib/vitro/webapp/auth/policy/SuppressDisplayNotRelatedPropertyByUriTemplateTest.java
+++ b/api/src/test/java/edu/cornell/mannlib/vitro/webapp/auth/policy/SuppressDisplayNotRelatedPropertyByUriTemplateTest.java
@@ -80,7 +80,7 @@ public class SuppressDisplayNotRelatedPropertyByUriTemplateTest extends PolicyTe
         DynamicPolicy policy = loader.loadPolicyFromTemplateDataSet(dataSetUri);
         assertTrue(policy != null);
         assertEquals(5000, policy.getPriority());
-        countRulesAndAttributes(policy, 1, Collections.singleton(5));
+        countRulesAndAttributes(policy, 1, Collections.singleton(6));
         policyDeniesAccess(policy, dataModel);
         policyNotAffectsOtherTypes(policy, dataModel);
         policyNotAffectsOtherEntities(policy, dataModel);
@@ -93,7 +93,7 @@ public class SuppressDisplayNotRelatedPropertyByUriTemplateTest extends PolicyTe
         AccessObject object = getAccessObject(targetModel, TEST_PROPERTY);
         TestAuthorizationRequest ar = new TestAuthorizationRequest(object, ao);
         ar.setRoleUris(Arrays.asList(roleUri));
-        ar.setEditorUris(new HashSet(Arrays.asList(TEST_ENTITY)));
+        ar.setEditorUris(new HashSet<String>(Arrays.asList(TEST_ENTITY)));
         assertEquals(INCONCLUSIVE, policy.decide(ar).getDecisionResult());
     }
 

--- a/api/src/test/java/edu/cornell/mannlib/vitro/webapp/auth/policy/UpdateRelatedAllowedPropertiesPolicyTemplateTest.java
+++ b/api/src/test/java/edu/cornell/mannlib/vitro/webapp/auth/policy/UpdateRelatedAllowedPropertiesPolicyTemplateTest.java
@@ -54,20 +54,20 @@ public class UpdateRelatedAllowedPropertiesPolicyTemplateTest extends PolicyTest
     public static Collection<Object[]> requests() {
         return Arrays.asList(new Object[][] {
 
-                { ADD, OBJECT_PROPERTY, SELF_EDITOR, 2, num(4, 5) },
-                { ADD, DATA_PROPERTY, SELF_EDITOR, 2, num(4, 5) },
-                { ADD, FAUX_OBJECT_PROPERTY, SELF_EDITOR, 2, num(4, 5) },
-                { ADD, FAUX_DATA_PROPERTY, SELF_EDITOR, 2, num(4, 5) },
+                { ADD, OBJECT_PROPERTY, SELF_EDITOR, 3, num(4, 5) },
+                { ADD, DATA_PROPERTY, SELF_EDITOR, 3, num(4, 5) },
+                { ADD, FAUX_OBJECT_PROPERTY, SELF_EDITOR, 3, num(4, 5) },
+                { ADD, FAUX_DATA_PROPERTY, SELF_EDITOR, 3, num(4, 5) },
 
-                { DROP, OBJECT_PROPERTY, SELF_EDITOR, 2, num(4, 5) },
-                { DROP, DATA_PROPERTY, SELF_EDITOR, 2, num(4, 5) },
-                { DROP, FAUX_OBJECT_PROPERTY, SELF_EDITOR, 2, num(4, 5) },
-                { DROP, FAUX_DATA_PROPERTY, SELF_EDITOR, 2, num(4, 5) },
+                { DROP, OBJECT_PROPERTY, SELF_EDITOR, 3, num(4, 5) },
+                { DROP, DATA_PROPERTY, SELF_EDITOR, 3, num(4, 5) },
+                { DROP, FAUX_OBJECT_PROPERTY, SELF_EDITOR, 3, num(4, 5) },
+                { DROP, FAUX_DATA_PROPERTY, SELF_EDITOR, 3, num(4, 5) },
 
-                { EDIT, OBJECT_PROPERTY, SELF_EDITOR, 2, num(4, 5) },
-                { EDIT, DATA_PROPERTY, SELF_EDITOR, 2, num(4, 5) },
-                { EDIT, FAUX_OBJECT_PROPERTY, SELF_EDITOR, 2, num(4, 5) },
-                { EDIT, FAUX_DATA_PROPERTY, SELF_EDITOR, 2, num(4, 5) }, });
+                { EDIT, OBJECT_PROPERTY, SELF_EDITOR, 3, num(4, 5) },
+                { EDIT, DATA_PROPERTY, SELF_EDITOR, 3, num(4, 5) },
+                { EDIT, FAUX_OBJECT_PROPERTY, SELF_EDITOR, 3, num(4, 5) },
+                { EDIT, FAUX_DATA_PROPERTY, SELF_EDITOR, 3, num(4, 5) }, });
 
     }
 

--- a/api/src/test/java/edu/cornell/mannlib/vitro/webapp/auth/requestedAction/TestAuthorizationRequest.java
+++ b/api/src/test/java/edu/cornell/mannlib/vitro/webapp/auth/requestedAction/TestAuthorizationRequest.java
@@ -46,4 +46,9 @@ public class TestAuthorizationRequest extends SimpleAuthorizationRequest {
         return isRoot;
     }
 
+    @Override
+    public String getExternalAuthId() {
+        return "";
+    }
+
 }

--- a/api/src/test/java/edu/cornell/mannlib/vitro/webapp/auth/requestedAction/TestAuthorizationRequest.java
+++ b/api/src/test/java/edu/cornell/mannlib/vitro/webapp/auth/requestedAction/TestAuthorizationRequest.java
@@ -1,0 +1,49 @@
+package edu.cornell.mannlib.vitro.webapp.auth.requestedAction;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+import edu.cornell.mannlib.vitro.webapp.auth.attributes.AccessOperation;
+import edu.cornell.mannlib.vitro.webapp.auth.objects.AccessObject;
+
+public class TestAuthorizationRequest extends SimpleAuthorizationRequest {
+
+    private Set<String> roleUris = Collections.emptySet();
+    private Set<String> editorUris = Collections.emptySet();
+    private boolean isRoot = false;
+
+    public TestAuthorizationRequest(AccessObject object, AccessOperation operation) {
+        super(object, operation);
+    }
+
+    public TestAuthorizationRequest(String namedAccessObject) {
+        super(namedAccessObject);
+    }
+
+    public void setRoleUris(Collection<String> roleUris) {
+        this.roleUris = new HashSet<String>(roleUris);
+    }
+
+    public void setEditorUris(Set<String> uris) {
+        this.editorUris = new HashSet<String>(uris);
+
+    }
+
+    @Override
+    public Set<String> getRoleUris() {
+        return roleUris;
+    }
+
+    @Override
+    public Set<String> getEditorUris() {
+        return editorUris;
+    }
+
+    @Override
+    public boolean isRootUser() {
+        return isRoot;
+    }
+
+}

--- a/home/src/main/resources/rdf/accessControl/firsttime/policy_related_editable_pages.n3
+++ b/home/src/main/resources/rdf/accessControl/firsttime/policy_related_editable_pages.n3
@@ -6,11 +6,20 @@
 @prefix : <https://vivoweb.org/ontology/vitro-application/auth/individual/edit-related-individual-pages/> .
 
 :Policy a access:Policy ;
+    access:hasRule :AllowEditRelatedPagesMatchedByExternalIdRule ;
     access:hasRule :AllowEditRelatedPagesRule .
 
 :AllowEditRelatedPagesRule a access:Rule;
     access:requiresCheck :SubjectRoleIsSelfEditor ;
     access:requiresCheck :SubjectUriIsProfileRelatedResource ;
+    access:requiresCheck :IsEditOperation ;
+    access:requiresCheck :IsObjectPropertyStatement ;
+    access:requiresCheck :ObjectUriIsSomeUri ;
+    access:requiresCheck :PredicateIsSomePredicate .
+    
+:AllowEditRelatedPagesMatchedByExternalIdRule a access:Rule;
+    access:requiresCheck :SubjectRoleIsSelfEditor ;
+    access:requiresCheck :SubjectUriIsProfileMatchedByExternalIdRelatedResource ;
     access:requiresCheck :IsEditOperation ;
     access:requiresCheck :IsObjectPropertyStatement ;
     access:requiresCheck :ObjectUriIsSomeUri ;
@@ -40,6 +49,11 @@
     access:useOperator access-individual:SparqlSelectQueryResultsContain ;
     access:hasTypeToCheck access-individual:StatementSubjectUri ;
     access:value access-individual:PersonProfileProximityToResourceUri .
+    
+:SubjectUriIsProfileMatchedByExternalIdRelatedResource a access:Check ;
+    access:useOperator access-individual:SparqlSelectQueryResultsContain ;
+    access:hasTypeToCheck access-individual:StatementSubjectUri ;
+    access:value access-individual:ExternalIdMatchProfileProximityToResourceUri .
 
 :IsObjectPropertyStatement a access:Check ;
     access:useOperator access-individual:Equals ;

--- a/home/src/main/resources/rdf/accessControl/firsttime/profile_proximity_query.n3
+++ b/home/src/main/resources/rdf/accessControl/firsttime/profile_proximity_query.n3
@@ -3,10 +3,23 @@
 @prefix access-individual: <https://vivoweb.org/ontology/vitro-application/auth/individual/> .
 @prefix access: <https://vivoweb.org/ontology/vitro-application/auth/vocabulary/> .
 
+# Reserved variable names:
+# profileUri - user account associated profile
+# objectUri - access object uri
+# externalAuthId - user account external auth id (should match with profile external auth id)
+# matchingPropertyUri - uri of property used for auth id matching, selfEditing.idMatchingProperty defined in runtime.properties 
+
+
 access-individual:PersonProfileProximityToResourceUri a access:SparqlSelectValuesQuery ;
     access:id """
     SELECT ?resourceUri WHERE {
-          BIND ( ?profileUri as ?resourceUri)
+      BIND (?profileUri as ?resourceUri)
     }
     """ .
 
+access-individual:ExternalIdMatchProfileProximityToResourceUri a access:SparqlSelectValuesQuery ;
+    access:id """
+    SELECT ?resourceUri WHERE {
+      ?resourceUri ?matchingPropertyUri ?externalAuthId .
+    }
+    """ .

--- a/home/src/main/resources/rdf/accessControl/firsttime/template_suppress_display_not_related_individual_page_by_type.n3
+++ b/home/src/main/resources/rdf/accessControl/firsttime/template_suppress_display_not_related_individual_page_by_type.n3
@@ -35,6 +35,7 @@
     access:requiresCheck :OperationCheck ;
     access:requiresCheck :AccessObjectTypeCheck ;
     access:requiresCheck :RelationCheck ;
+    access:requiresCheck :RelationExternalIdMatchCheck ;
     access:requiresCheck :AccessObjectClassCheck .
 
 ### Checks
@@ -69,6 +70,11 @@
     access:value access-individual:PersonProfileProximityToResourceUri
     .
 
+:RelationExternalIdMatchCheck a access:Check ;
+    access:useOperator access-individual:SparqlSelectQueryResultsNotContain ;
+    access:hasTypeToCheck access-individual:AccessObjectUri ;
+    access:value access-individual:ExternalIdMatchProfileProximityToResourceUri
+    .
 
 :IndividualTypeQuery a access:SparqlSelectValuesQuery ;
     access:id """

--- a/home/src/main/resources/rdf/accessControl/firsttime/template_suppress_display_not_related_property_by_uri.n3
+++ b/home/src/main/resources/rdf/accessControl/firsttime/template_suppress_display_not_related_property_by_uri.n3
@@ -96,6 +96,7 @@
     access:requiresCheck :AccessObjectStatementTypeCheck ;
     access:requiresCheck :StatementPredicateCheck ;
     access:requiresCheck :RelationCheck ;
+    access:requiresCheck :RelationExternalIdMatchCheck ;
     .
 
 #Checks
@@ -104,6 +105,12 @@
     access:useOperator access-individual:SparqlSelectQueryResultsNotContain ;
     access:hasTypeToCheck access-individual:StatementSubjectUri ;
     access:value access-individual:PersonProfileProximityToResourceUri ;
+    .
+
+:RelationExternalIdMatchCheck a access:Check ;
+    access:useOperator access-individual:SparqlSelectQueryResultsNotContain ;
+    access:hasTypeToCheck access-individual:StatementSubjectUri ;
+    access:value access-individual:ExternalIdMatchProfileProximityToResourceUri ;
     .
 
 :AccessObjectStatementTypeCheck a access:Check ;

--- a/home/src/main/resources/rdf/accessControl/firsttime/template_update_related_allowed_property.n3
+++ b/home/src/main/resources/rdf/accessControl/firsttime/template_update_related_allowed_property.n3
@@ -8,7 +8,7 @@
 :PolicyTemplate a access:PolicyTemplate ;
     access:hasRule :AllowMatchingPropertyStatement ;
     access:hasRule :AllowMatchingProperty ;
-    access:hasRule :AllowxternalIdMatchingPropertyStatement ;
+    access:hasRule :AllowExternalIdMatchingPropertyStatement ;
  
     access:hasDataSet :SelfEditorAddObjectPropertyDataSet ;
     access:hasDataSet :SelfEditorAddDataPropertyDataSet ;
@@ -229,7 +229,7 @@
     access:requiresCheck :RelationCheck ;
     .
 
-:AllowxternalIdMatchingPropertyStatement a access:Rule;
+:AllowExternalIdMatchingPropertyStatement a access:Rule;
     access:requiresCheck :SubjectRoleCheck ;
     access:requiresCheck :OperationCheck ;
     access:requiresCheck :AccessObjectStatementTypeCheck ;

--- a/home/src/main/resources/rdf/accessControl/firsttime/template_update_related_allowed_property.n3
+++ b/home/src/main/resources/rdf/accessControl/firsttime/template_update_related_allowed_property.n3
@@ -8,6 +8,7 @@
 :PolicyTemplate a access:PolicyTemplate ;
     access:hasRule :AllowMatchingPropertyStatement ;
     access:hasRule :AllowMatchingProperty ;
+    access:hasRule :AllowxternalIdMatchingPropertyStatement ;
  
     access:hasDataSet :SelfEditorAddObjectPropertyDataSet ;
     access:hasDataSet :SelfEditorAddDataPropertyDataSet ;
@@ -228,10 +229,23 @@
     access:requiresCheck :RelationCheck ;
     .
 
+:AllowxternalIdMatchingPropertyStatement a access:Rule;
+    access:requiresCheck :SubjectRoleCheck ;
+    access:requiresCheck :OperationCheck ;
+    access:requiresCheck :AccessObjectStatementTypeCheck ;
+    access:requiresCheck :StatementPredicateCheck ;
+    access:requiresCheck :RelationExternalIdMatchCheck ;
+    .
+
 :RelationCheck a access:Check ;
     access:useOperator access-individual:SparqlSelectQueryResultsContain ;
     access:hasTypeToCheck access-individual:StatementSubjectUri ;
     access:value access-individual:PersonProfileProximityToResourceUri .
+
+:RelationExternalIdMatchCheck a access:Check ;
+    access:useOperator access-individual:SparqlSelectQueryResultsContain ;
+    access:hasTypeToCheck access-individual:StatementSubjectUri ;
+    access:value access-individual:ExternalIdMatchProfileProximityToResourceUri .
 
 :AccessObjectStatementTypeCheck a access:Check ;
     access:useOperator access-individual:Equals ;


### PR DESCRIPTION
**[VIVO GitHub issue](https://github.com/vivo-project/VIVO/issues/3945)**

* Other Relevant Links (Mailing list discussion, related pull requests, etc.)
[VIVO PR](https://github.com/vivo-project/VIVO/pull/3947)

# What does this pull request do?
Fixes broken profile linking made by using External Auth ID.

# What's new?

- Refactored PolicyHelper and AuthorizationRequest to use UserAccount instead of of IdentifierBundle.
- Modified SparqlSelectQueryResultsChecker to support queries that contain externalAuthId and matchingPropertyUri
- Modified existing policies to find related profiles by using External Auth ID

# How should this be tested?
See VIVO PR

# Interested parties
@VIVO-project/vivo-committers
