### PR TITLE
Add Jquery and Jquery UI webjars

### DIFF
--- a/webapp/pom.xml
+++ b/webapp/pom.xml
@@ -66,6 +66,21 @@
                                     <outputDirectory>target/${project.artifactId}-${project.version}/webjars/jquery/</outputDirectory>
                                 </artifactItem>
                                 <artifactItem>
+                                    <groupId>org.webjars.npm</groupId>
+                                    <artifactId>jquery-migrate</artifactId>
+                                    <type>jar</type>
+                                    <includes>
+                                        META-INF/resources/webjars/jquery-migrate/*/dist/*.js
+                                    </includes>
+                                    <fileMappers>
+                                        <org.codehaus.plexus.components.io.filemappers.RegExpFileMapper>
+                                            <pattern>^META-INF/resources/webjars/jquery-migrate/[^/]+/</pattern>
+                                            <replacement>./</replacement>
+                                        </org.codehaus.plexus.components.io.filemappers.RegExpFileMapper>
+                                    </fileMappers>
+                                    <outputDirectory>target/${project.artifactId}-${project.version}/webjars/jquery-migrate/</outputDirectory>
+                                </artifactItem>
+                                <artifactItem>
                                     <groupId>org.webjars</groupId>
                                     <artifactId>jquery-ui</artifactId>
                                     <type>jar</type>
@@ -106,6 +121,11 @@
     </build>
 
     <dependencies>
+        <dependency>
+            <groupId>org.webjars.npm</groupId>
+            <artifactId>jquery-migrate</artifactId>
+            <version>3.4.1</version>
+        </dependency>
         <dependency>
             <groupId>org.mvnpm</groupId>
             <artifactId>datatables.net</artifactId>

--- a/webapp/pom.xml
+++ b/webapp/pom.xml
@@ -35,6 +35,21 @@
                         <configuration>
                             <artifactItems>
                                 <artifactItem>
+                                    <groupId>org.mvnpm</groupId>
+                                    <artifactId>datatables.net</artifactId>
+                                    <type>jar</type>
+                                    <includes>
+                                        META-INF/resources/_static/datatables.net/*/js/*.js
+                                    </includes>
+                                    <fileMappers>
+                                        <org.codehaus.plexus.components.io.filemappers.RegExpFileMapper>
+                                            <pattern>^META-INF/resources/_static/datatables.net/[^/]+/</pattern>
+                                            <replacement>./</replacement>
+                                        </org.codehaus.plexus.components.io.filemappers.RegExpFileMapper>
+                                    </fileMappers>
+                                    <outputDirectory>target/${project.artifactId}-${project.version}/webjars/datatables/</outputDirectory>
+                                </artifactItem>
+                                <artifactItem>
                                     <groupId>org.webjars</groupId>
                                     <artifactId>jquery</artifactId>
                                     <type>jar</type>
@@ -91,6 +106,11 @@
     </build>
 
     <dependencies>
+        <dependency>
+            <groupId>org.mvnpm</groupId>
+            <artifactId>datatables.net</artifactId>
+            <version>2.0.5</version>
+        </dependency>
         <dependency>
             <groupId>org.webjars</groupId>
             <artifactId>jquery</artifactId>

--- a/webapp/pom.xml
+++ b/webapp/pom.xml
@@ -22,6 +22,59 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <version>3.6.1</version>
+                <executions>
+                    <execution>
+                        <id>unpack-webjars</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>unpack</goal>
+                        </goals>
+                        <configuration>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>org.webjars</groupId>
+                                    <artifactId>jquery</artifactId>
+                                    <type>jar</type>
+                                    <includes>
+                                        META-INF/resources/webjars/jquery/*/*.map,
+                                        META-INF/resources/webjars/jquery/*/*.js
+                                    </includes>
+                                    <fileMappers>
+                                        <org.codehaus.plexus.components.io.filemappers.RegExpFileMapper>
+                                            <pattern>^META-INF/resources/webjars/jquery/[^/]+/</pattern>
+                                            <replacement>./</replacement>
+                                        </org.codehaus.plexus.components.io.filemappers.RegExpFileMapper>
+                                    </fileMappers>
+                                    <outputDirectory>target/${project.artifactId}-${project.version}/webjars/jquery/</outputDirectory>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>org.webjars</groupId>
+                                    <artifactId>jquery-ui</artifactId>
+                                    <type>jar</type>
+                                    <includes>
+                                        META-INF/resources/webjars/jquery-ui/*/*.css,
+                                        META-INF/resources/webjars/jquery-ui/*/images/*.png,
+                                        META-INF/resources/webjars/jquery-ui/*/*.js
+                                    </includes>
+                                    <fileMappers>
+                                        <org.codehaus.plexus.components.io.filemappers.RegExpFileMapper>
+                                            <pattern>^META-INF/resources/webjars/jquery-ui/[^/]+/</pattern>
+                                            <replacement>./</replacement>
+                                        </org.codehaus.plexus.components.io.filemappers.RegExpFileMapper>
+                                    </fileMappers>
+                                    <outputDirectory>target/${project.artifactId}-${project.version}/webjars/jquery-ui/</outputDirectory>
+                                </artifactItem>
+                            </artifactItems>
+                            <overWriteReleases>true</overWriteReleases>
+                            <overWriteSnapshots>true</overWriteSnapshots>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <artifactId>maven-war-plugin</artifactId>
                 <configuration>
                     <packagingExcludes>WEB-INF/lib/*.jar</packagingExcludes>
@@ -38,6 +91,16 @@
     </build>
 
     <dependencies>
+        <dependency>
+            <groupId>org.webjars</groupId>
+            <artifactId>jquery</artifactId>
+            <version>3.7.1</version>
+        </dependency>
+        <dependency>
+           <groupId>org.webjars</groupId>
+            <artifactId>jquery-ui</artifactId>
+            <version>1.13.2</version>
+        </dependency>
         <dependency>
             <groupId>org.vivoweb</groupId>
             <artifactId>vitro-api</artifactId>


### PR DESCRIPTION
# What does this pull request do?
Added webjars with latest jquery and jquery ui versions
Added datatables dependency used by Map of Science 
https://mvnrepository.com/artifact/org.mvnpm/datatables.net/2.0.5
Added jquery migrate dependency
https://mvnrepository.com/artifact/org.webjars.npm/jquery-migrate/3.4.1
All dependencies are licensed under the MIT license.

# How should this be tested?
Build Vitro and VIVO

# Interested parties
@gneissone 

# Reviewers' expertise

Candidates for reviewing this PR should have some of the following expertises:
1. Maven

# Reviewers' report template
## General comment
A reviewer should provide here comments and suggestions for requested changes if any.
## Testing
A reviewer should briefly describe here how it was tested
## Code reviewing
A reviewer should briefly describe here which part was code reviewed