### PR TITLE
Sparql authorization cache fixes

### DIFF
--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/auth/checks/SparqlSelectQueryResultsChecker.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/auth/checks/SparqlSelectQueryResultsChecker.java
@@ -46,7 +46,7 @@ public class SparqlSelectQueryResultsChecker {
         AccessObject ao = ar.getAccessObject();
         Model m = ao.getModel();
         if (m == null) {
-            log.debug("SparqlQueryContains model is not provided");
+            log.error("Model not provided");
             return false;
         }
 
@@ -116,10 +116,11 @@ public class SparqlSelectQueryResultsChecker {
             AuthorizationRequest ar) {
         HashMap<String, Set<String>> queryMap = QueryResultsMapCache.get();
         String queryMapKey = createQueryMapKey(profileUri, queryTemplate, ar);
+        HashSet<String> results = new HashSet<>();
         if (queryMap.containsKey(queryMapKey)) {
-            return queryMap.get(queryMapKey);
+            results.addAll(queryMap.get(queryMapKey));
+            return results;
         }
-        Set<String> results = new HashSet<>();
         ParameterizedSparqlString pss = new ParameterizedSparqlString();
         pss.setCommandText(queryTemplate);
         setVariables(profileUri, ar, pss);
@@ -140,7 +141,9 @@ public class SparqlSelectQueryResultsChecker {
             queryExecution.close();
         }
         debug("query results: " + results);
-        queryMap.put(queryMapKey, results);
+        Set<String> queryMapValue = new HashSet<>();
+        queryMapValue.addAll(results);
+        queryMap.put(queryMapKey, queryMapValue);
         QueryResultsMapCache.update(queryMap);
         return results;
     }

--- a/api/src/test/java/edu/cornell/mannlib/vitro/webapp/auth/checks/SparqlSelectQueryResultsCheckerTest.java
+++ b/api/src/test/java/edu/cornell/mannlib/vitro/webapp/auth/checks/SparqlSelectQueryResultsCheckerTest.java
@@ -1,0 +1,98 @@
+package edu.cornell.mannlib.vitro.webapp.auth.checks;
+
+import static edu.cornell.mannlib.vitro.testing.ModelUtilitiesTestHelper.dataProperty;
+import static edu.cornell.mannlib.vitro.webapp.auth.checks.SparqlSelectQueryResultsChecker.sparqlSelectQueryResultsContain;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+
+import edu.cornell.mannlib.vitro.webapp.auth.attributes.AccessOperation;
+import edu.cornell.mannlib.vitro.webapp.auth.attributes.MutableAttributeValueSet;
+import edu.cornell.mannlib.vitro.webapp.auth.objects.NamedAccessObject;
+import edu.cornell.mannlib.vitro.webapp.auth.requestedAction.AuthorizationRequest;
+import edu.cornell.mannlib.vitro.webapp.auth.requestedAction.TestAuthorizationRequest;
+import edu.cornell.mannlib.vitro.webapp.config.ConfigurationProperties;
+import org.apache.jena.ontology.OntModel;
+import org.apache.jena.ontology.OntModelSpec;
+import org.apache.jena.ontology.impl.OntModelImpl;
+import org.junit.Before;
+import org.junit.Test;
+import stubs.edu.cornell.mannlib.vitro.webapp.config.ConfigurationPropertiesStub;
+
+public class SparqlSelectQueryResultsCheckerTest {
+
+    private static final String SIMPLE_QUERY = "SELECT ?value WHERE {?subject ?property ?value .}";
+    private static final String NOT_PRESENT_VALUE = "not present value";
+    private static final String TEST_URI = "test:uri";
+    private static final String TEST_PROPERTY = "test:property";
+    private static final String PRESENT_VALUE = "present value";
+
+    @Before
+    public void init() {
+        ConfigurationProperties configuration = new ConfigurationPropertiesStub();
+        ConfigurationProperties.setInstance(configuration);
+    }
+
+    @Test
+    public void testSimpleQuery() {
+        assertTrue(QueryResultsMapCache.get().isEmpty());
+        MutableAttributeValueSet values = new MutableAttributeValueSet(PRESENT_VALUE);
+        Check check = new StatementObjectUriCheck(TEST_URI, values);
+        check.setConfiguration(SIMPLE_QUERY);
+        NamedAccessObject ao = new NamedAccessObject(TEST_URI);
+        OntModel model = new OntModelImpl(OntModelSpec.OWL_MEM);
+        model.add(dataProperty(TEST_URI, TEST_PROPERTY, PRESENT_VALUE));
+        ao.setModel(model);
+        AuthorizationRequest ar = new TestAuthorizationRequest(ao, AccessOperation.DISPLAY);
+        boolean result = SparqlSelectQueryResultsChecker.sparqlSelectQueryResultsContain(check, ar, null);
+        assertTrue(result);
+    }
+
+    @Test
+    public void testCacheNotCorruptedAfterCaching() throws IOException {
+        try (QueryResultsMapCache cache = new QueryResultsMapCache();) {
+            assertTrue(QueryResultsMapCache.get().isEmpty());
+            MutableAttributeValueSet values = new MutableAttributeValueSet(NOT_PRESENT_VALUE);
+            Check check = new StatementObjectUriCheck(TEST_URI, values);
+            check.setConfiguration(SIMPLE_QUERY);
+            NamedAccessObject ao = new NamedAccessObject(TEST_URI);
+            OntModel model = new OntModelImpl(OntModelSpec.OWL_MEM);
+            model.add(dataProperty(TEST_URI, TEST_PROPERTY, PRESENT_VALUE));
+            ao.setModel(model);
+            AuthorizationRequest ar = new TestAuthorizationRequest(ao, AccessOperation.DISPLAY);
+            assertFalse(sparqlSelectQueryResultsContain(check, ar, null));
+            assertEquals(1, QueryResultsMapCache.get().size());
+            values.remove(NOT_PRESENT_VALUE);
+            values.add(PRESENT_VALUE);
+            // Test that SPARQL results weren't modified after being cached
+            assertTrue(sparqlSelectQueryResultsContain(check, ar, null));
+        }
+    }
+
+    @Test
+    public void testCacheResultsNotCorruptedOnReuse() throws IOException {
+        try (QueryResultsMapCache cache = new QueryResultsMapCache();) {
+            assertTrue(QueryResultsMapCache.get().isEmpty());
+            MutableAttributeValueSet values = new MutableAttributeValueSet(PRESENT_VALUE);
+            Check check = new StatementObjectUriCheck(TEST_URI, values);
+            check.setConfiguration(SIMPLE_QUERY);
+            NamedAccessObject ao = new NamedAccessObject(TEST_URI);
+            OntModel model = new OntModelImpl(OntModelSpec.OWL_MEM);
+            model.add(dataProperty(TEST_URI, TEST_PROPERTY, PRESENT_VALUE));
+            ao.setModel(model);
+            AuthorizationRequest ar = new TestAuthorizationRequest(ao, AccessOperation.DISPLAY);
+            assertTrue(sparqlSelectQueryResultsContain(check, ar, null));
+            assertEquals(1, QueryResultsMapCache.get().size());
+            values.remove(PRESENT_VALUE);
+            values.add(NOT_PRESENT_VALUE);
+            assertFalse(sparqlSelectQueryResultsContain(check, ar, null));
+            values.remove(NOT_PRESENT_VALUE);
+            values.add(PRESENT_VALUE);
+            // Test that SPARQL results weren't modified by previous cache client
+            assertTrue(sparqlSelectQueryResultsContain(check, ar, null));
+        }
+    }
+
+}


### PR DESCRIPTION
**[VIVO GitHub issue](https://github.com/vivo-project/VIVO/issues/3956)**

# Additional notes
This PR is stacked on top of https://github.com/vivo-project/Vitro/pull/444
Only the last commit is related to this PR.

# What does this pull request do?
Fixes failing authorization checks due to corrupted sparql results cache.

# What's new?
Fixed SparqlSelectQueryResultsChecker
Added tests to verify that issue is resolved.
Log cases when model wasn't provided as errors.

# How should this be tested?
* Run tests without fix to see that cache is being corrupted.
* Run tests with fix to verify that cache is not being corrupted.

# Interested parties
@VIVO-project/vivo-committers
