### PR TITLE
Avoid duplicate statements in CONSTRUCT query to improve perfomance

### DIFF
--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/dao/jena/JenaModelUtils.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/dao/jena/JenaModelUtils.java
@@ -2,6 +2,9 @@
 
 package edu.cornell.mannlib.vitro.webapp.dao.jena;
 
+import static edu.cornell.mannlib.vitro.webapp.dao.jena.SparqlGraph.sparqlNode;
+import static edu.cornell.mannlib.vitro.webapp.dao.jena.SparqlGraph.sparqlNodeDelete;
+
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -565,14 +568,16 @@ public class JenaModelUtils {
 
     private static void addStatementPatterns(List<Statement> stmts,
     		StringBuffer patternBuff, boolean whereClause) {
+        Set<String> lines = new HashSet<>();
         for(Statement stmt : stmts) {
             Triple t = stmt.asTriple();
-            patternBuff.append(SparqlGraph.sparqlNodeDelete(t.getSubject(), null));
-            patternBuff.append(" ");
-            patternBuff.append(SparqlGraph.sparqlNodeDelete(t.getPredicate(), null));
-            patternBuff.append(" ");
-            patternBuff.append(SparqlGraph.sparqlNodeDelete(t.getObject(), null));
-            patternBuff.append(" .\n");
+            String lineWithoutVars = getLine(patternBuff, t, false);
+            if (lines.contains(lineWithoutVars)) {
+                continue;
+            } else {
+                lines.add(lineWithoutVars);
+            }
+            patternBuff.append(getLine(patternBuff, t, true));
             if (whereClause) {
                 if (t.getSubject().isBlank()) {
                     patternBuff.append("    FILTER(isBlank(").append(
@@ -583,6 +588,24 @@ public class JenaModelUtils {
                     		SparqlGraph.sparqlNodeDelete(t.getObject(), null)).append(")) \n");
                 }
             }
+        }
+    }
+
+    private static String getLine(StringBuffer patternBuff, Triple t, boolean createBlankNodeVariables) {
+        if (createBlankNodeVariables) {
+            return sparqlNodeDelete(t.getSubject(), null) +
+                    " " +
+                    sparqlNodeDelete(t.getPredicate(), null) +
+                    " " +
+                    sparqlNodeDelete(t.getObject(), null) +
+                    " .\n";
+        } else {
+            return sparqlNode(t.getSubject(), null) +
+                    " " +
+                    sparqlNode(t.getPredicate(), null) +
+                    " " +
+                    sparqlNode(t.getObject(), null) +
+                    " .\n";
         }
     }
 

--- a/api/src/test/java/edu/cornell/mannlib/vitro/webapp/dao/jena/JenaModelUtilsTest.java
+++ b/api/src/test/java/edu/cornell/mannlib/vitro/webapp/dao/jena/JenaModelUtilsTest.java
@@ -1,0 +1,39 @@
+package edu.cornell.mannlib.vitro.webapp.dao.jena;
+
+import static org.junit.Assert.assertTrue;
+
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.ModelFactory;
+import org.apache.jena.rdf.model.Resource;
+import org.apache.jena.rdf.model.ResourceFactory;
+import org.apache.jena.rdf.model.impl.PropertyImpl;
+import org.apache.jena.rdf.model.impl.ResourceImpl;
+import org.apache.jena.rdf.model.impl.StatementImpl;
+import org.junit.Test;
+
+public class JenaModelUtilsTest {
+
+    @Test
+    public void removeUsingSparqlConstructTest() {
+        Model removeFrom = getModel();
+        Model toRemove = getModel();
+        JenaModelUtils.removeUsingSparqlConstruct(toRemove, removeFrom);
+        assertTrue(removeFrom.isEmpty());
+    }
+
+    private Model getModel() {
+        Model m = ModelFactory.createDefaultModel();
+        for (int i = 0; i < 1000; i++) {
+            m.add(getStatement());
+        }
+        return m;
+    }
+
+    private StatementImpl getStatement() {
+        ResourceImpl subject = new ResourceImpl("test:uri");
+        PropertyImpl property = new PropertyImpl("test:property");
+        Resource object = ResourceFactory.createResource();
+        StatementImpl statement = new StatementImpl(subject, property, object);
+        return statement;
+    }
+}


### PR DESCRIPTION
**[VIVO GitHub issue](https://github.com/vivo-project/VIVO/issues/3979)**

# What does this pull request do?
Improved performance of removing blank statements.

# What's new?
Removed duplicate lines from CONSTRUCT query
Added test

# How should this be tested?
A description of what steps someone could take to:
* Reproduce the problem in the issue
* Test that the pull request resolves the problem
* Run test without the fix, run test after the fix

# Interested parties
@VIVO-project/vivo-committers

# Reviewers' expertise
Candidates for reviewing this PR should have some of the following expertises:
Java, Jena

# Reviewers' report template

## General comment
A reviewer should provide here comments and suggestions for requested changes if any.
## Testing
A reviewer should briefly describe here how it was tested
## Code reviewing
A reviewer should briefly describe here which part was code reviewed