### PR TITLE
Filter unavailable variable substitutions in Sparql query data getter.

### DIFF
--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/utils/dataGetter/SparqlQueryDataGetter.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/utils/dataGetter/SparqlQueryDataGetter.java
@@ -27,7 +27,7 @@ import org.apache.jena.rdf.model.RDFNode;
 import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.rdf.model.ResourceFactory;
 import org.apache.jena.shared.Lock;
-
+import org.apache.jena.sparql.ARQException;
 import edu.cornell.mannlib.vitro.webapp.controller.VitroRequest;
 import edu.cornell.mannlib.vitro.webapp.dao.DisplayVocabulary;
 import edu.cornell.mannlib.vitro.webapp.dao.jena.QueryUtils;
@@ -239,7 +239,14 @@ public class SparqlQueryDataGetter extends DataGetterBase implements DataGetter{
         for (String key : keys) {
             String value = parameters.get(key);
             if (value != null) {
-                substitution.apply(pss, key, value);
+                try {
+                    substitution.apply(pss, key, value);    
+                } catch(ARQException arcException) {
+                    log.error(String.format(
+                            "Exception happend while trying to substitute value %s of variable %s in query\n%s",
+                            value, key, pss.toString()));
+                    throw arcException;
+                }
             }
         }
     }

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/utils/dataGetter/SparqlQueryDataGetter.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/utils/dataGetter/SparqlQueryDataGetter.java
@@ -9,6 +9,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
@@ -169,6 +170,8 @@ public class SparqlQueryDataGetter extends DataGetterBase implements DataGetter{
     public Map<String, Object> getData(Map<String, Object> pageData) {
     	Map<String, String> merged = mergeParameters(vreq.getParameterMap(), pageData);
 
+    	merged = filterUnavailableParameters(merged);
+
     	String boundQueryText = bindParameters(queryText, merged);
 
     	if (modelURI != null) {
@@ -177,6 +180,14 @@ public class SparqlQueryDataGetter extends DataGetterBase implements DataGetter{
     	} else {
     		return doQueryOnRDFService(boundQueryText);
     	}
+    }
+
+    protected Map<String, String> filterUnavailableParameters(Map<String, String> merged) {
+        return merged
+            .entrySet()
+            .stream()
+            .filter(entry -> queryText.contains("?" + entry.getKey()))
+            .collect(Collectors.toMap(map -> map.getKey(), map -> map.getValue()));
     }
 
     /** Merge the pageData with the request parameters. PageData overrides. */

--- a/api/src/test/java/edu/cornell/mannlib/vitro/webapp/utils/dataGetter/SparqlQueryDataGetterTest.java
+++ b/api/src/test/java/edu/cornell/mannlib/vitro/webapp/utils/dataGetter/SparqlQueryDataGetterTest.java
@@ -1,6 +1,9 @@
 /* $This file is distributed under the terms of the license in LICENSE$ */
 package edu.cornell.mannlib.vitro.webapp.utils.dataGetter;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 import java.io.InputStream;
 import java.lang.reflect.InvocationTargetException;
 import java.util.HashMap;
@@ -30,6 +33,7 @@ import stubs.javax.servlet.http.HttpServletRequestStub;
 
 public class SparqlQueryDataGetterTest extends AbstractTestClass {
 
+    private static final String TO_FILTER = "toFilter";
     private static final PropertyImpl HAS_ID = new PropertyImpl("test:has-id");
     private static final String VAR_PARAM = "param";
     private static final String PERSON_TYPE = "http://xmlns.com/foaf/0.1/Person";
@@ -151,6 +155,17 @@ public class SparqlQueryDataGetterTest extends AbstractTestClass {
         params.put(VAR_PARAM, value.toString());
         Map<String, Object> data = sdg.getData(params);
         checkData(data);
+    }
+
+    @Test
+    public void testFilterUnavailableParameters() throws Exception {
+        SparqlQueryDataGetter sdg = getDataGetter("dataGetterStringParam");
+        Map<String, String> unfilteredParameters = new HashMap<String, String>();
+        unfilteredParameters.put(VAR_PARAM, "");
+        unfilteredParameters.put(TO_FILTER, "");
+        Map<String, String> filteredParameters = sdg.filterUnavailableParameters(unfilteredParameters);
+        assertFalse(filteredParameters.containsKey(TO_FILTER));
+        assertTrue(filteredParameters.containsKey(VAR_PARAM));
     }
 
     private SparqlQueryDataGetter getDataGetter(String dataGetterName)


### PR DESCRIPTION
**[VIVO GitHub issue](https://github.com/vivo-project/VIVO/issues/3970)**

# What does this pull request do?
Fixes the issue by filtering variable substitutions not specified in sparql query text.

# What's new?
Added test to check substitution filtering.
Improved error logging.

# How should this be tested?
* Reproduce the problem in the issue
* Verify that PR fixes the issue

# Interested parties
@VIVO-project/vivo-committers
