### PR TITLE
provide full union model in authorization request for sparql checks

### DIFF
--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/dao/filtering/filters/HideFromDisplayByPolicyFilter.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/dao/filtering/filters/HideFromDisplayByPolicyFilter.java
@@ -21,6 +21,7 @@ import edu.cornell.mannlib.vitro.webapp.beans.DataProperty;
 import edu.cornell.mannlib.vitro.webapp.beans.DataPropertyStatement;
 import edu.cornell.mannlib.vitro.webapp.beans.ObjectProperty;
 import edu.cornell.mannlib.vitro.webapp.beans.ObjectPropertyStatement;
+import edu.cornell.mannlib.vitro.webapp.modelaccess.ModelAccess;
 
 /**
  * Ask the current policies whether we can show these things to the user.
@@ -80,7 +81,7 @@ public class HideFromDisplayByPolicyFilter extends VitroFiltersImpl {
 			ObjectProperty predicate = getOrCreateProperty(ops);
 			String objectUri = ops.getObjectURI();
 			return checkAuthorization(new ObjectPropertyStatementAccessObject(
-					null, subjectUri, predicate, objectUri));
+					ModelAccess.getInstance().getOntModel(), subjectUri, predicate, objectUri));
 		}
 
 		/**


### PR DESCRIPTION
**[VIVO GitHub issue](https://github.com/vivo-project/VIVO/issues/3948)**

# What does this pull request do?
 Fixes failing sparql checks related to "suppress Display for object property in unrelated individuals", so that this not result in hidden object properties in related profiles.

# What's new?
Provided FULL_UNION model in HideFromDisplayByPolicyFilter to prevent SPARQL authorization checks from failing.

# How should this be tested?
* Reproduce the problem in the issue
* Test that the pull request fixes the issue

# Interested parties
@VIVO-project/vivo-committers
