### PR TITLE
Make display authorization checks for each displayed object property statement 

### DIFF
--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/web/templatemodels/individual/CollatedObjectPropertyTemplateModel.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/web/templatemodels/individual/CollatedObjectPropertyTemplateModel.java
@@ -231,10 +231,13 @@ public class CollatedObjectPropertyTemplateModel extends
 				subclasses.add(new SubclassTemplateModel(vclass,
 						listForThisSubclass));
 			}
-
-			listForThisSubclass.add(new ObjectPropertyStatementTemplateModel(
-					subjectUri, property, objectKey, map, getTemplateName(),
-					vreq));
+			String objectUri = map.get(objectKey);
+			if (isAuthorizedToDisplay(vreq, objectUri)) {
+			    listForThisSubclass.add(new ObjectPropertyStatementTemplateModel(
+	                    subjectUri, property, objectKey, map, getTemplateName(),
+	                    vreq));
+			}
+			
 
 		}
 

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/web/templatemodels/individual/ObjectPropertyTemplateModel.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/web/templatemodels/individual/ObjectPropertyTemplateModel.java
@@ -386,6 +386,20 @@ public abstract class ObjectPropertyTemplateModel extends PropertyTemplateModel 
         return objectKey;
     }
 
+    protected boolean isAuthorizedToDisplay(VitroRequest vreq, String objectUri) {
+        boolean isAuthorizedToDisplay = false; 
+        AccessObject ao;
+        if (isFaux()) {
+            ao = new FauxObjectPropertyStatementAccessObject(vreq.getJenaOntModel(), subjectUri, fauxProperty, objectUri);
+        } else {
+            ao = new ObjectPropertyStatementAccessObject(vreq.getJenaOntModel(), subjectUri, property, objectUri);
+        }
+        if (PolicyHelper.isAuthorizedForActions(vreq, ao, AccessOperation.DISPLAY) ) {
+            isAuthorizedToDisplay = true;
+        }
+        return isAuthorizedToDisplay;
+    }
+    
     /* Template properties */
 
     public String getType() {

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/web/templatemodels/individual/UncollatedObjectPropertyTemplateModel.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/web/templatemodels/individual/UncollatedObjectPropertyTemplateModel.java
@@ -8,7 +8,6 @@ import java.util.Map;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-
 import edu.cornell.mannlib.vitro.webapp.beans.Individual;
 import edu.cornell.mannlib.vitro.webapp.beans.ObjectProperty;
 import edu.cornell.mannlib.vitro.webapp.controller.VitroRequest;
@@ -45,8 +44,11 @@ public class UncollatedObjectPropertyTemplateModel extends ObjectPropertyTemplat
             /* Put into data structure to send to template */
             String objectKey = getObjectKey();
             for (Map<String, String> map : statementData) {
-                statements.add(new ObjectPropertyStatementTemplateModel(subjectUri,
-                        op, objectKey, map, getTemplateName(), vreq));
+                String objectUri = map.get(objectKey);
+                if (isAuthorizedToDisplay(vreq, objectUri)) {
+                    statements.add(new ObjectPropertyStatementTemplateModel(subjectUri,
+                            op, objectKey, map, getTemplateName(), vreq));    
+                }
             }
 
             postprocessStatementList(statements);


### PR DESCRIPTION
# What does this pull request do?
Until now permission to display object property statement is only checked once for all statements of a property by using ?SOME_URI as a dummy object.
This PR adds checks for each property statement displayed on profile page.

# What's new?
Added authorization requests for each object property statement displayed in profile in collated and uncollated object property template models.

# How should this be tested?
TBC

# Interested parties
@VIVO-project/vivo-committers
