### PR TITLE
Browse filter results on page

### DIFF
--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/dao/DisplayVocabulary.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/dao/DisplayVocabulary.java
@@ -137,6 +137,7 @@ public class DisplayVocabulary {
 
     /* URI of property for Fixed HTML Generator */
     public static final String FIXED_HTML_VALUE = DISPLAY_NS + "htmlValue";
+    public static final String SEARCH_FILTER_VALUE = DISPLAY_NS + "searchFilter";
 
 
     /* URI of property for Search Query Generator */

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/dao/VitroVocabulary.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/dao/VitroVocabulary.java
@@ -12,6 +12,7 @@ public class VitroVocabulary {
     public static final String VITRO_AUTH = "http://vitro.mannlib.cornell.edu/ns/vitro/authorization#";
     public static final String VITRO_PUBLIC = "http://vitro.mannlib.cornell.edu/ns/vitro/public#";
     public static final String VITRO_PUBLIC_ONTOLOGY = "http://vitro.mannlib.cornell.edu/ns/vitro/public";
+    public static final String VITRO_SEARCH_INDIVIDUAL ="https://vivoweb.org/ontology/vitro-search-individual/";
     // TODO change the following before 1.6 release
     public static final String PROPERTY_CONFIG_DATA = "http://vitro.mannlib.cornell.edu/ns/vitro/siteConfig/";
 

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/ManagePageGenerator.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/ManagePageGenerator.java
@@ -526,6 +526,8 @@ private String getExistingIsSelfContainedTemplateQuery() {
      	MenuManagementDataUtils.includeRequiredSystemData(vreq.getSession().getServletContext(), data);
     	data.put("classGroup", new ArrayList<String>());
     	data.put("classGroups", DataGetterUtils.getClassGroups(vreq));
+    	data.put("searchFilter", new ArrayList<String>());
+    	data.put("searchFilters", DataGetterUtils.getSearchFilters(vreq));
     	//for search individuals data get getter
     	data.put("classes", this.getAllVClasses(vreq));
     	data.put("availablePermissions", this.getAvailablePermissions(vreq));

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/preprocessors/utils/ProcessDataGetterN3Map.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/preprocessors/utils/ProcessDataGetterN3Map.java
@@ -7,29 +7,37 @@ import java.util.HashMap;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
+import edu.cornell.mannlib.vitro.webapp.utils.dataGetter.ClassGroupPageData;
+import edu.cornell.mannlib.vitro.webapp.utils.dataGetter.FixedHTMLDataGetter;
+import edu.cornell.mannlib.vitro.webapp.utils.dataGetter.IndividualsForClassesDataGetter;
+import edu.cornell.mannlib.vitro.webapp.utils.dataGetter.SearchFilterValuesDataGetter;
+import edu.cornell.mannlib.vitro.webapp.utils.dataGetter.SearchIndividualsDataGetter;
+import edu.cornell.mannlib.vitro.webapp.utils.dataGetter.SparqlQueryDataGetter;
+
 /*
  * This class determines what n3 should be returned for a particular data getter and can be overwritten or extended in VIVO.
  */
 public class ProcessDataGetterN3Map {
     private static final Log log = LogFactory.getLog(ProcessDataGetterN3Map.class);
 
-	private static HashMap<String, String> dataGetterMap;
+	private static HashMap<String, Class> dataGetterMap;
 
 	static {
-		dataGetterMap = new HashMap<String, String>();
-		dataGetterMap.put("edu.cornell.mannlib.vitro.webapp.utils.dataGetter.SparqlQueryDataGetter", "edu.cornell.mannlib.vitro.webapp.edit.n3editing.configuration.preprocessors.utils.ProcessSparqlDataGetterN3");
-		dataGetterMap.put("edu.cornell.mannlib.vitro.webapp.utils.dataGetter.ClassGroupPageData", "edu.cornell.mannlib.vitro.webapp.edit.n3editing.configuration.preprocessors.utils.ProcessClassGroupDataGetterN3");
-		dataGetterMap.put("edu.cornell.mannlib.vitro.webapp.utils.dataGetter.IndividualsForClassesDataGetter", "edu.cornell.mannlib.vitro.webapp.edit.n3editing.configuration.preprocessors.utils.ProcessIndividualsForClassesDataGetterN3");
-		dataGetterMap.put("edu.cornell.mannlib.vitro.webapp.utils.dataGetter.FixedHTMLDataGetter", "edu.cornell.mannlib.vitro.webapp.edit.n3editing.configuration.preprocessors.utils.ProcessFixedHTMLN3");
-		dataGetterMap.put("edu.cornell.mannlib.vitro.webapp.utils.dataGetter.SearchIndividualsDataGetter", "edu.cornell.mannlib.vitro.webapp.edit.n3editing.configuration.preprocessors.utils.ProcessSearchIndividualsDataGetterN3");
+		dataGetterMap = new HashMap<String, Class>(); 
+		dataGetterMap.put(SparqlQueryDataGetter.class.getCanonicalName(), ProcessSparqlDataGetterN3.class);
+		dataGetterMap.put(ClassGroupPageData.class.getCanonicalName(), ProcessClassGroupDataGetterN3.class);
+		dataGetterMap.put(SearchFilterValuesDataGetter.class.getCanonicalName(), ProcessSearchFilterValuesDataGetterN3.class);
+		dataGetterMap.put(IndividualsForClassesDataGetter.class.getCanonicalName(), ProcessIndividualsForClassesDataGetterN3.class);
+		dataGetterMap.put(FixedHTMLDataGetter.class.getCanonicalName(), ProcessFixedHTMLN3.class);
+		dataGetterMap.put(SearchIndividualsDataGetter.class.getCanonicalName(), ProcessSearchIndividualsDataGetterN3.class);
 	}
 
-    public static HashMap<String, String> getDataGetterTypeToProcessorMap() {
+    public static HashMap<String, Class> getDataGetterTypeToProcessorMap() {
 		return dataGetterMap;
     }
 
-	public static void replaceDataGetterMap(HashMap<String, String> newMap) {
-		dataGetterMap = new HashMap<String, String>();
+	public static void replaceDataGetterMap(HashMap<String, Class> newMap) {
+		dataGetterMap = new HashMap<String, Class>();
 		dataGetterMap.putAll(newMap);
 	}
 }

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/preprocessors/utils/ProcessDataGetterN3Utils.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/preprocessors/utils/ProcessDataGetterN3Utils.java
@@ -17,26 +17,26 @@ public class ProcessDataGetterN3Utils {
     private static final Log log = LogFactory.getLog(ProcessDataGetterN3Utils.class);
 
     public static ProcessDataGetterN3 getDataGetterProcessorN3(String dataGetterClass, ObjectNode jsonObject) {
-    	HashMap<String, String> map = ProcessDataGetterN3Map.getDataGetterTypeToProcessorMap();
+    	HashMap<String, Class> map = ProcessDataGetterN3Map.getDataGetterTypeToProcessorMap();
     	//
     	if(map.containsKey(dataGetterClass)) {
-    		String processorClass = map.get(dataGetterClass);
+    		Class<?> processorClass = map.get(dataGetterClass);
     		try {
     			ProcessDataGetterN3 pn = instantiateClass(processorClass, jsonObject);
     			return pn;
     		} catch(Exception ex) {
     			log.error("Exception occurred in trying to get processor class for n3 for " + dataGetterClass, ex);
     			return null;
-    		}
+    		} 
     	}
+    	log.error(ProcessDataGetterN3Map.class.getSimpleName() + " doesn't contain processor class for n3 for " + dataGetterClass);
     	return null;
     }
 
-    private static ProcessDataGetterN3 instantiateClass(String processorClass, ObjectNode jsonObject) {
+    private static ProcessDataGetterN3 instantiateClass(Class<?> processorClass, ObjectNode jsonObject) {
     	ProcessDataGetterN3 pn = null;
     	try {
-	    	Class<?> clz = Class.forName(processorClass);
-	    	Constructor<?>[] ctList = clz.getConstructors();
+	    	Constructor<?>[] ctList = processorClass.getConstructors();
 	    	for (Constructor<?> ct: ctList) {
 		    	Class<?>[] parameterTypes =ct.getParameterTypes();
 				if(parameterTypes.length > 0 && parameterTypes[0].isAssignableFrom(jsonObject.getClass())) {
@@ -47,7 +47,7 @@ public class ProcessDataGetterN3Utils {
 	    	}
 
     	} catch(Exception ex) {
-			log.error("Error occurred instantiating " + processorClass, ex);
+			log.error("Error occurred instantiating " + processorClass.getCanonicalName(), ex);
 		}
     	return pn;
 

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/preprocessors/utils/ProcessDataGetterN3Utils.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/preprocessors/utils/ProcessDataGetterN3Utils.java
@@ -28,9 +28,11 @@ public class ProcessDataGetterN3Utils {
     			log.error("Exception occurred in trying to get processor class for n3 for " + dataGetterClass, ex);
     			return null;
     		} 
+    	} else {
+    	    log.error(ProcessDataGetterN3Map.class.getSimpleName() + " doesn't contain processor class for n3 for " + dataGetterClass);
+    	    return null;
     	}
-    	log.error(ProcessDataGetterN3Map.class.getSimpleName() + " doesn't contain processor class for n3 for " + dataGetterClass);
-    	return null;
+    	
     }
 
     private static ProcessDataGetterN3 instantiateClass(Class<?> processorClass, ObjectNode jsonObject) {

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/preprocessors/utils/ProcessSearchFilterValuesDataGetterN3.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/preprocessors/utils/ProcessSearchFilterValuesDataGetterN3.java
@@ -1,0 +1,157 @@
+/* $This file is distributed under the terms of the license in LICENSE$ */
+
+package edu.cornell.mannlib.vitro.webapp.edit.n3editing.configuration.preprocessors.utils;
+
+import static edu.cornell.mannlib.vitro.webapp.dao.DisplayVocabulary.SEARCH_FILTER_VALUE;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import javax.servlet.ServletContext;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import edu.cornell.mannlib.vitro.webapp.dao.DisplayVocabulary;
+import edu.cornell.mannlib.vitro.webapp.dao.VitroVocabulary;
+import edu.cornell.mannlib.vitro.webapp.edit.n3editing.VTwo.fields.FieldVTwo;
+import edu.cornell.mannlib.vitro.webapp.utils.dataGetter.SearchFilterValuesDataGetter;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.jena.ontology.OntModel;
+import org.apache.jena.query.Query;
+import org.apache.jena.query.QueryExecution;
+import org.apache.jena.query.QueryExecutionFactory;
+import org.apache.jena.query.QueryFactory;
+import org.apache.jena.query.QuerySolution;
+import org.apache.jena.query.ResultSet;
+import org.apache.jena.rdf.model.Literal;
+import org.apache.jena.rdf.model.Resource;
+
+//Returns the appropriate n3 based on data getter
+public class ProcessSearchFilterValuesDataGetterN3 extends ProcessDataGetterAbstract {
+    private static String classType = "java:" + SearchFilterValuesDataGetter.class.getCanonicalName();
+    public static String searchFilterVarBase = "filterUri";
+    private Log log = LogFactory.getLog(ProcessSearchFilterValuesDataGetterN3.class);
+
+    public ProcessSearchFilterValuesDataGetterN3() {
+    }
+
+    public List<String> retrieveN3Required(int counter) {
+        return retrieveN3ForTypeAndFilter(counter);
+    }
+
+    public List<String> retrieveN3Optional(int counter) {
+        return null;
+    }
+
+    public List<String> retrieveN3ForTypeAndFilter(int counter) {
+        String n3ForType = getN3ForTypePartial(counter);
+        String n3 = n3ForType + "; \n" + "<" + DisplayVocabulary.SEARCH_FILTER_VALUE + "> "
+                + getN3VarName(searchFilterVarBase, counter) + " .";
+        List<String> n3List = new ArrayList<String>();
+        n3List.add(getPrefixes() + n3);
+        return n3List;
+    }
+
+    public String getN3ForTypePartial(int counter) {
+        String dataGetterVar = getDataGetterVar(counter);
+        String classTypeVar = getN3VarName(classTypeVarBase, counter);
+        String n3 = dataGetterVar + " a " + classTypeVar;
+        return n3;
+    }
+
+    public List<String> retrieveLiteralsOnForm(int counter) {
+        // no literals, just the class group URI
+        List<String> literalsOnForm = new ArrayList<String>();
+        return literalsOnForm;
+    }
+
+    public List<String> retrieveUrisOnForm(int counter) {
+        List<String> urisOnForm = new ArrayList<String>();
+        urisOnForm.add(getVarName("filterUri", counter));
+        urisOnForm.add(getVarName(classTypeVarBase, counter));
+        return urisOnForm;
+    }
+
+    public List<FieldVTwo> retrieveFields(int counter) {
+        List<FieldVTwo> fields = new ArrayList<FieldVTwo>();
+        fields.add(new FieldVTwo().setName(getVarName("filterUri", counter)));
+        fields.add(new FieldVTwo().setName(getVarName(classTypeVarBase, counter)));
+        return fields;
+    }
+
+    public List<String> getLiteralVarNamesBase() {
+        return Arrays.asList();
+    }
+
+    public List<String> getUriVarNamesBase() {
+        return Arrays.asList("filterUri", classTypeVarBase);
+    }
+
+    public String getClassType() {
+        return classType;
+    }
+
+    public void populateExistingValues(String dataGetterURI, int counter, OntModel queryModel) {
+        // First, put dataGetterURI within scope as well
+        this.populateExistingDataGetterURI(dataGetterURI, counter);
+        // Put in type
+        this.populateExistingClassType(this.getClassType(), counter);
+        // Sparql queries for values to be executed
+        // And then placed in the correct place/literal or uri
+        String querystr = getExistingValuesClassGroup(dataGetterURI);
+        QueryExecution qe = null;
+        try {
+            Query query = QueryFactory.create(querystr);
+            qe = QueryExecutionFactory.create(query, queryModel);
+            ResultSet results = qe.execSelect();
+            while (results.hasNext()) {
+                QuerySolution qs = results.nextSolution();
+                Resource classGroupResource = qs.getResource("filterUri");
+                // Put both literals in existing literals
+                existingUriValues.put(this.getVarName(searchFilterVarBase, counter),
+                        new ArrayList<String>(Arrays.asList(classGroupResource.getURI())));
+            }
+        } catch (Exception ex) {
+            log.error("Exception occurred in retrieving existing values with query " + querystr, ex);
+        }
+    }
+
+    protected String getExistingValuesClassGroup(String dataGetterURI) {
+        String query = getSparqlPrefix() + "\n" +
+            "SELECT ?filterUri ?filterName WHERE {" +
+            "<" + dataGetterURI + "> <" + SEARCH_FILTER_VALUE + "> ?filterUri .\n" +
+            "?filterUri <" + VitroVocabulary.LABEL + "> ?filterName .\n" +
+            "}";
+        return query;
+    }
+
+    public ObjectNode getExistingValuesJSON(String dataGetterURI, OntModel queryModel, ServletContext context) {
+        ObjectNode jObject = new ObjectMapper().createObjectNode();
+        jObject.put("dataGetterClass", classType);
+        jObject.put(classTypeVarBase, classType);
+        getExistingSearchFilters(dataGetterURI, jObject, queryModel);
+        return jObject;
+    }
+
+    private void getExistingSearchFilters(String dataGetterURI, ObjectNode jObject, OntModel queryModel) {
+        String querystr = getExistingValuesClassGroup(dataGetterURI);
+        QueryExecution qe = null;
+        try {
+            Query query = QueryFactory.create(querystr);
+            qe = QueryExecutionFactory.create(query, queryModel);
+            ResultSet results = qe.execSelect();
+            while (results.hasNext()) {
+                QuerySolution qs = results.nextSolution();
+                Resource filterUri = qs.getResource("filterUri");
+                Literal name = qs.getLiteral("filterName");
+                jObject.put("searchFilterUri", filterUri.getURI());
+                jObject.put("searchFilterName", name.getLexicalForm());
+            }
+        } catch (Exception ex) {
+            log.error("Exception occurred in retrieving existing values with query " + querystr, ex);
+        }
+    }
+
+}

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/preprocessors/utils/ProcessSearchFilterValuesDataGetterN3.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/preprocessors/utils/ProcessSearchFilterValuesDataGetterN3.java
@@ -69,14 +69,14 @@ public class ProcessSearchFilterValuesDataGetterN3 extends ProcessDataGetterAbst
 
     public List<String> retrieveUrisOnForm(int counter) {
         List<String> urisOnForm = new ArrayList<String>();
-        urisOnForm.add(getVarName("filterUri", counter));
+        urisOnForm.add(getVarName(searchFilterVarBase, counter));
         urisOnForm.add(getVarName(classTypeVarBase, counter));
         return urisOnForm;
     }
 
     public List<FieldVTwo> retrieveFields(int counter) {
         List<FieldVTwo> fields = new ArrayList<FieldVTwo>();
-        fields.add(new FieldVTwo().setName(getVarName("filterUri", counter)));
+        fields.add(new FieldVTwo().setName(getVarName(searchFilterVarBase, counter)));
         fields.add(new FieldVTwo().setName(getVarName(classTypeVarBase, counter)));
         return fields;
     }
@@ -86,7 +86,7 @@ public class ProcessSearchFilterValuesDataGetterN3 extends ProcessDataGetterAbst
     }
 
     public List<String> getUriVarNamesBase() {
-        return Arrays.asList("filterUri", classTypeVarBase);
+        return Arrays.asList(searchFilterVarBase, classTypeVarBase);
     }
 
     public String getClassType() {
@@ -108,7 +108,7 @@ public class ProcessSearchFilterValuesDataGetterN3 extends ProcessDataGetterAbst
             ResultSet results = qe.execSelect();
             while (results.hasNext()) {
                 QuerySolution qs = results.nextSolution();
-                Resource classGroupResource = qs.getResource("filterUri");
+                Resource classGroupResource = qs.getResource(searchFilterVarBase);
                 // Put both literals in existing literals
                 existingUriValues.put(this.getVarName(searchFilterVarBase, counter),
                         new ArrayList<String>(Arrays.asList(classGroupResource.getURI())));
@@ -144,7 +144,7 @@ public class ProcessSearchFilterValuesDataGetterN3 extends ProcessDataGetterAbst
             ResultSet results = qe.execSelect();
             while (results.hasNext()) {
                 QuerySolution qs = results.nextSolution();
-                Resource filterUri = qs.getResource("filterUri");
+                Resource filterUri = qs.getResource(searchFilterVarBase);
                 Literal name = qs.getLiteral("filterName");
                 jObject.put("searchFilterUri", filterUri.getURI());
                 jObject.put("searchFilterName", name.getLexicalForm());

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/modules/searchEngine/SearchQuery.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/modules/searchEngine/SearchQuery.java
@@ -139,4 +139,26 @@ public interface SearchQuery {
 	 * @return A negative value means that no limit has been specified.
 	 */
 	int getFacetMinCount();
+
+    /**
+     * @param text is the text a facet field should contain.
+     * @return this query
+     */
+	SearchQuery setFacetTextToMatch(String text);
+
+    /**
+     * @return The text a facet field.
+     */
+    String getFacetTextToMatch();
+
+    /**
+     * @param ignoreCase defines whether the text of a facet field should be compared case insensitively.
+     * @return this query
+     */
+    SearchQuery setFacetTextCompareCaseInsensitive(boolean ignoreCase);
+
+    /**
+     * @return defines whether the text of a facet field should be compared case insensitively.
+     */
+    boolean isFacetTextCompareCaseInsensitive();
 }

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/search/controller/FilterValue.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/search/controller/FilterValue.java
@@ -14,18 +14,14 @@ public class FilterValue {
 
     private boolean isDefaultValue;
 
-    private boolean publiclyAvailable = true;
+    private boolean display = false;
 
-    public boolean isPubliclyAvailable() {
-        return publiclyAvailable;
+    public boolean isDisplay() {
+        return display;
     }
 
-    public void setPubliclyAvailable(RDFNode rdfNode) {
-        if (rdfNode != null && rdfNode.isLiteral()) {
-            publiclyAvailable = rdfNode.asLiteral().getBoolean();
-        } else {
-            publiclyAvailable = false;
-        }
+    public void setDisplay(boolean value) {
+        display = value;
     }
 
     public FilterValue(String id) {

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/search/controller/FilterValue.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/search/controller/FilterValue.java
@@ -6,14 +6,10 @@ public class FilterValue {
 
     private String id;
     private String name = "";
-    private int order;
-
+    private int rank;
     private long count;
-
     private boolean selected = false;
-
     private boolean isDefaultValue;
-
     private boolean displayed = false;
 
     public boolean isDisplayed() {
@@ -46,13 +42,13 @@ public class FilterValue {
         }
     }
 
-    public Integer getOrder() {
-        return order;
+    public Integer getRank() {
+        return rank;
     }
 
-    public void setOrder(RDFNode rdfNode) {
+    public void setRank(RDFNode rdfNode) {
         if (rdfNode != null) {
-            order = rdfNode.asLiteral().getInt();
+            rank = rdfNode.asLiteral().getInt();
         }
     }
 

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/search/controller/FilterValue.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/search/controller/FilterValue.java
@@ -14,14 +14,14 @@ public class FilterValue {
 
     private boolean isDefaultValue;
 
-    private boolean display = false;
+    private boolean displayed = false;
 
-    public boolean isDisplay() {
-        return display;
+    public boolean isDisplayed() {
+        return displayed;
     }
 
-    public void setDisplay(boolean value) {
-        display = value;
+    public void setDisplayed(boolean value) {
+        displayed = value;
     }
 
     public FilterValue(String id) {
@@ -72,7 +72,7 @@ public class FilterValue {
         this.selected = value;
     }
 
-    public boolean getSelected() {
+    public boolean isSelected() {
         return selected;
     }
 

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/search/controller/PagedSearchController.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/search/controller/PagedSearchController.java
@@ -274,7 +274,7 @@ public class PagedSearchController extends FreemarkerHttpServlet {
                         SearchFiltering.getFiltersForTemplate(filterConfigurationsByField);
                 body.put("filters", filtersForTemplateById);
                 body.put("filterGroups", SearchFiltering.readFilterGroupsConfigurations(vreq, filtersForTemplateById));
-                body.put("sorting", sortConfigurations.values());
+                body.put("sortOptions", sortConfigurations);
                 body.put("emptySearch", isEmptySearchFilters(filterConfigurationsByField));
             }
 

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/search/controller/PagedSearchController.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/search/controller/PagedSearchController.java
@@ -266,7 +266,7 @@ public class PagedSearchController extends FreemarkerHttpServlet {
                     log.debug(getSpentTime(startTime) + "ms spent before sorting filterConfigurationsByField values.");
                 }
                 for (Entry<String, SearchFilter> entry : filterConfigurationsByField.entrySet()) {
-                    entry.getValue().sortValues();
+                    entry.getValue().sortValues(vreq.getCollator());
                 }
                 if (log.isDebugEnabled()) {
                     log.debug(getSpentTime(startTime) + "ms spent after sorting filterConfigurationsByField values.");

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/search/controller/PagedSearchController.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/search/controller/PagedSearchController.java
@@ -138,12 +138,12 @@ public class PagedSearchController extends FreemarkerHttpServlet {
 
     @Override
     protected ResponseValues processRequest(VitroRequest vreq) {
-    	Map<String, List<String>> requestFilters = SearchFiltering.getRequestFilters(vreq);
+        Map<String, List<String>> requestFilters = SearchFiltering.getRequestFilters(vreq);
         return process(vreq, requestFilters);
     }
- 
-	public static ResponseValues process(VitroRequest vreq, Map<String, List<String>> requestFilters) {
-		// There may be other non-html formats in the future
+
+    public static ResponseValues process(VitroRequest vreq, Map<String, List<String>> requestFilters) {
+        // There may be other non-html formats in the future
         Format format = getFormat(vreq);
         boolean wasXmlRequested = Format.XML == format;
         boolean wasCSVRequested = Format.CSV == format;
@@ -184,12 +184,12 @@ public class PagedSearchController extends FreemarkerHttpServlet {
             if (log.isDebugEnabled()) {
                 log.debug(getSpentTime(startTime) + "ms spent before get sort configurations.");
             }
-            
-        	SearchFiltering.setSelectedFilters(filterConfigurationsByField, requestFilters);
+
+            SearchFiltering.setSelectedFilters(filterConfigurationsByField, requestFilters);
             if (log.isDebugEnabled()) {
                 log.debug(getSpentTime(startTime) + "ms spent after setSelectedFilters.");
-            }	
-            
+            }
+
             Map<String, SortConfiguration> sortConfigurations = SearchFiltering.getSortConfigurations(vreq);
             if (log.isDebugEnabled()) {
                 log.debug(getSpentTime(startTime) + "ms spent before get query configurations.");
@@ -315,7 +315,7 @@ public class PagedSearchController extends FreemarkerHttpServlet {
         } catch (Throwable e) {
             return doSearchError(e, format);
         }
-	}
+    }
 
     private static long getSpentTime(long startTime) {
         return (System.nanoTime() - startTime) / 1000000;
@@ -461,7 +461,7 @@ public class PagedSearchController extends FreemarkerHttpServlet {
 
         SearchFiltering.addFacetFieldsToQuery(filters, query);
 
-    	SearchFiltering.addFiltersToQuery(query, filters);	
+        SearchFiltering.addFiltersToQuery(query, filters);
 
         log.debug("Query = " + query.toString());
         return query;

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/search/controller/PagedSearchController.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/search/controller/PagedSearchController.java
@@ -221,6 +221,7 @@ public class PagedSearchController extends FreemarkerHttpServlet {
             if (log.isDebugEnabled()) {
                 log.debug(getSpentTime(startTime) + "ms spent after addFacetCountersFromRequest.");
             }
+            addFilterValueLabels(filterConfigurationsByField, vreq);
             SearchResultDocumentList docs = response.getResults();
             if (docs == null) {
                 log.error("Document list for a search was null");
@@ -317,6 +318,21 @@ public class PagedSearchController extends FreemarkerHttpServlet {
         }
     }
 
+    private static void addFilterValueLabels(Map<String, SearchFilter> filterConfigurationsByField, VitroRequest vreq) {
+        for (SearchFilter filter : filterConfigurationsByField.values()) {
+            if (filter.isLocalizationRequired()) {
+                for (FilterValue value : filter.getValues().values()) {
+                    if (StringUtils.isBlank(value.getName())) {
+                        String label = SearchFiltering.getUriLabel(value.getId(), vreq);
+                        if (!StringUtils.isBlank(label)) {
+                            value.setName(label);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
     private static long getSpentTime(long startTime) {
         return (System.nanoTime() - startTime) / 1000000;
     }
@@ -347,7 +363,6 @@ public class PagedSearchController extends FreemarkerHttpServlet {
                 continue;
             }
             List<Count> values = resultField.getValues();
-
             for (Count value : values) {
                 if (value.getCount() == 0) {
                     continue;
@@ -366,12 +381,6 @@ public class PagedSearchController extends FreemarkerHttpServlet {
                     }
                     if (!SearchFiltering.isEmptyValues(requestedValues)) {
                         searchFilter.setSelected(true);
-                    }
-                }
-                if (searchFilter.isLocalizationRequired() && StringUtils.isBlank(filterValue.getName())) {
-                    String label = SearchFiltering.getUriLabel(value.getName(), vreq);
-                    if (!StringUtils.isBlank(label)) {
-                        filterValue.setName(label);
                     }
                 }
                 // COUNT should be from the real results of the query

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/search/controller/PagedSearchController.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/search/controller/PagedSearchController.java
@@ -78,7 +78,7 @@ public class PagedSearchController extends FreemarkerHttpServlet {
     public static final String PARAM_QUERY_TEXT = "querytext";
     public static final String PARAM_QUERY_SORT_BY = "sort";
 
-    protected static final Map<Format, Map<Result, String>> templateTable;
+    protected static final Map<Format, Map<Result, String>> templateTable = setupTemplateTable();
 
     protected enum Format {
         HTML,
@@ -90,10 +90,6 @@ public class PagedSearchController extends FreemarkerHttpServlet {
         PAGED,
         ERROR,
         BAD_QUERY
-    }
-
-    static {
-        templateTable = setupTemplateTable();
     }
 
     /**
@@ -142,8 +138,12 @@ public class PagedSearchController extends FreemarkerHttpServlet {
 
     @Override
     protected ResponseValues processRequest(VitroRequest vreq) {
-
-        // There may be other non-html formats in the future
+    	Map<String, List<String>> requestFilters = SearchFiltering.getRequestFilters(vreq);
+        return process(vreq, requestFilters);
+    }
+ 
+	public static ResponseValues process(VitroRequest vreq, Map<String, List<String>> requestFilters) {
+		// There may be other non-html formats in the future
         Format format = getFormat(vreq);
         boolean wasXmlRequested = Format.XML == format;
         boolean wasCSVRequested = Format.CSV == format;
@@ -184,18 +184,12 @@ public class PagedSearchController extends FreemarkerHttpServlet {
             if (log.isDebugEnabled()) {
                 log.debug(getSpentTime(startTime) + "ms spent before get sort configurations.");
             }
-            for (SearchFilter filter: filterConfigurationsByField.values()) {
-                filter.setInputText(SearchFiltering.getFilterInputText(vreq, filter.getId()));
-                filter.setRangeValues(SearchFiltering.getFilterRangeText(vreq, filter.getId()));
-            }
-            Map<String, List<String>> requestFilters = SearchFiltering.getRequestFilters(vreq);
-            if (log.isDebugEnabled()) {
-                log.debug(getSpentTime(startTime) + "ms spent after getRequestFilters.");
-            }
-            SearchFiltering.setSelectedFilters(filterConfigurationsByField, requestFilters);
+            
+        	SearchFiltering.setSelectedFilters(filterConfigurationsByField, requestFilters);
             if (log.isDebugEnabled()) {
                 log.debug(getSpentTime(startTime) + "ms spent after setSelectedFilters.");
-            }
+            }	
+            
             Map<String, SortConfiguration> sortConfigurations = SearchFiltering.getSortConfigurations(vreq);
             if (log.isDebugEnabled()) {
                 log.debug(getSpentTime(startTime) + "ms spent before get query configurations.");
@@ -321,13 +315,13 @@ public class PagedSearchController extends FreemarkerHttpServlet {
         } catch (Throwable e) {
             return doSearchError(e, format);
         }
-    }
+	}
 
-    private long getSpentTime(long startTime) {
+    private static long getSpentTime(long startTime) {
         return (System.nanoTime() - startTime) / 1000000;
     }
 
-    private Object isEmptySearchFilters(Map<String, SearchFilter> filterConfigurationsByField) {
+    private static Object isEmptySearchFilters(Map<String, SearchFilter> filterConfigurationsByField) {
         for (SearchFilter filter : filterConfigurationsByField.values()) {
             if (filter.isSelected()) {
                 return false;
@@ -336,7 +330,7 @@ public class PagedSearchController extends FreemarkerHttpServlet {
         return true;
     }
 
-    private void addFacetCountersFromRequest(SearchResponse response, Map<String, SearchFilter> filtersByField,
+    private static void addFacetCountersFromRequest(SearchResponse response, Map<String, SearchFilter> filtersByField,
             VitroRequest vreq) {
         long startTime = System.nanoTime();
         List<SearchFacetField> resultfacetFields = response.getFacetFields();
@@ -397,7 +391,7 @@ public class PagedSearchController extends FreemarkerHttpServlet {
         return query;
     }
 
-    private int getHitsPerPage(VitroRequest vreq) {
+    private static int getHitsPerPage(VitroRequest vreq) {
         int hitsPerPage = DEFAULT_HITS_PER_PAGE;
         try {
             int hits = Integer.parseInt(vreq.getParameter(PARAM_HITS_PER_PAGE));
@@ -411,7 +405,7 @@ public class PagedSearchController extends FreemarkerHttpServlet {
         return hitsPerPage;
     }
     
-    private int getDocumentsNumber(VitroRequest vreq) {
+    private static int getDocumentsNumber(VitroRequest vreq) {
         int documentsNumber = DEFAULT_DOCUMENTS_NUMBER;
         try {
             documentsNumber = Integer.parseInt(vreq.getParameter(PARAM_DOCUMENTS_NUMBER));
@@ -425,7 +419,7 @@ public class PagedSearchController extends FreemarkerHttpServlet {
         return documentsNumber;
     }
 
-    private int getStartIndex(VitroRequest vreq) {
+    private static int getStartIndex(VitroRequest vreq) {
         int startIndex = 0;
         try {
             startIndex = Integer.parseInt(vreq.getParameter(PARAM_START_INDEX));
@@ -436,7 +430,7 @@ public class PagedSearchController extends FreemarkerHttpServlet {
         return startIndex;
     }
 
-    private String getSnippet(SearchResultDocument doc, SearchResponse response) {
+    private static String getSnippet(SearchResultDocument doc, SearchResponse response) {
         String docId = doc.getStringValue(VitroSearchTermNames.DOCID);
         StringBuilder text = new StringBuilder();
         Map<String, Map<String, List<String>>> highlights = response.getHighlighting();
@@ -449,8 +443,8 @@ public class PagedSearchController extends FreemarkerHttpServlet {
         return text.toString();
     }
 
-    private SearchQuery getQuery(String queryText, int hitsPerPage, int startIndex, VitroRequest vreq,
-            Map<String, SearchFilter> filtersByField, Map<String, SortConfiguration> sortOptions) {
+    private static SearchQuery getQuery(String queryText, int hitsPerPage, int startIndex, VitroRequest vreq,
+            Map<String, SearchFilter> filters, Map<String, SortConfiguration> sortOptions) {
         // Lowercase the search term to support wildcard searches: The search engine
         // applies no text
         // processing to a wildcard search term.
@@ -465,24 +459,22 @@ public class PagedSearchController extends FreemarkerHttpServlet {
 
         addDefaultVitroFacets(vreq, query);
 
-        SearchFiltering.addFacetFieldsToQuery(filtersByField, query);
+        SearchFiltering.addFacetFieldsToQuery(filters, query);
 
-        Map<String, SearchFilter> filtersById = SearchFiltering.getFiltersById(filtersByField);
-
-        SearchFiltering.addFiltersToQuery(vreq, query, filtersById);
+    	SearchFiltering.addFiltersToQuery(query, filters);	
 
         log.debug("Query = " + query.toString());
         return query;
     }
 
-    private void addDefaultVitroFacets(VitroRequest vreq, SearchQuery query) {
+    private static void addDefaultVitroFacets(VitroRequest vreq, SearchQuery query) {
         String[] facets = vreq.getParameterValues(FACETS);
         if (facets != null && facets.length > 0) {
             query.addFacetFields(facets);
         }
     }
 
-    private void addSortRules(VitroRequest vreq, SearchQuery query, Map<String, SortConfiguration> sortOptions) {
+    private static void addSortRules(VitroRequest vreq, SearchQuery query, Map<String, SortConfiguration> sortOptions) {
         String sortType = getSortType(vreq);
         if (sortOptions.isEmpty()) {
             return;
@@ -503,7 +495,7 @@ public class PagedSearchController extends FreemarkerHttpServlet {
         // If text field is not empty, sort by relevance (no need to add sort field)
     }
 
-    private void addSortField(VitroRequest vreq, SearchQuery query, SortConfiguration conf,
+    private static void addSortField(VitroRequest vreq, SearchQuery query, SortConfiguration conf,
             Map<String, SortConfiguration> sortOptions, Set<String> appliedSortOptions) {
         if (conf == null || appliedSortOptions.contains(conf.getId())) {
             return;
@@ -520,7 +512,7 @@ public class PagedSearchController extends FreemarkerHttpServlet {
         }
     }
 
-    private String getSortType(VitroRequest vreq) {
+    private static String getSortType(VitroRequest vreq) {
         return vreq.getParameter(PARAM_QUERY_SORT_BY);
     }
 
@@ -558,12 +550,12 @@ public class PagedSearchController extends FreemarkerHttpServlet {
         return pagingLinks;
     }
 
-    private String getPreviousPageLink(int startIndex, int hitsPerPage, String baseUrl, ParamMap params) {
+    private static String getPreviousPageLink(int startIndex, int hitsPerPage, String baseUrl, ParamMap params) {
         params.put(PARAM_START_INDEX, String.valueOf(startIndex - hitsPerPage));
         return UrlBuilder.getUrl(baseUrl, params);
     }
 
-    private String getNextPageLink(int startIndex, int hitsPerPage, String baseUrl, ParamMap params) {
+    private static String getNextPageLink(int startIndex, int hitsPerPage, String baseUrl, ParamMap params) {
         params.put(PARAM_START_INDEX, String.valueOf(startIndex + hitsPerPage));
         return UrlBuilder.getUrl(baseUrl, params);
     }
@@ -585,13 +577,13 @@ public class PagedSearchController extends FreemarkerHttpServlet {
         }
     }
 
-    private ExceptionResponseValues doSearchError(Throwable e, Format f) {
+    private static ExceptionResponseValues doSearchError(Throwable e, Format f) {
         Map<String, Object> body = new HashMap<String, Object>();
         body.put("message", "Search failed: " + e.getMessage());
         return new ExceptionResponseValues(getTemplate(f, Result.ERROR), body, e);
     }
 
-    private TemplateResponseValues doFailedSearch(String message, String querytext, Format f, VitroRequest vreq) {
+    private static TemplateResponseValues doFailedSearch(String message, String querytext, Format f, VitroRequest vreq) {
         Map<String, Object> body = new HashMap<String, Object>();
         body.put("title", I18n.text(vreq, "search_for", querytext));
         if (StringUtils.isEmpty(message)) {
@@ -604,7 +596,7 @@ public class PagedSearchController extends FreemarkerHttpServlet {
     /**
      * Makes a message to display to user for a bad search term.
      */
-    private String makeBadSearchMessage(String querytext, String exceptionMsg, VitroRequest vreq) {
+    private static String makeBadSearchMessage(String querytext, String exceptionMsg, VitroRequest vreq) {
         String rv = "";
         try {
             // try to get the column in the search term that is causing the problems
@@ -666,7 +658,7 @@ public class PagedSearchController extends FreemarkerHttpServlet {
         }
     }
 
-    protected Format getFormat(VitroRequest req) {
+    protected static Format getFormat(VitroRequest req) {
         if (req != null && req.getParameter("xml") != null && "1".equals(req.getParameter("xml"))) {
             return Format.XML;
         } else if (req != null && req.getParameter("csv") != null && "1".equals(req.getParameter("csv"))) {

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/search/controller/PagedSearchController.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/search/controller/PagedSearchController.java
@@ -322,7 +322,7 @@ public class PagedSearchController extends FreemarkerHttpServlet {
         for (SearchFilter filter : filterConfigurationsByField.values()) {
             if (filter.isLocalizationRequired()) {
                 for (FilterValue value : filter.getValues().values()) {
-                    if (StringUtils.isBlank(value.getName())) {
+                    if (StringUtils.isBlank(value.getName()) && !value.getId().contains(" ")) {
                         String label = SearchFiltering.getUriLabel(value.getId(), vreq);
                         if (!StringUtils.isBlank(label)) {
                             value.setName(label);

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/search/controller/PagedSearchController.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/search/controller/PagedSearchController.java
@@ -371,7 +371,7 @@ public class PagedSearchController extends FreemarkerHttpServlet {
                 FilterValue filterValue = searchFilter.getValue(valueName);
                 if (filterValue == null) {
                     filterValue = new FilterValue(valueName);
-                    filterValue.setDisplay(true);
+                    filterValue.setDisplayed(true);
                     searchFilter.addValue(filterValue);
                 }
                 if (requestFiltersById.containsKey(searchFilter.getId())) {

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/search/controller/PagedSearchController.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/search/controller/PagedSearchController.java
@@ -516,7 +516,7 @@ public class PagedSearchController extends FreemarkerHttpServlet {
             log.error(String.format("Sort field is not set for '%s'", conf.getId()));
             return;
         }
-        query.addSortField(field, conf.getSortOrder());
+        query.addSortField(field, conf.getSortDirection());
         if (sortOptions.containsKey(conf.getFallback())) {
             addSortField(vreq, query, sortOptions.get(conf.getFallback()), sortOptions, appliedSortOptions);
         }

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/search/controller/PagedSearchController.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/search/controller/PagedSearchController.java
@@ -356,6 +356,7 @@ public class PagedSearchController extends FreemarkerHttpServlet {
                 FilterValue filterValue = searchFilter.getValue(valueName);
                 if (filterValue == null) {
                     filterValue = new FilterValue(valueName);
+                    filterValue.setDisplay(true);
                     searchFilter.addValue(filterValue);
                 }
                 if (requestFiltersById.containsKey(searchFilter.getId())) {

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/search/controller/SearchFacetsController.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/search/controller/SearchFacetsController.java
@@ -1,0 +1,122 @@
+/* $This file is distributed under the terms of the license in LICENSE$ */
+
+package edu.cornell.mannlib.vitro.webapp.search.controller;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServletResponse;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import edu.cornell.mannlib.vitro.webapp.application.ApplicationUtils;
+import edu.cornell.mannlib.vitro.webapp.controller.VitroRequest;
+import edu.cornell.mannlib.vitro.webapp.controller.ajax.VitroAjaxController;
+import edu.cornell.mannlib.vitro.webapp.modules.searchEngine.SearchEngine;
+import edu.cornell.mannlib.vitro.webapp.modules.searchEngine.SearchFacetField;
+import edu.cornell.mannlib.vitro.webapp.modules.searchEngine.SearchFacetField.Count;
+import edu.cornell.mannlib.vitro.webapp.modules.searchEngine.SearchQuery;
+import edu.cornell.mannlib.vitro.webapp.modules.searchEngine.SearchResponse;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+/**
+ * SearchFacetsController generates provides autocomplete options from the
+ * search index.
+ */
+
+@WebServlet(name = "SearchFacetsController", urlPatterns = { SearchFacetsController.SEARCH_FACETS_URL })
+public class SearchFacetsController extends VitroAjaxController {
+
+    public static final String SEARCH_FACETS_URL = "/searchfacets";
+    private static final String APPLICATION_JSON = "application/json";
+    private static final long serialVersionUID = 1L;
+    private static final Log log = LogFactory.getLog(SearchFacetsController.class);
+    private static final String PARAM_TERM = "term";
+    private static final String PARAM_FILTER = "facet_filter";
+    private static final int MAX_QUERY_LENGTH = 50;
+    private static ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    protected void doRequest(VitroRequest vreq, HttpServletResponse response) throws IOException, ServletException {
+
+        try {
+            String term = vreq.getParameter(PARAM_TERM);
+            String filterParam = vreq.getParameter(PARAM_FILTER);
+            String field = null;
+            Set<String> currentRoles = SearchFiltering.getCurrentUserRoles(vreq);
+            Map<String, SearchFilter> filters = SearchFiltering.readFilterConfigurations(currentRoles, vreq);
+            if (StringUtils.isNotBlank(filterParam)) {
+                SearchFilter filter = filters.get(filterParam);
+                if (filter != null && filter.isDisplayed()) {
+                    field = filter.getField();
+                }
+            }
+            if (StringUtils.isBlank(field)) {
+                log.debug("field '" + field + "' is empty.");
+                setEmptySearchResults(response);
+                return;
+            }
+            if (term == null) {
+                log.error("There was no parameter '" + PARAM_TERM + "' in the request.");
+                setEmptySearchResults(response);
+                return;
+            } else if (term.length() > MAX_QUERY_LENGTH) {
+                log.debug("The search was too long. The maximum " + "query length is " + MAX_QUERY_LENGTH);
+                setEmptySearchResults(response);
+                return;
+            }
+            Map<String, List<String>> requestFilters = SearchFiltering.getRequestFilters(vreq);
+            SearchFiltering.setSelectedFilters(filters, requestFilters);
+            String queryText = PagedSearchController.getQueryText(vreq);
+            Map<String, SortConfiguration> sortConfigurations = SearchFiltering.getSortConfigurations(vreq);
+            SearchQuery query = PagedSearchController.getQuery(queryText, 0, 0, vreq, filters, sortConfigurations);
+            log.debug("query for '" + term + "' is " + query.toString());
+
+            query.addFacetFields(field);
+            query.setFacetMinCount(1);
+            query.setFacetTextToMatch(term);
+            query.setFacetTextCompareCaseInsensitive(true);
+
+            SearchEngine search = ApplicationUtils.instance().getSearchEngine();
+            SearchResponse queryResponse = search.query(query);
+
+            if (queryResponse == null) {
+                log.error("Query response for a search was null");
+                setEmptySearchResults(response);
+                return;
+            }
+
+            SearchFacetField facetField = queryResponse.getFacetField(field);
+            List<Count> values = facetField.getValues();
+
+            if (values == null) {
+                log.error("Facet values for a search was null");
+                setEmptySearchResults(response);
+                return;
+            }
+
+            ArrayNode results = objectMapper.createArrayNode();
+            for (Count doc : values) {
+                String name = doc.getName();
+                results.add(name);
+            }
+            response.setContentType(APPLICATION_JSON);
+            response.getWriter().write(results.toString());
+        } catch (Throwable e) {
+            log.error(e, e);
+            setEmptySearchResults(response);
+        }
+    }
+
+    private void setEmptySearchResults(HttpServletResponse response) throws IOException {
+        response.setContentType(APPLICATION_JSON);
+        response.getWriter().write("[]");
+    }
+
+}

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/search/controller/SearchFilter.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/search/controller/SearchFilter.java
@@ -8,8 +8,10 @@ import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.StringUtils;
@@ -40,15 +42,15 @@ public class SearchFilter {
     private boolean selected = false;
     private boolean input = false;
     private Map<String, FilterValue> values = new LinkedHashMap<>();
-
     private boolean inputRegex = false;
-
     private boolean facetsRequired;
-
+    private boolean reverseFacetOrder;
     private String type = FILTER;
     private String rangeText = "";
     private String rangeInput = "";
     private boolean hidden = false;
+    private Optional<Locale> locale;
+    private boolean multilingual;
 
     public String getRangeInput() {
         return rangeInput;
@@ -62,8 +64,9 @@ public class SearchFilter {
         return rangeText;
     }
 
-    public SearchFilter(String id) {
+    public SearchFilter(String id, Optional<Locale> locale) {
         this.id = id;
+        this.locale = locale;
     }
 
     public String getName() {
@@ -87,6 +90,13 @@ public class SearchFilter {
     }
 
     public String getField() {
+        if (multilingual) {
+            if (locale.isPresent()) {
+                return locale.get().toLanguageTag() + field;
+            } else {
+                return Locale.getDefault().toLanguageTag() + field;
+            }
+        }
         return field;
     }
 
@@ -272,8 +282,8 @@ public class SearchFilter {
     public void sortValues() {
         List<Entry<String, FilterValue>> list = new LinkedList<>(values.entrySet());
         list.sort(new FilterValueComparator());
-        values = list.stream()
-                .collect(Collectors.toMap(Entry::getKey, Entry::getValue, (a, b) -> b, LinkedHashMap::new));
+        values = list.stream().collect(Collectors.toMap(Entry::getKey, Entry::getValue, (a, b) -> b,
+                LinkedHashMap::new));
     }
 
     public boolean isPublic() {
@@ -286,15 +296,22 @@ public class SearchFilter {
 
     private class FilterValueComparator implements Comparator<Map.Entry<String, FilterValue>> {
         public int compare(Entry<String, FilterValue> obj1, Entry<String, FilterValue> obj2) {
-            FilterValue filter1 = obj1.getValue();
-            FilterValue filter2 = obj2.getValue();
-            int result = filter1.getOrder().compareTo(filter2.getOrder());
+            FilterValue first = obj1.getValue();
+            FilterValue second = obj2.getValue();
+            // sort by order first
+            int result = first.getOrder().compareTo(second.getOrder());
             if (result == 0) {
                 // order are equal, sort by name
-                return filter1.getName().toLowerCase().compareTo(filter2.getName().toLowerCase());
-            } else {
-                return result;
+                result = first.getName().toLowerCase().compareTo(second.getName().toLowerCase());
+                if (result == 0) {
+                    // names are equal, sort by id
+                    result = first.getId().toLowerCase().compareTo(second.getId().toLowerCase());
+                }
+                if (reverseFacetOrder) {
+                    result = -result;
+                }
             }
+            return result;
         }
     }
 
@@ -330,5 +347,13 @@ public class SearchFilter {
 
     public void setMoreLimit(int moreLimit) {
         this.moreLimit = moreLimit;
+    }
+
+    public void setMulitlingual(boolean multilingual) {
+        this.multilingual = multilingual;
+    }
+
+    public void setReverseFacetOrder(boolean reverseFacetOrder) {
+        this.reverseFacetOrder = reverseFacetOrder;
     }
 }

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/search/controller/SearchFilter.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/search/controller/SearchFilter.java
@@ -61,7 +61,7 @@ public class SearchFilter {
     private String type = FILTER;
     private String rangeText = "";
     private String rangeInput = "";
-    private boolean display = false;
+    private boolean displayed = false;
     private Optional<Locale> locale;
     private boolean multilingual;
     private SortOption sortingObjectType = SortOption.labelText;
@@ -390,12 +390,12 @@ public class SearchFilter {
         return true;
     }
 
-    public void setDisplay(boolean b) {
-        this.display = b;
+    public void setDisplayed(boolean b) {
+        this.displayed = b;
     }
 
-    public boolean isDisplay() {
-        return display;
+    public boolean isDisplayed() {
+        return displayed;
     }
 
     public int getMoreLimit() {

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/search/controller/SearchFilter.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/search/controller/SearchFilter.java
@@ -28,7 +28,6 @@ public class SearchFilter {
     private String to = "";
     private String fromYear = "";
     private String toYear = "";
-    private boolean isPublic = false;
 
     private String min = "0";
     private String max = "2000";
@@ -48,7 +47,7 @@ public class SearchFilter {
     private String type = FILTER;
     private String rangeText = "";
     private String rangeInput = "";
-    private boolean hidden = false;
+    private boolean display = false;
     private Optional<Locale> locale;
     private boolean multilingual;
 
@@ -286,14 +285,6 @@ public class SearchFilter {
                 LinkedHashMap::new));
     }
 
-    public boolean isPublic() {
-        return isPublic;
-    }
-
-    public void setPublic(boolean isPublic) {
-        this.isPublic = isPublic;
-    }
-
     private class FilterValueComparator implements Comparator<Map.Entry<String, FilterValue>> {
         public int compare(Entry<String, FilterValue> obj1, Entry<String, FilterValue> obj2) {
             FilterValue first = obj1.getValue();
@@ -333,12 +324,12 @@ public class SearchFilter {
         return true;
     }
 
-    public void setHidden(boolean b) {
-        this.hidden = b;
+    public void setDisplay(boolean b) {
+        this.display = b;
     }
 
-    public boolean isHidden() {
-        return hidden;
+    public boolean isDisplay() {
+        return display;
     }
 
     public int getMoreLimit() {

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/search/controller/SearchFilter.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/search/controller/SearchFilter.java
@@ -25,6 +25,7 @@ import org.apache.jena.rdf.model.RDFNode;
 
 public class SearchFilter {
 
+    private static final String DEFAULT_PATTERN = "$0";
     private static final String FILTER = "Filter";
     private static final String RANGE_FILTER = "RangeFilter";
     private static final Log log = LogFactory.getLog(SearchFilter.class);
@@ -57,6 +58,7 @@ public class SearchFilter {
     private boolean input = false;
     private Map<String, FilterValue> values = new LinkedHashMap<>();
     private boolean inputRegex = false;
+    private String regexPattern = DEFAULT_PATTERN;
     private boolean facetsRequired;
     private Order valueSortDirection = Order.ASC;
     private String type = FILTER;
@@ -428,5 +430,13 @@ public class SearchFilter {
                 log.error(e, e);
             }
         }
+    }
+
+    public void setRegexPattern(String regexPattern) {
+        this.regexPattern = regexPattern;
+    }
+
+    public String getInputRegex() {
+        return regexPattern.replace(DEFAULT_PATTERN, inputText);
     }
 }

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/search/controller/SearchFilter.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/search/controller/SearchFilter.java
@@ -17,6 +17,7 @@ import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+import edu.cornell.mannlib.vitro.webapp.modules.searchEngine.SearchQuery.Order;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -46,7 +47,7 @@ public class SearchFilter {
     private String min = "0";
     private String max = "2000";
     private int moreLimit = 30;
-    private int order = 0;
+    private int rank = 0;
     private String field = "";
     private String endField = "";
     private String inputText = "";
@@ -57,14 +58,14 @@ public class SearchFilter {
     private Map<String, FilterValue> values = new LinkedHashMap<>();
     private boolean inputRegex = false;
     private boolean facetsRequired;
-    private boolean descendingOrder;
+    private Order valueSortDirection = Order.ASC;
     private String type = FILTER;
     private String rangeText = "";
     private String rangeInput = "";
     private boolean displayed = false;
     private Optional<Locale> locale;
     private boolean multilingual;
-    private SortOption sortingObjectType = SortOption.labelText;
+    private SortOption sortOption = SortOption.labelText;
 
     public String getRangeInput() {
         return rangeInput;
@@ -93,14 +94,14 @@ public class SearchFilter {
         }
     }
 
-    public void setOrder(RDFNode rdfNode) {
+    public void setRank(RDFNode rdfNode) {
         if (rdfNode != null) {
-            order = rdfNode.asLiteral().getInt();
+            rank = rdfNode.asLiteral().getInt();
         }
     }
 
-    public Integer getOrder() {
-        return order;
+    public Integer getRank() {
+        return rank;
     }
 
     public String getField() {
@@ -312,10 +313,10 @@ public class SearchFilter {
             FilterValue first = obj1.getValue();
             FilterValue second = obj2.getValue();
             // sort by order first
-            int result = first.getOrder().compareTo(second.getOrder());
+            int result = first.getRank().compareTo(second.getRank());
             if (result == 0) {
                 result = compareByObjectType(first, second);
-                if (descendingOrder) {
+                if (valueSortDirection.equals(Order.DESC)) {
                     result = -result;
                 }
             }
@@ -324,7 +325,7 @@ public class SearchFilter {
 
         private int compareByObjectType(FilterValue first, FilterValue second) {
             int result;
-            switch (sortingObjectType) {
+            switch (sortOption) {
                 case hitsCount:
                     result = Long.compare(first.getCount(), second.getCount());
                     break;
@@ -410,15 +411,19 @@ public class SearchFilter {
         this.multilingual = multilingual;
     }
 
-    public void setDescendingValuesOrder(boolean descendingOrder) {
-        this.descendingOrder = descendingOrder;
+    public void setValueSortDirection(boolean isDescending) {
+        if (isDescending) {
+            this.valueSortDirection = Order.DESC;
+        } else {
+            this.valueSortDirection = Order.ASC;
+        }
     }
 
-    public void setSortingObjectType(String uri) {
+    public void setSortOption(String uri) {
         if (uri.startsWith(VITRO_SEARCH_INDIVIDUAL)) {
             String optionName = uri.substring(VITRO_SEARCH_INDIVIDUAL.length());
             try {
-                sortingObjectType = SortOption.valueOf(optionName);
+                sortOption = SortOption.valueOf(optionName);
             } catch (Exception e) {
                 log.error(e, e);
             }

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/search/controller/SearchFilterGroup.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/search/controller/SearchFilterGroup.java
@@ -6,7 +6,7 @@ public class SearchFilterGroup {
 
     private String id;
     private String label;
-    private boolean display = false;
+    private boolean displayed = false;
 
     private LinkedHashSet<String> filters = new LinkedHashSet<>();
 
@@ -43,12 +43,12 @@ public class SearchFilterGroup {
         this.label = label;
     }
 
-    public boolean isDisplay() {
-        return display;
+    public boolean isDisplayed() {
+        return displayed;
     }
 
-    public void setDisplay(boolean display) {
-        this.display = display;
+    public void setDisplayed(boolean display) {
+        this.displayed = display;
     }
 
 }

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/search/controller/SearchFilterGroup.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/search/controller/SearchFilterGroup.java
@@ -6,8 +6,7 @@ public class SearchFilterGroup {
 
     private String id;
     private String label;
-    private boolean isPublic = false;
-    private boolean hidden = true;
+    private boolean display = false;
 
     private LinkedHashSet<String> filters = new LinkedHashSet<>();
 
@@ -44,20 +43,12 @@ public class SearchFilterGroup {
         this.label = label;
     }
 
-    public boolean isPublic() {
-        return isPublic;
+    public boolean isDisplay() {
+        return display;
     }
 
-    public void setPublic(boolean isPublic) {
-        this.isPublic = isPublic;
-    }
-
-    public boolean isHidden() {
-        return hidden;
-    }
-
-    public void setHidden(boolean hidden) {
-        this.hidden = hidden;
+    public void setDisplay(boolean display) {
+        this.display = display;
     }
 
 }

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/search/controller/SearchFiltering.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/search/controller/SearchFiltering.java
@@ -258,6 +258,7 @@ public class SearchFiltering {
                     Optional<Locale> locale = vreq != null ? Optional.of(vreq.getLocale()) : Optional.empty();
                     filter = createSearchFilter(filtersByField, solution, resultFilterId, resultFieldName, locale);
                 }
+                filter.setType(solution.get("filter_type"));
                 filter.setMulitlingual(solution.get("multilingual").asLiteral().getBoolean());
                 if (solution.get("value_id") == null) {
                     continue;

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/search/controller/SearchFiltering.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/search/controller/SearchFiltering.java
@@ -48,6 +48,7 @@ public class SearchFiltering {
     private static final String FILTER_RANGE = "filter_range_";
     private static final String FILTER_INPUT_PREFIX = "filter_input_";
     private static final String FILTERS = "filters";
+    public static final String ANY_VALUE = "[* TO *]";
 
     private static final String FILTER_QUERY = ""
             + "PREFIX search: <https://vivoweb.org/ontology/vitro-search#>\n"
@@ -173,7 +174,11 @@ public class SearchFiltering {
             }
             for (FilterValue fv : searchFilter.getValues().values()) {
                 if (fv.isDefault() || fv.getSelected()) {
-                    query.addFilterQuery(searchFilter.getField() + ":\"" + fv.getId() + "\"");
+                    if (ANY_VALUE.equals(fv.getId())) {
+                        query.addFilterQuery(searchFilter.getField() + ":" + ANY_VALUE );
+                    } else {
+                        query.addFilterQuery(searchFilter.getField() + ":\"" + fv.getId() + "\"");
+                    }
                 }
             }
         }

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/search/controller/SearchFiltering.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/search/controller/SearchFiltering.java
@@ -168,7 +168,7 @@ public class SearchFiltering {
 
     protected static void addFiltersToQuery(SearchQuery query, Map<String, SearchFilter> filters) {
         for (SearchFilter searchFilter : filters.values()) {
-            if (PARAM_QUERY_TEXT.equals(searchFilter.getId())){
+            if (PARAM_QUERY_TEXT.equals(searchFilter.getId())) {
                 continue;
             }
             if (searchFilter.isInput()) {

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/search/controller/SearchFiltering.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/search/controller/SearchFiltering.java
@@ -8,7 +8,6 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.Enumeration;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/search/controller/SearchFiltering.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/search/controller/SearchFiltering.java
@@ -56,7 +56,7 @@ public class SearchFiltering {
             + "PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>\n"
             + "PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>\n"
             + "SELECT ?filter_id ?filter_type ?filter_label ?value_label ?value_id  ?field_name ?public ?filter_rank "
-            + "?value_rank (STR(?isUriReq) as ?isUri ) ?multivalued ?input ?regex ?facet ?min ?max ?role "
+            + "?value_rank (STR(?isUriReq) as ?isUri ) ?multivalued ?input ?regex ?regexPattern ?facet ?min ?max ?role "
             + "?value_public ?more_limit ?multilingual ?isDescending\n"
             + "?filterDisplayLimitRole ?valueDisplayLimitRole ?sortingObjectType \n"
             + "WHERE {\n"
@@ -90,6 +90,7 @@ public class SearchFiltering {
             + "    OPTIONAL {?filter search:isUriValues ?isUriReq }\n"
             + "    OPTIONAL {?filter search:userInput ?input }\n"
             + "    OPTIONAL {?filter search:userInputRegex ?regex }\n"
+            + "    OPTIONAL {?filter search:regexPattern ?regexPattern }\n"
             + "    OPTIONAL {?filter search:facetResults ?facet }\n"
             + "    OPTIONAL {?filter search:reverseFacetOrder ?isDescendingDeprecated }\n"
             + "    OPTIONAL {"
@@ -527,6 +528,11 @@ public class SearchFiltering {
             filter.setSortOption(sortOption.asResource().getURI());
         }
 
+        RDFNode regexPattern = solution.get("regexPattern");
+        if (regexPattern != null && regexPattern.isLiteral()) {
+            filter.setRegexPattern(regexPattern.asLiteral().getLexicalForm());
+        }
+
         RDFNode moreLimit = solution.get("more_limit");
         if (moreLimit != null && moreLimit.isLiteral()) {
             filter.setMoreLimit(moreLimit.asLiteral().getInt());
@@ -547,11 +553,10 @@ public class SearchFiltering {
                 || PagedSearchController.PARAM_QUERY_TEXT.equals(searchFilter.getId())) {
             return;
         }
-        String searchText = searchFilter.getInputText();
         if (searchFilter.isInputRegex()) {
-            query.addFilterQuery(searchFilter.getField() + ":/" + searchText + "/");
+            query.addFilterQuery(searchFilter.getField() + ":/" + searchFilter.getInputRegex() + "/");
         } else {
-            query.addFilterQuery(searchFilter.getField() + ":\"" + searchText + "\"");
+            query.addFilterQuery(searchFilter.getField() + ":\"" + searchFilter.getInputText() + "\"");
         }
     }
 

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/search/controller/SearchFiltering.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/search/controller/SearchFiltering.java
@@ -183,7 +183,7 @@ public class SearchFiltering {
                 SearchFiltering.addRangeFilter(query, searchFilter);
             }
             for (FilterValue fv : searchFilter.getValues().values()) {
-                if (fv.isDefault() || fv.getSelected()) {
+                if (fv.isDefault() || fv.isSelected()) {
                     if (ANY_VALUE.equals(fv.getId())) {
                         query.addFilterQuery(searchFilter.getField() + ":" + ANY_VALUE );
                     } else {
@@ -276,7 +276,7 @@ public class SearchFiltering {
                     filter = createSearchFilter(filtersByField, solution, resultFilterId, resultFieldName, locale);
                 }
                 if (isDisplay(solution, vreq, "filterDisplayLimitRole", "public")) {
-                    filter.setDisplay(true);
+                    filter.setDisplayed(true);
                 }
                 filter.setType(solution.get("filter_type"));
                 filter.setMulitlingual(solution.get("multilingual").asLiteral().getBoolean());
@@ -293,7 +293,7 @@ public class SearchFiltering {
                 }
                 value = filter.getValue(valueId);
                 if (isDisplay(solution, vreq, "valueDisplayLimitRole", "value_public")) {
-                    value.setDisplay(true);
+                    value.setDisplayed(true);
                 }
                 RDFNode role = solution.get("role");
                 if (role != null && role.isResource()) {
@@ -355,7 +355,7 @@ public class SearchFiltering {
                 SearchFiltering.addRangeFilter(query, searchFilter);
             }
             for (FilterValue fv : searchFilter.getValues().values()) {
-                if (fv.isDefault() || fv.getSelected()) {
+                if (fv.isDefault()) {
                     query.addFilterQuery(searchFilter.getField() + ":\"" + fv.getId() + "\"");
                 }
             }
@@ -409,7 +409,7 @@ public class SearchFiltering {
                     groups.put(groupId, group);
                 }
                 if (isDisplay(solution, vreq, "groupDisplayLimitRole", "public")) {
-                    group.setDisplay(true);
+                    group.setDisplayed(true);
                 }
                 group.addFilterId(filterId);
             }
@@ -459,7 +459,7 @@ public class SearchFiltering {
                     }
                     RDFNode display = solution.get("display");
                     if (display != null) {
-                        config.setDisplay(display.asLiteral().getBoolean());
+                        config.setDisplayed(display.asLiteral().getBoolean());
                     }
                     sortConfigurations.put(id, config);
                 }
@@ -582,7 +582,7 @@ public class SearchFiltering {
                             } else {
                                 FilterValue value = new FilterValue(requestValue);
                                 value.setSelected(true);
-                                value.setDisplay(true);
+                                value.setDisplayed(true);
                                 filter.addValue(value);
                             }
                         }

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/search/controller/SearchFiltering.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/search/controller/SearchFiltering.java
@@ -56,8 +56,8 @@ public class SearchFiltering {
             + "PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>\n"
             + "SELECT ?filter_id ?filter_type ?filter_label ?value_label ?value_id  ?field_name ?public ?filter_order "
             + "?value_order (STR(?isUriReq) as ?isUri ) ?multivalued ?input ?regex ?facet ?min ?max ?role "
-            + "?value_public ?more_limit ?multilingual ?reverseFacetOrder\n"
-            + "?filterDisplayLimitRole ?valueDisplayLimitRole \n"
+            + "?value_public ?more_limit ?multilingual ?isDescending\n"
+            + "?filterDisplayLimitRole ?valueDisplayLimitRole ?sortingObjectType \n"
             + "WHERE {\n"
             + "    ?filter rdf:type search:Filter .\n"
             + "    ?filter rdfs:label ?filter_label .\n"
@@ -90,7 +90,8 @@ public class SearchFiltering {
             + "    OPTIONAL {?filter search:userInput ?input }\n"
             + "    OPTIONAL {?filter search:userInputRegex ?regex }\n"
             + "    OPTIONAL {?filter search:facetResults ?facet }\n"
-            + "    OPTIONAL {?filter search:reverseFacetOrder ?reverseFacetOrder }\n"
+            + "    OPTIONAL {?filter search:reverseFacetOrder ?isDescending }\n"
+            + "    OPTIONAL {?filter search:sortValuesBy ?sortingObjectType }\n"
             + "    OPTIONAL {?filter search:from ?min }\n"
             + "    OPTIONAL {?filter search:public ?public }\n"
             + "    OPTIONAL {?filter search:to ?max }\n"
@@ -506,9 +507,14 @@ public class SearchFiltering {
             filter.setFacetsRequired(facet.asLiteral().getBoolean());
         }
 
-        RDFNode reverseFacetOrder = solution.get("reverseFacetOrder");
-        if (reverseFacetOrder != null) {
-            filter.setReverseFacetOrder(reverseFacetOrder.asLiteral().getBoolean());
+        RDFNode descendingOrder = solution.get("isDescending");
+        if (descendingOrder != null && descendingOrder.isLiteral()) {
+            filter.setDescendingValuesOrder(descendingOrder.asLiteral().getBoolean());
+        }
+
+        RDFNode sortingObject = solution.get("sortingObjectType");
+        if (sortingObject != null && sortingObject.isURIResource()) {
+            filter.setSortingObjectType(sortingObject.asResource().getURI());
         }
 
         RDFNode moreLimit = solution.get("more_limit");

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/search/controller/SearchFiltering.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/search/controller/SearchFiltering.java
@@ -47,7 +47,7 @@ public class SearchFiltering {
 
     private static final String FILTER_RANGE = "filter_range_";
     private static final String FILTER_INPUT_PREFIX = "filter_input_";
-    private static final String FILTERS = "filters";
+    public static final String FILTERS = "filters";
     public static final String ANY_VALUE = "[* TO *]";
 
     private static final String FILTER_QUERY = ""

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/search/controller/SearchFiltering.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/search/controller/SearchFiltering.java
@@ -1,6 +1,7 @@
 package edu.cornell.mannlib.vitro.webapp.search.controller;
 
 import static edu.cornell.mannlib.vitro.webapp.dao.VitroVocabulary.ROLE_PUBLIC_URI;
+import static edu.cornell.mannlib.vitro.webapp.search.controller.PagedSearchController.PARAM_QUERY_TEXT;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -167,6 +168,9 @@ public class SearchFiltering {
 
     protected static void addFiltersToQuery(SearchQuery query, Map<String, SearchFilter> filters) {
         for (SearchFilter searchFilter : filters.values()) {
+            if (PARAM_QUERY_TEXT.equals(searchFilter.getId())){
+                continue;
+            }
             if (searchFilter.isInput()) {
                 SearchFiltering.addInputFilter(query, searchFilter);
             } else if (searchFilter.isRange()) {
@@ -219,6 +223,12 @@ public class SearchFiltering {
                 if (values != null && values.length > 0) {
                     String filterId = paramFilterName.replace(SearchFiltering.FILTER_INPUT_PREFIX, "");
                     requestFilters.put(filterId, new LinkedList<String>(Arrays.asList(values[0])));
+                }
+            }
+            if (paramFilterName.equals(PARAM_QUERY_TEXT)) {
+                String[] values = vreq.getParameterValues(paramFilterName);
+                if (values != null && values.length > 0) {
+                    requestFilters.put(PARAM_QUERY_TEXT, new LinkedList<String>(Arrays.asList(values[0])));
                 }
             }
         }

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/search/controller/SearchFiltering.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/search/controller/SearchFiltering.java
@@ -24,7 +24,6 @@ import edu.cornell.mannlib.vedit.beans.LoginStatusBean;
 import edu.cornell.mannlib.vitro.webapp.beans.UserAccount;
 import edu.cornell.mannlib.vitro.webapp.controller.VitroRequest;
 import edu.cornell.mannlib.vitro.webapp.controller.freemarker.UrlBuilder.ParamMap;
-import edu.cornell.mannlib.vitro.webapp.dao.VitroVocabulary;
 import edu.cornell.mannlib.vitro.webapp.modelaccess.ModelAccess;
 import edu.cornell.mannlib.vitro.webapp.modules.searchEngine.SearchQuery;
 import org.apache.commons.lang3.StringUtils;
@@ -313,8 +312,9 @@ public class SearchFiltering {
         return sortFilters(filtersByField);
     }
 
-    private static boolean isDisplay(QuerySolution solution, VitroRequest vreq, String limitVarName, String publicVarName) {
-        //Display if user is root
+    private static boolean isDisplay(QuerySolution solution, VitroRequest vreq, String limitVarName,
+            String publicVarName) {
+        // Display if user is root
         if (isRoot(vreq)) {
             return true;
         }
@@ -325,13 +325,13 @@ public class SearchFiltering {
         }
         RDFNode limitToRole = solution.get(limitVarName);
         Set<String> roles = getCurrentUserRoles(vreq);
-        //nodeLimit is not set and user is not Public, then display
+        // nodeLimit is not set and user is not Public, then display
         if (limitToRole == null && !roles.contains(ROLE_PUBLIC_URI)) {
             return true;
         }
-        //node limit is set and current user has that role
+        // node limit is set and current user has that role
         if (limitToRole != null && roles.contains(getNodeStringValue(limitToRole))) {
-           return true;
+            return true;
         }
         return false;
     }

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/search/controller/SearchFiltering.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/search/controller/SearchFiltering.java
@@ -657,12 +657,6 @@ public class SearchFiltering {
     }
 
     static Map<String, SearchFilter> getFiltersForTemplate(Map<String, SearchFilter> filtersByField) {
-        Iterator<Entry<String, SearchFilter>> iterator = filtersByField.entrySet().iterator();
-        while (iterator.hasNext()) {
-            Entry<String, SearchFilter> entry = iterator.next();
-            SearchFilter searchFilter = entry.getValue();
-            searchFilter.removeValuesWithZeroCount();
-        }
         return filtersByField.values().stream().collect(Collectors.toMap(SearchFilter::getId, Function.identity()));
     }
 

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/search/controller/SortConfiguration.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/search/controller/SortConfiguration.java
@@ -14,7 +14,7 @@ public class SortConfiguration {
     private String label = "";
     private int order = 0;
     private String fallback;
-    private boolean display = false;
+    private boolean displayed = false;
 
     public SortConfiguration(String id, String label, String field) {
         this.id = id;
@@ -97,11 +97,11 @@ public class SortConfiguration {
         this.fallback = id;
     }
 
-    public void setDisplay(boolean display) {
-        this.display = display;
+    public void setDisplayed(boolean display) {
+        this.displayed = display;
     }
 
-    public boolean isDisplay() {
-        return display;
+    public boolean isDisplayed() {
+        return displayed;
     }
 }

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/search/controller/SortConfiguration.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/search/controller/SortConfiguration.java
@@ -1,5 +1,8 @@
 package edu.cornell.mannlib.vitro.webapp.search.controller;
 
+import static edu.cornell.mannlib.vitro.webapp.modules.searchEngine.SearchQuery.Order.ASC;
+import static edu.cornell.mannlib.vitro.webapp.modules.searchEngine.SearchQuery.Order.DESC;
+
 import java.util.Locale;
 
 import edu.cornell.mannlib.vitro.webapp.modules.searchEngine.SearchQuery.Order;
@@ -9,10 +12,10 @@ public class SortConfiguration {
     private String id = "";
     private String field = "";
     private boolean multilingual = false;
-    private boolean ascOrder = false;
+    private Order sortDirection = DESC;
     private boolean selected = false;
     private String label = "";
-    private int order = 0;
+    private int rank = 0;
     private String fallback;
     private boolean displayed = false;
 
@@ -62,15 +65,16 @@ public class SortConfiguration {
         return field;
     }
 
-    public Order getSortOrder() {
-        if (ascOrder) {
-            return Order.ASC;
-        }
-        return Order.DESC;
+    public Order getSortDirection() {
+        return sortDirection;
     }
 
-    public void setAscOrder(boolean ascOrder) {
-        this.ascOrder = ascOrder;
+    public void setSortDirection(boolean isAscending) {
+        if (isAscending) {
+            sortDirection = ASC;
+        } else {
+            sortDirection = DESC;
+        }
     }
 
     public boolean isSelected() {
@@ -81,12 +85,12 @@ public class SortConfiguration {
         this.selected = selected;
     }
 
-    public int getOrder() {
-        return order;
+    public int getRank() {
+        return rank;
     }
 
-    public void setOrder(int order) {
-        this.order = order;
+    public void setRank(int rank) {
+        this.rank = rank;
     }
 
     public String getFallback() {

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/searchengine/base/BaseSearchQuery.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/searchengine/base/BaseSearchQuery.java
@@ -27,6 +27,8 @@ public class BaseSearchQuery implements SearchQuery {
 	private final Set<String> facetFields = new HashSet<>();
 	private int facetLimit = 100;
 	private int facetMinCount = -1;
+    private boolean facetTextToCompareIgnoreCase;
+    private String facetContainsText;
 
 	@Override
 	public SearchQuery setQuery(String query) {
@@ -146,5 +148,27 @@ public class BaseSearchQuery implements SearchQuery {
 				+ ", facetFields=" + facetFields + ", facetLimit=" + facetLimit
 				+ ", facetMinCount=" + facetMinCount + "]";
 	}
+
+    @Override
+    public SearchQuery setFacetTextToMatch(String text) {
+        facetContainsText = text;
+        return this;
+    }
+
+    @Override
+    public String getFacetTextToMatch() {
+        return facetContainsText;
+    }
+
+    @Override
+    public SearchQuery setFacetTextCompareCaseInsensitive(boolean b) {
+        facetTextToCompareIgnoreCase = b;
+        return this;
+    }
+
+    @Override
+    public boolean isFacetTextCompareCaseInsensitive() {
+        return facetTextToCompareIgnoreCase;
+    }
 
 }

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/searchengine/solr/SolrConversionUtils.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/searchengine/solr/SolrConversionUtils.java
@@ -4,6 +4,8 @@ package edu.cornell.mannlib.vitro.webapp.searchengine.solr;
 
 import static edu.cornell.mannlib.vitro.webapp.search.VitroSearchTermNames.ALLTEXT;
 import static edu.cornell.mannlib.vitro.webapp.search.VitroSearchTermNames.ALLTEXTUNSTEMMED;
+import static org.apache.solr.common.params.FacetParams.FACET_CONTAINS;
+import static org.apache.solr.common.params.FacetParams.FACET_CONTAINS_IGNORE_CASE;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -11,13 +13,13 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.solr.client.solrj.SolrQuery;
 import org.apache.solr.client.solrj.SolrQuery.ORDER;
 import org.apache.solr.client.solrj.response.FacetField;
 import org.apache.solr.client.solrj.response.QueryResponse;
 import org.apache.solr.common.SolrInputDocument;
 import org.apache.solr.common.SolrInputField;
-
 import edu.cornell.mannlib.vitro.webapp.modules.searchEngine.SearchFacetField;
 import edu.cornell.mannlib.vitro.webapp.modules.searchEngine.SearchInputDocument;
 import edu.cornell.mannlib.vitro.webapp.modules.searchEngine.SearchInputField;
@@ -162,6 +164,16 @@ public class SolrConversionUtils {
 		int minCount = query.getFacetMinCount();
 		if (minCount >= 0) {
 			solrQuery.setFacetMinCount(minCount);
+		}
+
+		String facetText = query.getFacetTextToMatch();
+		if (StringUtils.isNotBlank(facetText)) {
+		    solrQuery.setParam(FACET_CONTAINS, facetText);
+		}
+
+		boolean facetContainsIgnoreCase = query.isFacetTextCompareCaseInsensitive();
+		if (facetContainsIgnoreCase) {
+		    solrQuery.setParam(FACET_CONTAINS_IGNORE_CASE, facetContainsIgnoreCase);
 		}
 
 		return solrQuery;

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/searchindex/documentBuilding/SelectQueryDocumentModifier.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/searchindex/documentBuilding/SelectQueryDocumentModifier.java
@@ -66,6 +66,8 @@ public class SelectQueryDocumentModifier implements DocumentModifier,
 	 */
 	private List<String> fieldNames = new ArrayList<>();
 
+	protected List<String> varNames = new ArrayList<>();
+
 	/**
 	 * URIs of the types of individuals to whom these queries apply. If empty,
 	 * then the queries apply to all individuals.
@@ -91,6 +93,11 @@ public class SelectQueryDocumentModifier implements DocumentModifier,
 	public void addTargetField(String fieldName) {
 		fieldNames.add(fieldName);
 	}
+
+    @Property(uri = "http://vitro.mannlib.cornell.edu/ns/vitro/ApplicationSetup#hasVar")
+    public void addVar(String varName) {
+        varNames.add(varName);
+    }
 
 	@Property(uri = "http://vitro.mannlib.cornell.edu/ns/vitro/ApplicationSetup#hasTypeRestriction")
 	public void addTypeRestriction(String typeUri) {
@@ -154,7 +161,10 @@ public class SelectQueryDocumentModifier implements DocumentModifier,
 			QueryHolder queryHolder = new QueryHolder(query).bindToUri("uri",
 					ind.getURI());
 			List<String> list = createSelectQueryContext(rdfService,
-					queryHolder).execute().toStringFields().flatten();
+					queryHolder)
+			        .execute()
+			        .toStringFields(varNames.toArray(new String[varNames.size()]))
+			        .flatten();
 			log.debug(label + " - query: '" + query + "' returns " + list);
 			return list;
 		} catch (Throwable t) {

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/searchindex/documentBuilding/SelectQueryI18nDocumentModifier.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/searchindex/documentBuilding/SelectQueryI18nDocumentModifier.java
@@ -78,7 +78,10 @@ public class SelectQueryI18nDocumentModifier extends SelectQueryDocumentModifier
 			for (String locale : locales) {
 				LanguageFilteringRDFService lfrs = new LanguageFilteringRDFService(rdfService,
 						Collections.singletonList(locale));
-				List<String> list = createSelectQueryContext(lfrs, queryHolder).execute().toStringFields().flatten();
+				List<String> list = createSelectQueryContext(lfrs, queryHolder)
+				        .execute()
+				        .toStringFields(varNames.toArray(new String[varNames.size()]))
+				        .flatten();
 				mapLocaleToFields.put(locale, list);
 				log.debug(label + " for locale " + locale + " - query: '" + query + "' returns " + list);
 			}

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/utils/dataGetter/SearchFilterValuesDataGetter.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/utils/dataGetter/SearchFilterValuesDataGetter.java
@@ -5,12 +5,10 @@ import static edu.cornell.mannlib.vitro.webapp.search.controller.SearchFiltering
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import com.google.common.base.Optional;
 import edu.cornell.mannlib.vitro.webapp.config.ConfigurationProperties;
 import edu.cornell.mannlib.vitro.webapp.controller.VitroRequest;
 import edu.cornell.mannlib.vitro.webapp.dao.DisplayVocabulary;
@@ -57,13 +55,8 @@ public class SearchFilterValuesDataGetter extends DataGetterBase implements Data
         Map<String, Object> defaultSearchResults = PagedSearchController.process(vreq, requestFilters).getMap();
         responseMap.put("filterGenericInfo", defaultSearchResults);
         requestFilters = SearchFiltering.getRequestFilters(vreq);
-        Optional<FilterValue> filterValue = Optional.absent();
         if (!isValidFilterValueProvided(requestFilters, defaultSearchResults)) {
-            // get first filter value from emptyRequestMap and apply it for next request.
-            filterValue = getFirstFilterValue(defaultSearchResults);
-            if (filterValue.isPresent()) {
-                requestFilters.put(searchFilter, new ArrayList<String>(Arrays.asList(filterValue.get().getId())));
-            }
+            requestFilters.put(searchFilter, new ArrayList<String>(Arrays.asList(ANY_VALUE)));
         }
         responseMap.putAll(PagedSearchController.process(vreq, requestFilters).getMap());
         responseMap.put("searchFilter", this.searchFilter);
@@ -97,20 +90,6 @@ public class SearchFilterValuesDataGetter extends DataGetterBase implements Data
             log.error(e, e);
         }
         return false;
-    }
-
-    private Optional<FilterValue> getFirstFilterValue(Map<String, Object> defaultSearchResults) {
-        try {
-            Map<String, SearchFilter> filterMap = (Map<String, SearchFilter>) defaultSearchResults.get("filters");
-            SearchFilter f = filterMap.get(searchFilter);
-            Collection<FilterValue> values = f.getValues().values();
-            if (!values.isEmpty()) {
-                return Optional.of(values.iterator().next());
-            }
-        } catch (Exception e) {
-            log.error(e, e);
-        }
-        return Optional.absent();
     }
 
     /**

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/utils/dataGetter/SearchFilterValuesDataGetter.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/utils/dataGetter/SearchFilterValuesDataGetter.java
@@ -1,0 +1,164 @@
+/* $This file is distributed under the terms of the license in LICENSE$ */
+package edu.cornell.mannlib.vitro.webapp.utils.dataGetter;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.servlet.ServletContext;
+
+import com.google.common.base.Optional;
+import edu.cornell.mannlib.vitro.webapp.config.ConfigurationProperties;
+import edu.cornell.mannlib.vitro.webapp.controller.VitroRequest;
+import edu.cornell.mannlib.vitro.webapp.dao.DisplayVocabulary;
+import edu.cornell.mannlib.vitro.webapp.search.controller.FilterValue;
+import edu.cornell.mannlib.vitro.webapp.search.controller.PagedSearchController;
+import edu.cornell.mannlib.vitro.webapp.search.controller.SearchFilter;
+import edu.cornell.mannlib.vitro.webapp.search.controller.SearchFiltering;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.jena.query.Query;
+import org.apache.jena.query.QueryExecution;
+import org.apache.jena.query.QueryExecutionFactory;
+import org.apache.jena.query.QueryFactory;
+import org.apache.jena.query.QuerySolution;
+import org.apache.jena.query.QuerySolutionMap;
+import org.apache.jena.query.ResultSet;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.ResourceFactory;
+import org.apache.jena.shared.Lock;
+import org.apache.tika.utils.StringUtils;
+
+public class SearchFilterValuesDataGetter extends DataGetterBase implements DataGetter {
+    private static final String defaultTemplate = "browseSearchFilterValues.ftl";
+    private static final String searchFilterUri = "<" + DisplayVocabulary.SEARCH_FILTER_VALUE + ">";
+    private static final Log log = LogFactory.getLog(SearchFilterValuesDataGetter.class);
+
+    String dataGetterURI;
+    String searchFilter;
+    VitroRequest vreq;
+    ServletContext context;
+
+    /**
+     * Constructor with display model and data getter URI that will be called by reflection.
+     */
+    public SearchFilterValuesDataGetter(VitroRequest vreq, Model displayModel, String dataGetterURI) {
+        this.configure(vreq, displayModel, dataGetterURI);
+    }
+
+    @Override
+    public Map<String, Object> getData(Map<String, Object> pageData) {
+        Map<String, Object> responseMap = new HashMap<>();
+        responseMap.putAll(vreq.getParameterMap());
+        Map<String, List<String>> requestFilters = Collections.emptyMap();
+        Map<String, Object> defaultSearchResults = PagedSearchController.process(vreq, requestFilters).getMap();
+        responseMap.put("filterGenericInfo", defaultSearchResults);
+        requestFilters = SearchFiltering.getRequestFilters(vreq);
+        Optional<FilterValue> filterValue = Optional.absent();
+        if (!isValidFilterValueProvided(requestFilters, defaultSearchResults)) {
+            // get first filter value from emptyRequestMap and apply it for next request.
+            filterValue = getFirstFilterValue(defaultSearchResults);
+            if (filterValue.isPresent()) {
+                requestFilters.put(searchFilter, new ArrayList<String>(Arrays.asList(filterValue.get().getId())));
+            }
+        }
+        responseMap.putAll(PagedSearchController.process(vreq, requestFilters).getMap());
+        responseMap.put("searchFilter", this.searchFilter);
+        responseMap.put("bodyTemplate", defaultTemplate);
+        responseMap.put("languageAware", isLanguageAwarenessEnabled());
+        return responseMap;
+    }
+
+    private Boolean isLanguageAwarenessEnabled() {
+        ConfigurationProperties cp = ConfigurationProperties.getInstance();
+        return Boolean.valueOf(cp.getProperty("RDFService.languageFilter", "false"));
+    }
+
+    private boolean isValidFilterValueProvided(Map<String, List<String>> requestFilters,
+            Map<String, Object> defaultSearchResults) {
+        String mainFilterValue = vreq.getParameter("filters_main");
+        List<String> requestedValues = requestFilters.get(searchFilter);
+        if (StringUtils.isBlank(mainFilterValue) || requestedValues == null || requestedValues.isEmpty()
+                || StringUtils.isBlank(requestedValues.iterator().next())) {
+            return false;
+        }
+        String requestedValue = requestedValues.iterator().next();
+        try {
+            Map<String, SearchFilter> filterMap = (Map<String, SearchFilter>) defaultSearchResults.get("filters");
+            SearchFilter f = filterMap.get(searchFilter);
+            Map<String, FilterValue> values = f.getValues();
+            if (values.containsKey(requestedValue)) {
+                return true;
+            }
+        } catch (Exception e) {
+            log.error(e, e);
+        }
+        return false;
+    }
+
+    private Optional<FilterValue> getFirstFilterValue(Map<String, Object> defaultSearchResults) {
+        try {
+            Map<String, SearchFilter> filterMap = (Map<String, SearchFilter>) defaultSearchResults.get("filters");
+            SearchFilter f = filterMap.get(searchFilter);
+            Collection<FilterValue> values = f.getValues().values();
+            if (!values.isEmpty()) {
+                return Optional.of(values.iterator().next());
+            }
+        } catch (Exception e) {
+            log.error(e, e);
+        }
+        return Optional.absent();
+    }
+
+    /**
+     * Configure this instance based on the URI and display model.
+     */
+    protected void configure(VitroRequest vreq, Model displayModel, String dataGetterURI) {
+        if (vreq == null) {
+            throw new IllegalArgumentException("VitroRequest  may not be null.");
+        }
+        if (displayModel == null) {
+            throw new IllegalArgumentException("Display Model may not be null.");
+        }
+        if (dataGetterURI == null) {
+            throw new IllegalArgumentException("PageUri may not be null.");
+        }
+
+        this.vreq = vreq;
+        this.context = vreq.getSession().getServletContext();
+        this.dataGetterURI = dataGetterURI;
+
+        QuerySolutionMap initBindings = new QuerySolutionMap();
+        initBindings.add("dataGetterURI", ResourceFactory.createResource(this.dataGetterURI));
+
+        Query configurationQuery = QueryFactory.create(dataGetterQuery);
+        displayModel.enterCriticalSection(Lock.READ);
+        try (QueryExecution qexec = QueryExecutionFactory.create(configurationQuery, displayModel, initBindings)) {
+            ResultSet res = qexec.execSelect();
+            while (res.hasNext()) {
+                QuerySolution soln = res.next();
+                this.searchFilter = soln.getLiteral("id").toString();
+            }
+        } finally {
+            displayModel.leaveCriticalSection();
+        }
+    }
+
+    public static final String defaultVarNameForResults = "results";
+
+    /**
+     * Query to get search filter id for a given URI.
+     */
+    private static final String dataGetterQuery =
+        "PREFIX display: <" + DisplayVocabulary.DISPLAY_NS + "> \n" +
+        "PREFIX search: <https://vivoweb.org/ontology/vitro-search#>\n" +
+        "SELECT ?id WHERE { \n" +
+        "?dataGetterURI " + searchFilterUri + " ?searchFilter .\n" +
+        "?searchFilter search:id ?id .\n" +
+        "}";
+
+}

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/utils/dataGetter/SearchFilterValuesDataGetter.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/utils/dataGetter/SearchFilterValuesDataGetter.java
@@ -12,9 +12,7 @@ import java.util.Map;
 import edu.cornell.mannlib.vitro.webapp.config.ConfigurationProperties;
 import edu.cornell.mannlib.vitro.webapp.controller.VitroRequest;
 import edu.cornell.mannlib.vitro.webapp.dao.DisplayVocabulary;
-import edu.cornell.mannlib.vitro.webapp.search.controller.FilterValue;
 import edu.cornell.mannlib.vitro.webapp.search.controller.PagedSearchController;
-import edu.cornell.mannlib.vitro.webapp.search.controller.SearchFilter;
 import edu.cornell.mannlib.vitro.webapp.search.controller.SearchFiltering;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -55,7 +53,7 @@ public class SearchFilterValuesDataGetter extends DataGetterBase implements Data
         Map<String, Object> defaultSearchResults = PagedSearchController.process(vreq, requestFilters).getMap();
         responseMap.put("filterGenericInfo", defaultSearchResults);
         requestFilters = SearchFiltering.getRequestFilters(vreq);
-        if (!isValidFilterValueProvided(requestFilters, defaultSearchResults)) {
+        if (!isValidFilterValueProvided(requestFilters)) {
             requestFilters.put(searchFilter, new ArrayList<String>(Arrays.asList(ANY_VALUE)));
         }
         responseMap.putAll(PagedSearchController.process(vreq, requestFilters).getMap());
@@ -70,26 +68,17 @@ public class SearchFilterValuesDataGetter extends DataGetterBase implements Data
         return Boolean.valueOf(cp.getProperty("RDFService.languageFilter", "false"));
     }
 
-    private boolean isValidFilterValueProvided(Map<String, List<String>> requestFilters,
-            Map<String, Object> defaultSearchResults) {
-        String mainFilterValue = vreq.getParameter("filters_main");
-        List<String> requestedValues = requestFilters.get(searchFilter);
-        if (StringUtils.isBlank(mainFilterValue) || requestedValues == null || requestedValues.isEmpty()
-                || StringUtils.isBlank(requestedValues.iterator().next())) {
+    private boolean isValidFilterValueProvided(Map<String, List<String>> requestFilters) {
+        if (!requestFilters.containsKey(searchFilter)) {
             return false;
         }
-        String requestedValue = requestedValues.iterator().next();
-        try {
-            Map<String, SearchFilter> filterMap = (Map<String, SearchFilter>) defaultSearchResults.get("filters");
-            SearchFilter f = filterMap.get(searchFilter);
-            Map<String, FilterValue> values = f.getValues();
-            if (values.containsKey(requestedValue)) {
+        List<String> values = requestFilters.get(searchFilter);
+        for (String value : values) {
+            if (!StringUtils.isBlank(value)) {
                 return true;
             }
-        } catch (Exception e) {
-            log.error(e, e);
         }
-        return false;
+        return true;
     }
 
     /**

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/utils/dataGetter/SearchFilterValuesDataGetter.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/utils/dataGetter/SearchFilterValuesDataGetter.java
@@ -1,15 +1,14 @@
 /* $This file is distributed under the terms of the license in LICENSE$ */
 package edu.cornell.mannlib.vitro.webapp.utils.dataGetter;
 
+import static edu.cornell.mannlib.vitro.webapp.search.controller.SearchFiltering.ANY_VALUE;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
-import javax.servlet.ServletContext;
 
 import com.google.common.base.Optional;
 import edu.cornell.mannlib.vitro.webapp.config.ConfigurationProperties;
@@ -41,7 +40,6 @@ public class SearchFilterValuesDataGetter extends DataGetterBase implements Data
     private String dataGetterURI;
     private String searchFilter;
     private VitroRequest vreq;
-    private ServletContext context;
 
     /**
      * Constructor with display model and data getter URI that will be called by reflection.
@@ -54,7 +52,8 @@ public class SearchFilterValuesDataGetter extends DataGetterBase implements Data
     public Map<String, Object> getData(Map<String, Object> pageData) {
         Map<String, Object> responseMap = new HashMap<>();
         responseMap.putAll(vreq.getParameterMap());
-        Map<String, List<String>> requestFilters = Collections.emptyMap();
+        Map<String, List<String>> requestFilters = new HashMap<>();
+        requestFilters.put(searchFilter, new ArrayList<String>(Arrays.asList(ANY_VALUE)));
         Map<String, Object> defaultSearchResults = PagedSearchController.process(vreq, requestFilters).getMap();
         responseMap.put("filterGenericInfo", defaultSearchResults);
         requestFilters = SearchFiltering.getRequestFilters(vreq);
@@ -129,7 +128,6 @@ public class SearchFilterValuesDataGetter extends DataGetterBase implements Data
         }
 
         this.vreq = vreq;
-        this.context = vreq.getSession().getServletContext();
         this.dataGetterURI = dataGetterURI;
 
         QuerySolutionMap initBindings = new QuerySolutionMap();

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/utils/dataGetter/SearchFilterValuesDataGetter.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/utils/dataGetter/SearchFilterValuesDataGetter.java
@@ -38,10 +38,10 @@ public class SearchFilterValuesDataGetter extends DataGetterBase implements Data
     private static final String searchFilterUri = "<" + DisplayVocabulary.SEARCH_FILTER_VALUE + ">";
     private static final Log log = LogFactory.getLog(SearchFilterValuesDataGetter.class);
 
-    String dataGetterURI;
-    String searchFilter;
-    VitroRequest vreq;
-    ServletContext context;
+    private String dataGetterURI;
+    private String searchFilter;
+    private VitroRequest vreq;
+    private ServletContext context;
 
     /**
      * Constructor with display model and data getter URI that will be called by reflection.

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/utils/dataGetter/SearchFilterValuesDataGetter.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/utils/dataGetter/SearchFilterValuesDataGetter.java
@@ -48,11 +48,7 @@ public class SearchFilterValuesDataGetter extends DataGetterBase implements Data
     public Map<String, Object> getData(Map<String, Object> pageData) {
         Map<String, Object> responseMap = new HashMap<>();
         responseMap.putAll(vreq.getParameterMap());
-        Map<String, List<String>> requestFilters = new HashMap<>();
-        requestFilters.put(searchFilter, new ArrayList<String>(Arrays.asList(ANY_VALUE)));
-        Map<String, Object> defaultSearchResults = PagedSearchController.process(vreq, requestFilters).getMap();
-        responseMap.put("filterGenericInfo", defaultSearchResults);
-        requestFilters = SearchFiltering.getRequestFilters(vreq);
+        Map<String, List<String>> requestFilters = SearchFiltering.getRequestFilters(vreq);
         if (!isValidFilterValueProvided(requestFilters)) {
             requestFilters.put(searchFilter, new ArrayList<String>(Arrays.asList(ANY_VALUE)));
         }

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/web/templatemodels/searchresult/IndividualSearchResult.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/web/templatemodels/searchresult/IndividualSearchResult.java
@@ -28,6 +28,11 @@ public class IndividualSearchResult extends BaseTemplateModel {
     protected final VitroRequest vreq;
     protected final Individual individual;
 
+    public String getThumbUrl() {
+        String thumbUrl = individual.getThumbUrl();
+        return thumbUrl == null ? null : getUrl(thumbUrl);
+    }
+
     public IndividualSearchResult(Individual individual, VitroRequest vreq) {
         this.vreq = vreq;
         this.individual = individual;

--- a/home/src/main/resources/rdf/display/everytime/dataGetterLabels.n3
+++ b/home/src/main/resources/rdf/display/everytime/dataGetterLabels.n3
@@ -6,6 +6,7 @@
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
 <java:edu.cornell.mannlib.vitro.webapp.utils.dataGetter.ClassGroupPageData>  rdfs:label "Class Group Page" .
+<java:edu.cornell.mannlib.vitro.webapp.utils.dataGetter.SearchFilterValuesDataGetter>  rdfs:label "Search filter values" .
 <java:edu.cornell.mannlib.vitro.webapp.utils.dataGetter.BrowseDataGetter> rdfs:label "Browse Page" .
 <java:edu.cornell.mannlib.vitro.webapp.utils.dataGetter.IndividualsForClassesDataGetter> rdfs:label "Class Group Page - Selected Classes" .
 <java:edu.cornell.mannlib.vitro.webapp.utils.dataGetter.SparqlQueryDataGetter> rdfs:label "Sparql Query Results" .

--- a/home/src/main/resources/rdf/display/firsttime/search_individuals_vitro.n3
+++ b/home/src/main/resources/rdf/display/firsttime/search_individuals_vitro.n3
@@ -4,7 +4,7 @@
 @prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> .
 
 :filter_group_search_filters  a    vitro-search:FilterGroup ;
-        vitro-search:contains      :filter_category , :filter_type , :filter_querytext ;
+        vitro-search:contains      :filter_category , :filter_type , :filter_querytext;
         vitro-search:id            "main" ;
         vitro-search:order         1 ;
         vitro-search:public        true .
@@ -24,6 +24,27 @@
         vitro-search:id            "category" ;
         vitro-search:isUriValues   true ;
         vitro-search:public        true .
+
+:filter_raw_label_regex
+        a                           vitro-search:Filter ;
+        rdfs:label                  "Label regular expression"@en-US ;
+        vitro-search:facetResults   false ;
+        vitro-search:filterField    :field_name_raw ;
+        vitro-search:id             "raw_label_regex" ;
+        vitro-search:public         true ;
+        vitro-search:userInput      true ;
+        vitro-search:userInputRegex true .
+
+:filter_label_regex
+        a                           vitro-search:Filter ;
+        rdfs:label                  "Label regular expression"@en-US ;
+        vitro-search:facetResults   false ;
+        vitro-search:filterField    :field_label_display ;
+        vitro-search:id             "label_regex" ;
+        vitro-search:public         true ;
+        vitro-search:userInput      true ;
+        vitro-search:userInputRegex true .
+
 
 :filter_querytext
         a                          vitro-search:Filter ;
@@ -75,6 +96,11 @@
         vitro-search:isLanguageSpecific true ;
         vitro-search:indexField    "_label_sort" .
 
+:field_label_display
+        a                          vitro-search:SearchField ;
+        vitro-search:isLanguageSpecific true ;
+        vitro-search:indexField    "_label_display" .
+
 :field_name_raw
         a                          vitro-search:SearchField ;
         vitro-search:indexField    "nameRaw" .
@@ -85,7 +111,6 @@
 
 :field_type  a                    vitro-search:SearchField ;
         vitro-search:indexField   "type" ;
-        vitro-search:isLanguageSpecific true ;
         vitro-search:multivalued  true .
 
 :field_querytext

--- a/home/src/main/resources/rdf/display/firsttime/search_individuals_vitro.n3
+++ b/home/src/main/resources/rdf/display/firsttime/search_individuals_vitro.n3
@@ -117,3 +117,19 @@
 :field_querytext
         a                          vitro-search:SearchField ;
         vitro-search:indexField    "querytext" .
+
+#Sort by number of found results associated with value
+:hitsCount
+        a                          vitro-search:SortingObjectType .
+#Sort by label text
+:labelText
+        a                          vitro-search:SortingObjectType .
+#Sort by numbers in label
+:labelNumber
+        a                          vitro-search:SortingObjectType .
+#Sort by id text
+:idText
+        a                          vitro-search:SortingObjectType .
+#Sort by numbers in id
+:idNumber
+        a                          vitro-search:SortingObjectType .

--- a/home/src/main/resources/rdf/display/firsttime/search_individuals_vitro.n3
+++ b/home/src/main/resources/rdf/display/firsttime/search_individuals_vitro.n3
@@ -6,7 +6,7 @@
 :filter_group_search_filters  a    vitro-search:FilterGroup ;
         vitro-search:contains      :filter_category , :filter_type ;
         vitro-search:id            "main" ;
-        vitro-search:order         1 ;
+        vitro-search:rank          1 ;
         vitro-search:public        true .
 
 :filter_type  a                    vitro-search:Filter ;
@@ -14,7 +14,7 @@
         vitro-search:filterField   :field_type ;
         vitro-search:id            "type" ;
         vitro-search:isUriValues   true ;
-        vitro-search:order         30 ;
+        vitro-search:rank          30 ;
         vitro-search:public        false .
 
 :filter_category
@@ -48,44 +48,50 @@
 
 :filter_querytext
         a                          vitro-search:Filter ;
-        vitro-search:order         1 ;
+        vitro-search:rank          1 ;
         vitro-search:filterField   :field_querytext ;
         vitro-search:userInput     true ;
         vitro-search:id            "querytext" ;
         vitro-search:public        true .
 
+:ascending
+        a                          vitro-search:SortDirection .
+
+:descending
+        a                          vitro-search:SortDirection .
+
 :sort_title_desc  a                vitro-search:Sort ;
-        vitro-search:isAscending   false ;
+        vitro-search:direction     :descending  ;
         vitro-search:hasFallback   :sort_name_raw_desc ;
-        vitro-search:order         30 ;
+        vitro-search:rank          30 ;
         vitro-search:sortField     :field_label_sort ;
         vitro-search:display       true ;
         vitro-search:id            "titledesc" .
 
 :sort_title_asc  a                 vitro-search:Sort ;
-        vitro-search:isAscending   true ;
+        vitro-search:direction     :ascending  ;
         vitro-search:hasFallback   :sort_name_raw_asc ;
-        vitro-search:order         20 ;
+        vitro-search:rank          20 ;
         vitro-search:sortField     :field_label_sort ;
         vitro-search:display       true ;
         vitro-search:id            "titleasc" .
 
 :sort_name_raw_desc  a             vitro-search:Sort ;
-        vitro-search:isAscending   false ;
-        vitro-search:order         50 ;
+        vitro-search:direction     :descending  ;
+        vitro-search:rank          50 ;
         vitro-search:sortField     :field_name_raw ;
         vitro-search:id            "name_raw_desc" .
 
 :sort_name_raw_asc  a                vitro-search:Sort ;
-        vitro-search:isAscending   true ;
-        vitro-search:order         40 ;
+        vitro-search:direction     :ascending  ;
+        vitro-search:rank          40 ;
         vitro-search:sortField     :field_name_raw ;
         vitro-search:id            "name_raw_asc" .
 
 :sort_by_relevance a                vitro-search:Sort ;
         vitro-search:sortField     :field_score ;
         vitro-search:display       true ;
-        vitro-search:order         60 ;
+        vitro-search:rank          60 ;
         vitro-search:id            "relevance" .
 
 :field_score

--- a/home/src/main/resources/rdf/display/firsttime/search_individuals_vitro.n3
+++ b/home/src/main/resources/rdf/display/firsttime/search_individuals_vitro.n3
@@ -4,7 +4,7 @@
 @prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> .
 
 :filter_group_search_filters  a    vitro-search:FilterGroup ;
-        vitro-search:contains      :filter_category , :filter_type , :filter_querytext;
+        vitro-search:contains      :filter_category , :filter_type ;
         vitro-search:id            "main" ;
         vitro-search:order         1 ;
         vitro-search:public        true .
@@ -50,6 +50,7 @@
         a                          vitro-search:Filter ;
         vitro-search:order         1 ;
         vitro-search:filterField   :field_querytext ;
+        vitro-search:userInput     true ;
         vitro-search:id            "querytext" ;
         vitro-search:public        true .
 

--- a/home/src/main/resources/rdf/display/firsttime/search_individuals_vitro.n3
+++ b/home/src/main/resources/rdf/display/firsttime/search_individuals_vitro.n3
@@ -29,20 +29,22 @@
         a                           vitro-search:Filter ;
         rdfs:label                  "Label regular expression"@en-US ;
         vitro-search:facetResults   false ;
-        vitro-search:filterField    :field_name_raw ;
-        vitro-search:id             "raw_label_regex" ;
+        vitro-search:filterField    :field_name_lowercase_single_valued ;
+        vitro-search:id             "raw_initial" ;
         vitro-search:public         true ;
         vitro-search:userInput      true ;
+        vitro-search:regexPattern   "$0.*" ;
         vitro-search:userInputRegex true .
 
 :filter_label_regex
         a                           vitro-search:Filter ;
         rdfs:label                  "Label regular expression"@en-US ;
         vitro-search:facetResults   false ;
-        vitro-search:filterField    :field_label_display ;
-        vitro-search:id             "label_regex" ;
+        vitro-search:filterField    :field_label_sort ;
+        vitro-search:id             "initial" ;
         vitro-search:public         true ;
         vitro-search:userInput      true ;
+        vitro-search:regexPattern   "$0.*" ;
         vitro-search:userInputRegex true .
 
 
@@ -111,6 +113,12 @@
 :field_name_raw
         a                          vitro-search:SearchField ;
         vitro-search:indexField    "nameRaw" .
+
+:field_name_lowercase_single_valued
+        a                          vitro-search:SearchField ;
+        vitro-search:indexField    "nameLowercaseSingleValued" .
+
+
 
 :field_category
         a                          vitro-search:SearchField ;

--- a/home/src/main/resources/rdf/displayTbox/everytime/displayTBOX.n3
+++ b/home/src/main/resources/rdf/displayTbox/everytime/displayTBOX.n3
@@ -28,6 +28,8 @@ display:HomePage a owl:Class .
 
 display:ClassGroupPage a owl:Class .
 
+display:SearchFilterValuesDataGetter a owl:Class .
+
 display:IndividualsForClassesPage a owl:Class .
 
 display:InternalClassesPage a owl:Class .
@@ -56,6 +58,10 @@ display:RequiredAction a owl:Class ;
 <java:edu.cornell.mannlib.vitro.webapp.utils.dataGetter.ClassGroupPageData>
     a owl:Class ;
     rdfs:comment "A data getter for a VClassGroup page" .
+
+<java:edu.cornell.mannlib.vitro.webapp.utils.dataGetter.SearchFilterValuesDataGetter>
+    a owl:Class ;
+    rdfs:comment "A data getter for a search filter values page" .
 
 <java:edu.cornell.mannlib.vitro.webapp.utils.dataGetter.FixedHTMLDataGetter>
     a owl:Class ;

--- a/home/src/main/resources/rdf/i18n/de_DE/interface-i18n/firsttime/vitro_UiLabel.ttl
+++ b/home/src/main/resources/rdf/i18n/de_DE/interface-i18n/firsttime/vitro_UiLabel.ttl
@@ -6429,3 +6429,28 @@ uil-data:password_reset_admin_notification_email_html.Vitro
         uil:hasApp       "Vitro" ;
         uil:hasKey       "password_reset_admin_notification_email_html" ;
         uil:hasPackage   "Vitro-languages" .
+
+uil-data:browse_results_alphabetical_index.Vitro
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         uil:UILabel ;
+        rdfs:label       "a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q,r,s,t,u,v,w,x,y,z"@de-DE ;
+        uil:hasApp       "Vitro" ;
+        uil:hasKey       "browse_results_alphabetical_index" ;
+        uil:hasPackage   "Vitro-languages" .
+
+uil-data:browse_search_filter_facets.Vitro
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         uil:UILabel ;
+        rdfs:label       "Ergebnisse der Suchfilterung durchsuchen"@de-DE ;
+        uil:hasApp       "Vitro" ;
+        uil:hasKey       "browse_search_filter_facets" ;
+        uil:hasPackage   "Vitro-languages" .
+
+uil-data:select_search_filter_to_browse.Vitro
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         uil:UILabel ;
+        rdfs:label       "Suchfilter auswählen"@de-DE ;
+        uil:hasApp       "Vitro" ;
+        uil:hasKey       "select_search_filter_to_browse" ;
+        uil:hasPackage   "Vitro-languages" .
+

--- a/home/src/main/resources/rdf/i18n/en_CA/interface-i18n/firsttime/vitro_UiLabel.ttl
+++ b/home/src/main/resources/rdf/i18n/en_CA/interface-i18n/firsttime/vitro_UiLabel.ttl
@@ -6429,3 +6429,28 @@ uil-data:suppress_operation_for_unrelated_individuals_of_this_class.Vitro
         uil:hasApp       "Vitro" ;
         uil:hasKey       "suppress_operation_for_unrelated_individuals_of_this_class" ;
         uil:hasPackage   "Vitro-languages" .
+
+uil-data:browse_results_alphabetical_index.Vitro
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         uil:UILabel ;
+        rdfs:label       "a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q,r,s,t,u,v,w,x,y,z"@en-CA ;
+        uil:hasApp       "Vitro" ;
+        uil:hasKey       "browse_results_alphabetical_index" ;
+        uil:hasPackage   "Vitro-languages" .
+
+uil-data:browse_search_filter_facets.Vitro
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         uil:UILabel ;
+        rdfs:label       "Browse search filter results"@en-CA ;
+        uil:hasApp       "Vitro" ;
+        uil:hasKey       "browse_search_filter_facets" ;
+        uil:hasPackage   "Vitro-languages" .
+
+uil-data:select_search_filter_to_browse.Vitro
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         uil:UILabel ;
+        rdfs:label       "Select search filter"@en-CA ;
+        uil:hasApp       "Vitro" ;
+        uil:hasKey       "select_search_filter_to_browse" ;
+        uil:hasPackage   "Vitro-languages" .
+

--- a/home/src/main/resources/rdf/i18n/en_US/interface-i18n/firsttime/vitro_UiLabel.ttl
+++ b/home/src/main/resources/rdf/i18n/en_US/interface-i18n/firsttime/vitro_UiLabel.ttl
@@ -89,7 +89,7 @@ uil-data:accounts_search_results.Vitro
 uil-data:search_individual_results.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;
-        rdfs:label       "Search Class Individuals"@en-US ;
+        rdfs:label       "Search class individuals"@en-US ;
         uil:hasApp      "Vitro" ;
         uil:hasKey      "search_individual_results" ;
         uil:hasPackage  "Vitro-languages" .
@@ -1353,7 +1353,7 @@ uil-data:close_capitalized.Vitro
 uil-data:browse_class_group.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;
-        rdfs:label       "Browse Class Group"@en-US ;
+        rdfs:label       "Browse class group"@en-US ;
         uil:hasApp      "Vitro" ;
         uil:hasKey      "browse_class_group" ;
         uil:hasPackage  "Vitro-languages" .
@@ -2433,7 +2433,7 @@ uil-data:upload_photo.Vitro
 uil-data:sparql_query_results.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;
-        rdfs:label       "Sparql Query Results"@en-US ;
+        rdfs:label       "SPARQL query results"@en-US ;
         uil:hasApp      "Vitro" ;
         uil:hasKey      "sparql_query_results" ;
         uil:hasPackage  "Vitro-languages" .

--- a/home/src/main/resources/rdf/i18n/en_US/interface-i18n/firsttime/vitro_UiLabel.ttl
+++ b/home/src/main/resources/rdf/i18n/en_US/interface-i18n/firsttime/vitro_UiLabel.ttl
@@ -6922,3 +6922,12 @@ uil-data:remove_role_confirmation.Vitro
         rdfs:label       "Are you sure you would like to remove the role?"@en-US ;
         uil:hasApp       "Vitro" ;
         uil:hasKey       "remove_role_confirmation" .
+
+uil-data:there_are_no_results_to_display.Vitro
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         uil:UILabel ;
+        rdfs:label       "There are no results to display."@en-US ;
+        uil:hasApp       "Vitro" ;
+        uil:hasKey       "there_are_no_results_to_display" ;
+        uil:hasPackage   "Vitro-languages" .
+

--- a/home/src/main/resources/rdf/i18n/en_US/interface-i18n/firsttime/vitro_UiLabel.ttl
+++ b/home/src/main/resources/rdf/i18n/en_US/interface-i18n/firsttime/vitro_UiLabel.ttl
@@ -6871,6 +6871,29 @@ uil-data:reporting_config_dataSource_outputName.Vitro
         uil:hasApp       "Vitro" ;
         uil:hasKey       "reporting_config_dataSource_outputName" .
 
+uil-data:browse_results_alphabetical_index.Vitro
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         uil:UILabel ;
+        rdfs:label       "a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q,r,s,t,u,v,w,x,y,z"@en-US ;
+        uil:hasApp       "Vitro" ;
+        uil:hasKey       "browse_results_alphabetical_index" ;
+        uil:hasPackage   "Vitro-languages" .
+
+uil-data:browse_search_filter_facets.Vitro
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         uil:UILabel ;
+        rdfs:label       "Browse search filter results"@en-US ;
+        uil:hasApp       "Vitro" ;
+        uil:hasKey       "browse_search_filter_facets" ;
+        uil:hasPackage   "Vitro-languages" .
+
+uil-data:select_search_filter_to_browse.Vitro
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         uil:UILabel ;
+        rdfs:label       "Select search filter"@en-US ;
+        uil:hasApp       "Vitro" ;
+        uil:hasKey       "select_search_filter_to_browse" ;
+        uil:hasPackage   "Vitro-languages" .
 
 uil-data:user_roles.Vitro
         rdf:type         owl:NamedIndividual ;

--- a/home/src/main/resources/rdf/i18n/es/interface-i18n/firsttime/vitro_UiLabel.ttl
+++ b/home/src/main/resources/rdf/i18n/es/interface-i18n/firsttime/vitro_UiLabel.ttl
@@ -6429,3 +6429,28 @@ uil-data:password_reset_admin_notification_email_html.Vitro
         uil:hasApp       "Vitro" ;
         uil:hasKey       "password_reset_admin_notification_email_html" ;
         uil:hasPackage   "Vitro-languages" .
+
+uil-data:browse_results_alphabetical_index.Vitro
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         uil:UILabel ;
+        rdfs:label       "a,b,c,d,e,f,g,h,i,j,k,l,m,n,ñ,o,p,q,r,s,t,u,v,w,x,y,z"@es ;
+        uil:hasApp       "Vitro" ;
+        uil:hasKey       "browse_results_alphabetical_index" ;
+        uil:hasPackage   "Vitro-languages" .
+
+uil-data:browse_search_filter_facets.Vitro
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         uil:UILabel ;
+        rdfs:label       "Explorar resultados de búsqueda filtrada"@es ;
+        uil:hasApp       "Vitro" ;
+        uil:hasKey       "browse_search_filter_facets" ;
+        uil:hasPackage   "Vitro-languages" .
+
+uil-data:select_search_filter_to_browse.Vitro
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         uil:UILabel ;
+        rdfs:label       "Seleccionar filtro de búsqueda"@es ;
+        uil:hasApp       "Vitro" ;
+        uil:hasKey       "select_search_filter_to_browse" ;
+        uil:hasPackage   "Vitro-languages" .
+

--- a/home/src/main/resources/rdf/i18n/fr_CA/interface-i18n/firsttime/vitro_UiLabel.ttl
+++ b/home/src/main/resources/rdf/i18n/fr_CA/interface-i18n/firsttime/vitro_UiLabel.ttl
@@ -6429,3 +6429,28 @@ uil-data:password_reset_admin_notification_email_html.Vitro
         uil:hasApp       "Vitro" ;
         uil:hasKey       "password_reset_admin_notification_email_html" ;
         uil:hasPackage   "Vitro-languages" .
+
+uil-data:browse_results_alphabetical_index.Vitro
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         uil:UILabel ;
+        rdfs:label       "a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q,r,s,t,u,v,w,x,y,z"@fr-CA ;
+        uil:hasApp       "Vitro" ;
+        uil:hasKey       "browse_results_alphabetical_index" ;
+        uil:hasPackage   "Vitro-languages" .
+
+uil-data:browse_search_filter_facets.Vitro
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         uil:UILabel ;
+        rdfs:label       "Parcourir les résultats de filtrage de recherche"@fr-CA ;
+        uil:hasApp       "Vitro" ;
+        uil:hasKey       "browse_search_filter_facets" ;
+        uil:hasPackage   "Vitro-languages" .
+
+uil-data:select_search_filter_to_browse.Vitro
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         uil:UILabel ;
+        rdfs:label       "Sélectionner un filtre de recherche"@fr-CA ;
+        uil:hasApp       "Vitro" ;
+        uil:hasKey       "select_search_filter_to_browse" ;
+        uil:hasPackage   "Vitro-languages" .
+

--- a/home/src/main/resources/rdf/i18n/pt_BR/interface-i18n/firsttime/vitro_UiLabel.ttl
+++ b/home/src/main/resources/rdf/i18n/pt_BR/interface-i18n/firsttime/vitro_UiLabel.ttl
@@ -6429,3 +6429,28 @@ uil-data:password_reset_admin_notification_email_html.Vitro
         uil:hasApp       "Vitro" ;
         uil:hasKey       "password_reset_admin_notification_email_html" ;
         uil:hasPackage   "Vitro-languages" .
+
+uil-data:browse_results_alphabetical_index.Vitro
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         uil:UILabel ;
+        rdfs:label       "a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q,r,s,t,u,v,w,x,y,z"@pt-BR ;
+        uil:hasApp       "Vitro" ;
+        uil:hasKey       "browse_results_alphabetical_index" ;
+        uil:hasPackage   "Vitro-languages" .
+
+uil-data:browse_search_filter_facets.Vitro
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         uil:UILabel ;
+        rdfs:label       "Navegar pelos resultados de filtragem de pesquisa"@pt-BR ;
+        uil:hasApp       "Vitro" ;
+        uil:hasKey       "browse_search_filter_facets" ;
+        uil:hasPackage   "Vitro-languages" .
+
+uil-data:select_search_filter_to_browse.Vitro
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         uil:UILabel ;
+        rdfs:label       "Selecionar filtro de pesquisa"@pt-BR ;
+        uil:hasApp       "Vitro" ;
+        uil:hasKey       "select_search_filter_to_browse" ;
+        uil:hasPackage   "Vitro-languages" .
+

--- a/home/src/main/resources/rdf/i18n/ru_RU/interface-i18n/firsttime/vitro_UiLabel.ttl
+++ b/home/src/main/resources/rdf/i18n/ru_RU/interface-i18n/firsttime/vitro_UiLabel.ttl
@@ -6429,3 +6429,29 @@ uil-data:password_reset_admin_notification_email_html.Vitro
         uil:hasApp       "Vitro" ;
         uil:hasKey       "password_reset_admin_notification_email_html" ;
         uil:hasPackage   "Vitro-languages" .
+
+uil-data:browse_results_alphabetical_index.Vitro
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         uil:UILabel ;
+        rdfs:label       "а,б,в,г,д,е,ё,ж,з,и,ӣ,к,л,м,н,о,п,р,с,т,у,ф,х,ц,ч,ш,щ,э,ю,я"@ru-RU ;
+        uil:hasApp       "Vitro" ;
+        uil:hasKey       "browse_results_alphabetical_index" ;
+        uil:hasPackage   "Vitro-languages" .
+
+uil-data:browse_search_filter_facets.Vitro
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         uil:UILabel ;
+        rdfs:label       "Отображение результатов поискового фильтра"@ru-RU ;
+        uil:hasApp       "Vitro" ;
+        uil:hasKey       "browse_search_filter_facets" ;
+        uil:hasPackage   "Vitro-languages" .
+
+uil-data:select_search_filter_to_browse.Vitro
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         uil:UILabel ;
+        rdfs:label       "Выберите фильтр"@ru-RU ;
+        uil:hasApp       "Vitro" ;
+        uil:hasKey       "select_search_filter_to_browse" ;
+        uil:hasPackage   "Vitro-languages" .
+
+

--- a/home/src/main/resources/rdf/i18n/sr_Latn_RS/interface-i18n/firsttime/vitro_UiLabel.ttl
+++ b/home/src/main/resources/rdf/i18n/sr_Latn_RS/interface-i18n/firsttime/vitro_UiLabel.ttl
@@ -6429,3 +6429,27 @@ uil-data:password_reset_admin_notification_email_html.Vitro
         uil:hasApp       "Vitro" ;
         uil:hasKey       "password_reset_admin_notification_email_html" ;
         uil:hasPackage   "Vitro-languages" .
+
+uil-data:browse_results_alphabetical_index.Vitro
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         uil:UILabel ;
+        rdfs:label       "a,b,c,č,ć,d,dž,đ,e,f,g,h,i,j,k,l,lj,m,n,nj,o,p,r,s,š,t,u,v,z,ž"@sr-Latn-RS ;
+        uil:hasApp       "Vitro" ;
+        uil:hasKey       "browse_results_alphabetical_index" ;
+        uil:hasPackage   "Vitro-languages" .
+
+uil-data:browse_search_filter_facets.Vitro
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         uil:UILabel ;
+        rdfs:label       "Pregledajte rezultate filtriranja pretrage"@sr-Latn-RS ;
+        uil:hasApp       "Vitro" ;
+        uil:hasKey       "browse_search_filter_facets" ;
+        uil:hasPackage   "Vitro-languages" .
+
+uil-data:select_search_filter_to_browse.Vitro
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         uil:UILabel ;
+        rdfs:label       "Izaberite filter za pretragu"@sr-Latn-RS ;
+        uil:hasApp       "Vitro" ;
+        uil:hasKey       "select_search_filter_to_browse" ;
+        uil:hasPackage   "Vitro-languages" .

--- a/home/src/main/resources/rdf/tbox/filegraph/search_ontology.n3
+++ b/home/src/main/resources/rdf/tbox/filegraph/search_ontology.n3
@@ -138,9 +138,25 @@ search:display a                      owl:DatatypeProperty , owl:FunctionalPrope
         rdfs:domain                   search:Sort ;
         rdfs:range                    xsd:boolean .
 
+search:reverseFacetOrder a            owl:DatatypeProperty , owl:FunctionalProperty ;
+        rdfs:domain                   search:Filter ;
+        rdfs:range                    xsd:boolean .
+
+
 search:isDefaultForRole
         a                   <http://www.w3.org/2002/07/owl#ObjectProperty> ;
         rdfs:domain         <https://vivoweb.org/ontology/vitro-search#FilterValue> ;
+        rdfs:range          auth:PermissionSet .
+
+search:limitDisplayTo
+        a                   <http://www.w3.org/2002/07/owl#ObjectProperty> ;
+        rdfs:domain         [ rdf:type owl:Class ;
+                              owl:unionOf ( search:Sort
+                                            search:Filter
+                                            search:FilterGroup
+                                            search:FilterValue
+                                          )
+                            ] ; 
         rdfs:range          auth:PermissionSet .
 
 search:moreLimit

--- a/home/src/main/resources/rdf/tbox/filegraph/search_ontology.n3
+++ b/home/src/main/resources/rdf/tbox/filegraph/search_ontology.n3
@@ -41,6 +41,8 @@ search:PublicParameter  a             owl:Class .
 
 search:SearchField  a                 owl:Class .
 
+search:SortDirection  a               owl:Class .
+
 search:SortingObjectType  a           owl:Class .
 
 search:FilterValue  a                 owl:Class ;
@@ -62,10 +64,6 @@ search:multivalued  a                 owl:DatatypeProperty , owl:FunctionalPrope
         rdfs:domain                   search:SearchField ;
         rdfs:range                    xsd:boolean .
 
-search:isAscending  a                 owl:DatatypeProperty , owl:FunctionalProperty ;
-        rdfs:domain                   search:Sort ;
-        rdfs:range                    xsd:boolean .
-
 search:indexField  a                  owl:DatatypeProperty , owl:FunctionalProperty ;
         rdfs:domain                   search:SearchField ;
         rdfs:range                    xsd:string .
@@ -83,6 +81,15 @@ search:isLanguageSpecific
         rdfs:domain                   search:SearchField ;
         rdfs:range                    xsd:boolean .
 
+search:direction  a                   owl:ObjectProperty , owl:FunctionalProperty ;
+        rdfs:domain                   [ rdf:type owl:Class ;
+                                        owl:unionOf ( 
+                                            search:Sort
+                                            search:Filter
+                                        )
+                                      ] ;
+        rdfs:range                    search:SortDirection .
+
 search:filterField  a                 owl:ObjectProperty , owl:FunctionalProperty ;
         rdfs:domain                   search:Filter ;
         rdfs:range                    search:SearchField .
@@ -91,7 +98,7 @@ search:isUriValues  a                 owl:DatatypeProperty , owl:FunctionalPrope
         rdfs:domain                   search:Filter ;
         rdfs:range                    xsd:boolean .
 
-search:order  a                       owl:FunctionalProperty , owl:DatatypeProperty ;
+search:rank  a                        owl:FunctionalProperty , owl:DatatypeProperty ;
         rdfs:domain                   search:PublicParameter ;
         rdfs:range                    xsd:integer .
 

--- a/home/src/main/resources/rdf/tbox/filegraph/search_ontology.n3
+++ b/home/src/main/resources/rdf/tbox/filegraph/search_ontology.n3
@@ -115,6 +115,11 @@ search:userInputRegex
         rdfs:domain                   search:Filter ;
         rdfs:range                    xsd:boolean .
 
+search:regexPattern
+        a                             owl:DatatypeProperty , owl:FunctionalProperty ;
+        rdfs:domain                   search:Filter ;
+        rdfs:range                    xsd:string .
+
 search:sortField  a                   owl:FunctionalProperty , owl:ObjectProperty ;
         rdfs:domain                   search:Sort ;
         rdfs:range                    search:SearchField .

--- a/home/src/main/resources/rdf/tbox/filegraph/search_ontology.n3
+++ b/home/src/main/resources/rdf/tbox/filegraph/search_ontology.n3
@@ -41,6 +41,8 @@ search:PublicParameter  a             owl:Class .
 
 search:SearchField  a                 owl:Class .
 
+search:SortingObjectType  a           owl:Class .
+
 search:FilterValue  a                 owl:Class ;
         rdfs:subClassOf               search:PublicParameter .
 
@@ -126,9 +128,13 @@ search:to  a                          owl:DatatypeProperty , owl:FunctionalPrope
         rdfs:domain                   search:RangeFilter ;
         rdfs:range                    xsd:string .
 
-search:hasKnownValue  a                owl:ObjectProperty ;
-        rdfs:domain                    search:Filter ;
-        rdfs:range                     search:FilterValue .
+search:hasKnownValue  a               owl:ObjectProperty ;
+        rdfs:domain                   search:Filter ;
+        rdfs:range                    search:FilterValue .
+
+search:sortValuesBy  a                owl:ObjectProperty, owl:FunctionalProperty ;
+        rdfs:domain                   search:Filter ;
+        rdfs:range                    search:SortingObjectType .
 
 search:public  a                      owl:DatatypeProperty , owl:FunctionalProperty ;
         rdfs:domain                   search:PublicParameter ;

--- a/home/src/main/resources/rdf/tbox/filegraph/search_ontology.n3
+++ b/home/src/main/resources/rdf/tbox/filegraph/search_ontology.n3
@@ -163,4 +163,4 @@ search:moreLimit
         a                   <http://www.w3.org/2002/07/owl#DatatypeProperty> , <http://www.w3.org/2002/07/owl#FunctionalProperty> ;
         rdfs:domain         <https://vivoweb.org/ontology/vitro-search#Filter> ;
         rdfs:range          <http://www.w3.org/2001/XMLSchema#int> ;
-        rdfs:subPropertyOf  <http://www.w3.org/2002/07/owl#topDataProperty> .
+        .

--- a/webapp/src/main/webapp/css/search-results.css
+++ b/webapp/src/main/webapp/css/search-results.css
@@ -41,8 +41,42 @@
 	display: block;
 }
 
-.tab-pane > label {
+.tab > label {
 	display: inline-block;
+}
+
+.tab > a {
+	padding: 10px 15px;
+	position: relative;
+	display: block;
+	float: left;
+	text-decoration: none;
+	color: #555;
+}
+
+.tab {
+	display: block;
+}
+
+.tabs {
+	display: flex;
+	flex-direction: row;
+	flex-wrap: wrap;
+	gap: 1px;
+}
+
+#filter-groups > .tab {
+	border: 1px solid #ddd;
+	border-bottom: 0;
+	border-radius: 4px 4px 0 0;
+}
+#filter-groups {
+	border-bottom: 1px solid #ddd;	
+}
+
+#filter-groups > .tab.active {
+	margin-bottom: -1px;
+	background-color: #fff;
 }
 
 input[type=radio]:checked + label {
@@ -101,10 +135,18 @@ input[type=checkbox]:not(:checked) + label {
 	padding: 0.3em;
 }
 
+.filter-area >.tab.active {
+	width: 100%;
+}
+
 .range-filter {
 	padding: 15px;
 }
 
+.search-filter-group-container {
+	border-bottom: solid 1px #ddd;
+	width: 100%;
+}
 
 #search-filter-container > ul > li > a {
   padding: 7px 7px;

--- a/webapp/src/main/webapp/css/search-results.css
+++ b/webapp/src/main/webapp/css/search-results.css
@@ -45,7 +45,7 @@
 	display: inline-block;
 }
 
-.tab > a {
+.tab > a:not(.more-facets-link):not(.less-facets-link){
 	padding: 10px 15px;
 	position: relative;
 	display: block;
@@ -255,5 +255,11 @@ a.hidden-search-option {
 }
 
 .extended-search-input-group {
-  display: none;
+	display: none;
+}
+
+#search-form-footer select {
+	border: 1px solid #e0dfdf;
+	margin-left: .5em;
+	height : 3em;
 }

--- a/webapp/src/main/webapp/css/search-results.css
+++ b/webapp/src/main/webapp/css/search-results.css
@@ -263,3 +263,7 @@ a.hidden-search-option {
 	margin-left: .5em;
 	height : 3em;
 }
+
+.facet-input {
+	width: 100%;
+}

--- a/webapp/src/main/webapp/css/search.css
+++ b/webapp/src/main/webapp/css/search.css
@@ -80,6 +80,10 @@ span#searchHelp {
     font-size:.825em;
     padding-right:32px
 }
+
+.tab a:hover {
+	text-decoration: none;
+}
 img#downloadIcon {
     cursor: pointer;
     margin-left: 6px;

--- a/webapp/src/main/webapp/css/search/custom_filters.css
+++ b/webapp/src/main/webapp/css/search/custom_filters.css
@@ -1,0 +1,5 @@
+.li-selected > label {
+	background: url(../../images/arrowIcon.gif) 0px 5px no-repeat;
+	color: #2ea0cf;
+	padding-left: 16px;
+}

--- a/webapp/src/main/webapp/css/search/custom_filters.css
+++ b/webapp/src/main/webapp/css/search/custom_filters.css
@@ -1,5 +1,23 @@
-.li-selected > label {
+.li-selected>label {
 	background: url(../../images/arrowIcon.gif) 0px 5px no-repeat;
 	color: #2ea0cf;
 	padding-left: 16px;
+}
+
+.checked-search-input-label {
+	padding: 2px 5px 2px 5px;
+	border: 0px;
+	background-color: inherit;
+}
+
+.range-slider {
+	margin-bottom: 15px;
+}
+
+.range-slider-end {
+	display: inline-block;
+}
+
+.range-slider-start {
+	display: inline-block;
 }

--- a/webapp/src/main/webapp/css/search/custom_filters.css
+++ b/webapp/src/main/webapp/css/search/custom_filters.css
@@ -106,3 +106,11 @@
 	padding-bottom: 10px;
 	padding-left: 4px;
 }
+
+.download-url {
+	padding: 5px 25px 5px;
+}
+
+#downloadIcon {
+	padding-left: 7px;
+}

--- a/webapp/src/main/webapp/css/search/custom_filters.css
+++ b/webapp/src/main/webapp/css/search/custom_filters.css
@@ -113,4 +113,5 @@
 
 #downloadIcon {
 	padding-left: 7px;
+	font-size: 14px;
 }

--- a/webapp/src/main/webapp/css/search/custom_filters.css
+++ b/webapp/src/main/webapp/css/search/custom_filters.css
@@ -44,6 +44,7 @@
 #browsing-options {
 	border-bottom: 1px solid #dde4e3;
 	border-top: 1px solid #dde4e3;
+	padding-left: 11px;
 }
 
 .display-title {

--- a/webapp/src/main/webapp/css/search/custom_filters.css
+++ b/webapp/src/main/webapp/css/search/custom_filters.css
@@ -1,4 +1,5 @@
-.li-selected> a > label::before {
+/* $This file is distributed under the terms of the license in LICENSE$ */
+.li-selected>a>label::before {
 	content: url(../../images/checkMark.svg);
 	color: #2ea0cf;
 	padding-right: 5px;
@@ -27,7 +28,7 @@
 	margin: 0px;
 	border-bottom: 0px;
 	border-top: 0px;
-	border-left: 0px;
+	border-right: 0px;
 	height: 3em;
 	border-radius: unset;
 	color: rgb(112, 106, 102);
@@ -38,20 +39,60 @@
 	margin: 0px;
 	border-bottom: 0px;
 	border-top: 0px;
-	border-left: 0px;
+	border-right: 0px;
 	height: 3em;
 	border-radius: unset;
+	color: rgb(112, 106, 102);
+	font-family: inherit;
 }
 
 #browsing-options {
 	border-bottom: 1px solid #dde4e3;
-	border-top: 1px solid #dde4e3;
 	padding-left: 11px;
+	display: flex;
+	justify-content: space-between;
 }
 
 .display-title {
 	font-size: small;
 	display: block;
+}
+
+.pagination-container {
+	width: 100%;
+	padding: 20px 20px;
+	display: inline-block;
+	font-size: .8em;
+}
+
+.pagination-container:not(:last-child) {
+	border-bottom: 1px solid #dde4e3;
+}
+
+.pagination-container ul {
+	display: inline;
+}
+
+.pagination-container li.selected {
+	padding: 0 0.4em;
+	line-height: 1.5;
+	color: #333;
+	background: #ddd;
+}
+
+.pagination-container li {
+	display: inline-block;
+	border: none;
+}
+
+.pagination-container li a {
+	padding: 0 0.4em;
+}
+
+.pagination-container .round {
+	-moz-border-radius: 3px;
+	-webkit-border-radius: 3px;
+	border-radius: 3px;
 }
 
 #browse-filters {
@@ -69,6 +110,7 @@
 	margin-right: 10px;
 	padding-top: 10px;
 	padding-bottom: 10px;
+	list-style: none;
 }
 
 #browse-filters li a {
@@ -87,20 +129,20 @@
 }
 
 .li-selected a label {
-	color: #2ea0cf;	
-}
-
-li > a > label:hover {
 	color: #2ea0cf;
 }
 
-#browse-filters li:not(.li-selected) > a > label:hover::before {
+li>a>label:hover {
+	color: #2ea0cf;
+}
+
+#browse-filters li:not(.li-selected)>a>label:hover::before {
 	content: url(../../images/checkMark.svg);
 	padding-right: 5px;
 	margin-left: -17px;
 }
 
-#browse-filters li.li-selected > a > label:hover::before {
+#browse-filters li.li-selected>a>label:hover::before {
 	content: unset;
 	padding-right: unset;
 	margin-left: unset;
@@ -114,11 +156,11 @@ li > a > label:hover {
 	padding-top: 10px;
 }
 
-.facet-values label{
-	cursor:pointer;
+.facet-values label {
+	cursor: pointer;
 }
 
-.filter-tab > a:focus {
+.filter-tab>a:focus {
 	color: unset;
 	text-decoration: none;
 }
@@ -137,6 +179,8 @@ li > a > label:hover {
 #downloadIcon {
 	padding-left: 7px;
 	font-size: 14px;
+	color: rgb(112, 106, 102);
+	font-family: inherit;
 }
 
 .facet-input {
@@ -149,4 +193,107 @@ li > a > label:hover {
 
 .hidden-all-search-options {
 	display: none;
+}
+
+.download-results-text-button {
+	border: 0px;
+	background-color: transparent;
+}
+
+nav#alphabetical-index-container {
+	border-bottom: 1px solid #dde4e3;
+}
+
+nav#alphabetical-index-container {
+	width: 100%;
+	float: left;
+	padding-left: 10px;
+	margin-left: 1px;
+	box-sizing: border-box;
+}
+
+ul#alphabetical-index-individuals {
+	background-color: #fff;
+	float: left;
+}
+
+ul#alphabetical-index-individuals li {
+	float: left;
+	margin-right: 5px;
+	font-size: .8em;
+}
+
+#individuals-in-class ul {
+	list-style: none;
+}
+
+#individuals-in-class {
+	float: right;
+	width: 68%;
+	padding-bottom: 30px;
+	margin-bottom: 30px;
+	margin-right: 17px;
+	min-height: 170px;
+}
+
+#individuals-in-class span.title {
+	display: block;
+	margin: .8em 0 0 0;
+	font-size: .8em;
+	line-height: 1;
+}
+
+ul#alphabetical-index-individuals a:hover, ul#alphabetical-index-individuals a.selected
+	{
+	background: url(../../images/arrowSmall.svg) 0px 6px no-repeat;
+	color: #2ea0cf;
+}
+
+ul#alphabetical-index-individuals a {
+	display: block;
+	height: 35px;
+	margin-left: 0;
+	padding-left: 8px;
+	text-decoration: none;
+}
+
+#browse-by {
+	clear: both;
+	width: 90%;
+	margin: 0 auto;
+	overflow: hidden;
+}
+
+#browse-by h2 {
+	height: 44px;
+	line-height: 44px;
+	padding-left: 15px;
+	margin-bottom: 27px;
+}
+
+li.individual {
+	width: 90%;
+	padding: 20px 0;
+	margin-left: 20px;
+	margin-right: 30px;
+	overflow: hidden;
+}
+
+li.individual img {
+	float: left;
+	margin-right: 20px;
+}
+
+li.individual h1 {
+	padding: 0;
+	line-height: 1.2em;
+	font-weight: bold;
+}
+
+li.individual h1.thumb {
+	padding-top: 30px;
+}
+
+p.no-individuals {
+	margin: 1em 2em;
 }

--- a/webapp/src/main/webapp/css/search/custom_filters.css
+++ b/webapp/src/main/webapp/css/search/custom_filters.css
@@ -21,3 +21,22 @@
 .range-slider-start {
 	display: inline-block;
 }
+
+#filter-form-sort {
+	margin: 0px;
+	border-bottom: 0px;
+	border-top: 0px;
+	border-left: 0px;
+}
+
+#filter-form-hits-per-page {
+	margin: 0px;
+	border-bottom: 0px;
+	border-top: 0px;
+	border-left: 0px;
+}
+
+#browsing-options {
+	border-bottom: 1px solid #dde4e3;
+	border-top: 1px solid #dde4e3;
+}

--- a/webapp/src/main/webapp/css/search/custom_filters.css
+++ b/webapp/src/main/webapp/css/search/custom_filters.css
@@ -63,6 +63,7 @@
 	padding: 20px 20px;
 	display: inline-block;
 	font-size: .8em;
+	box-sizing: border-box;
 }
 
 .pagination-container:not(:last-child) {
@@ -202,6 +203,7 @@ li>a>label:hover {
 
 nav#alphabetical-index-container {
 	border-bottom: 1px solid #dde4e3;
+	border-right: 1px solid #dde4e3;
 }
 
 nav#alphabetical-index-container {

--- a/webapp/src/main/webapp/css/search/custom_filters.css
+++ b/webapp/src/main/webapp/css/search/custom_filters.css
@@ -1,7 +1,8 @@
-.li-selected>label {
-	background: url(../../images/arrowIcon.gif) 0px 5px no-repeat;
+.li-selected> a > label::before {
+	content: url(../../images/arrowIcon.gif);
 	color: #2ea0cf;
-	padding-left: 16px;
+	padding-right: 2px;
+	margin-left: -12px;
 }
 
 .checked-search-input-label {
@@ -27,6 +28,8 @@
 	border-bottom: 0px;
 	border-top: 0px;
 	border-left: 0px;
+	height: 3em;
+	border-radius: unset;
 }
 
 #filter-form-hits-per-page {
@@ -34,6 +37,8 @@
 	border-bottom: 0px;
 	border-top: 0px;
 	border-left: 0px;
+	height: 3em;
+	border-radius: unset;
 }
 
 #browsing-options {
@@ -41,6 +46,63 @@
 	border-top: 1px solid #dde4e3;
 }
 
+.display-title {
+	font-size: small;
+	display: block;
+}
+
+#browse-filters {
+	width: 271px;
+	float: left;
+	background-color: #f1f2ee;
+}
+
+#browse-filters>li:not(:last-child) {
+	border-bottom: 1px dotted #dde4e3;
+}
+
+#browse-filters>li {
+	margin-left: 10px;
+	margin-right: 10px;
+	padding-top: 10px;
+	padding-bottom: 10px;
+}
+
+#browse-filters li a {
+	padding-left: 10px;
+	text-decoration: none;
+	display: block;
+}
+
+#browse-filters li a label {
+	display: block;
+	margin: 0px;
+}
+
+.facet-values {
+	padding-left: 10px;
+}
+
+.facet-values li {
+	padding-top: 10px;
+}
+
 .facet-values label{
 	cursor:pointer;
+}
+
+.filter-tab > a:focus {
+	color: unset;
+	text-decoration: none;
+}
+
+.facet-values > li > a > label:hover {
+	color: #2ea0cf;
+}
+
+.range-filter {
+	padding-right: 16px;
+	padding-top: 10px;
+	padding-bottom: 10px;
+	padding-left: 4px;
 }

--- a/webapp/src/main/webapp/css/search/custom_filters.css
+++ b/webapp/src/main/webapp/css/search/custom_filters.css
@@ -1,8 +1,8 @@
 .li-selected> a > label::before {
-	content: url(../../images/arrowIcon.gif);
+	content: url(../../images/checkMark.svg);
 	color: #2ea0cf;
-	padding-right: 2px;
-	margin-left: -12px;
+	padding-right: 5px;
+	margin-left: -17px;
 }
 
 .checked-search-input-label {
@@ -30,6 +30,8 @@
 	border-left: 0px;
 	height: 3em;
 	border-radius: unset;
+	color: rgb(112, 106, 102);
+	font-family: inherit;
 }
 
 #filter-form-hits-per-page {
@@ -63,7 +65,7 @@
 }
 
 #browse-filters>li {
-	margin-left: 10px;
+	margin-left: 12px;
 	margin-right: 10px;
 	padding-top: 10px;
 	padding-bottom: 10px;
@@ -78,6 +80,30 @@
 #browse-filters li a label {
 	display: block;
 	margin: 0px;
+}
+
+#browse-filters li a label:hover {
+	color: #2ea0cf;
+}
+
+.li-selected a label {
+	color: #2ea0cf;	
+}
+
+li > a > label:hover {
+	color: #2ea0cf;
+}
+
+#browse-filters li:not(.li-selected) > a > label:hover::before {
+	content: url(../../images/checkMark.svg);
+	padding-right: 5px;
+	margin-left: -17px;
+}
+
+#browse-filters li.li-selected > a > label:hover::before {
+	content: unset;
+	padding-right: unset;
+	margin-left: unset;
 }
 
 .facet-values {
@@ -95,10 +121,6 @@
 .filter-tab > a:focus {
 	color: unset;
 	text-decoration: none;
-}
-
-.facet-values > li > a > label:hover {
-	color: #2ea0cf;
 }
 
 .range-filter {

--- a/webapp/src/main/webapp/css/search/custom_filters.css
+++ b/webapp/src/main/webapp/css/search/custom_filters.css
@@ -115,3 +115,15 @@
 	padding-left: 7px;
 	font-size: 14px;
 }
+
+.facet-input {
+	width: 100%;
+}
+
+.hidden-search-option {
+	display: none;
+}
+
+.hidden-all-search-options {
+	display: none;
+}

--- a/webapp/src/main/webapp/css/search/custom_filters.css
+++ b/webapp/src/main/webapp/css/search/custom_filters.css
@@ -227,6 +227,8 @@ ul#alphabetical-index-individuals li {
 
 #individuals-in-class ul {
 	list-style: none;
+	float: left;
+	width: 100%;
 }
 
 #individuals-in-class {
@@ -296,6 +298,12 @@ li.individual h1.thumb {
 	padding-top: 30px;
 }
 
-p.no-individuals {
-	margin: 1em 2em;
+p.no-individuals:first-child {
+	margin-top: 2em;
+	margin-left: 2em;
+	margin-bottom: 1em;
+}
+
+p.no-individuals:not(:first-child) {
+	margin-left: 2em;
 }

--- a/webapp/src/main/webapp/css/search/custom_filters.css
+++ b/webapp/src/main/webapp/css/search/custom_filters.css
@@ -40,3 +40,7 @@
 	border-bottom: 1px solid #dde4e3;
 	border-top: 1px solid #dde4e3;
 }
+
+.facet-values label{
+	cursor:pointer;
+}

--- a/webapp/src/main/webapp/images/arrowSmall.svg
+++ b/webapp/src/main/webapp/images/arrowSmall.svg
@@ -4,12 +4,12 @@
    id="Capa_1"
    x="0px"
    y="0px"
-   viewBox="0 0 12.100418 9.1516207"
+   viewBox="0 0 6.0988621 8.9971474"
    xml:space="preserve"
-   sodipodi:docname="checkMark.svg"
+   sodipodi:docname="arrowSmall.svg"
    inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
-   width="12.100418"
-   height="9.1516209"
+   width="6.0988622"
+   height="8.9971476"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns="http://www.w3.org/2000/svg"
@@ -37,9 +37,9 @@
    inkscape:window-height="2079"
    id="namedview45"
    showgrid="false"
-   inkscape:zoom="32"
-   inkscape:cx="4.453125"
-   inkscape:cy="3.359375"
+   inkscape:zoom="45.254834"
+   inkscape:cx="6.1540387"
+   inkscape:cy="-1.2926796"
    inkscape:window-x="25"
    inkscape:window-y="28"
    inkscape:window-maximized="1"
@@ -51,74 +51,75 @@
 
 <g
    id="g14"
-   transform="translate(-196.88023,-156.877)">
+   transform="translate(-200.77344,-156.95043)">
 </g>
 <g
    id="g16"
-   transform="translate(-196.88023,-156.877)">
+   transform="translate(-200.77344,-156.95043)">
 </g>
 <g
    id="g18"
-   transform="translate(-196.88023,-156.877)">
+   transform="translate(-200.77344,-156.95043)">
 </g>
 <g
    id="g20"
-   transform="translate(-196.88023,-156.877)">
+   transform="translate(-200.77344,-156.95043)">
 </g>
 <g
    id="g22"
-   transform="translate(-196.88023,-156.877)">
+   transform="translate(-200.77344,-156.95043)">
 </g>
 <g
    id="g24"
-   transform="translate(-196.88023,-156.877)">
+   transform="translate(-200.77344,-156.95043)">
 </g>
 <g
    id="g26"
-   transform="translate(-196.88023,-156.877)">
+   transform="translate(-200.77344,-156.95043)">
 </g>
 <g
    id="g28"
-   transform="translate(-196.88023,-156.877)">
+   transform="translate(-200.77344,-156.95043)">
 </g>
 <g
    id="g30"
-   transform="translate(-196.88023,-156.877)">
+   transform="translate(-200.77344,-156.95043)">
 </g>
 <g
    id="g32"
-   transform="translate(-196.88023,-156.877)">
+   transform="translate(-200.77344,-156.95043)">
 </g>
 <g
    id="g34"
-   transform="translate(-196.88023,-156.877)">
+   transform="translate(-200.77344,-156.95043)">
 </g>
 <g
    id="g36"
-   transform="translate(-196.88023,-156.877)">
+   transform="translate(-200.77344,-156.95043)">
 </g>
 <g
    id="g38"
-   transform="translate(-196.88023,-156.877)">
+   transform="translate(-200.77344,-156.95043)">
 </g>
 <g
    id="g40"
-   transform="translate(-196.88023,-156.877)">
+   transform="translate(-200.77344,-156.95043)">
 </g>
 <g
    id="g42"
-   transform="translate(-196.88023,-156.877)">
+   transform="translate(-200.77344,-156.95043)">
 </g>
 <g
    id="g6305"
-   transform="translate(0,-0.18062592)"><path
-     d="m 6.0553322,9.3322466 v 0 L 6.9702976,6.1736617 v 0 0 0 0 L 2.1666518,1.9814048 0,4.0056186 Z"
-     id="polygon8"
-     inkscape:connector-curvature="0"
-     sodipodi:nodetypes="cccccccccc"
-     style="fill:#b6d362;fill-opacity:1;stroke-width:0.058842" /><path
-     d="m 6.0553322,9.3322466 v 0 L 4.8585992,6.0859319 v 0 0 0 0 L 9.8171728,0.18062592 12.100418,2.0118498 Z"
-     id="polygon8-6"
-     inkscape:connector-curvature="0"
-     sodipodi:nodetypes="cccccccccc"
-     style="fill:#b6d362;fill-opacity:1;stroke-width:0.0624242" /></g></svg>
+   transform="translate(-3.8932091,-0.2540566)"><g
+     id="g1073"><path
+       d="m 9.9920711,4.7526302 v 0 L 7.3714499,4.0728922 v 0 0 0 0 l -3.4782407,3.568682 1.679454,1.6096296 z"
+       id="polygon8"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccccc"
+       style="fill:#b6d362;fill-opacity:1;stroke-width:0.0461968" /><path
+       d="m 9.9920711,4.7526302 v 0 l -2.6206213,0.679738 v 0 0 0 0 L 3.8932091,1.8636862 5.5726631,0.2540566 Z"
+       id="polygon8-4"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccccc"
+       style="fill:#b6d362;fill-opacity:1;stroke-width:0.0461968" /></g></g></svg>

--- a/webapp/src/main/webapp/images/checkMark.svg
+++ b/webapp/src/main/webapp/images/checkMark.svg
@@ -1,0 +1,125 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   id="Capa_1"
+   x="0px"
+   y="0px"
+   viewBox="0 0 12.100418 9.1516207"
+   xml:space="preserve"
+   sodipodi:docname="checkMark1.svg"
+   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   width="12.100418"
+   height="9.1516209"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/"><metadata
+   id="metadata49"><rdf:RDF><cc:Work
+       rdf:about=""><dc:format>image/svg+xml</dc:format><dc:type
+         rdf:resource="http://purl.org/dc/dcmitype/StillImage" /></cc:Work></rdf:RDF></metadata><defs
+   id="defs47">
+	
+
+		
+	</defs><sodipodi:namedview
+   pagecolor="#ffffff"
+   bordercolor="#666666"
+   borderopacity="1"
+   objecttolerance="10"
+   gridtolerance="10"
+   guidetolerance="10"
+   inkscape:pageopacity="0"
+   inkscape:pageshadow="2"
+   inkscape:window-width="1403"
+   inkscape:window-height="1032"
+   id="namedview45"
+   showgrid="false"
+   inkscape:zoom="16"
+   inkscape:cx="5.03125"
+   inkscape:cy="-6.0625"
+   inkscape:window-x="799"
+   inkscape:window-y="559"
+   inkscape:window-maximized="0"
+   inkscape:current-layer="Capa_1"
+   inkscape:document-rotation="0"
+   inkscape:pagecheckerboard="0" />
+
+
+<g
+   id="g14"
+   transform="translate(-196.88023,-156.877)">
+</g>
+<g
+   id="g16"
+   transform="translate(-196.88023,-156.877)">
+</g>
+<g
+   id="g18"
+   transform="translate(-196.88023,-156.877)">
+</g>
+<g
+   id="g20"
+   transform="translate(-196.88023,-156.877)">
+</g>
+<g
+   id="g22"
+   transform="translate(-196.88023,-156.877)">
+</g>
+<g
+   id="g24"
+   transform="translate(-196.88023,-156.877)">
+</g>
+<g
+   id="g26"
+   transform="translate(-196.88023,-156.877)">
+</g>
+<g
+   id="g28"
+   transform="translate(-196.88023,-156.877)">
+</g>
+<g
+   id="g30"
+   transform="translate(-196.88023,-156.877)">
+</g>
+<g
+   id="g32"
+   transform="translate(-196.88023,-156.877)">
+</g>
+<g
+   id="g34"
+   transform="translate(-196.88023,-156.877)">
+</g>
+<g
+   id="g36"
+   transform="translate(-196.88023,-156.877)">
+</g>
+<g
+   id="g38"
+   transform="translate(-196.88023,-156.877)">
+</g>
+<g
+   id="g40"
+   transform="translate(-196.88023,-156.877)">
+</g>
+<g
+   id="g42"
+   transform="translate(-196.88023,-156.877)">
+</g>
+<g
+   id="g6305"
+   transform="translate(0,-0.18062592)"><g
+     id="g6310"><path
+       d="m 1.196733,9.1516207 v 0 L 2.1116984,5.5967585 v 0 0 0 0 L -2.6919474,0.87853928 -4.8585992,3.1567118 Z"
+       id="polygon8"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccccc"
+       style="fill:#b6d362;fill-opacity:1;stroke-width:0.0624242"
+       transform="translate(4.8585992,0.18062592)" /><path
+       d="m 6.0553322,9.3322466 v 0 L 4.8585992,6.0859319 v 0 0 0 0 L 9.8171728,0.18062592 12.100418,2.0118498 Z"
+       id="polygon8-6"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccccc"
+       style="fill:#b6d362;fill-opacity:1;stroke-width:0.0624242" /></g></g></svg>

--- a/webapp/src/main/webapp/js/menupage/pageManagementUtils.js
+++ b/webapp/src/main/webapp/js/menupage/pageManagementUtils.js
@@ -102,6 +102,7 @@ var pageManagementUtils = {
 		//list of options
 		this.contentTypeSelectOptions =  $('select#typeSelect option');
 		this.classGroupSection = $("section#browseClassGroup");
+		this.searchFilterSection = $("section#searchFilterValues");
 		this.sparqlQuerySection = $("section#sparqlQuery");
 		this.fixedHTMLSection = $("section#fixedHtml");
 		this.searchIndividualsSection = $("section#searchIndividuals");
@@ -145,6 +146,7 @@ var pageManagementUtils = {
 	   // $("section#pageDetails").hide();
 	    this.headerBar.hide();
 	    this.classGroupSection.hide();
+	    this.searchFilterSection.hide();
 	    this.sparqlQuerySection.hide();
 	    this.fixedHTMLSection.hide();
 	    this.searchIndividualsSection.hide();
@@ -241,6 +243,7 @@ var pageManagementUtils = {
 	        pageManagementUtils.clearSourceTemplateValues();
 	        pageManagementUtils.headerBar.hide();
             pageManagementUtils.classGroupSection.hide();
+            pageManagementUtils.searchFilterSection.hide();
             pageManagementUtils.fixedHTMLSection.hide();
             pageManagementUtils.sparqlQuerySection.hide();
             pageManagementUtils.contentTypeSelectOptions.eq(0).prop('selected', 'selected');
@@ -287,6 +290,7 @@ var pageManagementUtils = {
 		}
 		//Hide all sections
 		pageManagementUtils.classGroupSection.hide();
+		pageManagementUtils.searchFilterSection.hide();
 		pageManagementUtils.fixedHTMLSection.hide();
 		pageManagementUtils.sparqlQuerySection.hide();
 		pageManagementUtils.searchIndividualsSection.hide();
@@ -359,6 +363,7 @@ var pageManagementUtils = {
     	pageManagementUtils.clearSourceTemplateValues();
         if ( _this.contentTypeSelect.val() == "browseClassGroup" ) {
             pageManagementUtils.classGroupSection.show();
+            pageManagementUtils.searchFilterSection.hide();
             pageManagementUtils.fixedHTMLSection.hide();
             pageManagementUtils.sparqlQuerySection.hide();
             pageManagementUtils.searchIndividualsSection.hide();
@@ -366,7 +371,7 @@ var pageManagementUtils = {
             pageManagementUtils.headerBar.show();
             $('div#selfContainedDiv').hide();
         }
-        if ( _this.contentTypeSelect.val() == "fixedHtml" || _this.contentTypeSelect.val() == "sparqlQuery" || _this.contentTypeSelect.val() == "searchIndividuals") {
+        if ( _this.contentTypeSelect.val() == "fixedHtml" || _this.contentTypeSelect.val() == "sparqlQuery" || _this.contentTypeSelect.val() == "searchIndividuals" || _this.contentTypeSelect.val() == "searchFilterValues") {
         	 pageManagementUtils.classGroupSection.hide();
         	 //if fixed html show that, otherwise show sparql results
             if ( _this.contentTypeSelect.val() == "fixedHtml" ) {
@@ -375,10 +380,18 @@ var pageManagementUtils = {
                 initTinyMCE.initEditor(pageManagementUtils.fixedHTMLSection.find("#fixedHTMLValue"));
             	pageManagementUtils.sparqlQuerySection.hide();
             	pageManagementUtils.searchIndividualsSection.hide();
+            	pageManagementUtils.searchFilterSection.hide();
             }
             else if (_this.contentTypeSelect.val() == "sparqlQuery"){
                 pageManagementUtils.headerBar.text(pageManagementUtils.sparqlResults + " - ");
                 pageManagementUtils.sparqlQuerySection.show();
+            	pageManagementUtils.fixedHTMLSection.hide();
+            	pageManagementUtils.searchIndividualsSection.hide();
+            	pageManagementUtils.searchFilterSection.hide();
+            } else if (_this.contentTypeSelect.val() == "searchFilterValues"){
+                pageManagementUtils.headerBar.text(pageManagementUtils.browseSearchFilter + " - ");
+                pageManagementUtils.searchFilterSection.show();
+                pageManagementUtils.sparqlQuerySection.hide();
             	pageManagementUtils.fixedHTMLSection.hide();
             	pageManagementUtils.searchIndividualsSection.hide();
             } else {
@@ -386,6 +399,7 @@ var pageManagementUtils = {
             	pageManagementUtils.headerBar.text(pageManagementUtils.searchIndividuals + " - ");
                 pageManagementUtils.sparqlQuerySection.hide();
             	pageManagementUtils.fixedHTMLSection.hide();
+            	pageManagementUtils.searchFilterSection.hide();
             	pageManagementUtils.searchIndividualsSection.show();
             }
 
@@ -395,6 +409,7 @@ var pageManagementUtils = {
         }
         if ( _this.contentTypeSelect.val() == "" ) {
         	pageManagementUtils.classGroupSection.hide();
+        	pageManagementUtils.searchFilterSection.hide();
         	pageManagementUtils.fixedHTMLSection.hide();
         	pageManagementUtils.sparqlQuerySection.hide();
         	pageManagementUtils.searchIndividualsSection.hide();

--- a/webapp/src/main/webapp/js/menupage/pageManagementUtils.js
+++ b/webapp/src/main/webapp/js/menupage/pageManagementUtils.js
@@ -389,7 +389,7 @@ var pageManagementUtils = {
             	pageManagementUtils.searchIndividualsSection.hide();
             	pageManagementUtils.searchFilterSection.hide();
             } else if (_this.contentTypeSelect.val() == "searchFilterValues"){
-                pageManagementUtils.headerBar.text(pageManagementUtils.browseSearchFilter + " - ");
+                pageManagementUtils.headerBar.text(pageManagementUtils.browseSearchFilterValues + " - ");
                 pageManagementUtils.searchFilterSection.show();
                 pageManagementUtils.sparqlQuerySection.hide();
             	pageManagementUtils.fixedHTMLSection.hide();

--- a/webapp/src/main/webapp/js/menupage/processDataGetterUtils.js
+++ b/webapp/src/main/webapp/js/menupage/processDataGetterUtils.js
@@ -7,6 +7,7 @@
 //This will need to be overridden or extended, what have you.. in VIVO
 var processDataGetterUtils = {
 		dataGetterProcessorMap:{"browseClassGroup": processClassGroupDataGetterContent,
+								"searchFilterValues": processSearchFilterValuesDataGetterContent,
 								"sparqlQuery": processSparqlDataGetterContent,
 								"fixedHtml":processFixedHTMLDataGetterContent,
 								"individualsForClasses":processIndividualsForClassesDataGetterContent,

--- a/webapp/src/main/webapp/js/menupage/processSearchFilterValuesDataGetterContent.js
+++ b/webapp/src/main/webapp/js/menupage/processSearchFilterValuesDataGetterContent.js
@@ -1,0 +1,44 @@
+/* $This file is distributed under the terms of the license in LICENSE$ */
+
+$.extend(this, i18nStringsBrowseSearchFilters);
+//Process sparql data getter and provide a json object with the necessary information
+//Depending on what is included here, a different type of data getter might be used
+var processSearchFilterValuesDataGetterContent = {
+	dataGetterClass:null,
+	//can use this if expect to initialize from elsewhere
+	initProcessor:function(dataGetterClassInput) {
+		this.dataGetterClass = dataGetterClassInput;
+	},
+
+	processPageContentSection:function(pageContentSection) {
+		var searchFilter = pageContentSection.find("select[name='selectSearchFilter']").val();
+		//query model should also be an input, ensure class group URI is saved as URI and not string
+		var returnObject = {filterUri:searchFilter, dataGetterClass:this.dataGetterClass};
+		return returnObject;
+	},
+	//For an existing set of content where form is already set, fill in the values
+	populatePageContentSection:function(existingContentObject, pageContentSection) {
+		let searchFilterValue = existingContentObject["searchFilterUri"];
+		pageContentSection.find("select[name='selectSearchFilter']").val(searchFilterValue);
+	},
+
+	retrieveContentLabel:function() {
+		return i18nStringsBrowseSearchFilters.browseSearchFilter;
+	},
+	retrieveAdditionalLabelText:function(existingContentObject) {
+		var label = "";
+		var filterName = existingContentObject["searchFilterName"];
+		if(filterName != null) {
+			label = filterName;
+		}
+		return label;
+	},
+    //Validation on form submit: Check to see that filter has been selected
+    validateFormSubmission: function(pageContentSection, pageContentSectionLabel) {
+    	var validationError = "";
+    	 if (pageContentSection.find('select[name="selectSearchFilter"]').val() =='-1') {
+             validationError += pageContentSectionLabel + ": " + i18nStringsBrowseSearchFilters.supplySearchFilterValues + " <br />";
+         }
+    	 return validationError;
+    }
+}

--- a/webapp/src/main/webapp/js/search/search_results.js
+++ b/webapp/src/main/webapp/js/search/search_results.js
@@ -5,13 +5,13 @@ $("input:radio").on("click",function (e) {
     } else {
         input.prop("checked",true);
     }
-    $('#search-form').submit();
+    $('#' + searchFormId).submit();
 });
 
 $("input:checkbox").on("click",function (e) {
     var input=$(this);
     input.checked = !input.checked;
-    $('#search-form').submit();
+    $('#' + searchFormId).submit();
 });
 
 function clearInput(elementId) {
@@ -19,7 +19,7 @@ function clearInput(elementId) {
       inputEl.value = "";
       let srcButton = document.getElementById("button_" + elementId);
       srcButton.classList.add("unchecked-selected-search-input-label");
-      $('#search-form').submit();
+      $('#' + searchFormId).submit();
 }
 
 function createSliders(){
@@ -31,10 +31,10 @@ function createSliders(){
         $(this)[0].setPointerCapture(e.pointerId);
     });
     $(".noUi-handle").on("mouseup", function (e) {
-        $('#search-form').submit();
+        $('#' + searchFormId).submit();
     });
     $(".noUi-handle").on("pointerup", function (e) {
-        $('#search-form').submit();
+        $('#' + searchFormId).submit();
     });
 };
     
@@ -83,8 +83,8 @@ window.onload = (event) => {
       createSliders();
 };
 
-$('#search-form').submit(function () {
-$('#search-form')
+$('#' + searchFormId).submit(function () {
+$('#' + searchFormId)
     .find('input')
     .filter(function () {
         return !this.value;

--- a/webapp/src/main/webapp/js/search/search_results.js
+++ b/webapp/src/main/webapp/js/search/search_results.js
@@ -1,0 +1,105 @@
+$("input:radio").on("click",function (e) {
+    var input=$(this);
+    if (input.is(".selected-input")) { 
+        input.prop("checked",false);
+    } else {
+        input.prop("checked",true);
+    }
+    $('#search-form').submit();
+});
+
+$("input:checkbox").on("click",function (e) {
+    var input=$(this);
+    input.checked = !input.checked;
+    $('#search-form').submit();
+});
+
+function clearInput(elementId) {
+      let inputEl = document.getElementById(elementId);
+      inputEl.value = "";
+      let srcButton = document.getElementById("button_" + elementId);
+      srcButton.classList.add("unchecked-selected-search-input-label");
+      $('#search-form').submit();
+}
+
+function createSliders(){
+    sliders = document.getElementsByClassName('range-slider-container');
+    for (let sliderElement of sliders) {
+        createSlider(sliderElement);
+    }
+    $(".noUi-handle").on("mousedown", function (e) {
+        $(this)[0].setPointerCapture(e.pointerId);
+    });
+    $(".noUi-handle").on("mouseup", function (e) {
+        $('#search-form').submit();
+    });
+    $(".noUi-handle").on("pointerup", function (e) {
+        $('#search-form').submit();
+    });
+};
+    
+function createSlider(sliderContainer){
+    rangeSlider = sliderContainer.querySelector('.range-slider');
+    
+    noUiSlider.create(rangeSlider, {
+        range: {
+            min: Number(sliderContainer.getAttribute('min')),
+            max: Number(sliderContainer.getAttribute('max'))
+        },
+    
+        step: 1,
+        start: [Number(sliderContainer.querySelector('.range-slider-start').textContent), 
+                  Number(sliderContainer.querySelector('.range-slider-end').textContent)],
+    
+        format: wNumb({
+            decimals: 0
+        })
+    });
+    
+    var dateValues = [
+         sliderContainer.querySelector('.range-slider-start'),
+         sliderContainer.querySelector('.range-slider-end')
+    ];
+    
+    var input = sliderContainer.querySelector('.range-slider-input');
+    var first = true;
+    
+    rangeSlider.noUiSlider.on('update', function (values, handle) {
+        dateValues[handle].innerHTML = values[handle];
+        var active = input.getAttribute('active');
+        if (active === null){
+            input.setAttribute('active', "false");
+        } else if (active !== "true"){
+            input.setAttribute('active', "true");
+        } else {
+            var startDate = new Date(+values[0],0,1);
+            var endDate = new Date(+values[1],0,1);
+            input.value = startDate.toISOString() + " " + endDate.toISOString();
+        }
+    });
+}
+
+window.onload = (event) => {
+      createSliders();
+};
+
+$('#search-form').submit(function () {
+$('#search-form')
+    .find('input')
+    .filter(function () {
+        return !this.value;
+    })
+    .prop('name', '');
+});
+
+function expandSearchOptions(){
+    $(event.target).parent().children('.additional-search-options').removeClass("hidden-search-option");
+    $(event.target).parent().children('.less-facets-link').show();
+    $(event.target).hide();
+}
+
+function collapseSearchOptions(){
+    $(event.target).parent().children('.additional-search-options').addClass("hidden-search-option");
+    $(event.target).parent().children('.more-facets-link').show();
+    $(event.target).hide();
+}

--- a/webapp/src/main/webapp/js/search/search_results.js
+++ b/webapp/src/main/webapp/js/search/search_results.js
@@ -103,3 +103,20 @@ function collapseSearchOptions(){
     $(event.target).parent().children('.more-facets-link').show();
     $(event.target).hide();
 }
+
+function openTab(event, tabName) {
+  let currentTab = document.getElementById(tabName);
+  let tabs = currentTab.parentElement.querySelectorAll(':scope > .tab');
+  for (let i = 0; i < tabs.length; i++) {
+    let tab = tabs[i];
+    tab.classList.add('fade');
+  }
+  let tabElement = event.srcElement.parentElement;
+  let srcTabs = tabElement.parentElement.querySelectorAll(':scope > .tab');
+  for (let i = 0; i < srcTabs.length; i++) {
+    let tab = srcTabs[i];
+    tab.classList.remove('active');
+  }
+  tabElement.classList.add('active');
+  currentTab.classList.remove('fade');
+}

--- a/webapp/src/main/webapp/js/search/search_results.js
+++ b/webapp/src/main/webapp/js/search/search_results.js
@@ -14,11 +14,17 @@ $("input:checkbox").on("click",function (e) {
     $('#' + searchFormId).submit();
 });
 
-function clearInput(elementId) {
-      let inputEl = document.getElementById(elementId);
+function clearInput(event, elementId) {
+      let inputElements = document.querySelectorAll('input[id='+ elementId + ']');
+      if (inputElements.length == 0){
+          inputElements = document.querySelectorAll('input[name=' + elementId + ']');
+          if (inputElements.length == 0){
+              return;
+          }
+      }
+      let inputEl = inputElements[0];
       inputEl.value = "";
-      let srcButton = document.getElementById("button_" + elementId);
-      srcButton.classList.add("unchecked-selected-search-input-label");
+      event.target.classList.add("unchecked-selected-search-input-label");
       $('#' + searchFormId).submit();
 }
 

--- a/webapp/src/main/webapp/js/searchDownload.js
+++ b/webapp/src/main/webapp/js/searchDownload.js
@@ -18,7 +18,7 @@ $(document).ready(function(){
         $( "#amount" ).val( $( "#slider-vertical" ).slider( "value" ) );
     }
 
-    setTooltip("img#downloadIcon", {
+    setTooltip("#downloadIcon", {
         title: '<div class="clearfix"><div style="float:right; width:150px;border-left: 1px solid #A6B1B0; padding: 3px 0 0 20px">'
                     	+'<p><label for="amount" style="font-size:14px;">Maximum Records:</label>'
                     	+'<input disabled type="text" id="amount" style="margin-left:35px; border: 0; color: #f6931f; font-weight: bold; width:45px" /></p>'

--- a/webapp/src/main/webapp/templates/freemarker/body/menupage/browseSearchFilterValues.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/body/menupage/browseSearchFilterValues.ftl
@@ -79,20 +79,33 @@
                 <li id="${value.id?html}" class="li-selected">
                     <a href="#" class="selected">
                         <@sl.getInput f value sl.getValueID(f.id, valueNumber) valueNumber 'filter-form' />
-                        <@sl.getSelectedLabel sl.getValueID(filter.id, valueNumber)?html value f />
+                        <@sl.getSelectedLabel sl.getValueID(filter.id, valueNumber)?html value f getCurrentCount(f value) />
                     </a>
                 </li>
             <#else>
                 <li id="${value.id?html}">
                     <a href="#">
                         <@sl.getInput f value sl.getValueID(f.id, valueNumber) valueNumber 'filter-form' />
-                        <@sl.getLabel sl.getValueID(f.id, valueNumber) value f />
+                        <@sl.getLabel sl.getValueID(f.id, valueNumber) value f getCurrentCount(f value) />
                     </a>
                 </li>
             </#if>
             <#assign valueNumber = valueNumber + 1>
         </#list>
 </#macro>
+
+<#function getCurrentCount f v>
+    <#if filters[f.id]??>
+        <#assign filter = filters[f.id]>
+        <#if filter.values[v.id]??>
+            <#return filter.values[v.id].count >
+        <#else>
+            <#return 0 />
+        </#if>
+    <#else>
+        <#return 0 />
+    </#if>
+</#function>
 
 <#macro filterFacets f>
     <#assign selectedValue = "" >
@@ -109,14 +122,14 @@
             <li id="${value.id?html}" class="li-selected">
                 <a href="#" class="selected">
                     <@sl.getInput f value sl.getValueID(f.id, valueNumber) valueNumber 'filter-form' />
-                    <@sl.getSelectedLabel sl.getValueID(f.id, valueNumber)?html value f />
+                    <@sl.getSelectedLabel sl.getValueID(f.id, valueNumber)?html value f getCurrentCount(f value) />
                 </a>
             </li>
         <#else>
             <li id="${value.id?html}">
                 <a href="#">
                     <@sl.getInput f value sl.getValueID(f.id, valueNumber) valueNumber 'filter-form' />
-                    <@sl.getLabel sl.getValueID(f.id, valueNumber) value f />
+                    <@sl.getLabel sl.getValueID(f.id, valueNumber) value f getCurrentCount(f value) />
                 </a>
             </li>
         </#if>
@@ -130,8 +143,8 @@
     <#else>
         <#assign indexFilterName = "raw_label_regex">
     </#if>
-    <#if filters[indexFilterName]??>
-        <#assign indexFilter = filters[indexFilterName]>
+    <#if filterGenericInfo.filters[indexFilterName]??>
+        <#assign indexFilter = filterGenericInfo.filters[indexFilterName]>
         <nav id="alpha-browse-container" role="navigation">
             <ul id="alpha-browse-individuals">
             <li>

--- a/webapp/src/main/webapp/templates/freemarker/body/menupage/browseSearchFilterValues.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/body/menupage/browseSearchFilterValues.ftl
@@ -1,0 +1,104 @@
+<#-- $This file is distributed under the terms of the license in LICENSE$ -->
+
+<#if filterGenericInfo.filters[searchFilter]??>
+    <#assign f = filterGenericInfo.filters[searchFilter]>
+    <section id="menupage-intro" role="region">
+        <h2>${page.title}</h2>
+    </section>
+
+    ${stylesheets.add('<link rel="stylesheet" href="${urls.base}/css/menupage/menupage.css" />')}
+
+    <section id="noJavascriptContainer">
+        <section id="browse-by" role="region">
+            <nav role="navigation">
+                <@filterFacets />
+                <@alphabeticalIndexLinks />
+            </nav>
+            <section id="individuals-in-class" role="region">
+                <@printPagingLinks />
+                <@filteredResults />
+                <@printPagingLinks />
+            </section>
+        </section>
+    </section>
+</#if>
+
+<#macro filteredResults>
+    <ul role="list">
+        <#if individuals??>
+            <#list individuals as individual>
+                <li class="individual" role="listitem">
+                    <@shortView uri=individual.uri viewContext="index" />
+                </li>
+            </#list>
+        </#if>
+    </ul>
+</#macro>
+
+
+<#macro filterFacets>
+    <ul id="browse-classes">
+        <#assign selectedValue = "" >
+        <#list f.values?values as value>
+            <#if value.selected>
+                <#assign selectedValue = value.id >
+            </#if>
+            <#assign valueLabel = value.name >
+            <#if !(valueLabel?has_content)>
+                <#assign valueLabel = value.id >
+            </#if>
+            <li id="${value.id?html}">
+                <a href="${urls.currentPage}?filters_main=${searchFilter?url + ":"?url + value.id?url}" data-uri="${value.id?html}" <#if value.selected> class="selected" </#if> >${valueLabel?html}<span class="count-classes">(${value.count})</span>
+                </a>
+            </li>
+        </#list>
+    </ul>
+</#macro>
+
+
+<#macro alphabeticalIndexLinks>
+    <#if languageAware >
+        <#assign indexFilterName = "label_regex">
+    <#else>
+        <#assign indexFilterName = "raw_label_regex">
+    </#if>
+    <#if filters[indexFilterName]??>
+        <#assign indexFilter = filters[indexFilterName]>
+        <nav id="alpha-browse-container" role="navigation">
+            <ul id="alpha-browse-individuals">
+            <li><a 
+            <#if indexFilter.inputText == "">
+                 class="selected" 
+             </#if>
+            href="${urls.currentPage}?filters_main=${searchFilter?url + ":"?url + selectedValue?url}" title="select all">${i18n().all}</a></li>
+            <#list i18n().browse_results_alphabetical_index?split(",") as c>
+                <#assign regexValue = "[" + c?lower_case + c?upper_case + "].*">
+                <#assign regexEncodedValue = "%5B" + c?lower_case?url + c?upper_case?url + "%5D.*">
+                <li><a 
+                    <#if indexFilter.inputText == regexValue >
+                        class="selected" 
+                    </#if>
+                    href="${urls.currentPage}?filters_main=${searchFilter?url + ":"?url + selectedValue?url}&filter_input_${indexFilterName}=${regexEncodedValue}" title="${i18n().browse_all_starts_with(c?upper_case)}">${c?upper_case}</a>
+                </li>
+            </#list>
+            </ul>
+        </nav>
+    </#if>
+</#macro>
+
+<#macro printPagingLinks>
+    <#if (pagingLinks?? && pagingLinks?size > 0)>
+        <div class="pagination menupage">
+            ${i18n().pages}:
+            <ul>
+            <#list pagingLinks as link>
+                <#if link.url??>
+                    <li class="round"><a href="${link.url?html}" title="${i18n().page_link}">${link.text?html}</a></li>
+                <#else>
+                    <li class="round selected"><span>${link.text?html}</span></li> <#-- no link if current page -->
+                </#if>
+            </#list>
+            </ul>
+        </div>
+    </#if>
+</#macro>

--- a/webapp/src/main/webapp/templates/freemarker/body/menupage/browseSearchFilterValues.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/body/menupage/browseSearchFilterValues.ftl
@@ -19,12 +19,27 @@
                             <#list additionalFilters as filterId>
                                 <#if filterGenericInfo.filters[filterId]?? >
                                     <#assign filter = filterGenericInfo.filters[filterId] >
-                                    <#if ( user.loggedIn || filter.public ) && !filter.hidden >
+                                    <#if ( user.loggedIn || filter.public ) && (!filter.hidden || !f.facetsRequired ) >
                                         <li class="filter-tab">
-                                            <a href="#" <#if filter.selected> class="selected" </#if> >${filter.name?html}</a>
-                                            <ul id="facet-values">
-                                                <@collapsedFacets filter />
-                                            </ul>
+                                            <a href="#" <#if filter.selected || (filters[filterId]?? && filters[filterId].selected)> class="selected" </#if> >${filter.name?html}</a>
+                                            <#if filter.type == "RangeFilter">
+                                                <ul>
+                                                    <#if filters[filterId]?? && filters[filterId].selected>
+                                                        <li class="li-selected">
+                                                            <a href="#" class="selected">
+                                                                <@sl.userSelectedInput filters[filterId] "filter-form" />
+                                                            </a>
+                                                        </li>
+                                                    </#if>
+                                                    <li>
+                                                        <@sl.rangeFilter filters[filterId] 'filter-form'/>
+                                                    </li>
+                                                </ul>
+                                            <#else>
+                                                <ul id="facet-values">
+                                                    <@filterFacets filter />
+                                                </ul>
+                                            </#if>
                                         </li>
                                     </#if>
                                 </#if>
@@ -65,51 +80,6 @@
     </ul>
 </#macro>
 
-<#macro collapsedFacets f>
-        <#assign selectedValue = "" >
-        <#assign valueNumber = 1>
-        <#list f.values?values as value>
-            <#if user.loggedIn || value.publiclyAvailable>
-                <#if value.selected>
-                    <#assign selectedValue = value.id >
-                </#if>
-                <#assign valueLabel = value.name >
-                <#if !(valueLabel?has_content)>
-                    <#assign valueLabel = value.id >
-                </#if>
-                <#if value.selected>
-                    <li id="${value.id?html}" class="li-selected">
-                        <a href="#" class="selected">
-                            <@sl.getInput f value sl.getValueID(f.id, valueNumber) valueNumber 'filter-form' />
-                            <@sl.getSelectedLabel sl.getValueID(filter.id, valueNumber)?html value f getCurrentCount(f value) />
-                        </a>
-                    </li>
-                <#else>
-                    <li id="${value.id?html}">
-                        <a href="#">
-                            <@sl.getInput f value sl.getValueID(f.id, valueNumber) valueNumber 'filter-form' />
-                            <@sl.getLabel sl.getValueID(f.id, valueNumber) value f getCurrentCount(f value) />
-                        </a>
-                    </li>
-                </#if>
-                <#assign valueNumber = valueNumber + 1>
-            </#if>
-        </#list>
-</#macro>
-
-<#function getCurrentCount f v>
-    <#if filters[f.id]??>
-        <#assign filter = filters[f.id]>
-        <#if filter.values[v.id]??>
-            <#return filter.values[v.id].count >
-        <#else>
-            <#return 0 />
-        </#if>
-    <#else>
-        <#return 0 />
-    </#if>
-</#function>
-
 <#macro filterFacets f>
     <#assign selectedValue = "" >
     <#assign valueNumber = 1>
@@ -141,6 +111,19 @@
         </#if>
     </#list>
 </#macro>
+
+<#function getCurrentCount f v>
+    <#if filters[f.id]??>
+        <#assign filter = filters[f.id]>
+        <#if filter.values[v.id]??>
+            <#return filter.values[v.id].count >
+        <#else>
+            <#return 0 />
+        </#if>
+    <#else>
+        <#return 0 />
+    </#if>
+</#function>
 
 <#macro alphabeticalIndexLinks>
     <#if languageAware >
@@ -217,5 +200,9 @@
 
 ${scripts.add('<script type="text/javascript" src="${urls.base}/js/search/search_results.js"></script>')}
 ${stylesheets.add('<link rel="stylesheet" type="text/css" href="${urls.base}/css/search/custom_filters.css"/>')}
+${stylesheets.add('<link rel="stylesheet" type="text/css" href="${urls.base}/css/nouislider.css"/>')}
+${headScripts.add('<script type="text/javascript" src="${urls.base}/js/nouislider.min.js"></script>')}
+${headScripts.add('<script type="text/javascript" src="${urls.base}/js/wNumb.min.js"></script>')}
+
 
 

--- a/webapp/src/main/webapp/templates/freemarker/body/menupage/browseSearchFilterValues.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/body/menupage/browseSearchFilterValues.ftl
@@ -4,31 +4,32 @@
 <script>
     let searchFormId = "filter-form";
 </script>
-
+<#-- <#assign additionalFilters = ["type"]> -->
 <#if filterGenericInfo.filters[searchFilter]??>
     <section id="menupage-intro" role="region">
         <h2>${page.title}</h2>
     </section>
-    <#assign additionalFilters = ["type"]>
     ${stylesheets.add('<link rel="stylesheet" href="${urls.base}/css/menupage/menupage.css" />')}
     <form id="filter-form" name="filter-form" autocomplete="off" method="get" action="${urls.currentPage}">
         <section id="noJavascriptContainer">
             <section id="browse-by" role="region">
                 <nav role="navigation">
                     <ul id="browse-classes">
-                        <#list additionalFilters as filterId>
-                            <#if filterGenericInfo.filters[filterId]?? >
-                                <#assign filter = filterGenericInfo.filters[filterId] >
-                                <#if ( user.loggedIn || filter.public ) && !filter.hidden >
-                                    <li class="filter-tab">
-                                        <a href="#" <#if filter.selected> class="selected" </#if> >${filter.name?html}</a>
-                                        <ul id="facet-values">
-                                            <@collapsedFacets filter />
-                                        </ul>
-                                    </li>
+                        <#if additionalFilters?? >
+                            <#list additionalFilters as filterId>
+                                <#if filterGenericInfo.filters[filterId]?? >
+                                    <#assign filter = filterGenericInfo.filters[filterId] >
+                                    <#if ( user.loggedIn || filter.public ) && !filter.hidden >
+                                        <li class="filter-tab">
+                                            <a href="#" <#if filter.selected> class="selected" </#if> >${filter.name?html}</a>
+                                            <ul id="facet-values">
+                                                <@collapsedFacets filter />
+                                            </ul>
+                                        </li>
+                                    </#if>
                                 </#if>
-                            </#if>
-                        </#list>
+                            </#list>
+                        </#if>
                         <div class="divider" style="border-top: 0.5rem solid #fff;margin: -2px;"></div>
                         <@filterFacets filterGenericInfo.filters[searchFilter] />
                     </ul>

--- a/webapp/src/main/webapp/templates/freemarker/body/menupage/browseSearchFilterValues.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/body/menupage/browseSearchFilterValues.ftl
@@ -72,13 +72,12 @@
              </#if>
             href="${urls.currentPage}?filters_main=${searchFilter?url + ":"?url + selectedValue?url}" title="select all">${i18n().all}</a></li>
             <#list i18n().browse_results_alphabetical_index?split(",") as c>
-                <#assign regexValue = "[" + c?lower_case + c?upper_case + "].*">
-                <#assign regexEncodedValue = "%5B" + c?lower_case?url + c?upper_case?url + "%5D.*">
+                <#assign regexValue = "(" + c?lower_case?cap_first + "|" + c?lower_case + "|" + c?upper_case + ").*">
                 <li><a 
                     <#if indexFilter.inputText == regexValue >
                         class="selected" 
                     </#if>
-                    href="${urls.currentPage}?filters_main=${searchFilter?url + ":"?url + selectedValue?url}&filter_input_${indexFilterName}=${regexEncodedValue}" title="${i18n().browse_all_starts_with(c?upper_case)}">${c?upper_case}</a>
+                    href="${urls.currentPage}?filters_main=${searchFilter?url + ":"?url + selectedValue?url}&filter_input_${indexFilterName}=${regexValue?url}" title="${i18n().browse_all_starts_with(c?upper_case)}">${c?upper_case}</a>
                 </li>
             </#list>
             </ul>

--- a/webapp/src/main/webapp/templates/freemarker/body/menupage/browseSearchFilterValues.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/body/menupage/browseSearchFilterValues.ftl
@@ -1,26 +1,55 @@
 <#-- $This file is distributed under the terms of the license in LICENSE$ -->
+<#import "search-lib.ftl" as sl>
+
+<script>
+    let searchFormId = "filter-form";
+</script>
 
 <#if filterGenericInfo.filters[searchFilter]??>
-    <#assign f = filterGenericInfo.filters[searchFilter]>
     <section id="menupage-intro" role="region">
         <h2>${page.title}</h2>
     </section>
-
+    <#assign additionalFilters = ["type"]>
     ${stylesheets.add('<link rel="stylesheet" href="${urls.base}/css/menupage/menupage.css" />')}
-
-    <section id="noJavascriptContainer">
-        <section id="browse-by" role="region">
-            <nav role="navigation">
-                <@filterFacets />
-                <@alphabeticalIndexLinks />
-            </nav>
-            <section id="individuals-in-class" role="region">
-                <@printPagingLinks />
-                <@filteredResults />
-                <@printPagingLinks />
+    <form id="filter-form" name="filter-form" autocomplete="off" method="get" action="${urls.currentPage}">
+        <section id="noJavascriptContainer">
+            <section id="browse-by" role="region">
+                <nav role="navigation">
+                    <ul id="browse-classes">
+                        <#list additionalFilters as filterId>
+                            <#if filterGenericInfo.filters[filterId]?? >
+                                <#assign filter = filterGenericInfo.filters[filterId] >
+                                <#if ( user.loggedIn || filter.public ) && !filter.hidden >
+                                    <li class="filter-tab">
+                                        <a href="#" <#if filter.selected> class="selected" </#if> >${filter.name?html}</a>
+                                        <ul id="facet-values">
+                                            <@collapsedFacets filter />
+                                        </ul>
+                                    </li>
+                                </#if>
+                            </#if>
+                        </#list>
+                        <div class="divider" style="border-top: 0.5rem solid #fff;margin: -2px;"></div>
+                        <@filterFacets filterGenericInfo.filters[searchFilter] />
+                    </ul>
+                    <@alphabeticalIndexLinks />
+                </nav>
+                <section id="individuals-in-class" role="region">
+                    <@printPagingLinks />
+                    <@filteredResults />
+                    <@printPagingLinks />
+                </section>
             </section>
         </section>
-    </section>
+    </form>
+    
+    <script type="text/javascript">
+        $('.filter-tab > ul > li').not('.li-selected').hide();
+        $('.filter-tab > a').click(function() {
+            $(this).parent().find('ul > li').not('.li-selected').toggle();
+        });
+    </script>
+
 </#if>
 
 <#macro filteredResults>
@@ -35,10 +64,9 @@
     </ul>
 </#macro>
 
-
-<#macro filterFacets>
-    <ul id="browse-classes">
+<#macro collapsedFacets f>
         <#assign selectedValue = "" >
+        <#assign valueNumber = 1>
         <#list f.values?values as value>
             <#if value.selected>
                 <#assign selectedValue = value.id >
@@ -47,14 +75,54 @@
             <#if !(valueLabel?has_content)>
                 <#assign valueLabel = value.id >
             </#if>
-            <li id="${value.id?html}">
-                <a href="${urls.currentPage}?filters_main=${searchFilter?url + ":"?url + value.id?url}" data-uri="${value.id?html}" <#if value.selected> class="selected" </#if> >${valueLabel?html}<span class="count-classes">(${value.count})</span>
-                </a>
-            </li>
+            <#if value.selected>
+                <li id="${value.id?html}" class="li-selected">
+                    <a href="#" class="selected">
+                        <@sl.getInput f value sl.getValueID(f.id, valueNumber) valueNumber 'filter-form' />
+                        <@sl.getSelectedLabel sl.getValueID(filter.id, valueNumber)?html value f />
+                    </a>
+                </li>
+            <#else>
+                <li id="${value.id?html}">
+                    <a href="#">
+                        <@sl.getInput f value sl.getValueID(f.id, valueNumber) valueNumber 'filter-form' />
+                        <@sl.getLabel sl.getValueID(f.id, valueNumber) value f />
+                    </a>
+                </li>
+            </#if>
+            <#assign valueNumber = valueNumber + 1>
         </#list>
-    </ul>
 </#macro>
 
+<#macro filterFacets f>
+    <#assign selectedValue = "" >
+    <#assign valueNumber = 1>
+    <#list f.values?values as value>
+        <#if value.selected>
+            <#assign selectedValue = value.id >
+        </#if>
+        <#assign valueLabel = value.name >
+        <#if !(valueLabel?has_content)>
+            <#assign valueLabel = value.id >
+        </#if>
+        <#if value.selected>
+            <li id="${value.id?html}" class="li-selected">
+                <a href="#" class="selected">
+                    <@sl.getInput f value sl.getValueID(f.id, valueNumber) valueNumber 'filter-form' />
+                    <@sl.getSelectedLabel sl.getValueID(f.id, valueNumber)?html value f />
+                </a>
+            </li>
+        <#else>
+            <li id="${value.id?html}">
+                <a href="#">
+                    <@sl.getInput f value sl.getValueID(f.id, valueNumber) valueNumber 'filter-form' />
+                    <@sl.getLabel sl.getValueID(f.id, valueNumber) value f />
+                </a>
+            </li>
+        </#if>
+        <#assign valueNumber = valueNumber + 1>
+    </#list>
+</#macro>
 
 <#macro alphabeticalIndexLinks>
     <#if languageAware >
@@ -66,19 +134,22 @@
         <#assign indexFilter = filters[indexFilterName]>
         <nav id="alpha-browse-container" role="navigation">
             <ul id="alpha-browse-individuals">
-            <li><a 
-            <#if indexFilter.inputText == "">
-                 class="selected" 
-             </#if>
-            href="${urls.currentPage}?filters_main=${searchFilter?url + ":"?url + selectedValue?url}" title="select all">${i18n().all}</a></li>
+            <li>
+                 <a href="#" <#if indexFilter.inputText == ""> class="selected" </#if> >
+                     <@getAlphabetInput indexFilter '' sl.getValueID(indexFilter.id, 0) />
+                     <@getAlphabetLabel sl.getValueID(indexFilter.id, 0) i18n().all />
+                 </a>
+            </li>
+            <#assign valueNumber = 1>
             <#list i18n().browse_results_alphabetical_index?split(",") as c>
                 <#assign regexValue = "(" + c?lower_case?cap_first + "|" + c?lower_case + "|" + c?upper_case + ").*">
-                <li><a 
-                    <#if indexFilter.inputText == regexValue >
-                        class="selected" 
-                    </#if>
-                    href="${urls.currentPage}?filters_main=${searchFilter?url + ":"?url + selectedValue?url}&filter_input_${indexFilterName}=${regexValue?url}" title="${i18n().browse_all_starts_with(c?upper_case)}">${c?upper_case}</a>
+                <li>
+                    <a href="#" <#if indexFilter.inputText == regexValue > class="selected" </#if> >
+                        <@getAlphabetInput indexFilter regexValue sl.getValueID(indexFilter.id, valueNumber) />
+                        <@getAlphabetLabel sl.getValueID(indexFilter.id, valueNumber) c?upper_case />
+                    </a>
                 </li>
+                <#assign valueNumber = valueNumber + 1>
             </#list>
             </ul>
         </nav>
@@ -101,3 +172,32 @@
         </div>
     </#if>
 </#macro>
+
+<#macro getAlphabetLabel valueId label>
+    <label for="${valueId}" >${label?html}</label>
+</#macro>
+<#-- create radio input fields for alphabetical indexes -->
+<#macro getAlphabetInput filter filterValue valueID form="filter-form">
+    <#assign checked = "">
+    <#if filter.inputText == filterValue>
+        <#assign checked = " checked=\"checked\" " >
+        <#assign class = "selected-input" >
+    </#if>
+    <#assign type = "radio" >
+    <#assign filterName = filter.id >
+
+    <input 
+        form="${form}" 
+        type="radio" 
+        id="${valueID?html}" 
+        value="${filter.id?html + ":"?html + filterValue?html}"
+        name="filters_${filter.id?html}" 
+        style="display:none;" 
+        ${checked} 
+    >
+</#macro>
+
+${scripts.add('<script type="text/javascript" src="${urls.base}/js/search/search_results.js"></script>')}
+${stylesheets.add('<link rel="stylesheet" type="text/css" href="${urls.base}/css/search/custom_filters.css"/>')}
+
+

--- a/webapp/src/main/webapp/templates/freemarker/body/menupage/browseSearchFilterValues.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/body/menupage/browseSearchFilterValues.ftl
@@ -68,29 +68,31 @@
         <#assign selectedValue = "" >
         <#assign valueNumber = 1>
         <#list f.values?values as value>
-            <#if value.selected>
-                <#assign selectedValue = value.id >
+            <#if user.loggedIn || value.publiclyAvailable>
+                <#if value.selected>
+                    <#assign selectedValue = value.id >
+                </#if>
+                <#assign valueLabel = value.name >
+                <#if !(valueLabel?has_content)>
+                    <#assign valueLabel = value.id >
+                </#if>
+                <#if value.selected>
+                    <li id="${value.id?html}" class="li-selected">
+                        <a href="#" class="selected">
+                            <@sl.getInput f value sl.getValueID(f.id, valueNumber) valueNumber 'filter-form' />
+                            <@sl.getSelectedLabel sl.getValueID(filter.id, valueNumber)?html value f getCurrentCount(f value) />
+                        </a>
+                    </li>
+                <#else>
+                    <li id="${value.id?html}">
+                        <a href="#">
+                            <@sl.getInput f value sl.getValueID(f.id, valueNumber) valueNumber 'filter-form' />
+                            <@sl.getLabel sl.getValueID(f.id, valueNumber) value f getCurrentCount(f value) />
+                        </a>
+                    </li>
+                </#if>
+                <#assign valueNumber = valueNumber + 1>
             </#if>
-            <#assign valueLabel = value.name >
-            <#if !(valueLabel?has_content)>
-                <#assign valueLabel = value.id >
-            </#if>
-            <#if value.selected>
-                <li id="${value.id?html}" class="li-selected">
-                    <a href="#" class="selected">
-                        <@sl.getInput f value sl.getValueID(f.id, valueNumber) valueNumber 'filter-form' />
-                        <@sl.getSelectedLabel sl.getValueID(filter.id, valueNumber)?html value f getCurrentCount(f value) />
-                    </a>
-                </li>
-            <#else>
-                <li id="${value.id?html}">
-                    <a href="#">
-                        <@sl.getInput f value sl.getValueID(f.id, valueNumber) valueNumber 'filter-form' />
-                        <@sl.getLabel sl.getValueID(f.id, valueNumber) value f getCurrentCount(f value) />
-                    </a>
-                </li>
-            </#if>
-            <#assign valueNumber = valueNumber + 1>
         </#list>
 </#macro>
 
@@ -111,29 +113,31 @@
     <#assign selectedValue = "" >
     <#assign valueNumber = 1>
     <#list f.values?values as value>
-        <#if value.selected>
-            <#assign selectedValue = value.id >
+        <#if user.loggedIn || value.publiclyAvailable>
+            <#if value.selected>
+                <#assign selectedValue = value.id >
+            </#if>
+            <#assign valueLabel = value.name >
+            <#if !(valueLabel?has_content)>
+                <#assign valueLabel = value.id >
+            </#if>
+            <#if value.selected>
+                <li id="${value.id?html}" class="li-selected">
+                    <a href="#" class="selected">
+                        <@sl.getInput f value sl.getValueID(f.id, valueNumber) valueNumber 'filter-form' />
+                        <@sl.getSelectedLabel sl.getValueID(f.id, valueNumber)?html value f getCurrentCount(f value) />
+                    </a>
+                </li>
+            <#else>
+                <li id="${value.id?html}">
+                    <a href="#">
+                        <@sl.getInput f value sl.getValueID(f.id, valueNumber) valueNumber 'filter-form' />
+                        <@sl.getLabel sl.getValueID(f.id, valueNumber) value f getCurrentCount(f value) />
+                    </a>
+                </li>
+            </#if>
+            <#assign valueNumber = valueNumber + 1>
         </#if>
-        <#assign valueLabel = value.name >
-        <#if !(valueLabel?has_content)>
-            <#assign valueLabel = value.id >
-        </#if>
-        <#if value.selected>
-            <li id="${value.id?html}" class="li-selected">
-                <a href="#" class="selected">
-                    <@sl.getInput f value sl.getValueID(f.id, valueNumber) valueNumber 'filter-form' />
-                    <@sl.getSelectedLabel sl.getValueID(f.id, valueNumber)?html value f getCurrentCount(f value) />
-                </a>
-            </li>
-        <#else>
-            <li id="${value.id?html}">
-                <a href="#">
-                    <@sl.getInput f value sl.getValueID(f.id, valueNumber) valueNumber 'filter-form' />
-                    <@sl.getLabel sl.getValueID(f.id, valueNumber) value f getCurrentCount(f value) />
-                </a>
-            </li>
-        </#if>
-        <#assign valueNumber = valueNumber + 1>
     </#list>
 </#macro>
 

--- a/webapp/src/main/webapp/templates/freemarker/body/menupage/browseSearchFilterValues.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/body/menupage/browseSearchFilterValues.ftl
@@ -106,7 +106,7 @@
         <#if individuals??>
             <#list individuals as individual>
                 <li class="individual" role="listitem">
-                    <@shortView uri=individual.uri viewContext="index" />
+                    <@shortView uri=individual.uri viewContext="browse" />
                 </li>
             </#list>
         </#if>

--- a/webapp/src/main/webapp/templates/freemarker/body/menupage/browseSearchFilterValues.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/body/menupage/browseSearchFilterValues.ftl
@@ -65,7 +65,7 @@
 <#macro filterTab filterId>
     <#if filters[filterId]?? >
         <#assign filter = filters[filterId] >
-        <#if filter.display >
+        <#if filter.displayed>
             <#assign filterValues><@getValues filter /></#assign>
             <#if filterValues?has_content>
                 <li class="filter-tab">
@@ -116,7 +116,7 @@
 <#macro filterFacets f >
     <#assign idCounter = 1 >
     <#list f.values?values as value>
-        <#if !value.display>
+        <#if !value.displayed>
             <#continue>
         </#if>
         <#assign valueLabel = value.name >
@@ -227,7 +227,7 @@
             <#list sortOptionIds as sortOptionId>
                 <#if sortOptions[sortOptionId]??>
                     <#assign option = sortOptions[sortOptionId]>
-                    <#if option.display>
+                    <#if option.displayed>
                         <#if option.selected>
                             <option value="${option.id}" selected="selected">${i18n().search_results_sort_by(option.label)}</option>
                             <#assign addDefaultOption = false>

--- a/webapp/src/main/webapp/templates/freemarker/body/menupage/browseSearchFilterValues.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/body/menupage/browseSearchFilterValues.ftl
@@ -113,7 +113,7 @@
         <#elseif filters[indexFilterName]?? && filters[indexFilterName].inputText?has_content>
             <#assign selectedLetter = filters[indexFilterName].inputText >
             <li>
-                <p class="no-individuals">${i18n().there_are_no_entries_starting_with} ${selectedLetter}</p>
+                <p class="no-individuals">${i18n().there_are_no_entries_starting_with} ${selectedLetter}.</p>
                 <p class="no-individuals">${i18n().try_another_letter}</p>
             </li>
         <#else>

--- a/webapp/src/main/webapp/templates/freemarker/body/menupage/browseSearchFilterValues.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/body/menupage/browseSearchFilterValues.ftl
@@ -4,9 +4,9 @@
 <#-- <#assign additionalFilters = ["type"]> -->
 <#if filters[searchFilter]??>
     <#if languageAware >
-        <#assign indexFilterName = "label_regex">
+        <#assign indexFilterName = "initial">
     <#else>
-        <#assign indexFilterName = "raw_label_regex">
+        <#assign indexFilterName = "raw_initial">
     </#if>
     <script>
         let searchFormId = "filter-form";
@@ -112,12 +112,6 @@
             </#list>
         <#elseif filters[indexFilterName]?? && filters[indexFilterName].inputText?has_content>
             <#assign selectedLetter = filters[indexFilterName].inputText >
-            <#list i18n().browse_results_alphabetical_index?split(",") as c>
-                <#assign regexValue = "(" + c?lower_case?cap_first + "|" + c?lower_case + "|" + c?upper_case + ").*">
-                <#if filters[indexFilterName].inputText == regexValue >
-                    <#assign selectedLetter = c?upper_case >
-                </#if> 
-            </#list>
             <li>
                 <p class="no-individuals">${i18n().there_are_no_entries_starting_with} ${selectedLetter}</p>
                 <p class="no-individuals">${i18n().try_another_letter}</p>
@@ -190,10 +184,9 @@
             </li>
             <#assign idCounter = 1>
             <#list i18n().browse_results_alphabetical_index?split(",") as c>
-                <#assign regexValue = "(" + c?lower_case?cap_first + "|" + c?lower_case + "|" + c?upper_case + ").*">
                 <li>
-                    <a href="#" <#if indexFilter.inputText == regexValue > class="selected" </#if> >
-                        <@getAlphabetInput indexFilter regexValue sl.getValueID(indexFilter.id, idCounter) />
+                    <a href="#" <#if indexFilter.inputText == c > class="selected" </#if> >
+                        <@getAlphabetInput indexFilter c sl.getValueID(indexFilter.id, idCounter) />
                         <@getAlphabetLabel sl.getValueID(indexFilter.id, idCounter) c?upper_case />
                     </a>
                 </li>

--- a/webapp/src/main/webapp/templates/freemarker/body/menupage/browseSearchFilterValues.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/body/menupage/browseSearchFilterValues.ftl
@@ -51,6 +51,7 @@
                 </section>
             </section>
         </section>
+        <input form="filter-form" type="hidden" name="lang" value="${locale!}">
     </form>
     
     <script type="text/javascript">

--- a/webapp/src/main/webapp/templates/freemarker/body/menupage/browseSearchFilterValues.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/body/menupage/browseSearchFilterValues.ftl
@@ -20,13 +20,11 @@
         if (!queryText.includes('filters_${searchFilter}')) {
             queryText += "&filters_${searchFilter}=${searchFilter}:${"[* TO *]"?url}";
         }
-        
     </script>
 
     <section id="menupage-intro" role="region">
         <h2>${page.title}</h2>
     </section>
-    ${stylesheets.add('<link rel="stylesheet" href="${urls.base}/css/menupage/menupage.css" />')}
     <form id="filter-form" name="filter-form" autocomplete="off" method="get" action="${urls.currentPage}">
         <section id="noJavascriptContainer">
             <section id="browse-by" role="region">
@@ -41,15 +39,15 @@
                             <@filterFacets filters[searchFilter] />
                         </#if>
                     </ul>
-                    <@alphabeticalIndexLinks indexFilterName/>
                 </nav>
                 <section id="individuals-in-class" role="region">
-                    <@printPagingLinks />
                     <div id="browsing-options">
-                        <@showSortOptions />
+                        <button type="button" id="downloadIcon" class="download-results-text-button">${i18n().download_results}</button>
                         <@sl.showHits "filter-form" />
-                        <img id="downloadIcon" alt="${i18n().download_results}" title="${i18n().download_results}" />
+                        <@showSortOptions />
                     </div>
+                    <@alphabeticalIndexLinks indexFilterName/>
+                    <@printPagingLinks />
                     <@filteredResults indexFilterName />
                     <@printPagingLinks />
                 </section>
@@ -182,8 +180,8 @@
 <#macro alphabeticalIndexLinks indexFilterName>
     <#if filters[indexFilterName]??>
         <#assign indexFilter = filters[indexFilterName]>
-        <nav id="alpha-browse-container" role="navigation">
-            <ul id="alpha-browse-individuals">
+        <nav id="alphabetical-index-container" role="navigation">
+            <ul id="alphabetical-index-individuals">
             <li>
                  <a href="#" <#if indexFilter.inputText == ""> class="selected" </#if> >
                      <@getAlphabetInput indexFilter '' sl.getValueID(indexFilter.id, 0) />
@@ -208,7 +206,7 @@
 
 <#macro printPagingLinks>
     <#if (pagingLinks?? && pagingLinks?size > 0)>
-        <div class="pagination menupage">
+        <div class="pagination-container">
             ${i18n().pages}:
             <ul>
             <#list pagingLinks as link>
@@ -248,6 +246,9 @@
 </#macro>
 
 <#macro showSortOptions>
+    <#if !sortOptionIds??>
+        <#assign sortOptionIds = ["titledesc", "titleasc"]>
+    </#if>
     <#if sortOptions?has_content && sortOptionIds?? && sortOptionIds?is_sequence>
         <select form="filter-form" name="sort" id="filter-form-sort" onchange="this.form.submit()" >
             <#assign addDefaultOption = true>

--- a/webapp/src/main/webapp/templates/freemarker/body/menupage/browseSearchFilterValues.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/body/menupage/browseSearchFilterValues.ftl
@@ -120,7 +120,10 @@
                     <#assign selectedLetter = c?upper_case >
                 </#if> 
             </#list>
-            <li><p class="no-individuals">${i18n().there_are_no_entries_starting_with} ${selectedLetter} </p></li>
+            <li>
+                <p class="no-individuals">${i18n().there_are_no_entries_starting_with} ${selectedLetter}</p>
+                <p class="no-individuals">${i18n().try_another_letter}</p>
+            </li>
         <#else>
             <li><p class="no-individuals">${i18n().there_are_no_results_to_display}</p></li>
         </#if>

--- a/webapp/src/main/webapp/templates/freemarker/body/menupage/browseSearchFilterValues.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/body/menupage/browseSearchFilterValues.ftl
@@ -113,17 +113,14 @@
     </ul>
 </#macro>
 
-<#macro filterFacets f idStart=1 zeroCount=false>
-    <#assign idCounter = idStart >
+<#macro filterFacets f >
+    <#assign idCounter = 1 >
     <#list f.values?values as value>
         <#if !value.display>
             <#continue>
         </#if>
         <#assign valueLabel = value.name >
         <#assign resultsCount = getCurrentCount(f value) >
-        <#if (resultsCount == 0) != zeroCount>
-            <#continue>
-        </#if>
         <#if !(valueLabel?has_content)>
             <#assign valueLabel = value.id >
         </#if>
@@ -135,8 +132,8 @@
                 </a>
             </li>
         <#else>
-            <#if zeroCount=false>
-                    <li id="${value.id?html}">
+            <#if resultsCount != 0>
+                <li id="${value.id?html}">
                     <a href="#">
                         <@sl.getInput f value sl.getValueID(f.id, idCounter) idCounter 'filter-form' />
                         <@sl.getLabel sl.getValueID(f.id, idCounter) value f resultsCount />
@@ -146,9 +143,6 @@
         </#if>
         <#assign idCounter = idCounter + 1>
     </#list>
-    <#if zeroCount=false>
-        <@filterFacets f idCounter true />
-    </#if>
 </#macro>
 
 <#function getCurrentCount f v>

--- a/webapp/src/main/webapp/templates/freemarker/body/menupage/browseSearchFilterValues.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/body/menupage/browseSearchFilterValues.ftl
@@ -1,11 +1,24 @@
 <#-- $This file is distributed under the terms of the license in LICENSE$ -->
 <#import "search-lib.ftl" as sl>
 
-<script>
-    let searchFormId = "filter-form";
-</script>
 <#-- <#assign additionalFilters = ["type"]> -->
 <#if filterGenericInfo.filters[searchFilter]??>
+
+    <script>
+        let searchFormId = "filter-form";
+        let urlsBase = "${urls.base}";
+        if (window.location.toString().indexOf("?") == -1){
+            var queryText = 'querytext=${querytext?js_string}';
+        } else {
+            var queryText = window.location.toString().split("?")[1];
+        }
+        //If main filter is not set, then set it to default value [* TO *]
+        if (!queryText.includes('filters_${searchFilter}')) {
+            queryText += "&filters_${searchFilter}=${searchFilter}:${"[* TO *]"?url}";
+        }
+        
+    </script>
+
     <section id="menupage-intro" role="region">
         <h2>${page.title}</h2>
     </section>
@@ -31,6 +44,7 @@
                     <div id="browsing-options">
                         <@showSortOptions />
                         <@sl.showHits "filter-form" />
+                        <img id="downloadIcon" alt="${i18n().download_results}" title="${i18n().download_results}" />
                     </div>
                     <@filteredResults />
                     <@printPagingLinks />
@@ -122,7 +136,7 @@
             </li>
         <#else>
             <#if zeroCount=false>
-                	<li id="${value.id?html}">
+                    <li id="${value.id?html}">
                     <a href="#">
                         <@sl.getInput f value sl.getValueID(f.id, idCounter) idCounter 'filter-form' />
                         <@sl.getLabel sl.getValueID(f.id, idCounter) value f resultsCount />
@@ -248,10 +262,16 @@
 </#macro>
 
 ${scripts.add('<script type="text/javascript" src="${urls.base}/js/search/search_results.js"></script>')}
+${scripts.add('<script type="text/javascript" src="${urls.base}/js/searchDownload.js"></script>')}
 ${stylesheets.add('<link rel="stylesheet" type="text/css" href="${urls.base}/css/search/custom_filters.css"/>')}
 ${stylesheets.add('<link rel="stylesheet" type="text/css" href="${urls.base}/css/nouislider.css"/>')}
 ${headScripts.add('<script type="text/javascript" src="${urls.base}/js/nouislider.min.js"></script>')}
 ${headScripts.add('<script type="text/javascript" src="${urls.base}/js/wNumb.min.js"></script>')}
 
+${stylesheets.add('<link rel="stylesheet" href="${urls.base}/webjars/jquery-ui/jquery-ui.css" />',
+                  '<link rel="stylesheet" type="text/css" href="${urls.base}/css/jquery_plugins/qtip/jquery.qtip.min.css" />')}
 
+${headScripts.add('<script type="text/javascript" src="${urls.base}/webjars/jquery-ui/jquery-ui.js"></script>',
+                  '<script type="text/javascript" src="${urls.base}/js/jquery_plugins/qtip/jquery.qtip.min.js"></script>'
+                  )}
 

--- a/webapp/src/main/webapp/templates/freemarker/body/menupage/browseSearchFilterValues.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/body/menupage/browseSearchFilterValues.ftl
@@ -104,12 +104,12 @@
 
 <#macro filteredResults>
     <ul role="list">
-        <#if individuals??>
+        <#if individuals?has_content>
             <#list individuals as individual>
-                <li class="individual" role="listitem">
-                    <@shortView uri=individual.uri viewContext="browse" />
-                </li>
+                <@shortView uri=individual.uri viewContext="browse" />
             </#list>
+        <#else>
+            <li><p class="no-individuals">${i18n().there_are_no_results_to_display}</p></li>
         </#if>
     </ul>
 </#macro>

--- a/webapp/src/main/webapp/templates/freemarker/body/menupage/browseSearchFilterValues.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/body/menupage/browseSearchFilterValues.ftl
@@ -54,9 +54,9 @@
     </form>
     
     <script type="text/javascript">
-        $('.filter-tab > ul > li').not('.li-selected').hide();
+        $('.filter-tab > ul > li').not('.li-selected').addClass('hidden-all-search-options');
         $('.filter-tab > a').click(function() {
-            $(this).parent().find('ul > li').not('.li-selected').toggle();
+            $(this).parent().find('ul > li').not('.li-selected').toggleClass('hidden-all-search-options');
         });
     </script>
 
@@ -114,7 +114,14 @@
 </#macro>
 
 <#macro filterFacets f >
+    <#if ( !filter.localizationRequired && filter.values?values?size > filter.moreLimit) >
+        <li>
+            <@sl.createAutocomplete filter "filter-form" />
+        </li>
+    </#if>
     <#assign idCounter = 1 >
+    <#assign notSelectedCount = 0>
+    <#assign additionalLabels = false>
     <#list f.values?values as value>
         <#if !value.displayed>
             <#continue>
@@ -126,7 +133,7 @@
         </#if>
         <#if value.selected>
             <#if value.id != "[* TO *]">
-                <li id="${value.id?html}" class="li-selected">
+                <li class="li-selected">
                     <a href="#" class="selected">
                         <@sl.getInput f value sl.getValueID(f.id, idCounter) idCounter 'filter-form' />
                         <@sl.getSelectedLabel sl.getValueID(f.id, idCounter)?html value f resultsCount />
@@ -135,16 +142,24 @@
             </#if>
         <#else>
             <#if resultsCount != 0>
-                <li id="${value.id?html}">
+                <#if f.moreLimit = notSelectedCount >
+                    <#assign additionalLabels = true>
+                    <li class="more-facets-link" href="javascript:void(0);" onclick="expandSearchOptions(this)">${i18n().paging_link_more}</li>
+                </#if>
+                <li <#if additionalLabels>class="additional-search-options hidden-search-option"</#if> >
                     <a href="#">
                         <@sl.getInput f value sl.getValueID(f.id, idCounter) idCounter 'filter-form' />
                         <@sl.getLabel sl.getValueID(f.id, idCounter) value f resultsCount />
                     </a>
                 </li>
+                <#assign notSelectedCount += 1>
             </#if>
         </#if>
         <#assign idCounter = idCounter + 1>
     </#list>
+    <#if additionalLabels >
+        <li class="less-facets-link additional-search-options hidden-search-option" href="javascript:void(0);" onclick="collapseSearchOptions(this)">${i18n().display_less}</li>
+    </#if>
 </#macro>
 
 <#macro alphabeticalIndexLinks>

--- a/webapp/src/main/webapp/templates/freemarker/body/menupage/browseSearchFilterValues.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/body/menupage/browseSearchFilterValues.ftl
@@ -113,7 +113,7 @@
         <#elseif filters[indexFilterName]?? && filters[indexFilterName].inputText?has_content>
             <#assign selectedLetter = filters[indexFilterName].inputText >
             <li>
-                <p class="no-individuals">${i18n().there_are_no_entries_starting_with} ${selectedLetter}.</p>
+                <p class="no-individuals">${i18n().there_are_no_entries_starting_with} <i>${selectedLetter?upper_case}</i>.</p>
                 <p class="no-individuals">${i18n().try_another_letter}</p>
             </li>
         <#else>

--- a/webapp/src/main/webapp/templates/freemarker/body/menupage/browseSearchFilterValues.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/body/menupage/browseSearchFilterValues.ftl
@@ -31,7 +31,7 @@
                                                             </a>
                                                         </li>
                                                     </#if>
-                                                    <li>
+                                                    <li <#if filter.selected || (filters[filterId]?? && filters[filterId].selected)> class="li-selected" </#if>>
                                                         <@sl.rangeFilter filters[filterId] 'filter-form'/>
                                                     </li>
                                                 </ul>

--- a/webapp/src/main/webapp/templates/freemarker/body/menupage/browseSearchFilterValues.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/body/menupage/browseSearchFilterValues.ftl
@@ -52,27 +52,37 @@
     <#if filterGenericInfo.filters[filterId]?? >
         <#assign filter = filterGenericInfo.filters[filterId] >
         <#if filter.display >
-            <li class="filter-tab">
-                <a href="#">${filter.name?html}</a>
-                <#if filter.type == "RangeFilter">
-                    <ul class="facet-values">
-                        <#if filters[filterId]?? && filters[filterId].selected>
-                            <li class="li-selected">
-                                <a href="#" class="selected">
-                                    <@sl.userSelectedInput filters[filterId] "filter-form" />
-                                </a>
-                            </li>
-                        </#if>
-                        <li <#if filter.selected || (filters[filterId]?? && filters[filterId].selected)> class="li-selected" </#if>>
-                            <@sl.rangeFilter filters[filterId] 'filter-form'/>
-                        </li>
-                    </ul>
-                <#else>
-                    <ul class="facet-values">
-                        <@filterFacets filter />
-                    </ul>
-                </#if>
+            <#assign filterValues><@getValues filter filterId /></#assign>
+            <#if filterValues?has_content>
+                <li class="filter-tab">
+                    <a href="#">${filter.name?html}</a>
+                    ${filterValues}
+                </li>
+            </#if>
+        </#if>
+    </#if>
+</#macro>
+
+<#macro getValues filter filterId>
+    <#if filter.type == "RangeFilter">
+        <ul class="facet-values">
+            <#if filters[filterId]?? && filters[filterId].selected>
+                <li class="li-selected">
+                    <a href="#" class="selected">
+                        <@sl.userSelectedInput filters[filterId] "filter-form" />
+                    </a>
+                </li>
+            </#if>
+            <li <#if filter.selected || (filters[filterId]?? && filters[filterId].selected)> class="li-selected" </#if>>
+                <@sl.rangeFilter filters[filterId] 'filter-form'/>
             </li>
+        </ul>
+    <#else>
+        <#assign facets><@filterFacets filter /></#assign>
+        <#if facets?has_content>
+            <ul class="facet-values">
+                ${facets}
+            </ul>
         </#if>
     </#if>
 </#macro>
@@ -111,12 +121,14 @@
                 </a>
             </li>
         <#else>
-            <li id="${value.id?html}">
-                <a href="#">
-                    <@sl.getInput f value sl.getValueID(f.id, idCounter) idCounter 'filter-form' />
-                    <@sl.getLabel sl.getValueID(f.id, idCounter) value f resultsCount />
-                </a>
-            </li>
+            <#if zeroCount=false>
+                	<li id="${value.id?html}">
+                    <a href="#">
+                        <@sl.getInput f value sl.getValueID(f.id, idCounter) idCounter 'filter-form' />
+                        <@sl.getLabel sl.getValueID(f.id, idCounter) value f resultsCount />
+                    </a>
+                </li>
+            </#if>
         </#if>
         <#assign idCounter = idCounter + 1>
     </#list>

--- a/webapp/src/main/webapp/templates/freemarker/body/menupage/browseSearchFilterValues.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/body/menupage/browseSearchFilterValues.ftl
@@ -14,7 +14,7 @@
         <section id="noJavascriptContainer">
             <section id="browse-by" role="region">
                 <nav role="navigation">
-                    <ul id="browse-classes">
+                    <ul id="browse-filters">
                         <#if additionalFilters?has_content && additionalFilters?is_sequence >
                             <#list additionalFilters as filterId>
                                 <@filterTab filterId />
@@ -55,7 +55,7 @@
             <li class="filter-tab">
                 <a href="#">${filter.name?html}</a>
                 <#if filter.type == "RangeFilter">
-                    <ul>
+                    <ul class="facet-values">
                         <#if filters[filterId]?? && filters[filterId].selected>
                             <li class="li-selected">
                                 <a href="#" class="selected">

--- a/webapp/src/main/webapp/templates/freemarker/body/menupage/browseSearchFilterValues.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/body/menupage/browseSearchFilterValues.ftl
@@ -114,7 +114,7 @@
     </ul>
 </#macro>
 
-<#macro filterFacets f >
+<#macro filterFacets filter >
     <#if ( !filter.localizationRequired && filter.values?values?size > filter.moreLimit) >
         <li>
             <@sl.createAutocomplete filter "filter-form" />
@@ -123,7 +123,7 @@
     <#assign idCounter = 1 >
     <#assign notSelectedCount = 0>
     <#assign additionalLabels = false>
-    <#list f.values?values as value>
+    <#list filter.values?values as value>
         <#if !value.displayed>
             <#continue>
         </#if>
@@ -136,21 +136,21 @@
             <#if value.id != "[* TO *]">
                 <li class="li-selected">
                     <a href="#" class="selected">
-                        <@sl.getInput f value sl.getValueID(f.id, idCounter) idCounter 'filter-form' />
-                        <@sl.getSelectedLabel sl.getValueID(f.id, idCounter)?html value f resultsCount />
+                        <@sl.getInput filter value sl.getValueID(filter.id, idCounter) idCounter 'filter-form' />
+                        <@sl.getSelectedLabel sl.getValueID(filter.id, idCounter)?html value filter resultsCount />
                     </a>
                 </li>
             </#if>
         <#else>
             <#if resultsCount != 0>
-                <#if f.moreLimit = notSelectedCount >
+                <#if filter.moreLimit = notSelectedCount >
                     <#assign additionalLabels = true>
                     <li class="more-facets-link" href="javascript:void(0);" onclick="expandSearchOptions(this)">${i18n().paging_link_more}</li>
                 </#if>
                 <li <#if additionalLabels>class="additional-search-options hidden-search-option"</#if> >
                     <a href="#">
-                        <@sl.getInput f value sl.getValueID(f.id, idCounter) idCounter 'filter-form' />
-                        <@sl.getLabel sl.getValueID(f.id, idCounter) value f resultsCount />
+                        <@sl.getInput filter value sl.getValueID(filter.id, idCounter) idCounter 'filter-form' />
+                        <@sl.getLabel sl.getValueID(filter.id, idCounter) value filter resultsCount />
                     </a>
                 </li>
                 <#assign notSelectedCount += 1>

--- a/webapp/src/main/webapp/templates/freemarker/body/menupage/browseSearchFilterValues.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/body/menupage/browseSearchFilterValues.ftl
@@ -2,7 +2,7 @@
 <#import "search-lib.ftl" as sl>
 
 <#-- <#assign additionalFilters = ["type"]> -->
-<#if filterGenericInfo.filters[searchFilter]??>
+<#if filters[searchFilter]??>
 
     <script>
         let searchFormId = "filter-form";
@@ -34,7 +34,7 @@
                             </#list>
                             <@filterTab searchFilter />
                         <#else>
-                            <@filterFacets filterGenericInfo.filters[searchFilter] />
+                            <@filterFacets filters[searchFilter] />
                         </#if>
                     </ul>
                     <@alphabeticalIndexLinks />
@@ -63,10 +63,10 @@
 </#if>
 
 <#macro filterTab filterId>
-    <#if filterGenericInfo.filters[filterId]?? >
-        <#assign filter = filterGenericInfo.filters[filterId] >
+    <#if filters[filterId]?? >
+        <#assign filter = filters[filterId] >
         <#if filter.display >
-            <#assign filterValues><@getValues filter filterId /></#assign>
+            <#assign filterValues><@getValues filter /></#assign>
             <#if filterValues?has_content>
                 <li class="filter-tab">
                     <a href="#">${filter.name?html}</a>
@@ -77,18 +77,18 @@
     </#if>
 </#macro>
 
-<#macro getValues filter filterId>
+<#macro getValues filter>
     <#if filter.type == "RangeFilter">
         <ul class="facet-values">
-            <#if filters[filterId]?? && filters[filterId].selected>
+            <#if filter.selected>
                 <li class="li-selected">
                     <a href="#" class="selected">
-                        <@sl.userSelectedInput filters[filterId] "filter-form" />
+                        <@sl.userSelectedInput filter "filter-form" />
                     </a>
                 </li>
             </#if>
-            <li <#if filter.selected || (filters[filterId]?? && filters[filterId].selected)> class="li-selected" </#if>>
-                <@sl.rangeFilter filters[filterId] 'filter-form'/>
+            <li <#if filter.selected> class="li-selected" </#if>>
+                <@sl.rangeFilter filter 'filter-form'/>
             </li>
         </ul>
     <#else>
@@ -120,17 +120,19 @@
             <#continue>
         </#if>
         <#assign valueLabel = value.name >
-        <#assign resultsCount = getCurrentCount(f value) >
+        <#assign resultsCount = value.count >
         <#if !(valueLabel?has_content)>
             <#assign valueLabel = value.id >
         </#if>
         <#if value.selected>
-            <li id="${value.id?html}" class="li-selected">
-                <a href="#" class="selected">
-                    <@sl.getInput f value sl.getValueID(f.id, idCounter) idCounter 'filter-form' />
-                    <@sl.getSelectedLabel sl.getValueID(f.id, idCounter)?html value f resultsCount />
-                </a>
-            </li>
+            <#if value.id != "[* TO *]">
+                <li id="${value.id?html}" class="li-selected">
+                    <a href="#" class="selected">
+                        <@sl.getInput f value sl.getValueID(f.id, idCounter) idCounter 'filter-form' />
+                        <@sl.getSelectedLabel sl.getValueID(f.id, idCounter)?html value f resultsCount />
+                    </a>
+                </li>
+            </#if>
         <#else>
             <#if resultsCount != 0>
                 <li id="${value.id?html}">
@@ -145,27 +147,14 @@
     </#list>
 </#macro>
 
-<#function getCurrentCount f v>
-    <#if filters[f.id]??>
-        <#assign filter = filters[f.id]>
-        <#if filter.values[v.id]??>
-            <#return filter.values[v.id].count >
-        <#else>
-            <#return 0 />
-        </#if>
-    <#else>
-        <#return 0 />
-    </#if>
-</#function>
-
 <#macro alphabeticalIndexLinks>
     <#if languageAware >
         <#assign indexFilterName = "label_regex">
     <#else>
         <#assign indexFilterName = "raw_label_regex">
     </#if>
-    <#if filterGenericInfo.filters[indexFilterName]??>
-        <#assign indexFilter = filterGenericInfo.filters[indexFilterName]>
+    <#if filters[indexFilterName]??>
+        <#assign indexFilter = filters[indexFilterName]>
         <nav id="alpha-browse-container" role="navigation">
             <ul id="alpha-browse-individuals">
             <li>

--- a/webapp/src/main/webapp/templates/freemarker/body/menupage/browseSearchFilterValues.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/body/menupage/browseSearchFilterValues.ftl
@@ -277,11 +277,10 @@ ${stylesheets.add('<link rel="stylesheet" type="text/css" href="${urls.base}/css
 ${stylesheets.add('<link rel="stylesheet" type="text/css" href="${urls.base}/css/nouislider.css"/>')}
 ${headScripts.add('<script type="text/javascript" src="${urls.base}/js/nouislider.min.js"></script>')}
 ${headScripts.add('<script type="text/javascript" src="${urls.base}/js/wNumb.min.js"></script>')}
+${headScripts.add('<script type="text/javascript" src="${urls.base}/webjars/floatingui/floating-ui.core.umd.js"></script>')}
+${headScripts.add('<script type="text/javascript" src="${urls.base}/webjars/floatingui/floating-ui.dom.umd.js"></script>')}
+${headScripts.add('<script type="text/javascript" src="${urls.base}/js/tooltip/tooltip-utils.js"></script>')}
+${stylesheets.add('<link rel="stylesheet" href="${urls.base}/webjars/jquery-ui/jquery-ui.css" />')}
 
-${stylesheets.add('<link rel="stylesheet" href="${urls.base}/webjars/jquery-ui/jquery-ui.css" />',
-                  '<link rel="stylesheet" type="text/css" href="${urls.base}/css/jquery_plugins/qtip/jquery.qtip.min.css" />')}
-
-${headScripts.add('<script type="text/javascript" src="${urls.base}/webjars/jquery-ui/jquery-ui.js"></script>',
-                  '<script type="text/javascript" src="${urls.base}/js/jquery_plugins/qtip/jquery.qtip.min.js"></script>'
-                  )}
+${headScripts.add('<script type="text/javascript" src="${urls.base}/webjars/jquery-ui/jquery-ui.js"></script>')}
 

--- a/webapp/src/main/webapp/templates/freemarker/body/menupage/browseSearchFilterValues.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/body/menupage/browseSearchFilterValues.ftl
@@ -51,7 +51,7 @@
 <#macro filterTab filterId>
     <#if filterGenericInfo.filters[filterId]?? >
         <#assign filter = filterGenericInfo.filters[filterId] >
-        <#if ( user.loggedIn || filter.public ) && !filter.hidden >
+        <#if filter.display >
             <li class="filter-tab">
                 <a href="#">${filter.name?html}</a>
                 <#if filter.type == "RangeFilter">
@@ -89,36 +89,40 @@
     </ul>
 </#macro>
 
-<#macro filterFacets f>
-    <#assign selectedValue = "" >
-    <#assign valueNumber = 1>
+<#macro filterFacets f idStart=1 zeroCount=false>
+    <#assign idCounter = idStart >
     <#list f.values?values as value>
-        <#if user.loggedIn || value.publiclyAvailable>
-            <#if value.selected>
-                <#assign selectedValue = value.id >
-            </#if>
-            <#assign valueLabel = value.name >
-            <#if !(valueLabel?has_content)>
-                <#assign valueLabel = value.id >
-            </#if>
-            <#if value.selected>
-                <li id="${value.id?html}" class="li-selected">
-                    <a href="#" class="selected">
-                        <@sl.getInput f value sl.getValueID(f.id, valueNumber) valueNumber 'filter-form' />
-                        <@sl.getSelectedLabel sl.getValueID(f.id, valueNumber)?html value f getCurrentCount(f value) />
-                    </a>
-                </li>
-            <#else>
-                <li id="${value.id?html}">
-                    <a href="#">
-                        <@sl.getInput f value sl.getValueID(f.id, valueNumber) valueNumber 'filter-form' />
-                        <@sl.getLabel sl.getValueID(f.id, valueNumber) value f getCurrentCount(f value) />
-                    </a>
-                </li>
-            </#if>
-            <#assign valueNumber = valueNumber + 1>
+        <#if !value.display>
+            <#continue>
         </#if>
+        <#assign valueLabel = value.name >
+        <#assign resultsCount = getCurrentCount(f value) >
+        <#if (resultsCount == 0) != zeroCount>
+            <#continue>
+        </#if>
+        <#if !(valueLabel?has_content)>
+            <#assign valueLabel = value.id >
+        </#if>
+        <#if value.selected>
+            <li id="${value.id?html}" class="li-selected">
+                <a href="#" class="selected">
+                    <@sl.getInput f value sl.getValueID(f.id, idCounter) idCounter 'filter-form' />
+                    <@sl.getSelectedLabel sl.getValueID(f.id, idCounter)?html value f resultsCount />
+                </a>
+            </li>
+        <#else>
+            <li id="${value.id?html}">
+                <a href="#">
+                    <@sl.getInput f value sl.getValueID(f.id, idCounter) idCounter 'filter-form' />
+                    <@sl.getLabel sl.getValueID(f.id, idCounter) value f resultsCount />
+                </a>
+            </li>
+        </#if>
+        <#assign idCounter = idCounter + 1>
     </#list>
+    <#if zeroCount=false>
+        <@filterFacets f idCounter true />
+    </#if>
 </#macro>
 
 <#function getCurrentCount f v>
@@ -150,16 +154,16 @@
                      <@getAlphabetLabel sl.getValueID(indexFilter.id, 0) i18n().all />
                  </a>
             </li>
-            <#assign valueNumber = 1>
+            <#assign idCounter = 1>
             <#list i18n().browse_results_alphabetical_index?split(",") as c>
                 <#assign regexValue = "(" + c?lower_case?cap_first + "|" + c?lower_case + "|" + c?upper_case + ").*">
                 <li>
                     <a href="#" <#if indexFilter.inputText == regexValue > class="selected" </#if> >
-                        <@getAlphabetInput indexFilter regexValue sl.getValueID(indexFilter.id, valueNumber) />
-                        <@getAlphabetLabel sl.getValueID(indexFilter.id, valueNumber) c?upper_case />
+                        <@getAlphabetInput indexFilter regexValue sl.getValueID(indexFilter.id, idCounter) />
+                        <@getAlphabetLabel sl.getValueID(indexFilter.id, idCounter) c?upper_case />
                     </a>
                 </li>
-                <#assign valueNumber = valueNumber + 1>
+                <#assign idCounter = idCounter + 1>
             </#list>
             </ul>
         </nav>

--- a/webapp/src/main/webapp/templates/freemarker/body/menupage/browseSearchFilterValues.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/body/menupage/browseSearchFilterValues.ftl
@@ -3,7 +3,11 @@
 
 <#-- <#assign additionalFilters = ["type"]> -->
 <#if filters[searchFilter]??>
-
+    <#if languageAware >
+        <#assign indexFilterName = "label_regex">
+    <#else>
+        <#assign indexFilterName = "raw_label_regex">
+    </#if>
     <script>
         let searchFormId = "filter-form";
         let urlsBase = "${urls.base}";
@@ -37,7 +41,7 @@
                             <@filterFacets filters[searchFilter] />
                         </#if>
                     </ul>
-                    <@alphabeticalIndexLinks />
+                    <@alphabeticalIndexLinks indexFilterName/>
                 </nav>
                 <section id="individuals-in-class" role="region">
                     <@printPagingLinks />
@@ -46,7 +50,7 @@
                         <@sl.showHits "filter-form" />
                         <img id="downloadIcon" alt="${i18n().download_results}" title="${i18n().download_results}" />
                     </div>
-                    <@filteredResults />
+                    <@filteredResults indexFilterName />
                     <@printPagingLinks />
                 </section>
             </section>
@@ -102,12 +106,21 @@
     </#if>
 </#macro>
 
-<#macro filteredResults>
+<#macro filteredResults indexFilterName>
     <ul role="list">
         <#if individuals?has_content>
             <#list individuals as individual>
                 <@shortView uri=individual.uri viewContext="browse" />
             </#list>
+        <#elseif filters[indexFilterName]?? && filters[indexFilterName].inputText?has_content>
+            <#assign selectedLetter = filters[indexFilterName].inputText >
+            <#list i18n().browse_results_alphabetical_index?split(",") as c>
+                <#assign regexValue = "(" + c?lower_case?cap_first + "|" + c?lower_case + "|" + c?upper_case + ").*">
+                <#if filters[indexFilterName].inputText == regexValue >
+                    <#assign selectedLetter = c?upper_case >
+                </#if> 
+            </#list>
+            <li><p class="no-individuals">${i18n().there_are_no_entries_starting_with} ${selectedLetter} </p></li>
         <#else>
             <li><p class="no-individuals">${i18n().there_are_no_results_to_display}</p></li>
         </#if>
@@ -163,12 +176,7 @@
     </#if>
 </#macro>
 
-<#macro alphabeticalIndexLinks>
-    <#if languageAware >
-        <#assign indexFilterName = "label_regex">
-    <#else>
-        <#assign indexFilterName = "raw_label_regex">
-    </#if>
+<#macro alphabeticalIndexLinks indexFilterName>
     <#if filters[indexFilterName]??>
         <#assign indexFilter = filters[indexFilterName]>
         <nav id="alpha-browse-container" role="navigation">

--- a/webapp/src/main/webapp/templates/freemarker/body/menupage/browseSearchFilterValues.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/body/menupage/browseSearchFilterValues.ftl
@@ -15,38 +15,14 @@
             <section id="browse-by" role="region">
                 <nav role="navigation">
                     <ul id="browse-classes">
-                        <#if additionalFilters?? && additionalFilters?is_sequence>
+                        <#if additionalFilters?has_content && additionalFilters?is_sequence >
                             <#list additionalFilters as filterId>
-                                <#if filterGenericInfo.filters[filterId]?? >
-                                    <#assign filter = filterGenericInfo.filters[filterId] >
-                                    <#if ( user.loggedIn || filter.public ) && (!filter.hidden || !f.facetsRequired ) >
-                                        <li class="filter-tab">
-                                            <a href="#" <#if filter.selected || (filters[filterId]?? && filters[filterId].selected)> class="selected" </#if> >${filter.name?html}</a>
-                                            <#if filter.type == "RangeFilter">
-                                                <ul>
-                                                    <#if filters[filterId]?? && filters[filterId].selected>
-                                                        <li class="li-selected">
-                                                            <a href="#" class="selected">
-                                                                <@sl.userSelectedInput filters[filterId] "filter-form" />
-                                                            </a>
-                                                        </li>
-                                                    </#if>
-                                                    <li <#if filter.selected || (filters[filterId]?? && filters[filterId].selected)> class="li-selected" </#if>>
-                                                        <@sl.rangeFilter filters[filterId] 'filter-form'/>
-                                                    </li>
-                                                </ul>
-                                            <#else>
-                                                <ul id="facet-values">
-                                                    <@filterFacets filter />
-                                                </ul>
-                                            </#if>
-                                        </li>
-                                    </#if>
-                                </#if>
+                                <@filterTab filterId />
                             </#list>
+                            <@filterTab searchFilter />
+                        <#else>
+                            <@filterFacets filterGenericInfo.filters[searchFilter] />
                         </#if>
-                        <div class="divider" style="border-top: 0.5rem solid #fff;margin: -2px;"></div>
-                        <@filterFacets filterGenericInfo.filters[searchFilter] />
                     </ul>
                     <@alphabeticalIndexLinks />
                 </nav>
@@ -71,6 +47,35 @@
     </script>
 
 </#if>
+
+<#macro filterTab filterId>
+    <#if filterGenericInfo.filters[filterId]?? >
+        <#assign filter = filterGenericInfo.filters[filterId] >
+        <#if ( user.loggedIn || filter.public ) && !filter.hidden >
+            <li class="filter-tab">
+                <a href="#">${filter.name?html}</a>
+                <#if filter.type == "RangeFilter">
+                    <ul>
+                        <#if filters[filterId]?? && filters[filterId].selected>
+                            <li class="li-selected">
+                                <a href="#" class="selected">
+                                    <@sl.userSelectedInput filters[filterId] "filter-form" />
+                                </a>
+                            </li>
+                        </#if>
+                        <li <#if filter.selected || (filters[filterId]?? && filters[filterId].selected)> class="li-selected" </#if>>
+                            <@sl.rangeFilter filters[filterId] 'filter-form'/>
+                        </li>
+                    </ul>
+                <#else>
+                    <ul class="facet-values">
+                        <@filterFacets filter />
+                    </ul>
+                </#if>
+            </li>
+        </#if>
+    </#if>
+</#macro>
 
 <#macro filteredResults>
     <ul role="list">

--- a/webapp/src/main/webapp/templates/freemarker/body/menupage/browseSearchFilterValues.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/body/menupage/browseSearchFilterValues.ftl
@@ -15,7 +15,7 @@
             <section id="browse-by" role="region">
                 <nav role="navigation">
                     <ul id="browse-classes">
-                        <#if additionalFilters?? >
+                        <#if additionalFilters?? && additionalFilters?is_sequence>
                             <#list additionalFilters as filterId>
                                 <#if filterGenericInfo.filters[filterId]?? >
                                     <#assign filter = filterGenericInfo.filters[filterId] >
@@ -52,6 +52,10 @@
                 </nav>
                 <section id="individuals-in-class" role="region">
                     <@printPagingLinks />
+                    <div id="browsing-options">
+                        <@showSortOptions />
+                        <@sl.showHits "filter-form" />
+                    </div>
                     <@filteredResults />
                     <@printPagingLinks />
                 </section>
@@ -196,6 +200,30 @@
         style="display:none;" 
         ${checked} 
     >
+</#macro>
+
+<#macro showSortOptions>
+    <#if sortOptions?has_content && sortOptionIds?? && sortOptionIds?is_sequence>
+        <select form="filter-form" name="sort" id="filter-form-sort" onchange="this.form.submit()" >
+            <#assign addDefaultOption = true>
+            <#list sortOptionIds as sortOptionId>
+                <#if sortOptions[sortOptionId]??>
+                    <#assign option = sortOptions[sortOptionId]>
+                    <#if option.display>
+                        <#if option.selected>
+                            <option value="${option.id}" selected="selected">${i18n().search_results_sort_by(option.label)}</option>
+                            <#assign addDefaultOption = false>
+                        <#else>
+                            <option value="${option.id}" >${i18n().search_results_sort_by(option.label)}</option>
+                        </#if>
+                    </#if>
+                </#if>
+            </#list>
+            <#if addDefaultOption>
+                <option disabled selected value="" style="display:none">${i18n().search_results_sort_by('')}</option>
+            </#if>
+        </select>
+    </#if>
 </#macro>
 
 ${scripts.add('<script type="text/javascript" src="${urls.base}/js/search/search_results.js"></script>')}

--- a/webapp/src/main/webapp/templates/freemarker/body/menupage/browseSearchFilterValues.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/body/menupage/browseSearchFilterValues.ftl
@@ -153,7 +153,7 @@
                 <li class="li-selected">
                     <a href="#" class="selected">
                         <@sl.getInput filter value sl.getValueID(filter.id, idCounter) idCounter 'filter-form' />
-                        <@sl.getSelectedLabel sl.getValueID(filter.id, idCounter)?html value filter resultsCount />
+                        <@sl.getLabel sl.getValueID(filter.id, idCounter)?html value filter resultsCount />
                     </a>
                 </li>
             </#if>

--- a/webapp/src/main/webapp/templates/freemarker/body/partials/shortview/view-browse-default.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/body/partials/shortview/view-browse-default.ftl
@@ -17,7 +17,7 @@
     </h1>
 </#if>
 
-<#assign cleanTypes = 'edu.cornell.mannlib.vitro.webapp.web.TemplateUtils$DropFromSequence'?new()(individual.mostSpecificTypes, vclass) />
+<#assign cleanTypes = 'edu.cornell.mannlib.vitro.webapp.web.TemplateUtils$DropFromSequence'?new()(individual.mostSpecificTypes, vclass!"") />
 <#if cleanTypes?size == 1>
     <span class="title">${cleanTypes[0]}</span>
 <#elseif (cleanTypes?size > 1) >

--- a/webapp/src/main/webapp/templates/freemarker/body/search/search-lib.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/body/search/search-lib.ftl
@@ -104,7 +104,7 @@
             <#if v.selected>
                 <@getInput filter v getValueID(filter.id, valueNumber) valueNumber />
                 <#if user.loggedIn || filter.public>
-                    <@getSelectedLabel getValueID(filter.id, valueNumber)?html v filter />
+                    <@getSelectedLabel getValueID(filter.id, valueNumber)?html v filter v.count />
                 </#if>
             </#if>
             <#assign valueNumber = valueNumber + 1>
@@ -187,7 +187,7 @@
                         </#if>
                         <#if user.loggedIn || v.publiclyAvailable>
                             <@getInput filter v getValueID(filter.id, valueNumber) valueNumber />
-                            <@getLabel getValueID(filter.id, valueNumber)?html v filter additionalLabels />
+                            <@getLabel getValueID(filter.id, valueNumber)?html v filter additionalLabels v.count />
                         </#if>
                     </#if>
                     <#assign valueNumber = valueNumber + 1>
@@ -226,15 +226,15 @@
 </#macro>
 
 
-<#macro getSelectedLabel valueId value filter >
+<#macro getSelectedLabel valueId value filter count >
     <#assign label = filter.name + " : " + value.name >
     <#if !filter.localizationRequired>
         <#assign label = filter.name + " : " + value.id >
     </#if>
-    <label for="${valueId}">${getValueLabel(label, value.count)?html}</label>
+    <label for="${valueId}">${getValueLabel(label, count)?html}</label>
 </#macro>
 
-<#macro getLabel valueId value filter additional=false >
+<#macro getLabel valueId value filter count additional=false >
     <#assign label = value.name >
     <#assign additionalClass = "" >
     <#if !filter.localizationRequired>
@@ -243,7 +243,7 @@
     <#if additional=true>
         <#assign additionalClass = "additional-search-options hidden-search-option" >
     </#if>
-    <label class="${additionalClass}" for="${valueId}" >${getValueLabel(label, value.count)?html}</label>
+    <label class="${additionalClass}" for="${valueId}" >${getValueLabel(label, count)?html}</label>
 </#macro>
 
 <#macro userSelectedInput filter>

--- a/webapp/src/main/webapp/templates/freemarker/body/search/search-lib.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/body/search/search-lib.ftl
@@ -109,7 +109,7 @@
             </#if>
             <#assign valueNumber = valueNumber + 1>
         </#list>
-        <@userSelectedInput filter />
+        <@userSelectedInput filter "search-form" />
     </#list>
 </#macro>
 
@@ -170,7 +170,7 @@
             <#if filter.id == "querytext">
             <#-- skip query text filter -->
             <#elseif filter.type == "RangeFilter">
-                <@rangeFilter filter/>
+                <@rangeFilter filter "search-form" />
             <#else>
                 <#if filter.input>
                     <div class="user-filter-search-input">
@@ -199,7 +199,7 @@
         </div>
 </#macro>
 
-<#macro rangeFilter filter>
+<#macro rangeFilter filter form>
     <#assign min = filter.min >
     <#assign max = filter.max >
     <#assign from = filter.fromYear >
@@ -220,7 +220,7 @@
             <#else>
                 <div class="range-slider-end">${max?html}</div>
             </#if>
-            <input form="search-form" id="filter_range_${filter.id?html}" style="display:none;" class="range-slider-input" name="filter_range_${filter.id?html}" value="${filter.rangeInput?html}"/>
+            <input form="${form}" id="filter_range_${filter.id?html}" style="display:none;" class="range-slider-input" name="filter_range_${filter.id?html}" value="${filter.rangeInput?html}"/>
         </div>
     </div>
 </#macro>
@@ -246,15 +246,15 @@
     <label class="${additionalClass}" for="${valueId}" >${getValueLabel(label, count)?html}</label>
 </#macro>
 
-<#macro userSelectedInput filter>
+<#macro userSelectedInput filter form>
     <#if filter.inputText?has_content>
-        <button form="search-form" type="button" id="button_filter_input_${filter.id?html}" onclick="clearInput('filter_input_${filter.id?js_string?html}')" class="checked-search-input-label">${filter.name?html} : ${filter.inputText?html}</button>
+        <button form="${form}" type="button" id="button_filter_input_${filter.id?html}" onclick="clearInput('filter_input_${filter.id?js_string?html}')" class="checked-search-input-label">${filter.name?html} : ${filter.inputText?html}</button>
     </#if>
     <#assign from = filter.fromYear >
     <#assign to = filter.toYear >
     <#if from?has_content && to?has_content >
         <#assign range = i18n().from + " " + from + " " + i18n().to + " " + to >
-        <button form="search-form" type="button" id="button_filter_range_${filter.id?html}" onclick="clearInput('filter_range_${filter.id?js_string?html}')" class="checked-search-input-label">${filter.name?html} : ${range?html}</button>
+        <button form="${form}" type="button" id="button_filter_range_${filter.id?html}" onclick="clearInput('filter_range_${filter.id?js_string?html}')" class="checked-search-input-label">${filter.name?html} : ${range?html}</button>
     </#if>
 </#macro>
 

--- a/webapp/src/main/webapp/templates/freemarker/body/search/search-lib.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/body/search/search-lib.ftl
@@ -187,7 +187,7 @@
                         </#if>
                         <#if user.loggedIn || v.publiclyAvailable>
                             <@getInput filter v getValueID(filter.id, valueNumber) valueNumber />
-                            <@getLabel getValueID(filter.id, valueNumber)?html v filter additionalLabels v.count />
+                            <@getLabel getValueID(filter.id, valueNumber)?html v filter v.count additionalLabels />
                         </#if>
                     </#if>
                     <#assign valueNumber = valueNumber + 1>

--- a/webapp/src/main/webapp/templates/freemarker/body/search/search-lib.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/body/search/search-lib.ftl
@@ -30,17 +30,17 @@
 <#macro searchForm>
         <div id="selected-filters">
             <@printSelectedFilterValueLabels filters />
-        </div>  
-        <div id="filter-groups">
-            <ul class="nav nav-tabs">
-                <#assign active = true>
-                <#list filterGroups as group>
-                    <#if ( user.loggedIn || group.public ) && !group.hidden >
-                        <@searchFormGroupTab group active/>
-                        <#assign active = false>
-                    </#if>  
-                </#list>
-            </ul>
+        </div>
+        <div id="filter-groups" class="tabs">
+            <#assign active = true>
+            <#list filterGroups as group>
+                <#if ( user.loggedIn || group.public ) && !group.hidden >
+                    <@searchFormGroupTab group active/>
+                    <#assign active = false>
+                </#if>  
+            </#list>
+        </div>
+        <div class="tabs filter-area">
             <#assign active = true>
             <#list filterGroups as group>
                 <#if ( user.loggedIn || group.public ) && !group.hidden >
@@ -49,6 +49,7 @@
                 </#if>
             </#list>
         </div>
+        
         <div id="search-form-footer">
             <div>
                 <@printResultNumbers />
@@ -61,13 +62,10 @@
 </#macro>
 
 <#macro groupFilters group active>
-    <#if active >
-        <div id="${group.id}" class="tab-pane fade in active filter-area">
-    <#else>
-        <div id="${group.id}" class="tab-pane fade filter-area">
-    </#if>
-            <div id="search-filter-group-container-${group.id}">
-                <ul class="nav nav-tabs">
+    
+        <div id="${group.id}" class="tab <#if active >active<#else>fade</#if>">
+            <div id="search-filter-group-container-${group.id}" class="search-filter-group-container">
+                <div class="tabs">
                     <#assign assignedActive = false>
                     <#list group.filters as filterId>
                         <#if filters[filterId]??>
@@ -80,7 +78,7 @@
                             </#if>
                         </#if>
                     </#list>
-                </ul>
+                </div>
             </div>
             <div id="search-filter-group-tab-content-${group.id}" class="tab-content">
                 <#assign assignedActive = false>
@@ -153,27 +151,22 @@
 </#macro>
 
 <#macro searchFormGroupTab group active >
-    <#if active>
-         <li class="active form-group-tab">
-    <#else>
-        <li class="form-group-tab">
-    </#if>
-            <a data-toggle="tab" href="#${group.id?html}">${group.label?html}</a>
-        </li>
+    <div class="tab <#if active>active</#if>">
+        <a href="#" onclick="openTab(event, '${group.id?html}');return false;">${group.label?html}</a>
+    </div>
 </#macro>
 
 <#macro searchFormFilterTab filter assignedActive>
     <#if filter.id == "querytext">
-        <#-- skip query text filter -->
         <#return>
     </#if>
-        <li class="filter-tab">
-            <a data-toggle="tab" href="#${filter.id?html}">${filter.name?html}</a>
-        </li>
+        <div class="tab filter-tab" >
+            <a href="#" onclick="openTab(event, '${filter.id?html}');return false;">${filter.name?html}</a>
+        </div>
 </#macro>
 
 <#macro printFilterValues filter assignedActive isEmptySearch>
-        <div id="${filter.id?html}" class="tab-pane fade filter-area">
+        <div id="${filter.id?html}" class="tab fade filter-area">
             <#if filter.id == "querytext">
             <#-- skip query text filter -->
             <#elseif filter.type == "RangeFilter">

--- a/webapp/src/main/webapp/templates/freemarker/body/search/search-lib.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/body/search/search-lib.ftl
@@ -248,13 +248,17 @@
 
 <#macro userSelectedInput filter form>
     <#if filter.inputText?has_content>
-        <button form="${form}" type="button" id="button_filter_input_${filter.id?html}" onclick="clearInput('filter_input_${filter.id?js_string?html}')" class="checked-search-input-label">${filter.name?html} : ${filter.inputText?html}</button>
+        <#assign inputID = "filter_input_" + filter.id >
+        <#if filter.id == "querytext">
+            <#assign inputID = filter.id >
+        </#if>
+        <button form="${form}" type="button" id="button_filter_input_${filter.id?html}" onclick="clearInput(event,'${inputID?js_string?html}')" class="checked-search-input-label">${filter.name?html} : ${filter.inputText?html}</button>
     </#if>
     <#assign from = filter.fromYear >
     <#assign to = filter.toYear >
     <#if from?has_content && to?has_content >
         <#assign range = i18n().from + " " + from + " " + i18n().to + " " + to >
-        <button form="${form}" type="button" id="button_filter_range_${filter.id?html}" onclick="clearInput('filter_range_${filter.id?js_string?html}')" class="checked-search-input-label">${filter.name?html} : ${range?html}</button>
+        <button form="${form}" type="button" id="button_filter_range_${filter.id?html}" onclick="clearInput(event,'filter_range_${filter.id?js_string?html}')" class="checked-search-input-label">${filter.name?html} : ${range?html}</button>
     </#if>
 </#macro>
 

--- a/webapp/src/main/webapp/templates/freemarker/body/search/search-lib.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/body/search/search-lib.ftl
@@ -265,6 +265,7 @@
 <#macro getInput filter filterValue valueID valueNumber form="search-form">
     <#assign checked = "" >
     <#assign class = "" >
+    <#assign inputName = "filters_" + valueID >
     <#if filterValue.selected>
         <#assign checked = " checked=\"checked\" " >
         <#assign class = "selected-input" >
@@ -272,6 +273,7 @@
     <#assign type = "checkbox" >
     <#if !filter.multivalued>
         <#assign type = "radio" >
+        <#assign inputName = "filters_" + filter.id >
     </#if>
     <#assign filterName = filter.id >
     <#if filter.multivalued>
@@ -283,7 +285,7 @@
         type="${type}" 
         id="${valueID?html}" 
         value="${filter.id?html + ":" + filterValue.id?html}" 
-        name="filters_${valueID?html}" 
+        name="${inputName?html}" 
         style="display:none;" 
         ${checked} 
         class="${class}" 

--- a/webapp/src/main/webapp/templates/freemarker/body/search/search-lib.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/body/search/search-lib.ftl
@@ -31,25 +31,23 @@
         <div id="selected-filters">
             <@printSelectedFilterValueLabels filters />
         </div>
-        <div id="filter-groups" class="tabs">
-            <#assign active = true>
-            <#list filterGroups as group>
-                <#if group.displayed >
-                    <@searchFormGroupTab group active/>
-                    <#assign active = false>
-                </#if>  
-            </#list>
-        </div>
-        <div class="tabs filter-area">
-            <#assign active = true>
-            <#list filterGroups as group>
-                <#if group.displayed >
-                      <@groupFilters group active/>
-                      <#assign active = false>
-                </#if>
-            </#list>
-        </div>
-        
+        <#assign filterGroupTabsContent>
+            <@filterGroupTabs/>
+        </#assign>
+        <#if filterGroupTabsContent?has_content>
+            <div id="filter-groups" class="tabs">
+                ${filterGroupTabsContent}
+            </div>
+            <div class="tabs filter-area">
+                <#assign active = true>
+                <#list filterGroups as group>
+                    <#if group.displayed && !isEmptyGroup(group)>
+                        <@groupFilters group active/>
+                        <#assign active = false>
+                    </#if>
+                </#list>
+            </div>
+        </#if>
         <div id="search-form-footer">
             <div>
                 <@printResultNumbers />
@@ -63,8 +61,17 @@
         </div> 
 </#macro>
 
+<#macro filterGroupTabs >
+    <#assign active = true>
+    <#list filterGroups as group>
+        <#if group.displayed && !isEmptyGroup(group)>
+            <@searchFormGroupTab group active/>
+            <#assign active = false>
+        </#if>
+    </#list>
+</#macro>
+
 <#macro groupFilters group active>
-    
         <div id="${group.id}" class="tab <#if active >active<#else>fade</#if>">
             <div id="search-filter-group-container-${group.id}" class="search-filter-group-container">
                 <div class="tabs">
@@ -72,7 +79,7 @@
                     <#list group.filters as filterId>
                         <#if filters[filterId]??>
                             <#assign f = filters[filterId]>
-                            <#if f.displayed >
+                            <#if f.displayed && !isEmptyFilter(f) >
                                 <@searchFormFilterTab f assignedActive/>  
                                 <#if !assignedActive && (f.selected || emptySearch )>
                                     <#assign assignedActive = true>
@@ -87,7 +94,7 @@
                 <#list group.filters as filterId>
                     <#if filters[filterId]??>
                         <#assign f = filters[filterId]>
-                        <#if f.displayed >
+                        <#if f.displayed && !isEmptyFilter(f) >
                             <@printFilterValues f assignedActive emptySearch/>  
                             <#if !assignedActive && ( f.selected || emptySearch )>
                                 <#assign assignedActive = true>
@@ -157,12 +164,9 @@
 </#macro>
 
 <#macro searchFormFilterTab filter assignedActive>
-    <#if filter.id == "querytext">
-        <#return>
-    </#if>
-        <div class="tab filter-tab" >
-            <a href="#" onclick="openTab(event, '${filter.id?html}');return false;">${filter.name?html}</a>
-        </div>
+    <div class="tab filter-tab" >
+        <a href="#" onclick="openTab(event, '${filter.id?html}');return false;">${filter.name?html}</a>
+    </div>
 </#macro>
 
 <#macro printFilterValues filter assignedActive isEmptySearch>
@@ -296,4 +300,20 @@
         <#assign result = result + " (" + count + ")" >
     </#if>
     <#return result />
+</#function>
+
+<#function isEmptyFilter filter >
+    <#return filter.id == "querytext" || (filter.type != "RangeFilter" && !filter.input && filter.values?values?filter(v -> !v.selected)?size == 0 ) />
+</#function>
+
+<#function isEmptyGroup group >
+	<#list group.filters as filterId>
+        <#if filters[filterId]??>
+            <#assign f = filters[filterId]>
+            <#if f.displayed && !isEmptyFilter(f) >
+                <#return false />
+            </#if>
+        </#if>
+    </#list>
+    <#return true />
 </#function>

--- a/webapp/src/main/webapp/templates/freemarker/body/search/search-lib.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/body/search/search-lib.ftl
@@ -34,7 +34,7 @@
         <div id="filter-groups" class="tabs">
             <#assign active = true>
             <#list filterGroups as group>
-                <#if group.display >
+                <#if group.displayed >
                     <@searchFormGroupTab group active/>
                     <#assign active = false>
                 </#if>  
@@ -43,7 +43,7 @@
         <div class="tabs filter-area">
             <#assign active = true>
             <#list filterGroups as group>
-                <#if group.display >
+                <#if group.displayed >
                       <@groupFilters group active/>
                       <#assign active = false>
                 </#if>
@@ -72,7 +72,7 @@
                     <#list group.filters as filterId>
                         <#if filters[filterId]??>
                             <#assign f = filters[filterId]>
-                            <#if f.display >
+                            <#if f.displayed >
                                 <@searchFormFilterTab f assignedActive/>  
                                 <#if !assignedActive && (f.selected || emptySearch )>
                                     <#assign assignedActive = true>
@@ -87,7 +87,7 @@
                 <#list group.filters as filterId>
                     <#if filters[filterId]??>
                         <#assign f = filters[filterId]>
-                        <#if f.display >
+                        <#if f.displayed >
                             <@printFilterValues f assignedActive emptySearch/>  
                             <#if !assignedActive && ( f.selected || emptySearch )>
                                 <#assign assignedActive = true>
@@ -105,7 +105,7 @@
         <#list filter.values?values as v>
             <#if v.selected>
                 <@getInput filter v getValueID(filter.id, valueNumber) valueNumber />
-                <#if filter.display>
+                <#if filter.displayed>
                     <@getSelectedLabel getValueID(filter.id, valueNumber)?html v filter v.count />
                 </#if>
             </#if>
@@ -121,7 +121,7 @@
             <select form="search-form" name="sort" id="search-form-sort" onchange="this.form.submit()" >
                 <#assign addDefaultOption = true>
                 <#list sortOptions?values as option>
-                    <#if option.display>
+                    <#if option.displayed>
                         <#if option.selected>
                             <option value="${option.id}" selected="selected">${i18n().search_results_sort_by(option.label)}</option>
                             <#assign addDefaultOption = false>
@@ -185,7 +185,7 @@
                             <#assign additionalLabels = true>
                             <a class="more-facets-link" href="javascript:void(0);" onclick="expandSearchOptions(this)">${i18n().paging_link_more}</a>
                         </#if>
-                        <#if v.display>
+                        <#if v.displayed>
                             <@getInput filter v getValueID(filter.id, valueNumber) valueNumber />
                             <@getLabel getValueID(filter.id, valueNumber)?html v filter v.count additionalLabels />
                         </#if>

--- a/webapp/src/main/webapp/templates/freemarker/body/search/search-lib.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/body/search/search-lib.ftl
@@ -1,41 +1,3 @@
-<#-- $This file is distributed under the terms of the license in LICENSE$ -->
-
-${stylesheets.add('<link rel="stylesheet" type="text/css" href="${urls.base}/css/nouislider.css"/>')}
-${stylesheets.add('<link rel="stylesheet" type="text/css" href="${urls.base}/css/search-results.css"/>')}
-
-${headScripts.add('<script type="text/javascript" src="${urls.base}/webjars/floatingui/floating-ui.core.umd.js"></script>')}
-${headScripts.add('<script type="text/javascript" src="${urls.base}/webjars/floatingui/floating-ui.dom.umd.js"></script>')}
-${headScripts.add('<script type="text/javascript" src="${urls.base}/js/tooltip/tooltip-utils.js"></script>')}
-
-${stylesheets.add('<link rel="stylesheet" type="text/css" href="${urls.base}/js/bootstrap/css/bootstrap.min.css"/>')}
-${stylesheets.add('<link rel="stylesheet" type="text/css" href="${urls.base}/js/bootstrap/css/bootstrap-theme.min.css"/>')}
-${headScripts.add('<script type="text/javascript" src="${urls.base}/js/nouislider.min.js"></script>')}
-${headScripts.add('<script type="text/javascript" src="${urls.base}/js/wNumb.min.js"></script>')}
-${headScripts.add('<script type="text/javascript" src="${urls.base}/js/bootstrap/js/bootstrap.min.js"></script>')}
-
-<#include "search-lib.ftl">
-
-<script>
-	let searchFormId = "search-form";
-</script>
-
-<@searchForm  />
-
-<div class="contentsBrowseGroup">
-
-    <@printPagingLinks />
-    <#-- Search results -->
-    <ul class="searchhits">
-        <#list individuals as individual>
-            <li>
-                <@shortView uri=individual.uri viewContext="search" />
-            </li>
-        </#list>
-    </ul>
-
-    <@printPagingLinks />
-    <br />
-</div> 
 
 <#macro printPagingLinks>
 
@@ -144,7 +106,7 @@ ${headScripts.add('<script type="text/javascript" src="${urls.base}/js/bootstrap
             <#if v.selected>
                 <@getInput filter v getValueID(filter.id, valueNumber) valueNumber />
                 <#if user.loggedIn || filter.public>
-                    <@getSelectedLabel valueNumber, v, filter />
+                    <@getSelectedLabel getValueID(filter.id, valueNumber)?html v filter />
                 </#if>
             </#if>
             <#assign valueNumber = valueNumber + 1>
@@ -232,7 +194,7 @@ ${headScripts.add('<script type="text/javascript" src="${urls.base}/js/bootstrap
                         </#if>
                         <#if user.loggedIn || v.publiclyAvailable>
                             <@getInput filter v getValueID(filter.id, valueNumber) valueNumber />
-                            <@getLabel valueNumber, v, filter, additionalLabels />
+                            <@getLabel getValueID(filter.id, valueNumber)?html v filter additionalLabels />
                         </#if>
                     </#if>
                     <#assign valueNumber = valueNumber + 1>
@@ -271,15 +233,15 @@ ${headScripts.add('<script type="text/javascript" src="${urls.base}/js/bootstrap
 </#macro>
 
 
-<#macro getSelectedLabel valueID value filter >
+<#macro getSelectedLabel valueId value filter >
     <#assign label = filter.name + " : " + value.name >
     <#if !filter.localizationRequired>
         <#assign label = filter.name + " : " + value.id >
     </#if>
-    <label for="${getValueID(filter.id, valueNumber)?html}">${getValueLabel(label, value.count)?html}</label>
+    <label for="${valueId}">${getValueLabel(label, value.count)?html}</label>
 </#macro>
 
-<#macro getLabel valueID value filter additional=false >
+<#macro getLabel valueId value filter additional=false >
     <#assign label = value.name >
     <#assign additionalClass = "" >
     <#if !filter.localizationRequired>
@@ -288,10 +250,8 @@ ${headScripts.add('<script type="text/javascript" src="${urls.base}/js/bootstrap
     <#if additional=true>
         <#assign additionalClass = "additional-search-options hidden-search-option" >
     </#if>
-
-    <label class="${additionalClass}" for="${getValueID(filter.id, valueNumber)?html}" >${getValueLabel(label, value.count)?html}</label>
+    <label class="${additionalClass}" for="${valueId}" >${getValueLabel(label, value.count)?html}</label>
 </#macro>
-
 
 <#macro userSelectedInput filter>
     <#if filter.inputText?has_content>
@@ -343,20 +303,8 @@ ${headScripts.add('<script type="text/javascript" src="${urls.base}/js/bootstrap
 
 <#function getValueLabel label count >
     <#assign result = label >
-    ${label}
     <#if count!=0>
         <#assign result = result + " (" + count + ")" >
     </#if>
     <#return result />
 </#function>
-
-${stylesheets.add('<link rel="stylesheet" href="//code.jquery.com/ui/1.10.3/themes/smoothness/jquery-ui.css" />',
-  				  '<link rel="stylesheet" href="${urls.base}/css/search.css" />')}
-
-${headScripts.add('<script src="//code.jquery.com/ui/1.10.3/jquery-ui.js"></script>',
-                  '<script type="text/javascript" src="${urls.base}/js/tiny_mce/tiny_mce.js"></script>'
-                  )}
-
-${scripts.add('<script type="text/javascript" src="${urls.base}/js/searchDownload.js"></script>')}
-${scripts.add('<script type="text/javascript" src="${urls.base}/js/search/search_results.js"></script>')}
-

--- a/webapp/src/main/webapp/templates/freemarker/body/search/search-lib.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/body/search/search-lib.ftl
@@ -283,17 +283,7 @@
     <#if filter.multivalued>
         <#assign filterName = filterName + "_" + valueNumber >
     </#if>
-
-    <input 
-        form="${form}" 
-        type="${type}" 
-        id="${valueID?html}" 
-        value="${filter.id?html + ":" + filterValue.id?html}" 
-        name="${inputName?html}" 
-        style="display:none;" 
-        ${checked} 
-        class="${class}" 
-    >
+    <input form="${form}" type="${type}" id="${valueID?html}" value="${filter.id?html + ":" + filterValue.id?html}" name="${inputName?html}" style="display:none;" ${checked} <#if class?has_content>class="${class}"</#if> >
 </#macro>
 
 <#function getValueID id number>

--- a/webapp/src/main/webapp/templates/freemarker/body/search/search-lib.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/body/search/search-lib.ftl
@@ -55,7 +55,9 @@
                 <@printResultNumbers />
             </div>
             <div>
-                <@printHits />
+                <div>
+                    <@showHits />
+                </div>
                 <@printSorting />
             </div>
         </div> 
@@ -114,11 +116,11 @@
 </#macro>
 
 <#macro printSorting>
-    <#if sorting?has_content>
+    <#if sortOptions?has_content>
         <div>
             <select form="search-form" name="sort" id="search-form-sort" onchange="this.form.submit()" >
                 <#assign addDefaultOption = true>
-                <#list sorting as option>
+                <#list sortOptions?values as option>
                     <#if option.display>
                         <#if option.selected>
                             <option value="${option.id}" selected="selected">${i18n().search_results_sort_by(option.label)}</option>
@@ -136,9 +138,8 @@
     </#if>
 </#macro>
 
-<#macro printHits>
-    <div>
-    <select form="search-form" name="hitsPerPage" id="search-form-hits-per-page" onchange="this.form.submit()">
+<#macro showHits form="search-form">
+    <select form="${form}" name="hitsPerPage" id="${form}-hits-per-page" onchange="this.form.submit()">
         <#list hitsPerPageOptions as option>
             <#if option == hitsPerPage>
                 <option value="${option}" selected="selected">${i18n().search_results_per_page(option)}</option>
@@ -147,7 +148,6 @@
             </#if>
         </#list>
     </select>
-    </div>
 </#macro>
 
 <#macro searchFormGroupTab group active >

--- a/webapp/src/main/webapp/templates/freemarker/body/search/search-lib.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/body/search/search-lib.ftl
@@ -34,7 +34,7 @@
         <div id="filter-groups" class="tabs">
             <#assign active = true>
             <#list filterGroups as group>
-                <#if ( user.loggedIn || group.public ) && !group.hidden >
+                <#if group.display >
                     <@searchFormGroupTab group active/>
                     <#assign active = false>
                 </#if>  
@@ -43,7 +43,7 @@
         <div class="tabs filter-area">
             <#assign active = true>
             <#list filterGroups as group>
-                <#if ( user.loggedIn || group.public ) && !group.hidden >
+                <#if group.display >
                       <@groupFilters group active/>
                       <#assign active = false>
                 </#if>
@@ -72,7 +72,7 @@
                     <#list group.filters as filterId>
                         <#if filters[filterId]??>
                             <#assign f = filters[filterId]>
-                            <#if ( user.loggedIn || f.public ) && !f.hidden >
+                            <#if f.display >
                                 <@searchFormFilterTab f assignedActive/>  
                                 <#if !assignedActive && (f.selected || emptySearch )>
                                     <#assign assignedActive = true>
@@ -87,7 +87,7 @@
                 <#list group.filters as filterId>
                     <#if filters[filterId]??>
                         <#assign f = filters[filterId]>
-                        <#if ( user.loggedIn || f.public ) && !f.hidden >
+                        <#if f.display >
                             <@printFilterValues f assignedActive emptySearch/>  
                             <#if !assignedActive && ( f.selected || emptySearch )>
                                 <#assign assignedActive = true>
@@ -105,7 +105,7 @@
         <#list filter.values?values as v>
             <#if v.selected>
                 <@getInput filter v getValueID(filter.id, valueNumber) valueNumber />
-                <#if user.loggedIn || filter.public>
+                <#if filter.display>
                     <@getSelectedLabel getValueID(filter.id, valueNumber)?html v filter v.count />
                 </#if>
             </#if>
@@ -185,7 +185,7 @@
                             <#assign additionalLabels = true>
                             <a class="more-facets-link" href="javascript:void(0);" onclick="expandSearchOptions(this)">${i18n().paging_link_more}</a>
                         </#if>
-                        <#if user.loggedIn || v.publiclyAvailable>
+                        <#if v.display>
                             <@getInput filter v getValueID(filter.id, valueNumber) valueNumber />
                             <@getLabel getValueID(filter.id, valueNumber)?html v filter v.count additionalLabels />
                         </#if>

--- a/webapp/src/main/webapp/templates/freemarker/body/search/search-pagedResults.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/body/search/search-pagedResults.ftl
@@ -52,129 +52,10 @@ ${headScripts.add('<script type="text/javascript" src="${urls.base}/js/bootstrap
 
 <#macro printResultNumbers>
     <h2 class="searchResultsHeader">
-    <#escape x as x?html>
-        ${i18n().results_found(hitCount)} 
-    </#escape>
-    <script type="text/javascript">
-        var url = window.location.toString();
-        if (url.indexOf("?") == -1){
-            var queryText = 'querytext=${querytext?js_string}';
-        } else {
-            var urlArray = url.split("?");
-            var queryText = urlArray[1];
-        }
-
-        var urlsBase = '${urls.base}';
-        
-        $("input:radio").on("click",function (e) {
-            var input=$(this);
-            if (input.is(".selected-input")) { 
-                input.prop("checked",false);
-            } else {
-                input.prop("checked",true);
-            }
-            $('#search-form').submit();
-        });
-        
-        $("input:checkbox").on("click",function (e) {
-            var input=$(this);
-            input.checked = !input.checked;
-            $('#search-form').submit();
-        });
-        
-        function clearInput(elementId) {
-              let inputEl = document.getElementById(elementId);
-              inputEl.value = "";
-              let srcButton = document.getElementById("button_" + elementId);
-              srcButton.classList.add("unchecked-selected-search-input-label");
-              $('#search-form').submit();
-        }
-        
-        function createSliders(){
-            sliders = document.getElementsByClassName('range-slider-container');
-            for (let sliderElement of sliders) {
-                createSlider(sliderElement);
-            }
-            $(".noUi-handle").on("mousedown", function (e) {
-                $(this)[0].setPointerCapture(e.pointerId);
-            });
-            $(".noUi-handle").on("mouseup", function (e) {
-                $('#search-form').submit();
-            });
-            $(".noUi-handle").on("pointerup", function (e) {
-                $('#search-form').submit();
-            });
-        };
-            
-        function createSlider(sliderContainer){
-            rangeSlider = sliderContainer.querySelector('.range-slider');
-            
-            noUiSlider.create(rangeSlider, {
-                range: {
-                    min: Number(sliderContainer.getAttribute('min')),
-                    max: Number(sliderContainer.getAttribute('max'))
-                },
-            
-                step: 1,
-                start: [Number(sliderContainer.querySelector('.range-slider-start').textContent), 
-                          Number(sliderContainer.querySelector('.range-slider-end').textContent)],
-            
-                format: wNumb({
-                    decimals: 0
-                })
-            });
-            
-            var dateValues = [
-                 sliderContainer.querySelector('.range-slider-start'),
-                 sliderContainer.querySelector('.range-slider-end')
-            ];
-            
-            var input = sliderContainer.querySelector('.range-slider-input');
-            var first = true;
-            
-            rangeSlider.noUiSlider.on('update', function (values, handle) {
-                dateValues[handle].innerHTML = values[handle];
-                var active = input.getAttribute('active');
-                if (active === null){
-                    input.setAttribute('active', "false");
-                } else if (active !== "true"){
-                    input.setAttribute('active', "true");
-                } else {
-                    var startDate = new Date(+values[0],0,1);
-                    var endDate = new Date(+values[1],0,1);
-                    input.value = startDate.toISOString() + " " + endDate.toISOString();
-                }
-            });
-        }
-        
-        window.onload = (event) => {
-              createSliders();
-        };
-        
-        $('#search-form').submit(function () {
-        $('#search-form')
-            .find('input')
-            .filter(function () {
-                return !this.value;
-            })
-            .prop('name', '');
-        });
-        
-        function expandSearchOptions(){
-            $(event.target).parent().children('.additional-search-options').removeClass("hidden-search-option");
-            $(event.target).parent().children('.less-facets-link').show();
-            $(event.target).hide();
-        }
-    
-        function collapseSearchOptions(){
-            $(event.target).parent().children('.additional-search-options').addClass("hidden-search-option");
-            $(event.target).parent().children('.more-facets-link').show();
-            $(event.target).hide();
-        }
-    
-    </script>
-    <img id="downloadIcon" src="images/download-icon.png" alt="${i18n().download_results}" title="${i18n().download_results}" />
-    <#-- <span id="downloadResults" style="float:left"></span>  -->
+        <#escape x as x?html>
+            ${i18n().results_found(hitCount)} 
+        </#escape>
+        <img id="downloadIcon" src="images/download-icon.png" alt="${i18n().download_results}" title="${i18n().download_results}" />
     </h2>
 </#macro>
 
@@ -335,7 +216,6 @@ ${headScripts.add('<script type="text/javascript" src="${urls.base}/js/bootstrap
                         <@createUserInput filter />
                     </div>
                 </#if>
-    
                 <#assign valueNumber = 1>
                 <#assign additionalLabels = false>
                 <#list filter.values?values as v>
@@ -350,7 +230,6 @@ ${headScripts.add('<script type="text/javascript" src="${urls.base}/js/bootstrap
                         </#if>
                     </#if>
                     <#assign valueNumber = valueNumber + 1>
-
                 </#list>
                 <#if additionalLabels >
                     <a class="less-facets-link additional-search-options hidden-search-option" href="javascript:void(0);" onclick="collapseSearchOptions(this)">${i18n().display_less}</a>
@@ -464,7 +343,6 @@ ${headScripts.add('<script type="text/javascript" src="${urls.base}/js/bootstrap
     </#if>
     <#return result />
 </#function>
-<!-- end contentsBrowseGroup -->
 
 ${stylesheets.add('<link rel="stylesheet" href="//code.jquery.com/ui/1.10.3/themes/smoothness/jquery-ui.css" />',
   				  '<link rel="stylesheet" href="${urls.base}/css/search.css" />')}
@@ -474,3 +352,5 @@ ${headScripts.add('<script src="//code.jquery.com/ui/1.10.3/jquery-ui.js"></scri
                   )}
 
 ${scripts.add('<script type="text/javascript" src="${urls.base}/js/searchDownload.js"></script>')}
+${scripts.add('<script type="text/javascript" src="${urls.base}/js/search/search_results.js"></script>')}
+

--- a/webapp/src/main/webapp/templates/freemarker/body/search/search-pagedResults.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/body/search/search-pagedResults.ftl
@@ -22,7 +22,7 @@ ${headScripts.add('<script type="text/javascript" src="${urls.base}/js/bootstrap
     <ul class="searchhits">
         <#list individuals as individual>
             <li>
-            	<@shortView uri=individual.uri viewContext="search" />
+                <@shortView uri=individual.uri viewContext="search" />
             </li>
         </#list>
     </ul>
@@ -51,419 +51,418 @@ ${headScripts.add('<script type="text/javascript" src="${urls.base}/js/bootstrap
 </#macro>
 
 <#macro printResultNumbers>
-	<h2 class="searchResultsHeader">
-	<#escape x as x?html>
-	    ${i18n().results_found(hitCount)} 
-	</#escape>
-	<script type="text/javascript">
-		var url = window.location.toString();
-		if (url.indexOf("?") == -1){
-			var queryText = 'querytext=${querytext?js_string}';
-		} else {
-			var urlArray = url.split("?");
-			var queryText = urlArray[1];
-		}
+    <h2 class="searchResultsHeader">
+    <#escape x as x?html>
+        ${i18n().results_found(hitCount)} 
+    </#escape>
+    <script type="text/javascript">
+        var url = window.location.toString();
+        if (url.indexOf("?") == -1){
+            var queryText = 'querytext=${querytext?js_string}';
+        } else {
+            var urlArray = url.split("?");
+            var queryText = urlArray[1];
+        }
 
-		var urlsBase = '${urls.base}';
-		
-		$("input:radio").on("click",function (e) {
-		    var input=$(this);
-		    if (input.is(".selected-input")) { 
-		        input.prop("checked",false);
-		    } else {
-		        input.prop("checked",true);
-		    }
-	        $('#search-form').submit();
-		});
-		
-		$("input:checkbox").on("click",function (e) {
-		    var input=$(this);
-		    input.checked = !input.checked;
-	        $('#search-form').submit();
-		});
-		
-		function clearInput(elementId) {
-	  		let inputEl = document.getElementById(elementId);
-	  		inputEl.value = "";
-	  		let srcButton = document.getElementById("button_" + elementId);
-	  		srcButton.classList.add("unchecked-selected-search-input-label");
-	  		$('#search-form').submit();
-		}
-		
-		function createSliders(){
-			sliders = document.getElementsByClassName('range-slider-container');
-			for (let sliderElement of sliders) {
-				createSlider(sliderElement);
-			}
-			$(".noUi-handle").on("mousedown", function (e) {
-			    $(this)[0].setPointerCapture(e.pointerId);
-			});
-			$(".noUi-handle").on("mouseup", function (e) {
-				$('#search-form').submit();
-			});
-			$(".noUi-handle").on("pointerup", function (e) {
-				$('#search-form').submit();
-			});
-		};
-			
-		function createSlider(sliderContainer){
-			rangeSlider = sliderContainer.querySelector('.range-slider');
-			
-			noUiSlider.create(rangeSlider, {
-			    range: {
-			        min: Number(sliderContainer.getAttribute('min')),
-			        max: Number(sliderContainer.getAttribute('max'))
-			    },
-			
-			    step: 1,
-			    start: [Number(sliderContainer.querySelector('.range-slider-start').textContent), 
-			  			Number(sliderContainer.querySelector('.range-slider-end').textContent)],
-			
-			    format: wNumb({
-			        decimals: 0
-			    })
-			});
-			
-			var dateValues = [
-			     sliderContainer.querySelector('.range-slider-start'),
-			     sliderContainer.querySelector('.range-slider-end')
-			];
-			
-			var input = sliderContainer.querySelector('.range-slider-input');
-			var first = true;
-			
-			rangeSlider.noUiSlider.on('update', function (values, handle) {
-			    dateValues[handle].innerHTML = values[handle];
-			    var active = input.getAttribute('active');
-			    if (active === null){
-			    	input.setAttribute('active', "false");
-			    } else if (active !== "true"){
-			        input.setAttribute('active', "true");
-			    } else {
-			    	var startDate = new Date(+values[0],0,1);
-			    	var endDate = new Date(+values[1],0,1);
-			    	input.value = startDate.toISOString() + " " + endDate.toISOString();
-			    }
-			});
-		}
-		
-		window.onload = (event) => {
-	  		createSliders();
-		};
-		
-		$('#search-form').submit(function () {
-	    $('#search-form')
-	        .find('input')
-	        .filter(function () {
-	            return !this.value;
-	        })
-	        .prop('name', '');
-		});
-		
-		function expandSearchOptions(){
-			$(event.target).parent().children('.additional-search-options').removeClass("hidden-search-option");
-			$(event.target).parent().children('.less-facets-link').show();
-			$(event.target).hide();
-		}
-	
-		function collapseSearchOptions(){
-			$(event.target).parent().children('.additional-search-options').addClass("hidden-search-option");
-			$(event.target).parent().children('.more-facets-link').show();
-			$(event.target).hide();
-		}
-	
-	</script>
-	<img id="downloadIcon" src="images/download-icon.png" alt="${i18n().download_results}" title="${i18n().download_results}" />
-	<#-- <span id="downloadResults" style="float:left"></span>  -->
-	</h2>
+        var urlsBase = '${urls.base}';
+        
+        $("input:radio").on("click",function (e) {
+            var input=$(this);
+            if (input.is(".selected-input")) { 
+                input.prop("checked",false);
+            } else {
+                input.prop("checked",true);
+            }
+            $('#search-form').submit();
+        });
+        
+        $("input:checkbox").on("click",function (e) {
+            var input=$(this);
+            input.checked = !input.checked;
+            $('#search-form').submit();
+        });
+        
+        function clearInput(elementId) {
+              let inputEl = document.getElementById(elementId);
+              inputEl.value = "";
+              let srcButton = document.getElementById("button_" + elementId);
+              srcButton.classList.add("unchecked-selected-search-input-label");
+              $('#search-form').submit();
+        }
+        
+        function createSliders(){
+            sliders = document.getElementsByClassName('range-slider-container');
+            for (let sliderElement of sliders) {
+                createSlider(sliderElement);
+            }
+            $(".noUi-handle").on("mousedown", function (e) {
+                $(this)[0].setPointerCapture(e.pointerId);
+            });
+            $(".noUi-handle").on("mouseup", function (e) {
+                $('#search-form').submit();
+            });
+            $(".noUi-handle").on("pointerup", function (e) {
+                $('#search-form').submit();
+            });
+        };
+            
+        function createSlider(sliderContainer){
+            rangeSlider = sliderContainer.querySelector('.range-slider');
+            
+            noUiSlider.create(rangeSlider, {
+                range: {
+                    min: Number(sliderContainer.getAttribute('min')),
+                    max: Number(sliderContainer.getAttribute('max'))
+                },
+            
+                step: 1,
+                start: [Number(sliderContainer.querySelector('.range-slider-start').textContent), 
+                          Number(sliderContainer.querySelector('.range-slider-end').textContent)],
+            
+                format: wNumb({
+                    decimals: 0
+                })
+            });
+            
+            var dateValues = [
+                 sliderContainer.querySelector('.range-slider-start'),
+                 sliderContainer.querySelector('.range-slider-end')
+            ];
+            
+            var input = sliderContainer.querySelector('.range-slider-input');
+            var first = true;
+            
+            rangeSlider.noUiSlider.on('update', function (values, handle) {
+                dateValues[handle].innerHTML = values[handle];
+                var active = input.getAttribute('active');
+                if (active === null){
+                    input.setAttribute('active', "false");
+                } else if (active !== "true"){
+                    input.setAttribute('active', "true");
+                } else {
+                    var startDate = new Date(+values[0],0,1);
+                    var endDate = new Date(+values[1],0,1);
+                    input.value = startDate.toISOString() + " " + endDate.toISOString();
+                }
+            });
+        }
+        
+        window.onload = (event) => {
+              createSliders();
+        };
+        
+        $('#search-form').submit(function () {
+        $('#search-form')
+            .find('input')
+            .filter(function () {
+                return !this.value;
+            })
+            .prop('name', '');
+        });
+        
+        function expandSearchOptions(){
+            $(event.target).parent().children('.additional-search-options').removeClass("hidden-search-option");
+            $(event.target).parent().children('.less-facets-link').show();
+            $(event.target).hide();
+        }
+    
+        function collapseSearchOptions(){
+            $(event.target).parent().children('.additional-search-options').addClass("hidden-search-option");
+            $(event.target).parent().children('.more-facets-link').show();
+            $(event.target).hide();
+        }
+    
+    </script>
+    <img id="downloadIcon" src="images/download-icon.png" alt="${i18n().download_results}" title="${i18n().download_results}" />
+    <#-- <span id="downloadResults" style="float:left"></span>  -->
+    </h2>
 </#macro>
 
 <#macro searchForm>
-	<form id="search-form" name="search-form" autocomplete="off" method="get" action="${urls.base}/search">
-		<div id="selected-filters">
-			<@printSelectedFilterValueLabels filters />
-		</div>  
-		<div id="filter-groups">
-			<ul class="nav nav-tabs">
-				<#assign active = true>
-				<#list filterGroups as group>
-					<#if ( user.loggedIn || group.public ) && !group.hidden >
-						<@searchFormGroupTab group active/>
-						<#assign active = false>
-					</#if>  
-				</#list>
-			</ul>
-			<#assign active = true>
-			<#list filterGroups as group>
-				<#if ( user.loggedIn || group.public ) && !group.hidden >
-			  		<@groupFilters group active/>
-			  		<#assign active = false>
-				</#if>
-			</#list>
-		</div>
-		<div id="search-form-footer">
-			<div>
-				<@printResultNumbers />
-			</div>
-			<div>
-				<@printHits />
-				<@printSorting />
-			</div>
-		</div> 
-	</form>
+        <div id="selected-filters">
+            <@printSelectedFilterValueLabels filters />
+        </div>  
+        <div id="filter-groups">
+            <ul class="nav nav-tabs">
+                <#assign active = true>
+                <#list filterGroups as group>
+                    <#if ( user.loggedIn || group.public ) && !group.hidden >
+                        <@searchFormGroupTab group active/>
+                        <#assign active = false>
+                    </#if>  
+                </#list>
+            </ul>
+            <#assign active = true>
+            <#list filterGroups as group>
+                <#if ( user.loggedIn || group.public ) && !group.hidden >
+                      <@groupFilters group active/>
+                      <#assign active = false>
+                </#if>
+            </#list>
+        </div>
+        <div id="search-form-footer">
+            <div>
+                <@printResultNumbers />
+            </div>
+            <div>
+                <@printHits />
+                <@printSorting />
+            </div>
+        </div> 
 </#macro>
 
 <#macro groupFilters group active>
-	<#if active >
-		<div id="${group.id}" class="tab-pane fade in active filter-area">
-	<#else>
-		<div id="${group.id}" class="tab-pane fade filter-area">
-	</#if>
-			<div id="search-filter-group-container-${group.id}">
-				<ul class="nav nav-tabs">
-					<#assign assignedActive = false>
-					<#list group.filters as filterId>
-						<#if filters[filterId]??>
-							<#assign f = filters[filterId]>
-							<#if ( user.loggedIn || f.public ) && !f.hidden >
-								<@searchFormFilterTab f assignedActive/>  
-								<#if !assignedActive && (f.selected || emptySearch )>
-									<#assign assignedActive = true>
-								</#if>
-							</#if>
-						</#if>
-					</#list>
-				</ul>
-			</div>
-			<div id="search-filter-group-tab-content-${group.id}" class="tab-content">
-				<#assign assignedActive = false>
-				<#list group.filters as filterId>
-					<#if filters[filterId]??>
-						<#assign f = filters[filterId]>
-						<#if ( user.loggedIn || f.public ) && !f.hidden >
-							<@printFilterValues f assignedActive emptySearch/>  
-							<#if !assignedActive && ( f.selected || emptySearch )>
-								<#assign assignedActive = true>
-							</#if>
-						</#if>
-					</#if>
-				</#list>
-			</div>
-		</div>
+    <#if active >
+        <div id="${group.id}" class="tab-pane fade in active filter-area">
+    <#else>
+        <div id="${group.id}" class="tab-pane fade filter-area">
+    </#if>
+            <div id="search-filter-group-container-${group.id}">
+                <ul class="nav nav-tabs">
+                    <#assign assignedActive = false>
+                    <#list group.filters as filterId>
+                        <#if filters[filterId]??>
+                            <#assign f = filters[filterId]>
+                            <#if ( user.loggedIn || f.public ) && !f.hidden >
+                                <@searchFormFilterTab f assignedActive/>  
+                                <#if !assignedActive && (f.selected || emptySearch )>
+                                    <#assign assignedActive = true>
+                                </#if>
+                            </#if>
+                        </#if>
+                    </#list>
+                </ul>
+            </div>
+            <div id="search-filter-group-tab-content-${group.id}" class="tab-content">
+                <#assign assignedActive = false>
+                <#list group.filters as filterId>
+                    <#if filters[filterId]??>
+                        <#assign f = filters[filterId]>
+                        <#if ( user.loggedIn || f.public ) && !f.hidden >
+                            <@printFilterValues f assignedActive emptySearch/>  
+                            <#if !assignedActive && ( f.selected || emptySearch )>
+                                <#assign assignedActive = true>
+                            </#if>
+                        </#if>
+                    </#if>
+                </#list>
+            </div>
+        </div>
 </#macro>
 
 <#macro printSelectedFilterValueLabels filters>
-	<#list filters?values as filter>
-		<#assign valueNumber = 1>
-		<#list filter.values?values as v>
-			<#if v.selected>
-				<@getInput filter v getValueID(filter.id, valueNumber) valueNumber />
-				<#if user.loggedIn || filter.public>
-					${getSelectedLabel(valueNumber, v, filter)}
-				</#if>
-			</#if>
-			<#assign valueNumber = valueNumber + 1>
-		</#list>
-		<@userSelectedInput filter />
-	</#list>
+    <#list filters?values as filter>
+        <#assign valueNumber = 1>
+        <#list filter.values?values as v>
+            <#if v.selected>
+                <@getInput filter v getValueID(filter.id, valueNumber) valueNumber />
+                <#if user.loggedIn || filter.public>
+                    <@getSelectedLabel valueNumber, v, filter />
+                </#if>
+            </#if>
+            <#assign valueNumber = valueNumber + 1>
+        </#list>
+        <@userSelectedInput filter />
+    </#list>
 </#macro>
 
 <#macro printSorting>
-	<#if sorting?has_content>
-		<div>
-			<select form="search-form" name="sort" id="search-form-sort" onchange="this.form.submit()" >
-			    <#assign addDefaultOption = true>
-				<#list sorting as option>
-					<#if option.display>
-						<#if option.selected>
-							<option value="${option.id}" selected="selected">${i18n().search_results_sort_by(option.label)}</option>
-							<#assign addDefaultOption = false>
-						<#else>
-							<option value="${option.id}" >${i18n().search_results_sort_by(option.label)}</option>
-						</#if>
-					</#if>
-				</#list>
-				<#if addDefaultOption>
-					<option disabled selected value="" style="display:none">${i18n().search_results_sort_by('')}</option>
-				</#if>
-			</select>
-		</div>
-	</#if>
+    <#if sorting?has_content>
+        <div>
+            <select form="search-form" name="sort" id="search-form-sort" onchange="this.form.submit()" >
+                <#assign addDefaultOption = true>
+                <#list sorting as option>
+                    <#if option.display>
+                        <#if option.selected>
+                            <option value="${option.id}" selected="selected">${i18n().search_results_sort_by(option.label)}</option>
+                            <#assign addDefaultOption = false>
+                        <#else>
+                            <option value="${option.id}" >${i18n().search_results_sort_by(option.label)}</option>
+                        </#if>
+                    </#if>
+                </#list>
+                <#if addDefaultOption>
+                    <option disabled selected value="" style="display:none">${i18n().search_results_sort_by('')}</option>
+                </#if>
+            </select>
+        </div>
+    </#if>
 </#macro>
 
 <#macro printHits>
-	<div>
-	<select form="search-form" name="hitsPerPage" id="search-form-hits-per-page" onchange="this.form.submit()">
-		<#list hitsPerPageOptions as option>
-			<#if option == hitsPerPage>
-				<option value="${option}" selected="selected">${i18n().search_results_per_page(option)}</option>
-			<#else>
-				<option value="${option}">${i18n().search_results_per_page(option)}</option>
-			</#if>
-		</#list>
-	</select>
-	</div>
+    <div>
+    <select form="search-form" name="hitsPerPage" id="search-form-hits-per-page" onchange="this.form.submit()">
+        <#list hitsPerPageOptions as option>
+            <#if option == hitsPerPage>
+                <option value="${option}" selected="selected">${i18n().search_results_per_page(option)}</option>
+            <#else>
+                <option value="${option}">${i18n().search_results_per_page(option)}</option>
+            </#if>
+        </#list>
+    </select>
+    </div>
 </#macro>
 
 <#macro searchFormGroupTab group active >
-	<#if active>
-	 	<li class="active form-group-tab">
-	<#else>
-		<li class="form-group-tab">
-	</#if>
-			<a data-toggle="tab" href="#${group.id?html}">${group.label?html}</a>
-		</li>
+    <#if active>
+         <li class="active form-group-tab">
+    <#else>
+        <li class="form-group-tab">
+    </#if>
+            <a data-toggle="tab" href="#${group.id?html}">${group.label?html}</a>
+        </li>
 </#macro>
 
 <#macro searchFormFilterTab filter assignedActive>
-	<#if filter.id == "querytext">
-		<#-- skip query text filter -->
-		<#return>
-	</#if>
-		<li class="filter-tab">
-			<a data-toggle="tab" href="#${filter.id?html}">${filter.name?html}</a>
-		</li>
+    <#if filter.id == "querytext">
+        <#-- skip query text filter -->
+        <#return>
+    </#if>
+        <li class="filter-tab">
+            <a data-toggle="tab" href="#${filter.id?html}">${filter.name?html}</a>
+        </li>
 </#macro>
 
 <#macro printFilterValues filter assignedActive isEmptySearch>
-		<div id="${filter.id?html}" class="tab-pane fade filter-area">
-			<#if filter.id == "querytext">
-			<#-- skip query text filter -->
-			<#elseif filter.type == "RangeFilter">
-				<@rangeFilter filter/>
-			<#else>
-				<#if filter.input>
-					<div class="user-filter-search-input">
-						<@createUserInput filter />
-					</div>
-				</#if>
-	
-				<#assign valueNumber = 1>
-				<#assign additionalLabels = false>
-				<#list filter.values?values as v>
-					<#if !v.selected>
-						<#if filter.moreLimit = valueNumber - 1 >
-							<#assign additionalLabels = true>
-							<a class="more-facets-link" href="javascript:void(0);" onclick="expandSearchOptions(this)">${i18n().paging_link_more}</a>
-						</#if>
-						<#if user.loggedIn || v.publiclyAvailable>
-						    <@getInput filter v getValueID(filter.id, valueNumber) valueNumber />
-						    ${getLabel(valueNumber, v, filter, additionalLabels)}
-						</#if>
-					</#if>
-					<#assign valueNumber = valueNumber + 1>
+        <div id="${filter.id?html}" class="tab-pane fade filter-area">
+            <#if filter.id == "querytext">
+            <#-- skip query text filter -->
+            <#elseif filter.type == "RangeFilter">
+                <@rangeFilter filter/>
+            <#else>
+                <#if filter.input>
+                    <div class="user-filter-search-input">
+                        <@createUserInput filter />
+                    </div>
+                </#if>
+    
+                <#assign valueNumber = 1>
+                <#assign additionalLabels = false>
+                <#list filter.values?values as v>
+                    <#if !v.selected>
+                        <#if filter.moreLimit = valueNumber - 1 >
+                            <#assign additionalLabels = true>
+                            <a class="more-facets-link" href="javascript:void(0);" onclick="expandSearchOptions(this)">${i18n().paging_link_more}</a>
+                        </#if>
+                        <#if user.loggedIn || v.publiclyAvailable>
+                            <@getInput filter v getValueID(filter.id, valueNumber) valueNumber />
+                            <@getLabel valueNumber, v, filter, additionalLabels />
+                        </#if>
+                    </#if>
+                    <#assign valueNumber = valueNumber + 1>
 
-				</#list>
-				<#if additionalLabels >
-					<a class="less-facets-link additional-search-options hidden-search-option" href="javascript:void(0);" onclick="collapseSearchOptions(this)">${i18n().display_less}</a>
-				</#if>  
-			</#if>
-		</div>
+                </#list>
+                <#if additionalLabels >
+                    <a class="less-facets-link additional-search-options hidden-search-option" href="javascript:void(0);" onclick="collapseSearchOptions(this)">${i18n().display_less}</a>
+                </#if>  
+            </#if>
+        </div>
 </#macro>
 
 <#macro rangeFilter filter>
-	<#assign min = filter.min >
-	<#assign max = filter.max >
-	<#assign from = filter.fromYear >
-	<#assign to = filter.toYear >
+    <#assign min = filter.min >
+    <#assign max = filter.max >
+    <#assign from = filter.fromYear >
+    <#assign to = filter.toYear >
 
-	<div class="range-filter" id="${filter.id?html}" class="tab-pane fade filter-area">
-		<div class="range-slider-container" min="${filter.min?html}" max="${filter.max?html}">
-			<div class="range-slider"></div>
-			${i18n().from}
-			<#if from?has_content>
-				<div class="range-slider-start">${from?html}</div>
-			<#else>
-				<div class="range-slider-start">${min?html}</div>
-			</#if>
-			${i18n().to}
-			<#if to?has_content>
-				<div class="range-slider-end">${to?html}</div>
-			<#else>
-				<div class="range-slider-end">${max?html}</div>
-			</#if>
-			<input form="search-form" id="filter_range_${filter.id?html}" style="display:none;" class="range-slider-input" name="filter_range_${filter.id?html}" value="${filter.rangeInput?html}"/>
-		</div>
-	</div>
+    <div class="range-filter" id="${filter.id?html}" class="tab-pane fade filter-area">
+        <div class="range-slider-container" min="${filter.min?html}" max="${filter.max?html}">
+            <div class="range-slider"></div>
+            ${i18n().from}
+            <#if from?has_content>
+                <div class="range-slider-start">${from?html}</div>
+            <#else>
+                <div class="range-slider-start">${min?html}</div>
+            </#if>
+            ${i18n().to}
+            <#if to?has_content>
+                <div class="range-slider-end">${to?html}</div>
+            <#else>
+                <div class="range-slider-end">${max?html}</div>
+            </#if>
+            <input form="search-form" id="filter_range_${filter.id?html}" style="display:none;" class="range-slider-input" name="filter_range_${filter.id?html}" value="${filter.rangeInput?html}"/>
+        </div>
+    </div>
 </#macro>
 
 
-<#function getSelectedLabel valueID value filter >
-	<#assign label = filter.name + " : " + value.name >
-	<#if !filter.localizationRequired>
-		<#assign label = filter.name + " : " + value.id >
-	</#if>
-	<#return "<label for=\"" + getValueID(filter.id, valueNumber)?html + "\">" + getValueLabel(label, value.count)?html + "</label>" />
-</#function>
+<#macro getSelectedLabel valueID value filter >
+    <#assign label = filter.name + " : " + value.name >
+    <#if !filter.localizationRequired>
+        <#assign label = filter.name + " : " + value.id >
+    </#if>
+    <label for="${getValueID(filter.id, valueNumber)?html}">${getValueLabel(label, value.count)?html}</label>
+</#macro>
 
-<#function getLabel valueID value filter additional=false >
-	<#assign label = value.name >
-	<#assign additionalClass = "" >
-	<#if !filter.localizationRequired>
-		<#assign label = value.id >
-	</#if>
-	<#if additional=true>
-		<#assign additionalClass = "additional-search-options hidden-search-option" >
-	</#if>
-	<#return "<label class=\"" + additionalClass + "\" for=\"" + getValueID(filter.id, valueNumber)?html + "\">" + getValueLabel(label, value.count)?html + "</label>" />
-</#function>
+<#macro getLabel valueID value filter additional=false >
+    <#assign label = value.name >
+    <#assign additionalClass = "" >
+    <#if !filter.localizationRequired>
+        <#assign label = value.id >
+    </#if>
+    <#if additional=true>
+        <#assign additionalClass = "additional-search-options hidden-search-option" >
+    </#if>
+
+    <label class="${additionalClass}" for="${getValueID(filter.id, valueNumber)?html}" >${getValueLabel(label, value.count)?html}</label>
+</#macro>
 
 
 <#macro userSelectedInput filter>
-	<#if filter.inputText?has_content>
-		<button form="search-form" type="button" id="button_filter_input_${filter.id?html}" onclick="clearInput('filter_input_${filter.id?js_string?html}')" class="checked-search-input-label">${filter.name?html} : ${filter.inputText?html}</button>
-	</#if>
-	<#assign from = filter.fromYear >
-	<#assign to = filter.toYear >
-	<#if from?has_content && to?has_content >
-		<#assign range = i18n().from + " " + from + " " + i18n().to + " " + to >
-		<button form="search-form" type="button" id="button_filter_range_${filter.id?html}" onclick="clearInput('filter_range_${filter.id?js_string?html}')" class="checked-search-input-label">${filter.name?html} : ${range?html}</button>
-	</#if>
+    <#if filter.inputText?has_content>
+        <button form="search-form" type="button" id="button_filter_input_${filter.id?html}" onclick="clearInput('filter_input_${filter.id?js_string?html}')" class="checked-search-input-label">${filter.name?html} : ${filter.inputText?html}</button>
+    </#if>
+    <#assign from = filter.fromYear >
+    <#assign to = filter.toYear >
+    <#if from?has_content && to?has_content >
+        <#assign range = i18n().from + " " + from + " " + i18n().to + " " + to >
+        <button form="search-form" type="button" id="button_filter_range_${filter.id?html}" onclick="clearInput('filter_range_${filter.id?js_string?html}')" class="checked-search-input-label">${filter.name?html} : ${range?html}</button>
+    </#if>
 </#macro>
 
 <#macro createUserInput filter>
-	<input form="search-form" id="filter_input_${filter.id?html}"  placeholder="${i18n().search_field_placeholder}" class="search-vivo" type="text" name="filter_input_${filter.id?html}" value="${filter.inputText?html}" autocapitalize="none" />
+    <input form="search-form" id="filter_input_${filter.id?html}"  placeholder="${i18n().search_field_placeholder}" class="search-vivo" type="text" name="filter_input_${filter.id?html}" value="${filter.inputText?html}" autocapitalize="none" />
 </#macro>
 
 <#macro getInput filter filterValue valueID valueNumber form="search-form">
-	<#assign checked = "" >
-	<#assign class = "" >
-	<#if filterValue.selected>
-		<#assign checked = " checked=\"checked\" " >
-		<#assign class = "selected-input" >
-	</#if>
-	<#assign type = "checkbox" >
-	<#if !filter.multivalued>
-		<#assign type = "radio" >
-	</#if>
-	<#assign filterName = filter.id >
-	<#if filter.multivalued>
-		<#assign filterName = filterName + "_" + valueNumber >
-	</#if>
+    <#assign checked = "" >
+    <#assign class = "" >
+    <#if filterValue.selected>
+        <#assign checked = " checked=\"checked\" " >
+        <#assign class = "selected-input" >
+    </#if>
+    <#assign type = "checkbox" >
+    <#if !filter.multivalued>
+        <#assign type = "radio" >
+    </#if>
+    <#assign filterName = filter.id >
+    <#if filter.multivalued>
+        <#assign filterName = filterName + "_" + valueNumber >
+    </#if>
 
-	<input 
-		form="${form}" 
-		type="${type}" 
-		id="${valueID?html}" 
-		value="${filter.id?html + ":" + filterValue.id?html}" 
-		name="filters_${valueID?html}" 
-		style="display:none;" 
-		${checked} 
-		class="${class}" 
-	>
+    <input 
+        form="${form}" 
+        type="${type}" 
+        id="${valueID?html}" 
+        value="${filter.id?html + ":" + filterValue.id?html}" 
+        name="filters_${valueID?html}" 
+        style="display:none;" 
+        ${checked} 
+        class="${class}" 
+    >
 </#macro>
 
 <#function getValueID id number>
-	<#return id + "__" + number /> 
+    <#return id + "__" + number /> 
 </#function>
 
 <#function getValueLabel label count >
-	<#assign result = label >
-	${label}
-	<#if count!=0>
-		<#assign result = result + " (" + count + ")" >
-	</#if>
-	<#return result />
+    <#assign result = label >
+    ${label}
+    <#if count!=0>
+        <#assign result = result + " (" + count + ")" >
+    </#if>
+    <#return result />
 </#function>
 <!-- end contentsBrowseGroup -->
 

--- a/webapp/src/main/webapp/templates/freemarker/body/search/search-pagedResults.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/body/search/search-pagedResults.ftl
@@ -226,7 +226,7 @@ ${headScripts.add('<script type="text/javascript" src="${urls.base}/js/bootstrap
 						<#if filters[filterId]??>
 							<#assign f = filters[filterId]>
 							<#if ( user.loggedIn || f.public ) && !f.hidden >
-								<@searchFormFilterTab f assignedActive emptySearch/>  
+								<@searchFormFilterTab f assignedActive/>  
 								<#if !assignedActive && (f.selected || emptySearch )>
 									<#assign assignedActive = true>
 								</#if>
@@ -257,7 +257,7 @@ ${headScripts.add('<script type="text/javascript" src="${urls.base}/js/bootstrap
 		<#assign valueNumber = 1>
 		<#list filter.values?values as v>
 			<#if v.selected>
-				${getInput(filter, v, getValueID(filter.id, valueNumber), valueNumber)}
+				<@getInput filter v getValueID(filter.id, valueNumber) valueNumber />
 				<#if user.loggedIn || filter.public>
 					${getSelectedLabel(valueNumber, v, filter)}
 				</#if>
@@ -315,7 +315,7 @@ ${headScripts.add('<script type="text/javascript" src="${urls.base}/js/bootstrap
 		</li>
 </#macro>
 
-<#macro searchFormFilterTab filter assignedActive isEmptySearch>
+<#macro searchFormFilterTab filter assignedActive>
 	<#if filter.id == "querytext">
 		<#-- skip query text filter -->
 		<#return>
@@ -347,7 +347,7 @@ ${headScripts.add('<script type="text/javascript" src="${urls.base}/js/bootstrap
 							<a class="more-facets-link" href="javascript:void(0);" onclick="expandSearchOptions(this)">${i18n().paging_link_more}</a>
 						</#if>
 						<#if user.loggedIn || v.publiclyAvailable>
-						    ${getInput(filter, v, getValueID(filter.id, valueNumber), valueNumber)}
+						    <@getInput filter v getValueID(filter.id, valueNumber) valueNumber />
 						    ${getLabel(valueNumber, v, filter, additionalLabels)}
 						</#if>
 					</#if>
@@ -425,7 +425,7 @@ ${headScripts.add('<script type="text/javascript" src="${urls.base}/js/bootstrap
 	<input form="search-form" id="filter_input_${filter.id?html}"  placeholder="${i18n().search_field_placeholder}" class="search-vivo" type="text" name="filter_input_${filter.id?html}" value="${filter.inputText?html}" autocapitalize="none" />
 </#macro>
 
-<#function getInput filter filterValue valueID valueNumber>
+<#macro getInput filter filterValue valueID valueNumber form="search-form">
 	<#assign checked = "" >
 	<#assign class = "" >
 	<#if filterValue.selected>
@@ -441,9 +441,17 @@ ${headScripts.add('<script type="text/javascript" src="${urls.base}/js/bootstrap
 		<#assign filterName = filterName + "_" + valueNumber >
 	</#if>
 
-	<#return "<input form=\"search-form\" type=\"" + type + "\" id=\"" + valueID?html + "\"  value=\"" + filter.id?html + ":" + filterValue.id?html 
-		+ "\" name=\"filters_" + valueID?html + "\" style=\"display:none;\" " + checked + "\" class=\"" + class + "\" >" />
-</#function>
+	<input 
+		form="${form}" 
+		type="${type}" 
+		id="${valueID?html}" 
+		value="${filter.id?html + ":" + filterValue.id?html}" 
+		name="filters_${valueID?html}" 
+		style="display:none;" 
+		${checked} 
+		class="${class}" 
+	>
+</#macro>
 
 <#function getValueID id number>
 	<#return id + "__" + number /> 

--- a/webapp/src/main/webapp/templates/freemarker/body/search/search-pagedResults.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/body/search/search-pagedResults.ftl
@@ -35,6 +35,7 @@ ${headScripts.add('<script type="text/javascript" src="${urls.base}/js/wNumb.min
             </li>
         </#list>
     </ul>
+    <input form="search-form" type="hidden" name="lang" value="${locale!}">
 
     <@printPagingLinks />
     <br />

--- a/webapp/src/main/webapp/templates/freemarker/body/search/search-pagedResults.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/body/search/search-pagedResults.ftl
@@ -7,16 +7,19 @@ ${headScripts.add('<script type="text/javascript" src="${urls.base}/webjars/floa
 ${headScripts.add('<script type="text/javascript" src="${urls.base}/webjars/floatingui/floating-ui.dom.umd.js"></script>')}
 ${headScripts.add('<script type="text/javascript" src="${urls.base}/js/tooltip/tooltip-utils.js"></script>')}
 
-${stylesheets.add('<link rel="stylesheet" type="text/css" href="${urls.base}/js/bootstrap/css/bootstrap.min.css"/>')}
-${stylesheets.add('<link rel="stylesheet" type="text/css" href="${urls.base}/js/bootstrap/css/bootstrap-theme.min.css"/>')}
 ${headScripts.add('<script type="text/javascript" src="${urls.base}/js/nouislider.min.js"></script>')}
 ${headScripts.add('<script type="text/javascript" src="${urls.base}/js/wNumb.min.js"></script>')}
-${headScripts.add('<script type="text/javascript" src="${urls.base}/js/bootstrap/js/bootstrap.min.js"></script>')}
 
 <#include "search-lib.ftl">
 
 <script>
 	let searchFormId = "search-form";
+	let urlsBase = "${urls.base}";
+	if (window.location.toString().indexOf("?") == -1){
+		var queryText = 'querytext=${querytext?js_string}';
+	} else {
+		var queryText = window.location.toString().split("?")[1];
+	}
 </script>
 
 <@searchForm  />

--- a/webapp/src/main/webapp/templates/freemarker/edit/forms/pageManagement--browseSearchFilterValues.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/edit/forms/pageManagement--browseSearchFilterValues.ftl
@@ -1,0 +1,41 @@
+<#-- $This file is distributed under the terms of the license in LICENSE$ -->
+<#--Browse Search Filter Values Section-->
+<#-----------Variable assignment-------------->
+<#--Requires Menu action be defined in parent template-->
+
+<#assign searchFilter = pageData.searchFilter />
+<#assign searchFilters = pageData.searchFilters />
+<#-- some additional processing here which shows or hides the class group selection and classes based on initial action-->
+<#assign selectFilterStyle = 'class="hidden"' />
+<#-- Reveal the class group and hide the class selects if adding a new menu item or editing an existing menu item with an empty class group (no classes)-->
+<#-- Menu action needs to be sent from  main template-->
+<#if menuAction == "Add" || !searchFilter?has_content>
+    <#assign selectFilterStyle = " " />
+</#if>
+
+<#--HTML Portion-->
+ <section id="searchFilterValues" class="contentSectionContainer">
+    <section id="selectContentType" name="selectContentType" ${selectFilterStyle} role="region">
+
+        <label for="selectSearchFilter">${i18n().select_search_filter_to_browse}<span class="requiredHint"> *</span></label>
+        <select name="selectSearchFilter" id="selectSearchFilter" role="combobox">
+            <option value="-1" role="option">${i18n().select_one}</option>
+            <#list searchFilters as filter>
+                <option value="${filter.URI}"  role="option">${filter.publicName}</option>
+            </#list>
+        </select>
+    </section>
+    <input  type="button" id="doneWithContent" class="doneWithContent" name="doneWithContent" value="${i18n().save_this_content}" />
+    <#if menuAction == "Add">
+        <span id="cancelContent"> ${i18n().or} <a class="cancel" href="javascript:"  id="cancelContentLink" title="${i18n().cancel_title}">${i18n().cancel_link}</a></span>
+    </#if>
+</section>
+<script>
+    var i18nStringsBrowseSearchFilters = {
+        browseSearchFilter: '${i18n().browse_search_filter_facets?js_string}',
+        allCapitalized: '${i18n().all_capitalized?js_string}',
+        supplySearchFilter: '${i18n().supply_search_filer?js_string}'
+    };
+</script>
+ <#--Include JavaScript specific to the types of data getters related to this content-->
+${scripts.add('<script type="text/javascript" src="${urls.base}/js/menupage/processSearchFilterValuesDataGetterContent.js"></script>')}

--- a/webapp/src/main/webapp/templates/freemarker/edit/forms/pageManagement--contentTemplates.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/edit/forms/pageManagement--contentTemplates.ftl
@@ -4,3 +4,4 @@
 <#include "pageManagement--sparqlQuery.ftl">
 <#include "pageManagement--fixedHtml.ftl">
 <#include "pageManagement--searchIndividuals.ftl">
+<#include "pageManagement--browseSearchFilterValues.ftl">

--- a/webapp/src/main/webapp/templates/freemarker/edit/forms/pageManagement--customDataScript.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/edit/forms/pageManagement--customDataScript.ftl
@@ -30,6 +30,7 @@ scripts list.-->
       dataGetterLabelToURI:{
       		//maps labels to URIs
       		"browseClassGroup": "java:edu.cornell.mannlib.vitro.webapp.utils.dataGetter.ClassGroupPageData",
+		"searchFilterValues": "java:edu.cornell.mannlib.vitro.webapp.utils.dataGetter.SearchFilterValuesDataGetter",
       		"individualsForClasses": "java:edu.cornell.mannlib.vitro.webapp.utils.dataGetter.IndividualsForClassesDataGetter",
       		"sparqlQuery":"java:edu.cornell.mannlib.vitro.webapp.utils.dataGetter.SparqlQueryDataGetter",
       		"fixedHtml":"java:edu.cornell.mannlib.vitro.webapp.utils.dataGetter.FixedHTMLDataGetter",

--- a/webapp/src/main/webapp/templates/freemarker/edit/forms/pageManagement.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/edit/forms/pageManagement.ftl
@@ -79,6 +79,7 @@
             <select id="typeSelect"  name="typeSelect" >
                 <option value="" selected="selected">${i18n().select_type}</option>
                 <option value="browseClassGroup">${i18n().browse_class_group}</option>
+                <option value="searchFilterValues">${i18n().browse_search_filter_facets}</option>
                 <option value="fixedHtml">${i18n().fixed_html}</option>
                 <option value="sparqlQuery">${i18n().sparql_query_results}</option>
                 <option value="searchIndividuals">${i18n().search_individual_results}</option>
@@ -177,6 +178,7 @@
 <script>
     var i18nStrings = {
         browseClassGroup: '${i18n().browse_class_group?js_string}',
+        browseSearchFilterValues: '${i18n().browse_search_filter_facets?js_string}',
         fixedHtml: '${i18n().fixed_html?js_string}',
         sparqlResults: '${i18n().sparql_query_results?js_string}',
         searchIndividuals: '${i18n().search_individual_results?js_string}',

--- a/webapp/src/main/webapp/templates/freemarker/page/partials/identity.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/page/partials/identity.ftl
@@ -29,7 +29,7 @@
 <section id="search" role="region">
     <fieldset>
         <legend>${i18n().search_form}</legend>
-        <form id="search-form" action="${urls.search}" name="search" role="search" accept-charset="UTF-8" method="GET">
+        <form id="search-form" action="${urls.search}" autocomplete="off" name="search" role="search" accept-charset="UTF-8" method="GET">
             <div id="search-field">
                 <input type="text" name="querytext" class="search-vitro" value="${querytext!}" autocapitalize="off" />
                 <input type="submit" value="${i18n().search_button}" class="submit">

--- a/webapp/src/main/webapp/themes/vitro/css/vitroTheme.css
+++ b/webapp/src/main/webapp/themes/vitro/css/vitroTheme.css
@@ -1048,6 +1048,14 @@ ul#find-filters a.selected {
     border-right: 1px dotted #dde4e3;
     font-weight: bold;
 }
+nav#alpha-browse-container {
+    border: 1px solid #dde4e3;
+    background-color: #fff;
+    border-left: 1px solid #dde4e3;
+    border-bottom: none;
+    float: right;
+    margin-right: 17px;
+}
 #profile-photo-display {
     width: 600px;
 }


### PR DESCRIPTION
[VIVO PR](https://github.com/vivo-project/VIVO/pull/4005)
# What does this pull request do?

- new page content type "Browse search filter results" to display search results limited by selected filter. Also additional filters and sort options could be defined in custom page template (template [example](https://github.com/TIBHannover/tib-fis-installer/blob/1.15.1-snapshot/project-installer/webapp/src/main/webapp/templates/freemarker/body/menupage/browsePersonSearchFilterValues.ftl))
- new facet autocomplete input field that appears if number of facets in bigger than more limit defined for the filter
- new property to limit variables of document modifiers to be populated into search indexes

# What's new?
Refactored PagedSearchController. 
Added search filter option to ManagePageGenerator
Refactored ProcessN3GetterDataMap
Created new data getter class display:SearchFilterValuesDataGetter , java implementation in SearchFilterValuesDataGetter.java
Created object property search:direction to configure sort direction of filter values and search results.
Created filters to filter result in alphabetical indexes 
:filter_label_regex - default regex filter that uses i18n field :field_label_display with name locale + _label_display
:filter_raw_label_regex - fallback regex filter that uses nameRaw search field for VIVO instances without i18n support
search:limitDisplayTo object property was created to limit user access to display of search groups, filters, values.
Resolved bug on search page which appears if user select too many filters. In that case search results are empty and selected filter values are not shown on the page, so the user can't unselect them. 
Added options to sort results, number of results on page and "Download results" options on custom pages

Applied changes for search ontology (from [ontology interests group meeting](https://wiki.lyrasis.org/display/VIVO/2025-01-08+Ontology+Interest+Group+Call))
Removed search:isAscending boolean data property,  new object property search:direction should be used instead. 
(search:isAscending is still could be used for backwards compatibility).
Removed search:reverseFacetOrder boolean data property, new object property search:direction should be used instead. 
(search:reverseFacetOrder is still could be used for backwards compatibility).
Renamed search:order integer data property into search:rank, 
(search:order is still could be used for backwards compatibility).
Created class search:SortDirection and two individuals search-ind:ascending and search-ind:descending to be used with search:direction object property.
Added facet autocomplete input field that is being visible in case filter has number of values greater than limit of facets to be shown before "more..." button

# How should this be tested?
How to test new page content type:
* Create a new page in Page management menu. 
* For the content select "Browse search filter results", select a type and save it.
* To select custom template select Template option "Custom template requiring content" and enter filename of custom Freemarker template in input field (Optional).
* Open page, try selecting facets, alphabetical index, pagination
* Test above in VIVO with and without language filtering

How to test facet autocomplete input
* To test facet autocomplete input you would need a filter that doesn't use URIs to store in search index. [An example](https://github.com/litvinovg/VIVO/compare/browse-filter-results...litvinovg:VIVO:facet-autocomplete-test-settings) of modification of organization filter
* Run full search re-index after filter modification.
* You can check how it work on /search page by selecting the filter and entering at least 3 characters in input field. 
* Suggestions should appear. Select a suggestion and page should reload with applied selected facet.
 
# Additional Notes:
Examples of customized [templates](https://github.com/TIBHannover/tib-fis-installer/tree/1.15.1-snapshot/project-installer/webapp/src/main/webapp/templates/freemarker/body/menupage), [document modifiers](https://github.com/TIBHannover/tib-fis-installer/blob/1.15.1-snapshot/project-installer/home/src/main/resources/rdf/display/everytime/searchFieldsConfigurationVivo.n3)
This change require documentation to be updated.

# Interested parties
@hauschke @VIVO-project/vivo-committers

# Reviewers' expertise

Candidates for reviewing this PR should have some of the following expertises:
1. Java
2. JavaScript
3. FreeMarker
4. SPARQL
5. Ontologies
1. Natural language knowledge
    1. English
    2. German
    3. Spanish
    4. French
    5. Portuguese
    6. Russian
    7. Serbian

# Reviewers' report template
**Please update the following template which should be used by reviewers.**
## General comment
A reviewer should provide here comments and suggestions for requested changes if any.
## Testing
A reviewer should briefly describe here how it was tested
## Code reviewing
A reviewer should briefly describe here which part was code reviewed