### PR TITLE
Replace slf4j-log4j12 with slf4j-reload4j

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -211,7 +211,7 @@
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
+            <artifactId>slf4j-reload4j</artifactId>
             <version>1.7.36</version>
         </dependency>
         <dependency>


### PR DESCRIPTION
**[VIVO GitHub issue](https://github.com/vivo-project/VIVO/issues)**: [3953](https://github.com/vivo-project/VIVO/issues/3953)

* Other Relevant Links (Mailing list discussion, related pull requests, etc.)
https://mvnrepository.com/artifact/org.slf4j/slf4j-log4j12/1.7.36

# What does this pull request do?
Align dependency with relocation of the [log4j artifact](https://mvnrepository.com/artifact/org.slf4j/slf4j-log4j12/1.7.36)

# What's new?
Instead of <artifactId>slf4j-log4j12</artifactId> the following artifact is used <artifactId>slf4j-reload4j</artifactId> in dependency/pom.xml

# How should this be tested?
A description of what steps someone could take to:
* Run VIVO
* Check whether logging of messages is working


# Interested parties
Tag (@ mention) interested parties or, if unsure, @VIVO-project/vivo-committers
