### PR TITLE
Update Freemarker version

### DIFF
--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/web/widgets/Widget.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/web/widgets/Widget.java
@@ -21,6 +21,7 @@ import freemarker.core.Macro;
 import freemarker.template.Template;
 import freemarker.template.TemplateHashModel;
 import freemarker.template.TemplateModelException;
+import freemarker.template.TemplateSequenceModel;
 
 public abstract class Widget {
 
@@ -111,7 +112,7 @@ public abstract class Widget {
         StringWriter out = new StringWriter();
 
         try {
-            String templateString = macro.getChildNodes().get(0).toString();
+            String templateString = getTemplateString(macro);
             // NB Using this method of creating a template from a string does not allow the widget template to import
             // other templates (but it can include other templates). We'd need to use a StringTemplateLoader
             // in the config instead. See StringTemplateLoader API doc.
@@ -128,6 +129,16 @@ public abstract class Widget {
         String output = out.toString();
         log.debug("Macro output: " + output);
         return output;
+    } 
+
+    private String getTemplateString(Macro macro) throws TemplateModelException {
+        TemplateSequenceModel childNodes = macro.getChildNodes();
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < childNodes.size(); i++) {
+            sb.append(childNodes.get(i));
+        }
+        String template = sb.toString();
+        return template;
     }
 
     private String processMacroToString(Environment env, String widgetName, String macroName, Map<String, Object> map) {

--- a/api/src/main/java/org/linkeddatafragments/views/HtmlTriplePatternFragmentWriterImpl.java
+++ b/api/src/main/java/org/linkeddatafragments/views/HtmlTriplePatternFragmentWriterImpl.java
@@ -48,7 +48,7 @@ public class HtmlTriplePatternFragmentWriterImpl extends TriplePatternFragmentWr
     public HtmlTriplePatternFragmentWriterImpl(Map<String, String> prefixes, HashMap<String, IDataSource> datasources) throws IOException {
         super(prefixes, datasources);
 
-        cfg = new Configuration(Configuration.VERSION_2_3_22);
+        cfg = new Configuration(Configuration.VERSION_2_3_32);
         cfg.setClassForTemplateLoading(getClass(), "/views");
         cfg.setDefaultEncoding("UTF-8");
         cfg.setTemplateExceptionHandler(TemplateExceptionHandler.RETHROW_HANDLER);

--- a/api/src/main/java/org/vivoweb/linkeddatafragments/views/HtmlTriplePatternFragmentWriterImpl.java
+++ b/api/src/main/java/org/vivoweb/linkeddatafragments/views/HtmlTriplePatternFragmentWriterImpl.java
@@ -65,7 +65,7 @@ public class HtmlTriplePatternFragmentWriterImpl extends TriplePatternFragmentWr
     public HtmlTriplePatternFragmentWriterImpl(Map<String, String> prefixes, HashMap<String, IDataSource> datasources) throws IOException {
         super(prefixes, datasources);
 
-        cfg = new Configuration(Configuration.VERSION_2_3_23);
+        cfg = new Configuration(Configuration.VERSION_2_3_32);
         cfg.setClassForTemplateLoading(getClass(), "/tpf");
         cfg.setDefaultEncoding("UTF-8");
         cfg.setTemplateExceptionHandler(TemplateExceptionHandler.RETHROW_HANDLER);

--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -222,7 +222,7 @@
         <dependency>
             <groupId>org.freemarker</groupId>
             <artifactId>freemarker</artifactId>
-            <version>2.3.23</version>
+            <version>2.3.32</version>
         </dependency>
         <dependency>
             <groupId>org.jsoup</groupId>


### PR DESCRIPTION
**[VIVO GitHub issue](https://github.com/vivo-project/VIVO/issues/3969)**

# What does this pull request do?
Updated Freemarker to latest version 2.3.32 (release date 2023-01-12)

# What's new?
Adapted get template string code to get all macro child nodes.

# How should this be tested?
A description of what steps someone could take to:
* Log in into VIVO
* Check that there are no errors on pages: profile page, search page, object property editing page, triple pattern fragments page

# Interested parties
@VIVO-project/vivo-committers
