### PR TITLE
Update Pull Request Template with reviewers' needed expertise

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -25,11 +25,39 @@ A description of what steps someone could take to:
 Any additional information that you think would be helpful when reviewing this PR.
 
 Example:
-* Does this change require documentation to be updated? 
-* Does this change add any new dependencies? 
-* Does this change require any other modifications to be made to the repository? 
+* Does this change require documentation to be updated?
+* Does this change add any new dependencies?
+* Does this change require any other modifications to be made to the repository?
 * Could this change impact execution of existing code?
-* Large pull requests should be avoided. If this PR is large (more than 1,000 lines of codes), please provide short explanation why your contribution can't be decoupled in smaller PRs. 
+* Large pull requests should be avoided. If this PR is large (more than 1,000 lines of codes), please provide short explanation why your contribution can't be decoupled in smaller PRs.
 
 # Interested parties
 Tag (@ mention) interested parties or, if unsure, @VIVO-project/vivo-committers
+
+# Reviewers' expertise
+**Please add any new expertise in the list which might be needed for reviewing your PR or remove any of the listed if it is not needed.**
+
+Candidates for reviewing this PR should have some of the following expertises:
+1. Java
+1. HTML, CSS, JavaScript
+1. FreeMarker
+1. SPARQL
+1. Ontologies
+1. Docker
+1. Natural language knowledge
+    1. English
+    2. German
+    3. Spanish
+    4. French
+    5. Portuguese
+    6. Russian
+    7. Serbian
+
+# Reviewers' report template
+**Please update the following template which should be used by reviewers.**
+## General comment
+A reviewer should provide here comments and suggestions for requested changes if any.
+## Testing
+A reviewer should briefly describe here how it was tested
+## Code reviewing
+A reviewer should briefly describe here which part was code reviewed


### PR DESCRIPTION
**[VIVO GitHub issue](https://github.com/vivo-project/VIVO/issues)**: [3966](https://github.com/vivo-project/VIVO/issues/3966)

* Other Relevant Links (Mailing list discussion, related pull requests, etc.)
[Linked VIVO PR](https://github.com/vivo-project/VIVO/pull/3967)

# What does this pull request do?
Update PR template

# What's new?

- A section for reviewers' skills has been added
- A section for reviewers' template has been added


# Interested parties
Tag (@ mention) interested parties or, if unsure, @VIVO-project/vivo-committers
