### PR TITLE
Fix for VIVO-3957

### DIFF
--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/IdModelSelector.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/IdModelSelector.java
@@ -1,6 +1,7 @@
 /* $This file is distributed under the terms of the license in LICENSE$ */
 package edu.cornell.mannlib.vitro.webapp.edit.n3editing.configuration;
 
+import static edu.cornell.mannlib.vitro.webapp.modelaccess.ModelAccess.WhichService.CONFIGURATION;
 import static edu.cornell.mannlib.vitro.webapp.modelaccess.ModelAccess.WhichService.CONTENT;
 
 import javax.servlet.ServletContext;
@@ -11,6 +12,8 @@ import org.apache.jena.rdf.model.ModelMaker;
 
 import edu.cornell.mannlib.vitro.webapp.dao.jena.VitroModelSource;
 import edu.cornell.mannlib.vitro.webapp.modelaccess.ModelAccess;
+import edu.cornell.mannlib.vitro.webapp.modelaccess.ModelNames;
+import edu.cornell.mannlib.vitro.webapp.modelaccess.ModelAccess.WhichService;
 
 public class IdModelSelector implements ModelSelector {
 
@@ -25,13 +28,26 @@ public class IdModelSelector implements ModelSelector {
 
 	@Override
 	public Model getModel(HttpServletRequest request, ServletContext context) {
-		ModelMaker modelMaker = ModelAccess.on(context).getModelMaker(CONTENT);
+		ModelMaker modelMaker = ModelAccess.getInstance().getModelMaker(getRdfService());
 		VitroModelSource mSource = new VitroModelSource(modelMaker, context);
 		return mSource.getModel(name);
 	}
 
+	private WhichService getRdfService() {
+		return isConfigurationModel() ? CONFIGURATION : CONTENT;
+	}
+
+	private boolean isConfigurationModel() {
+		return name.equals(VitroModelSource.ModelName.DISPLAY.toString()) ||
+			name.equals(VitroModelSource.ModelName.DISPLAY_TBOX.toString()) ||
+			name.equals(VitroModelSource.ModelName.DISPLAY_DISPLAY.toString());
+	}
+
 	@Override
 	public String getDefaultGraphUri() {
+		if (ModelNames.namesMap.containsKey(name)) {
+			return ModelNames.namesMap.get(name);
+		}
 		return name;
 	}
 


### PR DESCRIPTION
**[VIVO GitHub issue](https://github.com/vivo-project/VIVO/issues/3957)**

* Other Relevant Links (Mailing list discussion, related pull requests, etc.)

# What does this pull request do?
Added set of workarounds to fix the issue of updating data in configuration graphs with custom entry forms.

# What's new?

- Return Configuration RDF service in IdModelSelector for models with names DISPLAY, DISPLAY_TBOX and DISPLAY_DISPLAY. That's the only configuration models that are used by VitroModelSource.
- Return correct model uri by name in getDefaultGraphUri
- For memory-cached models (all configuration models) wrap model with RDFServiceModel to update in-memory model.


# How should this be tested?
A description of what steps someone could take to:
* Reproduce the problem in the issue
* Test that the pull request resolves the issue
* Try to create a person, set email, change label, set position using entry forms.

# Interested parties
@VIVO-project/vivo-committers
