### PR TITLE
Allow end date be equal to start date in Date time interval validator

### DIFF
--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/VTwo/DateTimeIntervalValidationVTwo.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/VTwo/DateTimeIntervalValidationVTwo.java
@@ -195,7 +195,7 @@ public class DateTimeIntervalValidationVTwo implements N3ValidatorVTwo {
                  Calendar endCal = endDate.asCalendar();
 
                  if( endCal != null ){
-                     if( !startCal.before( endCal ) ){
+                     if (!startCal.before(endCal) && !startCal.equals(endCal)) {
                          if( startPrecision == VitroVocabulary.Precision.YEAR
                              && endPrecision == VitroVocabulary.Precision.YEAR ){
                              errors.putAll( checkYears(startCal,endCal));

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/VTwo/DateTimeIntervalValidationVTwo.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/VTwo/DateTimeIntervalValidationVTwo.java
@@ -195,7 +195,7 @@ public class DateTimeIntervalValidationVTwo implements N3ValidatorVTwo {
                  Calendar endCal = endDate.asCalendar();
 
                  if( endCal != null ){
-                     if (!startCal.before(endCal) && !startCal.equals(endCal)) {
+                     if (startCal.after(endCal)) {
                          if( startPrecision == VitroVocabulary.Precision.YEAR
                              && endPrecision == VitroVocabulary.Precision.YEAR ){
                              errors.putAll( checkYears(startCal,endCal));


### PR DESCRIPTION
**[VIVO GitHub issue](https://github.com/vivo-project/VIVO/issues/3958)**

# What does this pull request do?
Allows start date to be the same as end date in date time interval entry form.

# What's new?
Allows start date to be the same as end date in date time interval entry form validator.

# How should this be tested?
* Reproduce the issue
* Test that the pull request resolves the issue

# Interested parties
@VIVO-project/vivo-committers
