### PR TITLE
Added search results sort fallback

### DIFF
--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/search/controller/SortConfiguration.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/search/controller/SortConfiguration.java
@@ -13,6 +13,7 @@ public class SortConfiguration {
     private boolean selected = false;
     private String label = "";
     private int order = 0;
+    private String fallback;
 
     public SortConfiguration(String id, String label, String field) {
         this.id = id;
@@ -85,6 +86,14 @@ public class SortConfiguration {
 
     public void setOrder(int order) {
         this.order = order;
+    }
+
+    public String getFallback() {
+        return fallback;
+    }
+
+    public void setFallback(String id) {
+        this.fallback = id;
     }
 
 }

--- a/home/src/main/resources/rdf/display/firsttime/search_individuals_vitro.n3
+++ b/home/src/main/resources/rdf/display/firsttime/search_individuals_vitro.n3
@@ -35,22 +35,45 @@
 :sort_title_desc  a                vitro-search:Sort ;
         vitro-search:order         20 ;
         vitro-search:sortField     :field_label_sort ;
+        vitro-search:hasFallback   :sort_name_raw_desc ;
         vitro-search:isAscending   false ;
         vitro-search:id            "titledesc" .
 
-:sort_title_asc  a                vitro-search:Sort ;
+:sort_title_asc  a                 vitro-search:Sort ;
         vitro-search:sortField     :field_label_sort ;
         vitro-search:isAscending   true ;
+        vitro-search:hasFallback   :sort_name_raw_asc ;
         vitro-search:order         30 ;
         vitro-search:id            "titleasc" .
 
+:sort_name_raw_desc  a             vitro-search:Sort ;
+        vitro-search:order         40 ;
+        vitro-search:sortField     :field_name_raw ;
+        vitro-search:isAscending   false ;
+        vitro-search:id            "name_raw_desc" .
+
+:sort_name_raw_asc  a                vitro-search:Sort ;
+        vitro-search:sortField     :field_name_raw ;
+        vitro-search:isAscending   true ;
+        vitro-search:order         50 ;
+        vitro-search:id            "name_raw_asc" .
+
 :sort_by_relevance a                vitro-search:Sort ;
+        vitro-search:sortField     :field_score ;
         vitro-search:id            "relevance" .
+
+:field_score
+        a                          vitro-search:SearchField ;
+        vitro-search:indexField    "score" .
 
 :field_label_sort
         a                          vitro-search:SearchField ;
         vitro-search:isLanguageSpecific true ;
         vitro-search:indexField    "_label_sort" .
+
+:field_name_raw
+        a                          vitro-search:SearchField ;
+        vitro-search:indexField    "nameRaw" .
 
 :field_category
         a                          vitro-search:SearchField ;

--- a/home/src/main/resources/rdf/i18n/de_DE/display/firsttime/search_individuals_vitro.n3
+++ b/home/src/main/resources/rdf/i18n/de_DE/display/firsttime/search_individuals_vitro.n3
@@ -12,3 +12,7 @@
 :field_type rdfs:label "Typ"@de-DE .
 :filter_querytext rdfs:label "Text"@de-DE .
 :field_querytext rdfs:label "Standardfeld"@de-DE .
+:sort_name_raw_desc rdfs:label "Roher Titel Z-A"@de-DE .
+:sort_name_raw_asc rdfs:label "Roher Titel A-Z"@de-DE .
+:field_score rdfs:label "Relevanzfeld"@de-DE .
+:field_name_raw rdfs:label "Rohes Titelfeld"@de-DE .

--- a/home/src/main/resources/rdf/i18n/en_CA/display/firsttime/search_individuals_vitro.n3
+++ b/home/src/main/resources/rdf/i18n/en_CA/display/firsttime/search_individuals_vitro.n3
@@ -12,3 +12,7 @@
 :field_type rdfs:label "Type"@en-CA .
 :filter_querytext rdfs:label "Text"@en-CA .
 :field_querytext rdfs:label "Default field"@en-CA .
+:sort_name_raw_desc rdfs:label "Raw title Z-A"@en-CA .
+:sort_name_raw_asc rdfs:label "Raw title A-Z"@en-CA .
+:field_score rdfs:label "Score"@en-CA .
+:field_name_raw rdfs:label "Raw name field"@en-CA .

--- a/home/src/main/resources/rdf/i18n/en_US/display/firsttime/search_individuals_vitro.n3
+++ b/home/src/main/resources/rdf/i18n/en_US/display/firsttime/search_individuals_vitro.n3
@@ -12,3 +12,8 @@
 :field_type rdfs:label "Type"@en-US .
 :filter_querytext rdfs:label "Text"@en-US .
 :field_querytext rdfs:label "Default field"@en-US .
+:sort_name_raw_desc rdfs:label "Raw title Z-A"@en-US .
+:sort_name_raw_asc rdfs:label "Raw title A-Z"@en-US .
+:field_score rdfs:label "Score"@en-US .
+:field_name_raw rdfs:label "Raw name field"@en-US .
+

--- a/home/src/main/resources/rdf/i18n/en_US/tbox/firsttime/searchOntologyLabels.n3
+++ b/home/src/main/resources/rdf/i18n/en_US/tbox/firsttime/searchOntologyLabels.n3
@@ -29,3 +29,4 @@ search:hasKnownValue rdfs:label "hasKnownValue"@en-US .
 search:public rdfs:label "public"@en-US .
 search:isDefaultForRole rdfs:label "Is default for role"@en-US .
 search:moreLimit rdfs:label "initial facet limit"@en-US .
+search:hasFallback rdfs:label "has fallback"@en-US .

--- a/home/src/main/resources/rdf/i18n/es/display/firsttime/search_individuals_vitro.n3
+++ b/home/src/main/resources/rdf/i18n/es/display/firsttime/search_individuals_vitro.n3
@@ -12,3 +12,7 @@
 :field_type rdfs:label "Tipo"@es .
 :filter_querytext rdfs:label "Texto"@es .
 :field_querytext rdfs:label "Campo predeterminado"@es .
+:sort_name_raw_desc rdfs:label "Título crudo Z-A"@es .
+:sort_name_raw_asc rdfs:label "Título crudo Z-A"@es .
+:field_score rdfs:label "Campo de relevancia"@es .
+:field_name_raw rdfs:label "Campo de título sin formato"@es .

--- a/home/src/main/resources/rdf/i18n/fr_CA/display/firsttime/search_individuals_vitro.n3
+++ b/home/src/main/resources/rdf/i18n/fr_CA/display/firsttime/search_individuals_vitro.n3
@@ -12,3 +12,7 @@
 :field_type rdfs:label "Taper"@fr-CA .
 :filter_querytext rdfs:label "Texte"@fr-CA .
 :field_querytext rdfs:label "Champ par défaut"@fr-CA .
+:sort_name_raw_desc rdfs:label "Titre brut Z-A"@fr-CA .
+:sort_name_raw_asc rdfs:label "Titre brut A-Z"@fr-CA .
+:field_score rdfs:label "Champ de pertinence"@fr-CA .
+:field_name_raw rdfs:label "Champ de nom brut"@fr-CA .

--- a/home/src/main/resources/rdf/i18n/pt_BR/display/firsttime/search_individuals_vitro.n3
+++ b/home/src/main/resources/rdf/i18n/pt_BR/display/firsttime/search_individuals_vitro.n3
@@ -12,3 +12,7 @@
 :field_type rdfs:label "Tipo"@pt-BR .
 :filter_querytext rdfs:label "Texto"@pt-BR .
 :field_querytext rdfs:label "Campo padrão"@pt-BR .
+:sort_name_raw_desc rdfs:label "Título bruto Z-A"@pt-BR .
+:sort_name_raw_asc rdfs:label "Título bruto Z-A"@pt-BR .
+:field_score rdfs:label "Campo de relevância"@pt-BR .
+:field_name_raw rdfs:label "Campo de título bruto"@pt-BR .

--- a/home/src/main/resources/rdf/i18n/ru_RU/display/firsttime/search_individuals_vitro.n3
+++ b/home/src/main/resources/rdf/i18n/ru_RU/display/firsttime/search_individuals_vitro.n3
@@ -12,3 +12,7 @@
 :field_type rdfs:label "Поле тип"@ru-RU .
 :filter_querytext rdfs:label "Текст"@ru-RU .
 :field_querytext rdfs:label "Поле фильтра по умолчанию"@ru-RU .
+:sort_name_raw_desc rdfs:label "сырому названию Я-А"@ru-RU .
+:sort_name_raw_asc rdfs:label "сырому названию А-Я"@ru-RU .
+:field_score rdfs:label "Релевантность"@ru-RU .
+:field_name_raw rdfs:label "Поле сортировки по сырому названию"@ru-RU .

--- a/home/src/main/resources/rdf/i18n/sr_Latn_RS/display/firsttime/search_individuals_vitro.n3
+++ b/home/src/main/resources/rdf/i18n/sr_Latn_RS/display/firsttime/search_individuals_vitro.n3
@@ -12,3 +12,7 @@
 :field_type rdfs:label "Tip"@sr-Latn-RS .
 :filter_querytext rdfs:label "Tekst"@sr-Latn-RS .
 :field_querytext rdfs:label "Podrazumevano polje"@sr-Latn-RS .
+:sort_name_raw_desc rdfs:label "neobrađen Naslov Z-A"@sr-Latn-RS .
+:sort_name_raw_asc rdfs:label "neobrađen Naslov A-Z"@sr-Latn-RS .
+:field_score rdfs:label "Polje za relevantnost"@sr-Latn-RS .
+:field_name_raw rdfs:label "Neobrađeno polje imena"@sr-Latn-RS .

--- a/home/src/main/resources/rdf/tbox/filegraph/search_ontology.n3
+++ b/home/src/main/resources/rdf/tbox/filegraph/search_ontology.n3
@@ -110,6 +110,10 @@ search:sortField  a                   owl:FunctionalProperty , owl:ObjectPropert
         rdfs:domain                   search:Sort ;
         rdfs:range                    search:SearchField .
 
+search:hasFallback  a                 owl:FunctionalProperty , owl:ObjectProperty ;
+        rdfs:domain                   search:Sort ;
+        rdfs:range                    search:Sort .
+
 search:id  a                          owl:DatatypeProperty , owl:FunctionalProperty ;
         rdfs:domain                   search:PublicParameter ;
         rdfs:range                    xsd:string .


### PR DESCRIPTION
**[VIVO GitHub issue](https://github.com/vivo-project/VIVO/issues/3938)**

# What does this pull request do?
Added sort fallback option to provide an option to sort on multiple fields.

# What's new?
Added vitro-search:hasFallback object property to specify fallback sort options.
Defined raw name field and field sort options in search configuration.
Defined score field for default (relevance) sort option.
Used raw name sort options as fallback for language specific sort options.

# How should this be tested?
* Reproduce the problem in the issue
* Test that the pull request fixed the issue

# Interested parties
@VIVO-project/vivo-committers
