### PR TITLE
Provide local fonts for TPF and Tenderfoot theme

### DIFF
--- a/api/src/main/resources/tpf/base.ftl.html
+++ b/api/src/main/resources/tpf/base.ftl.html
@@ -6,7 +6,7 @@
   <meta charset="utf-8">
     <title>Linked Data Fragments Server ${ (title!header)?ensure_starts_with("(")?ensure_ends_with(")") }</title>
   <link rel="stylesheet" href="${ assetsPath }style.css" />
-  <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Open+Sans:700italic,400,700|Droid+Sans+Mono" type="text/css" />
+  <link rel="stylesheet" href="../webjars/fonts/open-sans/open-sans.css" type="text/css" />
   <meta name="viewport" content="width=device-width,minimum-scale=1,maximum-scale=1">
 </head>
 <body>

--- a/webapp/pom.xml
+++ b/webapp/pom.xml
@@ -97,6 +97,23 @@
                                     </fileMappers>
                                     <outputDirectory>target/${project.artifactId}-${project.version}/webjars/jquery-ui/</outputDirectory>
                                 </artifactItem>
+                                <artifactItem>
+                                    <groupId>org.webjars.npm</groupId>
+                                    <artifactId>openfonts__noto-sans_all</artifactId>
+                                    <type>jar</type>
+                                    <includes>
+                                        META-INF/resources/webjars/openfonts__noto-sans_all/*/*.css,
+                                        META-INF/resources/webjars/openfonts__noto-sans_all/*/*/*.woff,
+                                        META-INF/resources/webjars/openfonts__noto-sans_all/*/*/*.woff2
+                                    </includes>
+                                    <fileMappers>
+                                        <org.codehaus.plexus.components.io.filemappers.RegExpFileMapper>
+                                            <pattern>^META-INF/resources/webjars/openfonts__noto-sans_all/[^/]+/</pattern>
+                                            <replacement>./</replacement>
+                                        </org.codehaus.plexus.components.io.filemappers.RegExpFileMapper>
+                                    </fileMappers>
+                                    <outputDirectory>target/${project.artifactId}-${project.version}/webjars/fonts/noto-sans/</outputDirectory>
+                                </artifactItem>
                             </artifactItems>
                             <overWriteReleases>true</overWriteReleases>
                             <overWriteSnapshots>true</overWriteSnapshots>
@@ -140,6 +157,11 @@
            <groupId>org.webjars</groupId>
             <artifactId>jquery-ui</artifactId>
             <version>1.13.2</version>
+        </dependency>
+        <dependency>
+            <groupId>org.webjars.npm</groupId>
+            <artifactId>openfonts__noto-sans_all</artifactId>
+            <version>1.44.0</version>
         </dependency>
         <dependency>
             <groupId>org.vivoweb</groupId>

--- a/webapp/pom.xml
+++ b/webapp/pom.xml
@@ -114,6 +114,25 @@
                                     </fileMappers>
                                     <outputDirectory>target/${project.artifactId}-${project.version}/webjars/fonts/noto-sans/</outputDirectory>
                                 </artifactItem>
+                                <artifactItem>
+                                    <groupId>org.webjars.npm</groupId>
+                                    <artifactId>npm-font-open-sans</artifactId>
+                                    <type>jar</type>
+                                    <includes>
+                                        META-INF/resources/webjars/npm-font-open-sans/*/*.css,
+                                        META-INF/resources/webjars/npm-font-open-sans/*/*/*/*.woff,
+                                        META-INF/resources/webjars/npm-font-open-sans/*/*/*/*.ttf,
+                                        META-INF/resources/webjars/npm-font-open-sans/*/*/*/*.svg,
+                                        META-INF/resources/webjars/npm-font-open-sans/*/*/*/*.woff2
+                                    </includes>
+                                    <fileMappers>
+                                        <org.codehaus.plexus.components.io.filemappers.RegExpFileMapper>
+                                            <pattern>^META-INF/resources/webjars/npm-font-open-sans/[^/]+/</pattern>
+                                            <replacement>./</replacement>
+                                        </org.codehaus.plexus.components.io.filemappers.RegExpFileMapper>
+                                    </fileMappers>
+                                    <outputDirectory>target/${project.artifactId}-${project.version}/webjars/fonts/open-sans/</outputDirectory>
+                                </artifactItem>
                             </artifactItems>
                             <overWriteReleases>true</overWriteReleases>
                             <overWriteSnapshots>true</overWriteSnapshots>
@@ -162,6 +181,11 @@
             <groupId>org.webjars.npm</groupId>
             <artifactId>openfonts__noto-sans_all</artifactId>
             <version>1.44.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.webjars.npm</groupId>
+            <artifactId>npm-font-open-sans</artifactId>
+            <version>1.1.0</version>
         </dependency>
         <dependency>
             <groupId>org.vivoweb</groupId>


### PR DESCRIPTION
[VIVO PR](https://github.com/vivo-project/VIVO/pull/3983)
# What does this pull request do?
Added local fonts, fixed Triple Pattern Fragment template to use local fonts.

# What's new?
Added webjar dependencies to provide:
Open Sans font, license Apache 2.0
https://mvnrepository.com/artifact/org.webjars.npm/npm-font-open-sans/1.1.0
Noto Sans font, license MIT
https://mvnrepository.com/artifact/org.webjars.npm/openfonts__noto-sans_all/1.44.0

# How should this be tested?
* Enable TPF by uncommenting tpf.activeFlag = true
* Open TPF page /tpf/core , in web development tools check that local fonts are being downloaded.

# Additional Notes:
Stacked on top of https://github.com/vivo-project/Vitro/pull/464 

# Interested parties
@hauschke 

# Reviewers' expertise
Candidates for reviewing this PR should have some of the following expertises:
1. Maven, web development

# Reviewers' report template
## General comment
A reviewer should provide here comments and suggestions for requested changes if any.
## Testing
A reviewer should briefly describe here how it was tested
## Code reviewing
A reviewer should briefly describe here which part was code reviewed