### PR TITLE
Small mapping update and response parsing fix.

### DIFF
--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/searchengine/elasticsearch/Elasticsearch_notes_on_the_first_draft.md
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/searchengine/elasticsearch/Elasticsearch_notes_on_the_first_draft.md
@@ -65,57 +65,79 @@ git clone -b feature/elasticsearchExperiments https://github.com/j2blake/Vitro.g
 ```
 curl -X PUT "localhost:9200/vivo?pretty" -H 'Content-Type: application/json' -d'
 {
-  "mappings": {
-    "_doc": { 
-      "properties": { 
-        "ALLTEXT": { 
-          "type": "text",
-          "analyzer": "english"
-        }, 
-        "ALLTEXTUNSTEMMED": { 
-          "type": "text",
-          "analyzer": "standard"
-        }, 
-        "DocId": {
-          "type": "keyword"  
-        }, 
-        "classgroup": {
-          "type": "keyword"  
-        }, 
-        "type": {
-          "type": "keyword"  
-        }, 
-        "mostSpecificTypeURIs": {
-          "type": "keyword"  
-        }, 
-        "indexedTime": { 
-          "type": "long" 
-        },
-        "nameRaw": { 
-          "type": "keyword" 
-        },
-        "URI": { 
-          "type": "keyword" 
-        },
-        "THUMBNAIL": { 
-          "type": "integer" 
-        },
-        "THUMBNAIL_URL": { 
-          "type": "keyword" 
-        },
-        "nameLowercaseSingleValued": {
-          "type": "text",
-          "analyzer": "standard",
-          "fielddata": "true"
-        },
-        "BETA" : {
-          "type" : "float"
+  "settings": {
+    "index": {
+      "analysis": {
+        "analyzer": {
+          "default": {
+            "type": "english"
+          }
         }
       }
     }
   },
-  "query": {
-    "default_field": "ALLTEXT"
+  "mappings": {
+    "dynamic_templates": [
+      {
+        "field_sort_template": {
+          "match": "*_label_sort",
+          "mapping": {
+            "type": "text",
+            "fields": {
+              "keyword": {
+                "type": "keyword"
+              }
+            },
+            "fielddata": true
+          }
+        }
+      }
+    ],
+    "properties": { 
+      "ALLTEXT": { 
+        "type": "text",
+        "analyzer": "english"
+      }, 
+      "ALLTEXTUNSTEMMED": { 
+        "type": "text",
+        "analyzer": "standard"
+      }, 
+      "DocId": {
+        "type": "keyword"  
+      }, 
+      "classgroup": {
+        "type": "keyword"  
+      }, 
+      "type": {
+        "type": "keyword"  
+      }, 
+      "mostSpecificTypeURIs": {
+        "type": "keyword"  
+      }, 
+      "indexedTime": { 
+        "type": "long" 
+      },
+      "nameRaw": { 
+        "type": "keyword" 
+      },
+      "URI": { 
+        "type": "keyword" 
+      },
+      "THUMBNAIL": { 
+        "type": "integer" 
+      },
+      "THUMBNAIL_URL": { 
+        "type": "keyword" 
+      },
+      "nameLowercaseSingleValued": {
+        "type": "text",
+        "analyzer": "standard",
+        "fielddata": true
+      },
+      "BETA" : {
+        "type" : "float"
+      }
+    }
   }
 }
 '

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/searchengine/elasticsearch/ResponseParser.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/searchengine/elasticsearch/ResponseParser.java
@@ -98,32 +98,36 @@ class ResponseParser {
         highlightingMap = new HashMap<>();
 
         @SuppressWarnings("unchecked")
-        Map<String, Object> uberHits = (Map<String, Object>) responseMap
-                .get("hits");
+        Map<String, Object> uberHits = (Map<String, Object>) responseMap.get("hits");
         if (uberHits == null) {
-            log.warn("Didn't find a 'hits' field " + "in the query response: "
-                    + responseMap);
+            log.warn("Didn't find a 'hits' field in the query response: " + responseMap);
             return;
         }
 
-        Integer total = (Integer) uberHits.get("total");
+        // Updated handling of the 'total' field
+        @SuppressWarnings("unchecked")
+        Map<String, Object> totalMap = (Map<String, Object>) uberHits.get("total");
+        if (totalMap == null) {
+            log.warn("Didn't find a 'hits.total' field in the query response: " + responseMap);
+            return;
+        }
+        Integer total = ((Number) totalMap.get("value")).intValue(); // Extract the integer value
+
         if (total == null) {
-            log.warn("Didn't find a 'hits.total' field "
-                    + "in the query response: " + responseMap);
+            log.warn("Didn't find a 'hits.total.value' field in the query response: " + responseMap);
             return;
         }
 
         @SuppressWarnings("unchecked")
-        List<Map<String, Object>> hits = (List<Map<String, Object>>) uberHits
-                .get("hits");
+        List<Map<String, Object>> hits = (List<Map<String, Object>>) uberHits.get("hits");
         if (hits == null) {
-            log.warn("Didn't find a 'hits.hits' field "
-                    + "in the query response: " + responseMap);
+            log.warn("Didn't find a 'hits.hits' field in the query response: " + responseMap);
             return;
         }
 
         parseDocuments(hits);
     }
+
 
     private void parseDocuments(List<Map<String, Object>> hits) {
         for (Map<String, Object> hit : hits) {

--- a/home/src/main/resources/config/example.applicationSetup.n3
+++ b/home/src/main/resources/config/example.applicationSetup.n3
@@ -69,13 +69,22 @@
 #    and more rigorous life-cycle checking.
 #
 
+#:instrumentedSearchEngineWrapper
+#    a   vitroWebapp:searchengine.InstrumentedSearchEngineWrapper ,
+#        vitroWebapp:modules.searchEngine.SearchEngine ;
+#    :wraps :solrSearchEngine .
+
+#:solrSearchEngine
+#    a   vitroWebapp:searchengine.solr.SolrSearchEngine ,
+#        vitroWebapp:modules.searchEngine.SearchEngine .
+
 :instrumentedSearchEngineWrapper
     a   vitroWebapp:searchengine.InstrumentedSearchEngineWrapper ,
         vitroWebapp:modules.searchEngine.SearchEngine ;
-    :wraps :solrSearchEngine .
+    :wraps :elasticSearchEngine .
 
-:solrSearchEngine
-    a   vitroWebapp:searchengine.solr.SolrSearchEngine ,
+:elasticSearchEngine
+    a   vitroWebapp:searchengine.elasticsearch.ElasticSearchEngine ,
         vitroWebapp:modules.searchEngine.SearchEngine .
 
 # ----------------------------


### PR DESCRIPTION
# What does this pull request do?
Updates current ES 6.x integration to 8.x.

# What's new?
Changes in ResponseParser and ES documentation on the first draft.

Example:
* Changed `src/main/java/edu/cornell/mannlib/vitro/webapp/searchengine/elasticsearch/ResponseParser.java` to be in line with current ES API
* Updated `src/main/java/edu/cornell/mannlib/vitro/webapp/searchengine/elasticsearch/Elasticsearch_notes_on_the_first_draft.md` with new mapping
* Updated example.applicationSetup.n3 to show ES setup example

# How should this be tested?
Common manual tests should be performed.

# Interested parties
@chenejac 

# Reviewers' expertise

Candidates for reviewing this PR should have some of the following expertises:
1. Java
2. Elasticsearch 8.*