### PR TITLE
Translated SPARQL interface to DE

### DIFF
--- a/home/src/main/resources/rdf/i18n/de_DE/interface-i18n/firsttime/vitro_UiLabel.ttl
+++ b/home/src/main/resources/rdf/i18n/de_DE/interface-i18n/firsttime/vitro_UiLabel.ttl
@@ -3945,7 +3945,7 @@ uil-data:date_time_value_for.Vitro
 uil-data:sparql_query_title.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;
-        rdfs:label       "SPARQL-Query"@de-DE ;
+        rdfs:label       "SPARQL-Abfrage"@de-DE ;
         uil:hasApp      "Vitro" ;
         uil:hasKey      "sparql_query_title" ;
         uil:hasPackage  "Vitro-languages" .

--- a/home/src/main/resources/rdf/i18n/de_DE/interface-i18n/firsttime/vitro_UiLabel.ttl
+++ b/home/src/main/resources/rdf/i18n/de_DE/interface-i18n/firsttime/vitro_UiLabel.ttl
@@ -577,7 +577,7 @@ uil-data:you_can.Vitro
 uil-data:supply_sparql_query.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;
-        rdfs:label       "Sie müssen eine Sparql-Anfrage angeben."@de-DE ;
+        rdfs:label       "Sie müssen eine Sparql-Abfrage angeben."@de-DE ;
         uil:hasApp      "Vitro" ;
         uil:hasKey      "supply_sparql_query" ;
         uil:hasPackage  "Vitro-languages" .
@@ -1281,7 +1281,7 @@ uil-data:password_saved.Vitro
 uil-data:supply_query_variable.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;
-        rdfs:label       "Sie müssen eine Variable angeben, um Anfrageergebnisse zu speichern."@de-DE ;
+        rdfs:label       "Sie müssen eine Variable angeben, um Abfrageergebnisse zu speichern."@de-DE ;
         uil:hasApp      "Vitro" ;
         uil:hasKey      "supply_query_variable" ;
         uil:hasPackage  "Vitro-languages" .
@@ -1321,7 +1321,7 @@ uil-data:verbose_property_status.Vitro
 uil-data:sparql_query_select_ask_results.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;
-        rdfs:label       "Format for SELECT and ASK query results"@de-DE ;
+        rdfs:label       "Format für SELECT- und ASK-Abfrageergebnisse"@de-DE ;
         uil:hasApp      "Vitro" ;
         uil:hasKey      "sparql_query_select_ask_results" ;
         uil:hasPackage  "Vitro-languages" .
@@ -2369,7 +2369,7 @@ uil-data:no_image.Vitro
 uil-data:sparql_query_save_results.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;
-        rdfs:label       "Save results to file"@de-DE ;
+        rdfs:label       "Ergebnisse in Datei speichern"@de-DE ;
         uil:hasApp      "Vitro" ;
         uil:hasKey      "sparql_query_save_results" ;
         uil:hasPackage  "Vitro-languages" .
@@ -3137,7 +3137,7 @@ uil-data:resource_uri.Vitro
 uil-data:sparql_query_run_query.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;
-        rdfs:label       "Run Query"@de-DE ;
+        rdfs:label       "Query starten"@de-DE ;
         uil:hasApp      "Vitro" ;
         uil:hasKey      "sparql_query_run_query" ;
         uil:hasPackage  "Vitro-languages" .
@@ -3353,7 +3353,7 @@ uil-data:search_tip_one.Vitro
 uil-data:sparql_query_construct_describe_results.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;
-        rdfs:label       "Format for CONSTRUCT and DESCRIBE query results"@de-DE ;
+        rdfs:label       "Format für CONSTRUCT- und DESCRIBE-Abfrageergebnisse"@de-DE ;
         uil:hasApp      "Vitro" ;
         uil:hasKey      "sparql_query_construct_describe_results" ;
         uil:hasPackage  "Vitro-languages" .
@@ -3945,7 +3945,7 @@ uil-data:date_time_value_for.Vitro
 uil-data:sparql_query_title.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;
-        rdfs:label       "SPARQL Query"@de-DE ;
+        rdfs:label       "SPARQL-Query"@de-DE ;
         uil:hasApp      "Vitro" ;
         uil:hasKey      "sparql_query_title" ;
         uil:hasPackage  "Vitro-languages" .
@@ -4233,7 +4233,7 @@ uil-data:browse_page_javascript_one.Vitro
 uil-data:sparql_query_builder.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;
-        rdfs:label       "SPARQL Query Builder"@de-DE ;
+        rdfs:label       "SPARQL-Query-Builder"@de-DE ;
         uil:hasApp      "Vitro" ;
         uil:hasKey      "sparql_query_builder" ;
         uil:hasPackage  "Vitro-languages" .
@@ -5081,7 +5081,7 @@ uil-data:return_to_the.Vitro
 uil-data:sparql_query.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;
-        rdfs:label       "SPARQL Query"@de-DE ;
+        rdfs:label       "SPARQL-Query"@de-DE ;
         uil:hasApp      "Vitro" ;
         uil:hasKey      "sparql_query" ;
         uil:hasPackage  "Vitro-languages" .

--- a/home/src/main/resources/rdf/i18n/de_DE/interface-i18n/firsttime/vitro_UiLabel.ttl
+++ b/home/src/main/resources/rdf/i18n/de_DE/interface-i18n/firsttime/vitro_UiLabel.ttl
@@ -5081,7 +5081,7 @@ uil-data:return_to_the.Vitro
 uil-data:sparql_query.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;
-        rdfs:label       "SPARQL-Query"@de-DE ;
+        rdfs:label       "SPARQL-Abfrage"@de-DE ;
         uil:hasApp      "Vitro" ;
         uil:hasKey      "sparql_query" ;
         uil:hasPackage  "Vitro-languages" .

--- a/home/src/main/resources/rdf/i18n/de_DE/interface-i18n/firsttime/vitro_UiLabel.ttl
+++ b/home/src/main/resources/rdf/i18n/de_DE/interface-i18n/firsttime/vitro_UiLabel.ttl
@@ -3137,7 +3137,7 @@ uil-data:resource_uri.Vitro
 uil-data:sparql_query_run_query.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;
-        rdfs:label       "Query starten"@de-DE ;
+        rdfs:label       "Abfrage starten"@de-DE ;
         uil:hasApp      "Vitro" ;
         uil:hasKey      "sparql_query_run_query" ;
         uil:hasPackage  "Vitro-languages" .


### PR DESCRIPTION
**[VIVO GitHub issue](https://github.com/vivo-project/VIVO/issues)**: https://github.com/vivo-project/VIVO/issues/3990

# What does this pull request do?
Adds labels for German translation of /admin/sparqlquery.

# What's new?
Untranslated labels are now translated, some missing hyphens were added, too.

# How should this be tested?
A German native speaker should have a look. 

# Interested parties
@VIVO-project/vivo-committers, German speaking VIVO users

# Reviewers' expertise
1. Natural language knowledge
    1. German

# Reviewers' report template
**Please update the following template which should be used by reviewers.**
## General comment
A reviewer should provide here comments and suggestions for requested changes if any.
## Testing
A reviewer should briefly describe here how it was tested
## Code reviewing
A reviewer should briefly describe here which part was code reviewed