### PR TITLE
Exclude context path from application generated links

### DIFF
--- a/api/src/main/java/edu/cornell/mannlib/vedit/controller/BaseEditController.java
+++ b/api/src/main/java/edu/cornell/mannlib/vedit/controller/BaseEditController.java
@@ -32,6 +32,7 @@ import edu.cornell.mannlib.vitro.webapp.auth.permissions.PermissionSets;
 import edu.cornell.mannlib.vitro.webapp.auth.policy.EntityPolicyController;
 import edu.cornell.mannlib.vitro.webapp.auth.policy.PolicyLoader;
 import edu.cornell.mannlib.vitro.webapp.beans.PermissionSet;
+import edu.cornell.mannlib.vitro.webapp.config.ContextPath;
 import edu.cornell.mannlib.vitro.webapp.controller.Controllers;
 import edu.cornell.mannlib.vitro.webapp.controller.VitroHttpServlet;
 import edu.cornell.mannlib.vitro.webapp.controller.VitroRequest;
@@ -223,7 +224,7 @@ public class BaseEditController extends VitroHttpServlet {
     }
 
     public String getDefaultLandingPage(HttpServletRequest request) {
-        return (request.getContextPath() + DEFAULT_LANDING_PAGE);
+        return (ContextPath.getPath(request) + DEFAULT_LANDING_PAGE);
     }
 
     protected static void addAccessAttributes(HttpServletRequest req, String entityURI, AccessObjectType aot) {

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/config/ContextPath.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/config/ContextPath.java
@@ -1,0 +1,23 @@
+package edu.cornell.mannlib.vitro.webapp.config;
+
+import javax.servlet.ServletContext;
+import javax.servlet.http.HttpServletRequest;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+public class ContextPath {
+    static final Log log = LogFactory.getLog(ContextPath.class);
+
+    public static String getPath(HttpServletRequest request) {
+        String path = ConfigurationProperties.getInstance().getProperty("context.path");
+        log.debug(String.format("Custom path %s, request path %s", path, request.getContextPath()));
+        return path == null ? request.getContextPath() : path;
+    }
+
+    public static String getPath(ServletContext ctx) {
+        String path = ConfigurationProperties.getInstance().getProperty("context.path");
+        log.debug(String.format("Custom path %s, ctx path %s", path, ctx.getContextPath()));
+        return path == null ? ctx.getContextPath() : path;
+    }
+}

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/config/ContextPath.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/config/ContextPath.java
@@ -7,17 +7,30 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
 public class ContextPath {
+    private static final String CONTEXT_PATH_EXCLUDE = "context.path.exclude";
     static final Log log = LogFactory.getLog(ContextPath.class);
 
     public static String getPath(HttpServletRequest request) {
-        String path = ConfigurationProperties.getInstance().getProperty("context.path");
-        log.debug(String.format("Custom path %s, request path %s", path, request.getContextPath()));
-        return path == null ? request.getContextPath() : path;
+        if (isContextPathExcluded()) {
+            return "";
+        } else {
+            return request.getContextPath();
+        }
     }
 
     public static String getPath(ServletContext ctx) {
-        String path = ConfigurationProperties.getInstance().getProperty("context.path");
-        log.debug(String.format("Custom path %s, ctx path %s", path, ctx.getContextPath()));
-        return path == null ? ctx.getContextPath() : path;
+        if (isContextPathExcluded()) {
+            return "";
+        } else {
+            return ctx.getContextPath();
+        }
+    }
+
+    private static boolean isContextPathExcluded() {
+        String value = ConfigurationProperties.getInstance().getProperty(CONTEXT_PATH_EXCLUDE);
+        if (value == null) {
+            return false;
+        }
+        return Boolean.parseBoolean(value);
     }
 }

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/OntologyController.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/OntologyController.java
@@ -25,6 +25,7 @@ import org.apache.jena.rdf.model.ModelFactory;
 import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.shared.Lock;
 
+import edu.cornell.mannlib.vitro.webapp.config.ContextPath;
 import edu.cornell.mannlib.vitro.webapp.modelaccess.ModelAccess;
 import edu.cornell.mannlib.vitro.webapp.utils.jena.JenaOutputUtils;
 import edu.cornell.mannlib.vitro.webapp.web.ContentType;
@@ -43,7 +44,7 @@ public class OntologyController extends VitroHttpServlet{
 		super.doGet(req, res);
 
         //get URL without hostname or servlet context
-        String url = req.getRequestURI().substring(req.getContextPath().length());
+        String url = req.getRequestURI().substring(ContextPath.getPath(req).length());
 
         String redirectURL = checkForRedirect ( url, req.getHeader("accept") );
 
@@ -216,11 +217,11 @@ public class OntologyController extends VitroHttpServlet{
 	        String hn = req.getHeader("Host");
 	        if (req.isSecure()) {
 	            res.setHeader("Location", res.encodeURL("https://" + hn
-	                    + req.getContextPath() + redirectURL));
+	                    + ContextPath.getPath(req) + redirectURL));
 	            log.info("doRedirect by using HTTPS");
 	        } else {
 	            res.setHeader("Location", res.encodeURL("http://" + hn
-	                    + req.getContextPath() + redirectURL));
+	                    + ContextPath.getPath(req) + redirectURL));
 	            log.info("doRedirect by using HTTP");
 	        }
 	       res.setStatus(res.SC_SEE_OTHER);

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/VitroHttpServlet.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/VitroHttpServlet.java
@@ -30,6 +30,7 @@ import edu.cornell.mannlib.vitro.webapp.auth.policy.PolicyHelper;
 import edu.cornell.mannlib.vitro.webapp.auth.requestedAction.AuthorizationRequest;
 import edu.cornell.mannlib.vitro.webapp.beans.DisplayMessage;
 import edu.cornell.mannlib.vitro.webapp.beans.ResourceBean;
+import edu.cornell.mannlib.vitro.webapp.config.ContextPath;
 import edu.cornell.mannlib.vitro.webapp.controller.authenticate.LogoutRedirector;
 import edu.cornell.mannlib.vitro.webapp.controller.freemarker.UrlBuilder;
 import edu.cornell.mannlib.vitro.webapp.i18n.I18n;
@@ -155,7 +156,7 @@ public class VitroHttpServlet extends HttpServlet implements MultipartRequestWra
 		try {
 			DisplayMessage.setMessage(request,
 					I18n.bundle(request).text("insufficient_authorization"));
-			response.sendRedirect(request.getContextPath());
+			response.sendRedirect(ContextPath.getPath(request));
 		} catch (IOException e) {
 			log.error("Could not redirect to show insufficient authorization.");
 		}
@@ -196,7 +197,7 @@ public class VitroHttpServlet extends HttpServlet implements MultipartRequestWra
 		} catch (UnsupportedEncodingException e) {
 			log.error("Really? No UTF-8 encoding?", e);
 		}
-		return request.getContextPath() + Controllers.AUTHENTICATE
+		return ContextPath.getPath(request) + Controllers.AUTHENTICATE
 				+ "?afterLogin=" + encodedAfterLoginUrl;
 	}
 

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/accounts/user/UserAccountsUserController.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/accounts/user/UserAccountsUserController.java
@@ -14,6 +14,7 @@ import edu.cornell.mannlib.vitro.webapp.auth.requestedAction.AuthorizationReques
 import edu.cornell.mannlib.vitro.webapp.auth.permissions.SimplePermission;
 import edu.cornell.mannlib.vitro.webapp.beans.DisplayMessage;
 import edu.cornell.mannlib.vitro.webapp.beans.UserAccount;
+import edu.cornell.mannlib.vitro.webapp.config.ContextPath;
 import edu.cornell.mannlib.vitro.webapp.controller.VitroRequest;
 import edu.cornell.mannlib.vitro.webapp.controller.authenticate.Authenticator;
 import edu.cornell.mannlib.vitro.webapp.controller.authenticate.Authenticator.LoginNotPermitted;
@@ -151,14 +152,15 @@ public class UserAccountsUserController extends FreemarkerHttpServlet {
 	 * Bridge the gap.
 	 */
 	private String stripContextPath(VitroRequest vreq, String uri) {
-		if ((uri == null) || uri.isEmpty() || uri.equals(vreq.getContextPath())) {
+		String contextPath = ContextPath.getPath(vreq);
+        if ((uri == null) || uri.isEmpty() || uri.equals(contextPath)) {
 			return "/";
 		}
 		if (uri.contains("://")) {
 			return uri;
 		}
-		if (uri.startsWith(vreq.getContextPath() + '/')) {
-			return uri.substring(vreq.getContextPath().length());
+		if (uri.startsWith(contextPath + '/')) {
+			return uri.substring(contextPath.length());
 		}
 		return uri;
 	}

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/admin/StartupStatusController.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/admin/StartupStatusController.java
@@ -7,6 +7,7 @@ import java.util.Map;
 
 import edu.cornell.mannlib.vitro.webapp.auth.permissions.SimplePermission;
 import edu.cornell.mannlib.vitro.webapp.auth.requestedAction.AuthorizationRequest;
+import edu.cornell.mannlib.vitro.webapp.config.ContextPath;
 import edu.cornell.mannlib.vitro.webapp.controller.VitroRequest;
 import edu.cornell.mannlib.vitro.webapp.controller.freemarker.FreemarkerHttpServlet;
 import edu.cornell.mannlib.vitro.webapp.controller.freemarker.responsevalues.ResponseValues;
@@ -40,7 +41,7 @@ public class StartupStatusController extends FreemarkerHttpServlet {
 	}
 
 	private String getContextPath() {
-		String cp = getServletContext().getContextPath();
+		String cp = ContextPath.getPath(getServletContext());
 		if ((cp == null) || cp.isEmpty()) {
 			return "The application";
 		} else {

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/authenticate/BaseLoginServlet.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/authenticate/BaseLoginServlet.java
@@ -10,7 +10,7 @@ import javax.servlet.http.HttpServletResponse;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-
+import edu.cornell.mannlib.vitro.webapp.config.ContextPath;
 import edu.cornell.mannlib.vitro.webapp.controller.login.LoginProcessBean;
 import edu.cornell.mannlib.vitro.webapp.controller.login.LoginProcessBean.MLevel;
 import edu.cornell.mannlib.vitro.webapp.controller.login.LoginProcessBean.Message;
@@ -66,6 +66,6 @@ public class BaseLoginServlet extends HttpServlet {
 		String uri = req.getRequestURI();
 		int authLength = url.length() - uri.length();
 		String auth = url.substring(0, authLength);
-		return auth + req.getContextPath();
+		return auth + ContextPath.getPath(req);
 	}
 }

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/authenticate/ForgotPasswordController.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/authenticate/ForgotPasswordController.java
@@ -21,6 +21,7 @@ import edu.cornell.mannlib.vitro.webapp.beans.CaptchaImplementation;
 import edu.cornell.mannlib.vitro.webapp.beans.CaptchaServiceBean;
 import edu.cornell.mannlib.vitro.webapp.beans.UserAccount;
 import edu.cornell.mannlib.vitro.webapp.config.ConfigurationProperties;
+import edu.cornell.mannlib.vitro.webapp.config.ContextPath;
 import edu.cornell.mannlib.vitro.webapp.controller.VitroRequest;
 import edu.cornell.mannlib.vitro.webapp.controller.freemarker.FreemarkerHttpServlet;
 import edu.cornell.mannlib.vitro.webapp.controller.freemarker.UrlBuilder;
@@ -224,7 +225,7 @@ public class ForgotPasswordController extends FreemarkerHttpServlet {
 
         dataContext.put("forgotPasswordUrl", getForgotPasswordUrl(vreq));
         dataContext.put("contactUrl", getContactUrl(vreq));
-        dataContext.put("contextPath", vreq.getContextPath());
+        dataContext.put("contextPath", ContextPath.getPath(vreq));
         dataContext.put("emailConfigured", FreemarkerEmailFactory.isConfigured(vreq));
         dataContext.put("emailValue", "");
         dataContext.put("contactEmailConfigured", StringUtils.isNotBlank(appBean.getContactMail()));
@@ -355,7 +356,7 @@ public class ForgotPasswordController extends FreemarkerHttpServlet {
      * @return The URL for the "Forgot Password" page as a string.
      */
     private String getForgotPasswordUrl(VitroRequest request) {
-        String contextPath = request.getContextPath();
+        String contextPath = ContextPath.getPath(request);
         return contextPath + "/forgotPassword";
     }
 
@@ -366,7 +367,7 @@ public class ForgotPasswordController extends FreemarkerHttpServlet {
      * @return The URL for the "Contact" page as a string.
      */
     private String getContactUrl(VitroRequest request) {
-        String contextPath = request.getContextPath();
+        String contextPath = ContextPath.getPath(request);
         return contextPath + "/contact";
     }
 

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/authenticate/LoginRedirector.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/authenticate/LoginRedirector.java
@@ -20,6 +20,7 @@ import edu.cornell.mannlib.vitro.webapp.auth.permissions.SimplePermission;
 import edu.cornell.mannlib.vitro.webapp.auth.policy.PolicyHelper;
 import edu.cornell.mannlib.vitro.webapp.beans.DisplayMessage;
 import edu.cornell.mannlib.vitro.webapp.beans.UserAccount;
+import edu.cornell.mannlib.vitro.webapp.config.ContextPath;
 import edu.cornell.mannlib.vitro.webapp.controller.Controllers;
 import edu.cornell.mannlib.vitro.webapp.i18n.I18n;
 import edu.cornell.mannlib.vitro.webapp.i18n.I18nBundle;
@@ -157,12 +158,12 @@ public class LoginRedirector {
 	}
 
 	private boolean isLoginPage(String page) {
-		return ((page != null) && page.endsWith(request.getContextPath()
+		return ((page != null) && page.endsWith(ContextPath.getPath(request)
 				+ Controllers.LOGIN));
 	}
 
 	private String getSiteAdminPageUrl() {
-		String contextPath = request.getContextPath();
+		String contextPath = ContextPath.getPath(request);
 		return contextPath + Controllers.SITE_ADMIN;
 	}
 
@@ -172,7 +173,7 @@ public class LoginRedirector {
 
 	private String getAssociatedIndividualHomePage() {
 		try {
-			return request.getContextPath() + "/individual?uri="
+			return ContextPath.getPath(request) + "/individual?uri="
 					+ URLEncoder.encode(uriOfAssociatedIndividual, "UTF-8");
 		} catch (UnsupportedEncodingException e) {
 			throw new IllegalStateException("No UTF-8 encoding? Really?", e);
@@ -180,7 +181,7 @@ public class LoginRedirector {
 	}
 
 	private String getApplicationHomePageUrl() {
-		String contextPath = request.getContextPath();
+		String contextPath = ContextPath.getPath(request);
 		if (contextPath.equals("")) {
 			return "/";
 		}

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/authenticate/LogoutRedirector.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/authenticate/LogoutRedirector.java
@@ -10,6 +10,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
 
+import edu.cornell.mannlib.vitro.webapp.config.ContextPath;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
@@ -34,7 +35,7 @@ public class LogoutRedirector {
 		if ((referringUri == null)
 				|| (getRestrictedPageUris(request).contains(referringUri))) {
 			log.debug("Sending to home page.");
-			return request.getContextPath();
+			return ContextPath.getPath(request);
 		} else {
 			log.debug("Sending back to referring page.");
 			return referrer;
@@ -43,7 +44,7 @@ public class LogoutRedirector {
 
 	private static String figureUriFromUrl(HttpServletRequest request,
 			String referrer) {
-		String postContext = breakBeforeContextPath(request.getContextPath(),
+		String postContext = breakBeforeContextPath(ContextPath.getPath(request),
 				referrer);
 		String uri = removeQueryString(postContext);
 		log.debug("referrer='" + referrer + "', uri='" + uri + "'");

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/datatools/dumprestore/DumpModelsAction.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/datatools/dumprestore/DumpModelsAction.java
@@ -12,7 +12,7 @@ import javax.servlet.http.HttpServletResponse;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-
+import edu.cornell.mannlib.vitro.webapp.config.ContextPath;
 import edu.cornell.mannlib.vitro.webapp.controller.datatools.dumprestore.DumpRestoreController.BadRequestException;
 import edu.cornell.mannlib.vitro.webapp.modelaccess.ModelAccess.WhichService;
 import edu.cornell.mannlib.vitro.webapp.rdfservice.RDFService;
@@ -46,7 +46,7 @@ class DumpModelsAction extends AbstractDumpRestoreAction {
 
 	void redirectToFilename() throws IOException {
 		String filename = which + N_QUADS_EXTENSION;
-		String urlPath = req.getContextPath() + req.getServletPath()
+		String urlPath = ContextPath.getPath(req) + req.getServletPath()
 				+ ACTION_DUMP;
 		resp.sendRedirect(urlPath + "/" + filename + "?" + queryString);
 	}

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/edit/Authenticate.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/edit/Authenticate.java
@@ -32,6 +32,7 @@ import edu.cornell.mannlib.vedit.beans.LoginStatusBean;
 import edu.cornell.mannlib.vedit.beans.LoginStatusBean.AuthenticationSource;
 import edu.cornell.mannlib.vitro.webapp.auth.checks.UserOnThread;
 import edu.cornell.mannlib.vitro.webapp.beans.UserAccount;
+import edu.cornell.mannlib.vitro.webapp.config.ContextPath;
 import edu.cornell.mannlib.vitro.webapp.controller.Controllers;
 import edu.cornell.mannlib.vitro.webapp.controller.VitroHttpServlet;
 import edu.cornell.mannlib.vitro.webapp.controller.VitroRequest;
@@ -193,10 +194,10 @@ public class Authenticate extends VitroHttpServlet {
 
 		if (afterLoginUrl != null) {
 			bean.setAfterLoginUrl(afterLoginUrl);
-			bean.setLoginPageUrl(request.getContextPath() + Controllers.LOGIN);
+			bean.setLoginPageUrl(ContextPath.getPath(request) + Controllers.LOGIN);
 		} else if (doReturn) {
 			bean.setAfterLoginUrl(referrer);
-			bean.setLoginPageUrl(request.getContextPath() + Controllers.LOGIN);
+			bean.setLoginPageUrl(ContextPath.getPath(request) + Controllers.LOGIN);
 		} else {
 			bean.setAfterLoginUrl(referrer);
 			bean.setLoginPageUrl(referrer);
@@ -231,7 +232,7 @@ public class Authenticate extends VitroHttpServlet {
 		if (referrer != null) {
 			return referrer;
 		} else {
-			return request.getContextPath() + Controllers.LOGIN;
+			return ContextPath.getPath(request) + Controllers.LOGIN;
 		}
 	}
 

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/edit/DeletePageController.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/edit/DeletePageController.java
@@ -25,6 +25,7 @@ import org.apache.jena.rdf.model.StmtIterator;
 import org.apache.jena.shared.Lock;
 
 import edu.cornell.mannlib.vitro.webapp.auth.permissions.SimplePermission;
+import edu.cornell.mannlib.vitro.webapp.config.ContextPath;
 import edu.cornell.mannlib.vitro.webapp.controller.VitroHttpServlet;
 import edu.cornell.mannlib.vitro.webapp.controller.VitroRequest;
 import edu.cornell.mannlib.vitro.webapp.dao.DisplayVocabulary;
@@ -50,7 +51,7 @@ public class DeletePageController extends VitroHttpServlet {
      	if(pageUri != null) {
     		doDeletePage(pageUri, vreq, resp);
     	}
-		resp.sendRedirect(rawRequest.getContextPath() + REDIRECT_URL);
+		resp.sendRedirect(ContextPath.getPath(rawRequest) + REDIRECT_URL);
     }
 
     protected void doGet(HttpServletRequest rawRequest, HttpServletResponse resp)  throws ServletException, IOException {

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/edit/EntityRetryController.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/edit/EntityRetryController.java
@@ -46,6 +46,7 @@ import edu.cornell.mannlib.vitro.webapp.beans.Individual;
 import edu.cornell.mannlib.vitro.webapp.beans.IndividualImpl;
 import edu.cornell.mannlib.vitro.webapp.beans.VClass;
 import edu.cornell.mannlib.vitro.webapp.beans.VClassGroup;
+import edu.cornell.mannlib.vitro.webapp.config.ContextPath;
 import edu.cornell.mannlib.vitro.webapp.controller.Controllers;
 import edu.cornell.mannlib.vitro.webapp.controller.VitroRequest;
 import edu.cornell.mannlib.vitro.webapp.dao.DataPropertyDao;
@@ -68,7 +69,7 @@ public class EntityRetryController extends BaseEditController {
         }
 
         VitroRequest vreq = new VitroRequest(request);
-        String siteAdminUrl = vreq.getContextPath() + Controllers.SITE_ADMIN;
+        String siteAdminUrl = ContextPath.getPath(vreq) + Controllers.SITE_ADMIN;
 
         //create an EditProcessObject for this and put it in the session
         EditProcessObject epo = super.createEpo(request);
@@ -332,7 +333,7 @@ public class EntityRetryController extends BaseEditController {
                 }
             } else {
                 try {
-                	String siteAdminUrl = request.getContextPath() + Controllers.SITE_ADMIN;
+                	String siteAdminUrl = ContextPath.getPath(request) + Controllers.SITE_ADMIN;
                     response.sendRedirect(siteAdminUrl);
                 } catch (IOException e) {
                     log.error("EntityInsertPageForwarder could not redirect to about page.");

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/edit/MenuManagementEdit.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/edit/MenuManagementEdit.java
@@ -25,6 +25,7 @@ import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.rdf.model.ResourceFactory;
 import org.apache.jena.shared.Lock;
 import edu.cornell.mannlib.vitro.webapp.auth.checks.UserOnThread;
+import edu.cornell.mannlib.vitro.webapp.config.ContextPath;
 import edu.cornell.mannlib.vitro.webapp.controller.VitroHttpServlet;
 import edu.cornell.mannlib.vitro.webapp.controller.VitroRequest;
 import edu.cornell.mannlib.vitro.webapp.dao.DisplayVocabulary;
@@ -59,7 +60,7 @@ public class MenuManagementEdit extends VitroHttpServlet {
     	}
         //Need to redirect correctly
     	if(!isReorder(command)){
-    		resp.sendRedirect(rawRequest.getContextPath() + REDIRECT_URL);
+    		resp.sendRedirect(ContextPath.getPath(rawRequest) + REDIRECT_URL);
     	}
     }
 

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/edit/OntologyEditController.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/edit/OntologyEditController.java
@@ -20,6 +20,7 @@ import edu.cornell.mannlib.vedit.beans.Option;
 import edu.cornell.mannlib.vedit.controller.BaseEditController;
 import edu.cornell.mannlib.vitro.webapp.auth.permissions.SimplePermission;
 import edu.cornell.mannlib.vitro.webapp.beans.Ontology;
+import edu.cornell.mannlib.vitro.webapp.config.ContextPath;
 import edu.cornell.mannlib.vitro.webapp.controller.Controllers;
 import edu.cornell.mannlib.vitro.webapp.controller.VitroRequest;
 import edu.cornell.mannlib.vitro.webapp.dao.OntologyDao;
@@ -84,7 +85,7 @@ public class OntologyEditController extends BaseEditController {
         // See OntologyDaoJena.ontologyFromOntologyResource() comments
         String realURI = OntologyDaoJena.adjustOntologyURI(o.getURI());
         request.setAttribute("realURI", realURI);
-        request.setAttribute("exportURL", request.getContextPath() + Controllers.EXPORT_RDF);
+        request.setAttribute("exportURL", ContextPath.getPath(request) + Controllers.EXPORT_RDF);
 
         request.setAttribute("epoKey",epo.getKey());
         request.setAttribute("title","Ontology Control Panel");

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/freemarker/ContactFormController.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/freemarker/ContactFormController.java
@@ -10,6 +10,8 @@ import javax.servlet.annotation.WebServlet;
 
 import edu.cornell.mannlib.vitro.webapp.beans.ApplicationBean;
 import edu.cornell.mannlib.vitro.webapp.beans.CaptchaServiceBean;
+import edu.cornell.mannlib.vitro.webapp.config.ConfigurationProperties;
+import edu.cornell.mannlib.vitro.webapp.config.ContextPath;
 import edu.cornell.mannlib.vitro.webapp.controller.VitroRequest;
 import edu.cornell.mannlib.vitro.webapp.controller.freemarker.responsevalues.ResponseValues;
 import edu.cornell.mannlib.vitro.webapp.controller.freemarker.responsevalues.TemplateResponseValues;
@@ -61,7 +63,7 @@ public class ContactFormController extends FreemarkerHttpServlet {
         else {
             CaptchaServiceBean.addCaptchaRelatedFieldsToPageContext(body);
 
-            body.put("contextPath", vreq.getContextPath());
+            body.put("contextPath", ContextPath.getPath(vreq));
             body.put("formAction", "submitFeedback");
 
             if (vreq.getHeader("Referer") == null) {

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/freemarker/ContactFormController.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/freemarker/ContactFormController.java
@@ -10,7 +10,6 @@ import javax.servlet.annotation.WebServlet;
 
 import edu.cornell.mannlib.vitro.webapp.beans.ApplicationBean;
 import edu.cornell.mannlib.vitro.webapp.beans.CaptchaServiceBean;
-import edu.cornell.mannlib.vitro.webapp.config.ConfigurationProperties;
 import edu.cornell.mannlib.vitro.webapp.config.ContextPath;
 import edu.cornell.mannlib.vitro.webapp.controller.VitroRequest;
 import edu.cornell.mannlib.vitro.webapp.controller.freemarker.responsevalues.ResponseValues;

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/freemarker/ContactMailController.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/freemarker/ContactMailController.java
@@ -30,6 +30,7 @@ import edu.cornell.mannlib.vitro.webapp.application.ApplicationUtils;
 import edu.cornell.mannlib.vitro.webapp.beans.ApplicationBean;
 import edu.cornell.mannlib.vitro.webapp.beans.CaptchaImplementation;
 import edu.cornell.mannlib.vitro.webapp.beans.CaptchaServiceBean;
+import edu.cornell.mannlib.vitro.webapp.config.ContextPath;
 import edu.cornell.mannlib.vitro.webapp.controller.VitroRequest;
 import edu.cornell.mannlib.vitro.webapp.controller.freemarker.TemplateProcessingHelper.TemplateProcessingException;
 import edu.cornell.mannlib.vitro.webapp.controller.freemarker.responsevalues.ResponseValues;
@@ -102,7 +103,7 @@ public class ContactMailController extends FreemarkerHttpServlet {
         String errorMsg = validateInput(webusername, webuseremail, comments, captchaInput, captchaId, vreq);
 
         if (errorMsg != null) {
-            return errorParametersNotValid(errorMsg, webusername, webuseremail, comments, vreq.getContextPath());
+            return errorParametersNotValid(errorMsg, webusername, webuseremail, comments, ContextPath.getPath(vreq));
         }
 
         String spamReason = checkForSpam(comments, formType);

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/freemarker/FreemarkerHttpServlet.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/freemarker/FreemarkerHttpServlet.java
@@ -26,6 +26,7 @@ import edu.cornell.mannlib.vitro.webapp.auth.policy.PolicyHelper;
 import edu.cornell.mannlib.vitro.webapp.auth.requestedAction.AuthorizationRequest;
 import edu.cornell.mannlib.vitro.webapp.beans.ApplicationBean;
 import edu.cornell.mannlib.vitro.webapp.beans.DisplayMessage;
+import edu.cornell.mannlib.vitro.webapp.config.ContextPath;
 import edu.cornell.mannlib.vitro.webapp.controller.VitroHttpServlet;
 import edu.cornell.mannlib.vitro.webapp.controller.VitroRequest;
 import edu.cornell.mannlib.vitro.webapp.controller.freemarker.TemplateProcessingHelper.TemplateProcessingException;
@@ -487,7 +488,7 @@ public class FreemarkerHttpServlet extends VitroHttpServlet  {
     }
 
     protected MainMenu getDisplayModelMenu(VitroRequest vreq){
-        String url = vreq.getRequestURI().substring(vreq.getContextPath().length());
+        String url = vreq.getRequestURI().substring(ContextPath.getPath(vreq).length());
         return vreq.getWebappDaoFactory().getMenuDao().getMainMenu(url);
     }
 

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/freemarker/FreemarkerSetup.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/freemarker/FreemarkerSetup.java
@@ -6,6 +6,7 @@ import javax.servlet.ServletContext;
 import javax.servlet.ServletContextEvent;
 import javax.servlet.ServletContextListener;
 
+import edu.cornell.mannlib.vitro.webapp.config.ContextPath;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
@@ -17,7 +18,7 @@ public class FreemarkerSetup implements ServletContextListener {
 	public void contextInitialized(ServletContextEvent event) {
 		ServletContext sc = event.getServletContext();
         FreemarkerComponentGenerator.setServletContext(sc);
-		UrlBuilder.contextPath = sc.getContextPath();
+		UrlBuilder.contextPath = ContextPath.getPath(sc);
 
 		log.info("Freemarker templating system initialized.");
 	}

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/grefine/JSONReconcileServlet.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/grefine/JSONReconcileServlet.java
@@ -28,6 +28,7 @@ import org.apache.commons.logging.LogFactory;
 
 import edu.cornell.mannlib.vitro.webapp.application.ApplicationUtils;
 import edu.cornell.mannlib.vitro.webapp.config.ConfigurationProperties;
+import edu.cornell.mannlib.vitro.webapp.config.ContextPath;
 import edu.cornell.mannlib.vitro.webapp.controller.VitroHttpServlet;
 import edu.cornell.mannlib.vitro.webapp.controller.VitroRequest;
 import edu.cornell.mannlib.vitro.webapp.modules.searchEngine.SearchEngine;
@@ -203,8 +204,8 @@ public class JSONReconcileServlet extends VitroHttpServlet {
 		if (serverPort == 8080) {
 			urlBuf.append(":").append(serverPort);
 		}
-		if (req.getContextPath() != null) {
-			urlBuf.append(req.getContextPath());
+		if (ContextPath.getPath(req) != null) {
+			urlBuf.append(ContextPath.getPath(req));
 		}
 		viewJson.put("url", urlBuf.toString() + "/individual?uri={{id}}");
 		json.put("view", viewJson);

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/individual/IndividualRequestAnalyzer.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/individual/IndividualRequestAnalyzer.java
@@ -16,6 +16,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
 import edu.cornell.mannlib.vitro.webapp.beans.Individual;
+import edu.cornell.mannlib.vitro.webapp.config.ContextPath;
 import edu.cornell.mannlib.vitro.webapp.controller.VitroRequest;
 import edu.cornell.mannlib.vitro.webapp.web.ContentType;
 
@@ -42,8 +43,7 @@ public class IndividualRequestAnalyzer {
 		this.vreq = vreq;
 
 		// get URL without hostname or servlet context
-		this.url = vreq.getRequestURI().substring(
-				vreq.getContextPath().length());
+		this.url = vreq.getRequestURI().substring(ContextPath.getPath(vreq).length());
 
 		this.analysisContext = analysisContext;
 	}

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/VTwo/EditConfigurationUtils.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/VTwo/EditConfigurationUtils.java
@@ -22,6 +22,7 @@ import edu.cornell.mannlib.vitro.webapp.beans.DataPropertyStatement;
 import edu.cornell.mannlib.vitro.webapp.beans.Individual;
 import edu.cornell.mannlib.vitro.webapp.beans.ObjectProperty;
 import edu.cornell.mannlib.vitro.webapp.beans.VClass;
+import edu.cornell.mannlib.vitro.webapp.config.ContextPath;
 import edu.cornell.mannlib.vitro.webapp.controller.VitroRequest;
 import edu.cornell.mannlib.vitro.webapp.dao.VitroVocabulary;
 import edu.cornell.mannlib.vitro.webapp.dao.WebappDaoFactory;
@@ -172,7 +173,7 @@ public class EditConfigurationUtils {
     }
 
     public static String getEditUrl(VitroRequest vreq) {
-    	return vreq.getContextPath() + getEditUrlWithoutContext(vreq);
+    	return ContextPath.getPath(vreq) + getEditUrlWithoutContext(vreq);
     }
 
     public static String getEditUrlWithoutContext(VitroRequest vreq) {
@@ -180,7 +181,7 @@ public class EditConfigurationUtils {
     }
 
     public static String getCancelUrlBase(VitroRequest vreq) {
-    	 return vreq.getContextPath() + "/postEditCleanupController";
+    	 return ContextPath.getPath(vreq) + "/postEditCleanupController";
     }
 
 

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/controller/EditRequestDispatchController.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/controller/EditRequestDispatchController.java
@@ -29,6 +29,7 @@ import edu.cornell.mannlib.vitro.webapp.beans.DataProperty;
 import edu.cornell.mannlib.vitro.webapp.beans.FauxProperty;
 import edu.cornell.mannlib.vitro.webapp.beans.Individual;
 import edu.cornell.mannlib.vitro.webapp.beans.Property;
+import edu.cornell.mannlib.vitro.webapp.config.ContextPath;
 import edu.cornell.mannlib.vitro.webapp.controller.VitroRequest;
 import edu.cornell.mannlib.vitro.webapp.controller.freemarker.FreemarkerHttpServlet;
 import edu.cornell.mannlib.vitro.webapp.controller.freemarker.UrlBuilder;
@@ -505,7 +506,7 @@ public class EditRequestDispatchController extends FreemarkerHttpServlet {
 
     //Get submission url
     private String getSubmissionUrl(VitroRequest vreq) {
-    	return vreq.getContextPath() + "/edit/process";
+    	return ContextPath.getPath(vreq) + "/edit/process";
     }
 
 

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/filters/StartupStatusDisplayFilter.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/filters/StartupStatusDisplayFilter.java
@@ -22,6 +22,7 @@ import javax.servlet.http.HttpServletResponse;
 import org.apache.commons.lang3.StringUtils;
 
 import edu.cornell.mannlib.vitro.webapp.beans.ApplicationBean;
+import edu.cornell.mannlib.vitro.webapp.config.ContextPath;
 import edu.cornell.mannlib.vitro.webapp.dao.WebappDaoFactory;
 import edu.cornell.mannlib.vitro.webapp.modelaccess.ModelAccess;
 import edu.cornell.mannlib.vitro.webapp.startup.StartupStatus;
@@ -107,7 +108,7 @@ public class StartupStatusDisplayFilter implements Filter {
 	}
 
 	private String getContextPath() {
-		String cp = ctx.getContextPath();
+		String cp = ContextPath.getPath(ctx);
 		if ((cp == null) || cp.isEmpty()) {
 			return "The application";
 		} else {

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/filters/URLRewritingHttpServletResponse.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/filters/URLRewritingHttpServletResponse.java
@@ -5,21 +5,19 @@ package edu.cornell.mannlib.vitro.webapp.filters;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
-import java.util.regex.Pattern;
 
 import javax.servlet.ServletContext;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpServletResponseWrapper;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
-
 import edu.cornell.mannlib.vitro.webapp.beans.IndividualImpl;
 import edu.cornell.mannlib.vitro.webapp.dao.WebappDaoFactory;
 import edu.cornell.mannlib.vitro.webapp.modelaccess.ModelAccess;
 import edu.cornell.mannlib.vitro.webapp.utils.NamespaceMapper;
 import edu.cornell.mannlib.vitro.webapp.utils.NamespaceMapperFactory;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 
 public class URLRewritingHttpServletResponse extends HttpServletResponseWrapper/*implements HttpServletResponse */{
 
@@ -28,15 +26,12 @@ public class URLRewritingHttpServletResponse extends HttpServletResponseWrapper/
 	private HttpServletResponse _response;
 	private ServletContext _context;
 	private WebappDaoFactory wadf;
-	private int contextPathDepth;
-	private Pattern slashPattern = Pattern.compile("/");
 
 	public URLRewritingHttpServletResponse(HttpServletResponse response, HttpServletRequest request, ServletContext context) {
 	    super(response);
 		this._response = response;
 		this._context = context;
-		this.wadf =	ModelAccess.on(context).getWebappDaoFactory();
-		this.contextPathDepth = slashPattern.split(request.getContextPath()).length-1;
+		this.wadf =	ModelAccess.getInstance().getWebappDaoFactory();
 	}
 
 	/** for testing. */
@@ -69,7 +64,6 @@ public class URLRewritingHttpServletResponse extends HttpServletResponseWrapper/
         if( log.isDebugEnabled() ){
             log.debug("START");
             log.debug("charEncoding: "  + this.getCharacterEncoding() );
-            log.debug("contextPathDepth," + contextPathDepth);
             log.debug("nsMap," + nsMap);
             log.debug("wadf.getDefaultNamespace(), " + wadf.getDefaultNamespace());
             log.debug("externallyLinkedNamespaces " + externallyLinkedNamespaces);
@@ -80,7 +74,6 @@ public class URLRewritingHttpServletResponse extends HttpServletResponseWrapper/
 	            inUrl,
 	            this.getCharacterEncoding(),
 	            /*wadf.getPortalDao().isSinglePortal()*/ true,
-	            contextPathDepth,
 	            nsMap,
 	            wadf.getDefaultNamespace(),
 	            externallyLinkedNamespaces
@@ -100,7 +93,6 @@ public class URLRewritingHttpServletResponse extends HttpServletResponseWrapper/
 	        String inUrl,
 	        String characterEncoding,
 	        Boolean isSInglePortal,
-	        int contextPathDepth,
 	        NamespaceMapper nsMap,
 	        String defaultNamespace,
 	        List<String> externalNamespaces) {

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/freemarker/config/FreemarkerConfigurationImpl.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/freemarker/config/FreemarkerConfigurationImpl.java
@@ -22,6 +22,8 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
 import edu.cornell.mannlib.vitro.webapp.beans.ApplicationBean;
+import edu.cornell.mannlib.vitro.webapp.config.ConfigurationProperties;
+import edu.cornell.mannlib.vitro.webapp.config.ContextPath;
 import edu.cornell.mannlib.vitro.webapp.controller.VitroRequest;
 import edu.cornell.mannlib.vitro.webapp.controller.freemarker.UrlBuilder;
 import edu.cornell.mannlib.vitro.webapp.controller.freemarker.UrlBuilder.Route;
@@ -300,7 +302,7 @@ public class FreemarkerConfigurationImpl extends Configuration {
 			Map<String, String> urls = new HashMap<String, String>();
 
 			// Templates use this to construct urls.
-			urls.put("base", ctx.getContextPath());
+			urls.put("base", ContextPath.getPath(ctx));
 			urls.put("home", UrlBuilder.getHomeUrl());
 			urls.put("about", UrlBuilder.getUrl(Route.ABOUT));
 			urls.put("search", UrlBuilder.getUrl(Route.SEARCH));

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/freemarker/config/FreemarkerConfigurationImpl.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/freemarker/config/FreemarkerConfigurationImpl.java
@@ -22,7 +22,6 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
 import edu.cornell.mannlib.vitro.webapp.beans.ApplicationBean;
-import edu.cornell.mannlib.vitro.webapp.config.ConfigurationProperties;
 import edu.cornell.mannlib.vitro.webapp.config.ContextPath;
 import edu.cornell.mannlib.vitro.webapp.controller.VitroRequest;
 import edu.cornell.mannlib.vitro.webapp.controller.freemarker.UrlBuilder;

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/searchengine/solr/SolrSearchEngine.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/searchengine/solr/SolrSearchEngine.java
@@ -20,6 +20,7 @@ import org.apache.solr.client.solrj.impl.HttpSolrClient;
 import org.apache.solr.client.solrj.response.QueryResponse;
 
 import edu.cornell.mannlib.vitro.webapp.config.ConfigurationProperties;
+import edu.cornell.mannlib.vitro.webapp.config.ContextPath;
 import edu.cornell.mannlib.vitro.webapp.modules.Application;
 import edu.cornell.mannlib.vitro.webapp.modules.ComponentStartupStatus;
 import edu.cornell.mannlib.vitro.webapp.modules.searchEngine.SearchEngine;
@@ -51,7 +52,7 @@ public class SolrSearchEngine implements SearchEngine {
 					+ "runtime.properties.  Vitro application needs the URL of "
 					+ "a solr server that it can use to index its data. It "
 					+ "should be something like http://localhost:${port}"
-					+ ctx.getContextPath() + "solr");
+					+ ContextPath.getPath(ctx) + "solr");
 			return;
 		}
 

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/web/templatemodels/edit/EditConfigurationTemplateModel.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/web/templatemodels/edit/EditConfigurationTemplateModel.java
@@ -26,6 +26,7 @@ import edu.cornell.mannlib.vitro.webapp.beans.Individual;
 import edu.cornell.mannlib.vitro.webapp.beans.ObjectProperty;
 import edu.cornell.mannlib.vitro.webapp.beans.Property;
 import edu.cornell.mannlib.vitro.webapp.beans.VClass;
+import edu.cornell.mannlib.vitro.webapp.config.ContextPath;
 import edu.cornell.mannlib.vitro.webapp.controller.VitroRequest;
 import edu.cornell.mannlib.vitro.webapp.controller.freemarker.UrlBuilder;
 import edu.cornell.mannlib.vitro.webapp.controller.freemarker.UrlBuilder.ParamMap;
@@ -715,11 +716,11 @@ public class EditConfigurationTemplateModel extends BaseTemplateModel {
 
     //Get confirm deletion url
     public String getDeleteProcessingUrl() {
-    	return vreq.getContextPath() + "/deletePropertyController";
+    	return ContextPath.getPath(vreq) + "/deletePropertyController";
     }
 
     public String getDeleteIndividualProcessingUrl() {
-      return vreq.getContextPath() + "/deleteIndividualController";
+      return ContextPath.getPath(vreq) + "/deleteIndividualController";
     }
 
     //TODO: Check if this logic is correct and delete prohibited does not expect a specific value

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/web/widgets/LoginWidget.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/web/widgets/LoginWidget.java
@@ -209,7 +209,7 @@ public class LoginWidget extends Widget {
      * What's the password recovery URL for this servlet?
      */
     private String getForgotPasswordUrl(HttpServletRequest request) {
-        String contextPath = request.getContextPath();
+        String contextPath = ContextPath.getPath(request);
         return contextPath + "/forgotPassword";
     }
 

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/web/widgets/LoginWidget.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/web/widgets/LoginWidget.java
@@ -15,6 +15,7 @@ import org.apache.commons.logging.LogFactory;
 import edu.cornell.mannlib.vedit.beans.LoginStatusBean;
 import edu.cornell.mannlib.vitro.webapp.beans.UserAccount;
 import edu.cornell.mannlib.vitro.webapp.config.ConfigurationProperties;
+import edu.cornell.mannlib.vitro.webapp.config.ContextPath;
 import edu.cornell.mannlib.vitro.webapp.controller.authenticate.LoginInProcessFlag;
 import edu.cornell.mannlib.vitro.webapp.controller.freemarker.UrlBuilder;
 import edu.cornell.mannlib.vitro.webapp.controller.freemarker.UrlBuilder.Route;
@@ -191,7 +192,7 @@ public class LoginWidget extends Widget {
      * What's the URL for this servlet?
      */
     private String getAuthenticateUrl(HttpServletRequest request) {
-        String contextPath = request.getContextPath();
+        String contextPath = ContextPath.getPath(request);
         return contextPath + "/authenticate";
     }
 
@@ -199,7 +200,7 @@ public class LoginWidget extends Widget {
      * What's the URL for this servlet, with the cancel parameter added?
      */
     private String getCancelUrl(HttpServletRequest request) {
-        String contextPath = request.getContextPath();
+        String contextPath = ContextPath.getPath(request);
         String urlParams = "?cancel=true";
         return contextPath + "/authenticate" + urlParams;
     }

--- a/api/src/main/java/org/linkeddatafragments/servlet/LinkedDataFragmentServlet.java
+++ b/api/src/main/java/org/linkeddatafragments/servlet/LinkedDataFragmentServlet.java
@@ -1,6 +1,7 @@
 package org.linkeddatafragments.servlet;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import edu.cornell.mannlib.vitro.webapp.config.ContextPath;
 import org.apache.jena.riot.Lang;
 import org.linkeddatafragments.config.ConfigReader;
 import org.linkeddatafragments.datasource.DataSourceFactory;
@@ -128,7 +129,7 @@ public class LinkedDataFragmentServlet extends HttpServlet {
      * @throws IOException
      */
     private IDataSource getDataSource(HttpServletRequest request) throws DataSourceNotFoundException {
-        String contextPath = request.getContextPath();
+        String contextPath = ContextPath.getPath(request);
         String requestURI = request.getRequestURI();
 
         String path = contextPath == null

--- a/api/src/main/java/org/vivoweb/linkeddatafragments/servlet/VitroLinkedDataFragmentServlet.java
+++ b/api/src/main/java/org/vivoweb/linkeddatafragments/servlet/VitroLinkedDataFragmentServlet.java
@@ -40,6 +40,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 
 import edu.cornell.mannlib.vitro.webapp.beans.Ontology;
 import edu.cornell.mannlib.vitro.webapp.config.ConfigurationProperties;
+import edu.cornell.mannlib.vitro.webapp.config.ContextPath;
 import edu.cornell.mannlib.vitro.webapp.controller.VitroHttpServlet;
 import edu.cornell.mannlib.vitro.webapp.dao.OntologyDao;
 import edu.cornell.mannlib.vitro.webapp.modelaccess.ModelAccess;
@@ -103,7 +104,7 @@ public class VitroLinkedDataFragmentServlet extends VitroHttpServlet {
             MIMEParse.register(Lang.NTRIPLES.getHeaderString());
             MIMEParse.register(Lang.RDFXML.getHeaderString());
 
-            HtmlTriplePatternFragmentWriterImpl.setContextPath(servletConfig.getServletContext().getContextPath());
+            HtmlTriplePatternFragmentWriterImpl.setContextPath(ContextPath.getPath(ctx));
         } catch (Exception e) {
             throw new ServletException(e);
         }
@@ -133,7 +134,7 @@ public class VitroLinkedDataFragmentServlet extends VitroHttpServlet {
     }
     
     private IDataSource getDataSource(HttpServletRequest request) throws DataSourceNotFoundException {
-        String contextPath = request.getContextPath();
+        String contextPath = ContextPath.getPath(request);
         String requestURI = request.getRequestURI();
 
         String path = contextPath == null

--- a/api/src/test/java/edu/cornell/mannlib/vitro/webapp/filters/URLRewritingHttpServletResponseTest.java
+++ b/api/src/test/java/edu/cornell/mannlib/vitro/webapp/filters/URLRewritingHttpServletResponseTest.java
@@ -25,35 +25,16 @@ public class URLRewritingHttpServletResponseTest {
     protected void urlEncodingStyleA(String urlToEncode, String expectedUrlResult ){
         URLRewritingHttpServletResponse urhsr = new URLRewritingHttpServletResponse(new stubs.javax.servlet.http.HttpServletResponseStub());
 
-        List<String>externalNamespaces = new ArrayList();
+        List<String>externalNamespaces = new ArrayList<>();
         externalNamespaces.add("http://vivo.med.cornell.edu/individual/");
 
         String actual = urhsr.encodeForVitro(urlToEncode, "UTF-8",
-                true, 1,
+                true,
                 getMockNamespaceMapper(),
                 "http://vivo.cornell.edu/individual/",
                 externalNamespaces);
         Assert.assertEquals(expectedUrlResult, actual);
     }
-
-    /*
-     * Style A is for sites that are running behind apache httpd at a
-     * URL like http://caruso.mannlib.cornell.edu/ with no portals.
-     */
-    protected void urlEncodingStyleB(String urlToEncode, String expectedUrlResult){
-        URLRewritingHttpServletResponse urhsr = new URLRewritingHttpServletResponse(new stubs.javax.servlet.http.HttpServletResponseStub());
-
-        List<String>externalNamespaces = new ArrayList();
-        externalNamespaces.add("http://vivo.med.cornell.edu/individual/");
-
-        String actual = urhsr.encodeForVitro(urlToEncode, "UTF-8",
-                true, 0,
-                getMockNamespaceMapper(),
-                "http://vivo.cornell.edu/individual/",
-                externalNamespaces);
-        Assert.assertEquals(expectedUrlResult, actual);
-    }
-
 
     @Test
     public void test40984(){ urlEncodingStyleA( "/vivo/js/jquery-1.12.4.min.js",
@@ -287,9 +268,6 @@ public class URLRewritingHttpServletResponseTest {
     public void test39472(){ urlEncodingStyleA(
     "/vivo/js/extensions/String.js", "/vivo/js/extensions/String.js"); }
     @Test
-    public void test394730(){ urlEncodingStyleA( "/vivo/js/jquery-1.12.4.min.js",
-    "/vivo/js/jquery-1.12.4.min.js"); }
-    @Test
     public void test39473(){ urlEncodingStyleA(
     "/vivo/js/jquery_plugins/jquery.bgiframe.pack.js",
     "/vivo/js/jquery_plugins/jquery.bgiframe.pack.js"); }
@@ -302,66 +280,13 @@ public class URLRewritingHttpServletResponseTest {
     "/vivo/js/jquery_plugins/ui.datepicker.js",
     "/vivo/js/jquery_plugins/ui.datepicker.js"); }
     @Test
-    public void test14958(){ urlEncodingStyleA( "/vivo/js/jquery-1.12.4.min.js",
-    "/vivo/js/jquery-1.12.4.min.js"); }
-    @Test
-    public void test14968(){ urlEncodingStyleA(
-    "/vivo/js/jquery_plugins/getURLParam.js",
-    "/vivo/js/jquery_plugins/getURLParam.js"); }
-    @Test
-    public void test14972(){ urlEncodingStyleA(
-    "/vivo/js/jquery_plugins/colorAnimations.js",
-    "/vivo/js/jquery_plugins/colorAnimations.js"); }
-    @Test
-    public void test14979(){ urlEncodingStyleA(
-    "/vivo/js/propertyGroupSwitcher.js",
-    "/vivo/js/propertyGroupSwitcher.js"); }
-    @Test
-    public void test14980(){ urlEncodingStyleA( "/vivo/js/controls.js",
-    "/vivo/js/controls.js"); }
-    @Test
-    public void test14982(){ urlEncodingStyleA(
-    "/vivo/js/jquery_plugins/jquery.form.js",
-    "/vivo/js/jquery_plugins/jquery.form.js"); }
-    @Test
-    public void test14986(){ urlEncodingStyleA(
-    "/vivo/js/tiny_mce/tiny_mce.js", "/vivo/js/tiny_mce/tiny_mce.js"); }
-    @Test
-    public void test14999(){ urlEncodingStyleA(
-    "/vivo/entityEdit?uri=http%3a%2f%2fbogus.com%2findividual%2fn3671",
-    "/vivo/entityEdit?uri=http%3A%2F%2Fbogus.com%2Findividual%2Fn3671"); }
-    @Test
-    public void test15011(){ urlEncodingStyleA(
-    "/vivo/themes/vivo-basic/site_icons/visualization/ajax-loader.gif",
-    "/vivo/themes/vivo-basic/site_icons/visualization/ajax-loader.gif"); }
-    @Test
-    public void test15014(){ urlEncodingStyleA(
-    "/vivo/visualization?render_mode=dynamic&container=vis_container&vis=person_pub_count&vis_mode=short&uri=http%3a%2f%2fbogus.com%2findividual%2fn3671",
-    "/vivo/visualization?render_mode=dynamic&container=vis_container&vis=person_pub_count&vis_mode=short&uri=http%3A%2F%2Fbogus.com%2Findividual%2Fn3671");
-    }
-    @Test
-    public void test15143(){ urlEncodingStyleA(
-    "/vivo/js/imageUpload/imageUploadUtils.js",
-    "/vivo/js/imageUpload/imageUploadUtils.js"); }
-    @Test
     public void test184670(){ urlEncodingStyleA(
     "/vivo/js/jquery-ui/css/smoothness/jquery-ui-1.12.1.css",
     "/vivo/js/jquery-ui/css/smoothness/jquery-ui-1.12.1.css"); }
     @Test
-    public void test18467(){ urlEncodingStyleA(
-    "/vivo/edit/forms/css/customForm.css",
-    "/vivo/edit/forms/css/customForm.css"); }
-    @Test
     public void test184680(){ urlEncodingStyleA(
     "/vivo/edit/forms/css/customFormWithAutocomplete.css",
     "/vivo/edit/forms/css/customFormWithAutocomplete.css"); }
-    @Test
-    public void test18468(){ urlEncodingStyleA(
-    "/vivo/js/jquery_plugins/thickbox/thickbox.css",
-    "/vivo/js/jquery_plugins/thickbox/thickbox.css"); }
-    @Test
-    public void test18472(){ urlEncodingStyleA(
-    "/vivo/edit/processRdfForm2.jsp", "/vivo/edit/processRdfForm2.jsp"); }
     @Test
     public void test18506(){ urlEncodingStyleA( "/vivo/individual?uri=",
     "/vivo/individual?uri="); }
@@ -369,24 +294,6 @@ public class URLRewritingHttpServletResponseTest {
     public void test18512(){ urlEncodingStyleA(
     "/vivo/autocomplete?tokenize=true&stem=true",
     "/vivo/autocomplete?tokenize=true&stem=true"); }
-    @Test
-    public void test18516(){ urlEncodingStyleA(
-    "/vivo/js/extensions/String.js", "/vivo/js/extensions/String.js"); }
-    @Test
-    public void test18543(){ urlEncodingStyleA( "/vivo/js/jquery-1.12.4.min.js",
-    "/vivo/js/jquery-1.12.4.min.js"); }
-    @Test
-    public void test185440(){ urlEncodingStyleA(
-    "/vivo/js/jquery_plugins/jquery.bgiframe.pack.js",
-    "/vivo/js/jquery_plugins/jquery.bgiframe.pack.js"); }
-    @Test
-    public void test18544(){ urlEncodingStyleA(
-    "/vivo/js/jquery_plugins/thickbox/thickbox-compressed.js",
-    "/vivo/js/jquery_plugins/thickbox/thickbox-compressed.js"); }
-    @Test
-    public void test18545(){ urlEncodingStyleA(
-    "/vivo/js/jquery_plugins/ui.datepicker.js",
-    "/vivo/js/jquery_plugins/ui.datepicker.js"); }
     @Test
     public void test18546(){ urlEncodingStyleA(
     "/vivo/js/jquery-ui/js/jquery-ui-1.12.1.min.js",
@@ -399,386 +306,95 @@ public class URLRewritingHttpServletResponseTest {
     "/vivo/edit/forms/js/customFormWithAutocomplete.js",
     "/vivo/edit/forms/js/customFormWithAutocomplete.js"); }
     @Test
-    public void test27127(){ urlEncodingStyleA(
-    "/vivo/js/jquery_plugins/thickbox/thickbox.css",
-    "/vivo/js/jquery_plugins/thickbox/thickbox.css"); }
-    @Test
     public void test27130(){ urlEncodingStyleA(
     "/vivo/edit/processDatapropRdfForm.jsp",
     "/vivo/edit/processDatapropRdfForm.jsp"); }
     @Test
-    public void test271590(){ urlEncodingStyleA(
-    "/vivo/js/extensions/String.js", "/vivo/js/extensions/String.js"); }
-    @Test
-    public void test27159(){ urlEncodingStyleA( "/vivo/js/jquery-1.12.4.min.js",
-    "/vivo/js/jquery-1.12.4.min.js"); }
-    @Test
-    public void test27160(){ urlEncodingStyleA(
-    "/vivo/js/jquery_plugins/jquery.bgiframe.pack.js",
-    "/vivo/js/jquery_plugins/jquery.bgiframe.pack.js"); }
-    @Test
-    public void test27161(){ urlEncodingStyleA(
-    "/vivo/js/jquery_plugins/thickbox/thickbox-compressed.js",
-    "/vivo/js/jquery_plugins/thickbox/thickbox-compressed.js"); }
-    @Test
-    public void test27166(){ urlEncodingStyleA(
-    "/vivo/js/jquery_plugins/ui.datepicker.js",
-    "/vivo/js/jquery_plugins/ui.datepicker.js"); }
-    @Test
-    public void test14842(){ urlEncodingStyleA(
-    "/vivo/js/jquery_plugins/thickbox/thickbox.css",
-    "/vivo/js/jquery_plugins/thickbox/thickbox.css"); }
-    @Test
-    public void test14846(){ urlEncodingStyleA(
-    "/vivo/edit/processDatapropRdfForm.jsp",
-    "/vivo/edit/processDatapropRdfForm.jsp"); }
-    @Test
-    public void test148510(){ urlEncodingStyleA(
-    "/vivo/js/extensions/String.js", "/vivo/js/extensions/String.js"); }
-    @Test
-    public void test14851(){ urlEncodingStyleA( "/vivo/js/jquery-1.12.4.min.js",
-    "/vivo/js/jquery-1.12.4.min.js"); }
-    @Test
-    public void test14852(){ urlEncodingStyleA(
-    "/vivo/js/jquery_plugins/jquery.bgiframe.pack.js",
-    "/vivo/js/jquery_plugins/jquery.bgiframe.pack.js"); }
-    @Test
-    public void test148530(){ urlEncodingStyleA(
-    "/vivo/js/jquery_plugins/thickbox/thickbox-compressed.js",
-    "/vivo/js/jquery_plugins/thickbox/thickbox-compressed.js"); }
-    @Test
-    public void test14853(){ urlEncodingStyleA(
-    "/vivo/js/jquery_plugins/ui.datepicker.js",
-    "/vivo/js/jquery_plugins/ui.datepicker.js"); }
-    @Test
-    public void test43748(){ urlEncodingStyleA(
-    "/vivo/js/jquery-ui/css/smoothness/jquery-ui-1.12.1.css",
-    "/vivo/js/jquery-ui/css/smoothness/jquery-ui-1.12.1.css"); }
-    @Test
-    public void test43749(){ urlEncodingStyleA(
-    "/vivo/edit/forms/css/customForm.css",
-    "/vivo/edit/forms/css/customForm.css"); }
-    @Test
-    public void test437500(){ urlEncodingStyleA(
-    "/vivo/edit/forms/css/customFormWithAutocomplete.css",
-    "/vivo/edit/forms/css/customFormWithAutocomplete.css"); }
-    @Test
-    public void test43750(){ urlEncodingStyleA(
-    "/vivo/js/jquery_plugins/thickbox/thickbox.css",
-    "/vivo/js/jquery_plugins/thickbox/thickbox.css"); }
-    @Test
-    public void test437540(){ urlEncodingStyleA(
-    "/vivo/edit/processRdfForm2.jsp", "/vivo/edit/processRdfForm2.jsp"); }
-    @Test
-    public void test43754(){ urlEncodingStyleA( "/vivo/individual?uri=",
-    "/vivo/individual?uri="); }
-    @Test
-    public void test43757(){ urlEncodingStyleA(
-    "/vivo/autocomplete?tokenize=true&stem=true",
-    "/vivo/autocomplete?tokenize=true&stem=true"); }
-    @Test
-    public void test43760(){ urlEncodingStyleA(
-    "/vivo/js/extensions/String.js", "/vivo/js/extensions/String.js"); }
-    @Test
-    public void test437610(){ urlEncodingStyleA( "/vivo/js/jquery-1.12.4.min.js",
-    "/vivo/js/jquery-1.12.4.min.js"); }
-    @Test
-    public void test43761(){ urlEncodingStyleA(
-    "/vivo/js/jquery_plugins/jquery.bgiframe.pack.js",
-    "/vivo/js/jquery_plugins/jquery.bgiframe.pack.js"); }
-    @Test
-    public void test43762(){ urlEncodingStyleA(
-    "/vivo/js/jquery_plugins/thickbox/thickbox-compressed.js",
-    "/vivo/js/jquery_plugins/thickbox/thickbox-compressed.js"); }
-    @Test
-    public void test437630(){ urlEncodingStyleA(
-    "/vivo/js/jquery_plugins/ui.datepicker.js",
-    "/vivo/js/jquery_plugins/ui.datepicker.js"); }
-    @Test
-    public void test43763(){ urlEncodingStyleA(
-    "/vivo/js/jquery-ui/js/jquery-ui-1.12.1.min.js",
-    "/vivo/js/jquery-ui/js/jquery-ui-1.12.1.min.js"); }
-    @Test
-    public void test437640(){ urlEncodingStyleA(
-    "/vivo/js/customFormUtils.js", "/vivo/js/customFormUtils.js"); }
-    @Test
-    public void test43764(){ urlEncodingStyleA(
-    "/vivo/edit/forms/js/customFormWithAutocomplete.js",
-    "/vivo/edit/forms/js/customFormWithAutocomplete.js"); }
-    @Test
-    public void test14550(){ urlEncodingStyleA(
-    "/vivo/js/jquery-ui/css/smoothness/jquery-ui-1.12.1.css",
-    "/vivo/js/jquery-ui/css/smoothness/jquery-ui-1.12.1.css"); }
-    @Test
-    public void test14551(){ urlEncodingStyleA(
-    "/vivo/edit/forms/css/customForm.css",
-    "/vivo/edit/forms/css/customForm.css"); }
-    @Test
-    public void test1455200(){ urlEncodingStyleA(
-    "/vivo/edit/forms/css/customFormWithAutocomplete.css",
-    "/vivo/edit/forms/css/customFormWithAutocomplete.css"); }
-    @Test
-    public void test14552(){ urlEncodingStyleA(
-    "/vivo/js/jquery_plugins/thickbox/thickbox.css",
-    "/vivo/js/jquery_plugins/thickbox/thickbox.css"); }
-    @Test
-    public void test14556(){ urlEncodingStyleA(
-    "/vivo/edit/processRdfForm2.jsp", "/vivo/edit/processRdfForm2.jsp"); }
-    @Test
-    public void test14557(){ urlEncodingStyleA( "/vivo/individual?uri=",
-    "/vivo/individual?uri="); }
-    @Test
-    public void test145610(){ urlEncodingStyleA(
-    "/vivo/autocomplete?tokenize=true&stem=true",
-    "/vivo/autocomplete?tokenize=true&stem=true"); }
-    @Test
     public void test14561(){ urlEncodingStyleA( "/vivo/admin/sparqlquery",
     "/vivo/admin/sparqlquery"); }
     @Test
-    public void test14565(){ urlEncodingStyleA(
-    "/vivo/js/extensions/String.js", "/vivo/js/extensions/String.js"); }
-    @Test
-    public void test145650(){ urlEncodingStyleA( "/vivo/js/jquery-1.12.4.min.js",
-    "/vivo/js/jquery-1.12.4.min.js"); }
-    @Test
-    public void test145660(){ urlEncodingStyleA(
-    "/vivo/js/jquery_plugins/jquery.bgiframe.pack.js",
-    "/vivo/js/jquery_plugins/jquery.bgiframe.pack.js"); }
-    @Test
-    public void test14566(){ urlEncodingStyleA(
-    "/vivo/js/jquery_plugins/thickbox/thickbox-compressed.js",
-    "/vivo/js/jquery_plugins/thickbox/thickbox-compressed.js"); }
-    @Test
-    public void test14567(){ urlEncodingStyleA(
-    "/vivo/js/jquery_plugins/ui.datepicker.js",
-    "/vivo/js/jquery_plugins/ui.datepicker.js"); }
-    @Test
-    public void test145680(){ urlEncodingStyleA(
-    "/vivo/js/jquery-ui/js/jquery-ui-1.12.1.min.js",
-    "/vivo/js/jquery-ui/js/jquery-ui-1.12.1.min.js"); }
-    @Test
-    public void test14568(){ urlEncodingStyleA(
-    "/vivo/js/customFormUtils.js", "/vivo/js/customFormUtils.js"); }
-    @Test
     public void test145690(){ urlEncodingStyleA(
     "/vivo/js/browserUtils.js", "/vivo/js/browserUtils.js"); }
-    @Test
-    public void test14569(){ urlEncodingStyleA(
-    "/vivo/edit/forms/js/customFormWithAutocomplete.js",
-    "/vivo/edit/forms/js/customFormWithAutocomplete.js"); }
-    @Test
-    public void test29078(){ urlEncodingStyleA(
-    "/vivo/js/jquery_plugins/thickbox/thickbox.css",
-    "/vivo/js/jquery_plugins/thickbox/thickbox.css"); }
-    @Test
-    public void test29081(){ urlEncodingStyleA(
-    "/vivo/edit/processDatapropRdfForm.jsp",
-    "/vivo/edit/processDatapropRdfForm.jsp"); }
-    @Test
-    public void test29084(){ urlEncodingStyleA(
-    "/vivo/js/extensions/String.js", "/vivo/js/extensions/String.js"); }
-    @Test
-    public void test29085(){ urlEncodingStyleA( "/vivo/js/jquery-1.12.4.min.js",
-    "/vivo/js/jquery-1.12.4.min.js"); }
-    @Test
-    public void test290860(){ urlEncodingStyleA(
-    "/vivo/js/jquery_plugins/jquery.bgiframe.pack.js",
-    "/vivo/js/jquery_plugins/jquery.bgiframe.pack.js"); }
-    @Test
-    public void test29086(){ urlEncodingStyleA(
-    "/vivo/js/jquery_plugins/thickbox/thickbox-compressed.js",
-    "/vivo/js/jquery_plugins/thickbox/thickbox-compressed.js"); }
-    @Test
-    public void test29087(){ urlEncodingStyleA(
-    "/vivo/js/jquery_plugins/ui.datepicker.js",
-    "/vivo/js/jquery_plugins/ui.datepicker.js"); }
-
-
-
 
     @Test
-    public void test35560(){ urlEncodingStyleB( "/js/jquery-1.12.4.min.js",
-    "/js/jquery-1.12.4.min.js"); }
+    public void test35560(){ urlEncodingStyleA("/js/jquery-1.12.4.min.js", "/js/jquery-1.12.4.min.js"); }
     @Test
-    public void test35562(){ urlEncodingStyleB(
-    "/js/jquery_plugins/getURLParam.js",
-    "/js/jquery_plugins/getURLParam.js"); }
+    public void test35562(){ urlEncodingStyleA("/js/jquery_plugins/getURLParam.js", "/js/jquery_plugins/getURLParam.js"); }
     @Test
-    public void test35564(){ urlEncodingStyleB(
-    "/js/jquery_plugins/colorAnimations.js",
-    "/js/jquery_plugins/colorAnimations.js"); }
+    public void test35564(){ urlEncodingStyleA("/js/jquery_plugins/colorAnimations.js", "/js/jquery_plugins/colorAnimations.js"); }
     @Test
-    public void test35568(){ urlEncodingStyleB(
-    "/js/propertyGroupSwitcher.js", "/js/propertyGroupSwitcher.js"); }
+    public void test35568(){ urlEncodingStyleA("/js/propertyGroupSwitcher.js", "/js/propertyGroupSwitcher.js"); }
     @Test
-    public void test35617(){ urlEncodingStyleB( "/js/controls.js",
-    "/js/controls.js"); }
+    public void test35617(){ urlEncodingStyleA("/js/controls.js", "/js/controls.js"); }
     @Test
-    public void test35618(){ urlEncodingStyleB(
-    "/js/jquery_plugins/jquery.form.js",
-    "/js/jquery_plugins/jquery.form.js"); }
+    public void test35618(){ urlEncodingStyleA("/js/jquery_plugins/jquery.form.js", "/js/jquery_plugins/jquery.form.js"); }
     @Test
-    public void test356180(){ urlEncodingStyleB(
-    "/js/tiny_mce/tiny_mce.js", "/js/tiny_mce/tiny_mce.js"); }
+    public void test356180(){ urlEncodingStyleA("/js/tiny_mce/tiny_mce.js", "/js/tiny_mce/tiny_mce.js"); }
     @Test
-    public void test37150(){ urlEncodingStyleB(
-    "/entityEdit?uri=http%3a%2f%2fbogus.com%2findividual%2fn3671",
-    "/entityEdit?uri=http%3A%2F%2Fbogus.com%2Findividual%2Fn3671"); }
+    public void test37150(){ urlEncodingStyleA("/entityEdit?uri=http%3a%2f%2fbogus.com%2findividual%2fn3671", "/entityEdit?uri=http%3A%2F%2Fbogus.com%2Findividual%2Fn3671"); }
     @Test
-    public void test37402(){ urlEncodingStyleB(
-    "/themes/vivo-basic/site_icons/visualization/ajax-loader.gif",
-    "/themes/vivo-basic/site_icons/visualization/ajax-loader.gif"); }
+    public void test37402(){ urlEncodingStyleA("/themes/vivo-basic/site_icons/visualization/ajax-loader.gif", "/themes/vivo-basic/site_icons/visualization/ajax-loader.gif"); }
     @Test
-    public void test37403(){ urlEncodingStyleB(
-    "/visualization?render_mode=dynamic&container=vis_container&vis=person_pub_count&vis_mode=short&uri=http%3a%2f%2fbogus.com%2findividual%2fn3671",
-    "/visualization?render_mode=dynamic&container=vis_container&vis=person_pub_count&vis_mode=short&uri=http%3A%2F%2Fbogus.com%2Findividual%2Fn3671");
+    public void test37403(){ urlEncodingStyleA("/visualization?render_mode=dynamic&container=vis_container&vis=person_pub_count&vis_mode=short&uri=http%3a%2f%2fbogus.com%2findividual%2fn3671", "/visualization?render_mode=dynamic&container=vis_container&vis=person_pub_count&vis_mode=short&uri=http%3A%2F%2Fbogus.com%2Findividual%2Fn3671");
     }
     @Test
-    public void test38667(){ urlEncodingStyleB(
-    "/js/imageUpload/imageUploadUtils.js",
-    "/js/imageUpload/imageUploadUtils.js"); }
+    public void test38667(){ urlEncodingStyleA("/js/imageUpload/imageUploadUtils.js", "/js/imageUpload/imageUploadUtils.js"); }
     @Test
-    public void test47087(){ urlEncodingStyleB(
-    "entityEdit?uri=http%3a%2f%2fxmlns.com%2ffoaf%2f0.1%2fAgent",
-    "entityEdit?uri=http%3A%2F%2Fxmlns.com%2Ffoaf%2F0.1%2FAgent");
+    public void test47088(){ urlEncodingStyleA("/vclassEdit?uri=http%3a%2f%2fxmlns.com%2ffoaf%2f0.1%2fAgent", "/vclassEdit?uri=http%3A%2F%2Fxmlns.com%2Ffoaf%2F0.1%2FAgent"); }
+    @Test
+    public void test470910(){ urlEncodingStyleA("entityEdit?uri=http%3a%2f%2fxmlns.com%2ffoaf%2f0.1%2fPerson", "entityEdit?uri=http%3A%2F%2Fxmlns.com%2Ffoaf%2F0.1%2FPerson");
     }
     @Test
-    public void test47088(){ urlEncodingStyleB(
-    "/vclassEdit?uri=http%3a%2f%2fxmlns.com%2ffoaf%2f0.1%2fAgent",
-    "/vclassEdit?uri=http%3A%2F%2Fxmlns.com%2Ffoaf%2F0.1%2FAgent"); }
+    public void test47091(){ urlEncodingStyleA("/vclassEdit?uri=http%3a%2f%2fxmlns.com%2ffoaf%2f0.1%2fPerson", "/vclassEdit?uri=http%3A%2F%2Fxmlns.com%2Ffoaf%2F0.1%2FPerson"); }
     @Test
-    public void test470910(){ urlEncodingStyleB(
-    "entityEdit?uri=http%3a%2f%2fxmlns.com%2ffoaf%2f0.1%2fPerson",
-    "entityEdit?uri=http%3A%2F%2Fxmlns.com%2Ffoaf%2F0.1%2FPerson");
+    public void test47093(){ urlEncodingStyleA("/vclassEdit?uri=http%3a%2f%2fwww.w3.org%2f2002%2f07%2fowl%23Thing", "/vclassEdit?uri=http%3A%2F%2Fwww.w3.org%2F2002%2F07%2Fowl%23Thing");
     }
     @Test
-    public void test47091(){ urlEncodingStyleB(
-    "/vclassEdit?uri=http%3a%2f%2fxmlns.com%2ffoaf%2f0.1%2fPerson",
-    "/vclassEdit?uri=http%3A%2F%2Fxmlns.com%2Ffoaf%2F0.1%2FPerson"); }
-    @Test
-    public void test470930(){ urlEncodingStyleB(
-    "entityEdit?uri=http%3a%2f%2fwww.w3.org%2f2002%2f07%2fowl%23Thing",
-    "entityEdit?uri=http%3A%2F%2Fwww.w3.org%2F2002%2F07%2Fowl%23Thing");
+    public void test04993(){ urlEncodingStyleA("vclassEdit?uri=http%3a%2f%2fvitro.mannlib.cornell.edu%2fns%2fbnode%23-20981c46%3a12c18866689%3a-7d2e", "vclassEdit?uri=http%3A%2F%2Fvitro.mannlib.cornell.edu%2Fns%2Fbnode%23-20981c46%3A12c18866689%3A-7d2e");
     }
     @Test
-    public void test47093(){ urlEncodingStyleB(
-    "/vclassEdit?uri=http%3a%2f%2fwww.w3.org%2f2002%2f07%2fowl%23Thing",
-    "/vclassEdit?uri=http%3A%2F%2Fwww.w3.org%2F2002%2F07%2Fowl%23Thing");
+    public void test04994(){ urlEncodingStyleA("vclassEdit?uri=http%3a%2f%2fvitro.mannlib.cornell.edu%2fns%2fbnode%23-20981c46%3a12c18866689%3a-7dad", "vclassEdit?uri=http%3A%2F%2Fvitro.mannlib.cornell.edu%2Fns%2Fbnode%23-20981c46%3A12c18866689%3A-7dad");
     }
     @Test
-    public void test04993(){ urlEncodingStyleB(
-    "vclassEdit?uri=http%3a%2f%2fvitro.mannlib.cornell.edu%2fns%2fbnode%23-20981c46%3a12c18866689%3a-7d2e",
-    "vclassEdit?uri=http%3A%2F%2Fvitro.mannlib.cornell.edu%2Fns%2Fbnode%23-20981c46%3A12c18866689%3A-7d2e");
+    public void test04995(){ urlEncodingStyleA("vclassEdit?uri=http%3a%2f%2fvitro.mannlib.cornell.edu%2fns%2fbnode%23-20981c46%3a12c18866689%3a-7d31", "vclassEdit?uri=http%3A%2F%2Fvitro.mannlib.cornell.edu%2Fns%2Fbnode%23-20981c46%3A12c18866689%3A-7d31");
     }
     @Test
-    public void test04994(){ urlEncodingStyleB(
-    "vclassEdit?uri=http%3a%2f%2fvitro.mannlib.cornell.edu%2fns%2fbnode%23-20981c46%3a12c18866689%3a-7dad",
-    "vclassEdit?uri=http%3A%2F%2Fvitro.mannlib.cornell.edu%2Fns%2Fbnode%23-20981c46%3A12c18866689%3A-7dad");
+    public void test04996(){ urlEncodingStyleA("vclassEdit?uri=http%3a%2f%2fvitro.mannlib.cornell.edu%2fns%2fbnode%23-20981c46%3a12c18866689%3a-7db7", "vclassEdit?uri=http%3A%2F%2Fvitro.mannlib.cornell.edu%2Fns%2Fbnode%23-20981c46%3A12c18866689%3A-7db7");
     }
     @Test
-    public void test04995(){ urlEncodingStyleB(
-    "vclassEdit?uri=http%3a%2f%2fvitro.mannlib.cornell.edu%2fns%2fbnode%23-20981c46%3a12c18866689%3a-7d31",
-    "vclassEdit?uri=http%3A%2F%2Fvitro.mannlib.cornell.edu%2Fns%2Fbnode%23-20981c46%3A12c18866689%3A-7d31");
+    public void test04997(){ urlEncodingStyleA("vclassEdit?uri=http%3a%2f%2fvitro.mannlib.cornell.edu%2fns%2fbnode%23-20981c46%3a12c18866689%3a-7df2", "vclassEdit?uri=http%3A%2F%2Fvitro.mannlib.cornell.edu%2Fns%2Fbnode%23-20981c46%3A12c18866689%3A-7df2");
     }
     @Test
-    public void test04996(){ urlEncodingStyleB(
-    "vclassEdit?uri=http%3a%2f%2fvitro.mannlib.cornell.edu%2fns%2fbnode%23-20981c46%3a12c18866689%3a-7db7",
-    "vclassEdit?uri=http%3A%2F%2Fvitro.mannlib.cornell.edu%2Fns%2Fbnode%23-20981c46%3A12c18866689%3A-7db7");
+    public void test04999(){ urlEncodingStyleA("vclassEdit?uri=http%3a%2f%2fxmlns.com%2ffoaf%2f0.1%2fOrganization", "vclassEdit?uri=http%3A%2F%2Fxmlns.com%2Ffoaf%2F0.1%2FOrganization");
+    }
+
+    @Test
+    public void test13898(){ urlEncodingStyleA("entityEdit?uri=http%3a%2f%2fvitro.mannlib.cornell.edu%2fns%2fvitro%2fpublic%23File", "entityEdit?uri=http%3A%2F%2Fvitro.mannlib.cornell.edu%2Fns%2Fvitro%2Fpublic%23File");
     }
     @Test
-    public void test04997(){ urlEncodingStyleB(
-    "vclassEdit?uri=http%3a%2f%2fvitro.mannlib.cornell.edu%2fns%2fbnode%23-20981c46%3a12c18866689%3a-7df2",
-    "vclassEdit?uri=http%3A%2F%2Fvitro.mannlib.cornell.edu%2Fns%2Fbnode%23-20981c46%3A12c18866689%3A-7df2");
+    public void test13899(){ urlEncodingStyleA("/vclassEdit?uri=http%3a%2f%2fvitro.mannlib.cornell.edu%2fns%2fvitro%2fpublic%23File", "/vclassEdit?uri=http%3A%2F%2Fvitro.mannlib.cornell.edu%2Fns%2Fvitro%2Fpublic%23File");
     }
     @Test
-    public void test04999(){ urlEncodingStyleB(
-    "vclassEdit?uri=http%3a%2f%2fxmlns.com%2ffoaf%2f0.1%2fOrganization",
-    "vclassEdit?uri=http%3A%2F%2Fxmlns.com%2Ffoaf%2F0.1%2FOrganization");
+    public void test38687(){ urlEncodingStyleA("vclassEdit?uri=http%3a%2f%2fvitro.mannlib.cornell.edu%2fns%2fbnode%23-20981c46%3a12c18866689%3a-7d75", "vclassEdit?uri=http%3A%2F%2Fvitro.mannlib.cornell.edu%2Fns%2Fbnode%23-20981c46%3A12c18866689%3A-7d75");
     }
     @Test
-    public void test05000(){ urlEncodingStyleB(
-    "vclassEdit?uri=http%3a%2f%2fxmlns.com%2ffoaf%2f0.1%2fPerson",
-    "vclassEdit?uri=http%3A%2F%2Fxmlns.com%2Ffoaf%2F0.1%2FPerson");
+    public void test38693(){ urlEncodingStyleA("vclassEdit?uri=http%3a%2f%2fvitro.mannlib.cornell.edu%2fns%2fbnode%23-20981c46%3a12c18866689%3a-7d76", "vclassEdit?uri=http%3A%2F%2Fvitro.mannlib.cornell.edu%2Fns%2Fbnode%23-20981c46%3A12c18866689%3A-7d76");
     }
     @Test
-    public void test13898(){ urlEncodingStyleB(
-    "entityEdit?uri=http%3a%2f%2fvitro.mannlib.cornell.edu%2fns%2fvitro%2fpublic%23File",
-    "entityEdit?uri=http%3A%2F%2Fvitro.mannlib.cornell.edu%2Fns%2Fvitro%2Fpublic%23File");
+    public void test38694(){ urlEncodingStyleA("vclassEdit?uri=http%3a%2f%2fvivoweb.org%2fontology%2fcore%23AbstractInformation", "vclassEdit?uri=http%3A%2F%2Fvivoweb.org%2Fontology%2Fcore%23AbstractInformation");
     }
     @Test
-    public void test13899(){ urlEncodingStyleB(
-    "/vclassEdit?uri=http%3a%2f%2fvitro.mannlib.cornell.edu%2fns%2fvitro%2fpublic%23File",
-    "/vclassEdit?uri=http%3A%2F%2Fvitro.mannlib.cornell.edu%2Fns%2Fvitro%2Fpublic%23File");
+    public void test38695(){ urlEncodingStyleA("vclassEdit?uri=http%3a%2f%2fvitro.mannlib.cornell.edu%2fns%2fbnode%23-20981c46%3a12c18866689%3a-7d77", "vclassEdit?uri=http%3A%2F%2Fvitro.mannlib.cornell.edu%2Fns%2Fbnode%23-20981c46%3A12c18866689%3A-7d77");
     }
     @Test
-    public void test28454(){ urlEncodingStyleB(
-    "entityEdit?uri=http%3a%2f%2fwww.w3.org%2f2002%2f07%2fowl%23Thing",
-    "entityEdit?uri=http%3A%2F%2Fwww.w3.org%2F2002%2F07%2Fowl%23Thing");
+    public void test38696(){ urlEncodingStyleA("vclassEdit?uri=http%3a%2f%2fpurl.org%2fontology%2fbibo%2fThesisDegree", "vclassEdit?uri=http%3A%2F%2Fpurl.org%2Fontology%2Fbibo%2FThesisDegree");
+    }
+   
+    @Test
+    public void test43124(){ urlEncodingStyleA("vclassEdit?uri=http%3a%2f%2fvivoweb.org%2fontology%2fcore%23Postdoc", "vclassEdit?uri=http%3A%2F%2Fvivoweb.org%2Fontology%2Fcore%23Postdoc");
     }
     @Test
-    public void test28458(){ urlEncodingStyleB(
-    "/vclassEdit?uri=http%3a%2f%2fwww.w3.org%2f2002%2f07%2fowl%23Thing",
-    "/vclassEdit?uri=http%3A%2F%2Fwww.w3.org%2F2002%2F07%2Fowl%23Thing");
-    }
-    @Test
-    public void test38687(){ urlEncodingStyleB(
-    "vclassEdit?uri=http%3a%2f%2fvitro.mannlib.cornell.edu%2fns%2fbnode%23-20981c46%3a12c18866689%3a-7d75",
-    "vclassEdit?uri=http%3A%2F%2Fvitro.mannlib.cornell.edu%2Fns%2Fbnode%23-20981c46%3A12c18866689%3A-7d75");
-    }
-    @Test
-    public void test38693(){ urlEncodingStyleB(
-    "vclassEdit?uri=http%3a%2f%2fvitro.mannlib.cornell.edu%2fns%2fbnode%23-20981c46%3a12c18866689%3a-7d76",
-    "vclassEdit?uri=http%3A%2F%2Fvitro.mannlib.cornell.edu%2Fns%2Fbnode%23-20981c46%3A12c18866689%3A-7d76");
-    }
-    @Test
-    public void test38694(){ urlEncodingStyleB(
-    "vclassEdit?uri=http%3a%2f%2fvivoweb.org%2fontology%2fcore%23AbstractInformation",
-    "vclassEdit?uri=http%3A%2F%2Fvivoweb.org%2Fontology%2Fcore%23AbstractInformation");
-    }
-    @Test
-    public void test38695(){ urlEncodingStyleB(
-    "vclassEdit?uri=http%3a%2f%2fvitro.mannlib.cornell.edu%2fns%2fbnode%23-20981c46%3a12c18866689%3a-7d77",
-    "vclassEdit?uri=http%3A%2F%2Fvitro.mannlib.cornell.edu%2Fns%2Fbnode%23-20981c46%3A12c18866689%3A-7d77");
-    }
-    @Test
-    public void test38696(){ urlEncodingStyleB(
-    "vclassEdit?uri=http%3a%2f%2fpurl.org%2fontology%2fbibo%2fThesisDegree",
-    "vclassEdit?uri=http%3A%2F%2Fpurl.org%2Fontology%2Fbibo%2FThesisDegree");
-    }
-    @Test
-    public void test43123(){ urlEncodingStyleB(
-    "vclassEdit?uri=http%3a%2f%2fxmlns.com%2ffoaf%2f0.1%2fPerson",
-    "vclassEdit?uri=http%3A%2F%2Fxmlns.com%2Ffoaf%2F0.1%2FPerson");
-    }
-    @Test
-    public void test43124(){ urlEncodingStyleB(
-    "vclassEdit?uri=http%3a%2f%2fvivoweb.org%2fontology%2fcore%23Postdoc",
-    "vclassEdit?uri=http%3A%2F%2Fvivoweb.org%2Fontology%2Fcore%23Postdoc");
-    }
-    @Test
-    public void test59983(){ urlEncodingStyleB(
-    "propertyEdit?uri=http%3a%2f%2fpurl.org%2fdc%2fterms%2fcontributor",
-    "propertyEdit?uri=http%3A%2F%2Fpurl.org%2Fdc%2Fterms%2Fcontributor");
-    }
-    @Test
-    public void test17004(){ urlEncodingStyleB(
-    "ingest?action=outputModel&modelName=http%3a%2f%2fvitro.mannlib.cornell.edu%2fdefault%2fvitro-kb-2",
-    "ingest?action=outputModel&modelName=http%3A%2F%2Fvitro.mannlib.cornell.edu%2Fdefault%2Fvitro-kb-2");
-    }
-    @Test
-    public void test17017(){ urlEncodingStyleB(
-    "ingest?action=outputModel&modelName=http%3a%2f%2fvitro.mannlib.cornell.edu%2fdefault%2fvitro-kb-inf",
-    "ingest?action=outputModel&modelName=http%3A%2F%2Fvitro.mannlib.cornell.edu%2Fdefault%2Fvitro-kb-inf");
-    }
-    @Test
-    public void test17021(){ urlEncodingStyleB(
-    "ingest?action=outputModel&modelName=http%3a%2f%2fvitro.mannlib.cornell.edu%2fdefault%2fvitro-kb-userAccounts",
-    "ingest?action=outputModel&modelName=http%3A%2F%2Fvitro.mannlib.cornell.edu%2Fdefault%2Fvitro-kb-userAccounts");
-    }
-    @Test
-    public void test17033(){ urlEncodingStyleB(
-    "ingest?action=outputModel&modelName=http%3a%2f%2fvitro.mannlib.cornell.edu%2fdefault%2fvitro-kb-displayMetadata",
-    "ingest?action=outputModel&modelName=http%3A%2F%2Fvitro.mannlib.cornell.edu%2Fdefault%2Fvitro-kb-displayMetadata");
+    public void test59983(){ urlEncodingStyleA("propertyEdit?uri=http%3a%2f%2fpurl.org%2fdc%2fterms%2fcontributor", "propertyEdit?uri=http%3A%2F%2Fpurl.org%2Fdc%2Fterms%2Fcontributor");
     }
 
     public NamespaceMapper getMockNamespaceMapper(){

--- a/home/src/main/resources/config/example.runtime.properties
+++ b/home/src/main/resources/config/example.runtime.properties
@@ -22,6 +22,9 @@
 #
 Vitro.defaultNamespace = http://vivo.mydomain.edu/individual/
 
+# In case Vitro is behind proxy you might want to avoid redirects by overriding
+# context path to empty string or other custom value
+#context.path = 
 #
 # URL of Solr context used in local Vitro search. This will usually consist of:
 #     scheme + server_name + port + "solr" + solr_core_name

--- a/home/src/main/resources/config/example.runtime.properties
+++ b/home/src/main/resources/config/example.runtime.properties
@@ -24,7 +24,7 @@ Vitro.defaultNamespace = http://vivo.mydomain.edu/individual/
 
 # In case Vitro is behind proxy you might want to avoid redirects by overriding
 # context path to empty string or other custom value
-#context.path = 
+#context.path =
 #
 # URL of Solr context used in local Vitro search. This will usually consist of:
 #     scheme + server_name + port + "solr" + solr_core_name

--- a/home/src/main/resources/config/example.runtime.properties
+++ b/home/src/main/resources/config/example.runtime.properties
@@ -22,10 +22,10 @@
 #
 Vitro.defaultNamespace = http://vivo.mydomain.edu/individual/
 
-# To exclude tomcat application context name from generated links uncomment following line.
-# Default value is false
+# To exclude the Tomcat application context name from generated links uncomment following line.
+# Default value is false.
 # context.path.exclude = true
-#
+
 # URL of Solr context used in local Vitro search. This will usually consist of:
 #     scheme + server_name + port + "solr" + solr_core_name
 # In a standard Solr installation, the Solr service will be available on port

--- a/home/src/main/resources/config/example.runtime.properties
+++ b/home/src/main/resources/config/example.runtime.properties
@@ -22,9 +22,9 @@
 #
 Vitro.defaultNamespace = http://vivo.mydomain.edu/individual/
 
-# In case Vitro is behind proxy you might want to avoid redirects by overriding
-# context path to empty string or other custom value
-#context.path =
+# To exclude tomcat application context name from generated links uncomment following line.
+# Default value is false
+# context.path.exclude = true
 #
 # URL of Solr context used in local Vitro search. This will usually consist of:
 #     scheme + server_name + port + "solr" + solr_core_name

--- a/webapp/src/main/webapp/admin/log4j.jsp
+++ b/webapp/src/main/webapp/admin/log4j.jsp
@@ -1,6 +1,7 @@
 <%-- $This file is distributed under the terms of the license in LICENSE$ --%>
 
 <%@ page import="edu.cornell.mannlib.vitro.webapp.controller.Controllers" %>
+<%@ page import="edu.cornell.mannlib.vitro.webapp.config.ContextPath"%>
 <%@ page import="org.apache.log4j.*" %>
 <%@ page import="java.util.*" %>
 
@@ -51,7 +52,7 @@ try {
     out.write("<p>" + notes + "</p>");
 
     // output category information in a form with a simple table
-    out.write("<form name=\"Formular\" ACTION=\""+request.getContextPath()+request.getServletPath()+"\" METHOD=\"POST\">");
+    out.write("<form name=\"Formular\" ACTION=\""+ContextPath.getPath(request)+request.getServletPath()+"\" METHOD=\"POST\">");
     out.write("<table cellpadding=4>\r\n");
     out.write(" <tr>\r\n");
     out.write("  <td><b>Logger</b></td>\r\n");

--- a/webapp/src/main/webapp/templates/edit/specific/ents_edit_head.jsp
+++ b/webapp/src/main/webapp/templates/edit/specific/ents_edit_head.jsp
@@ -1,9 +1,10 @@
 <%-- $This file is distributed under the terms of the license in LICENSE$ --%>
 
+<%@ page import="edu.cornell.mannlib.vitro.webapp.config.ContextPath"%>
 <%
 
 request.setAttribute("dwrDisabled", Boolean.FALSE);
-String context = request.getContextPath();
+String context = ContextPath.getPath(request);
 
 %>
 

--- a/webapp/src/main/webapp/templates/page/headContent.jsp
+++ b/webapp/src/main/webapp/templates/page/headContent.jsp
@@ -7,6 +7,7 @@
 <%@ page import="edu.cornell.mannlib.vitro.webapp.beans.ApplicationBean"%>
 <%@ page import="org.apache.commons.logging.Log" %>
 <%@ page import="org.apache.commons.logging.LogFactory" %>
+<%@ page import="edu.cornell.mannlib.vitro.webapp.config.ContextPath"%>
 <%!
   public static Log log = LogFactory.getLog("edu.cornell.mannlib.vitro.webapp.jsp.templates.page.headContent.jsp");
 %>
@@ -14,7 +15,7 @@
   VitroRequest vreq = new VitroRequest(request);
 
   String themeDir = vreq.getAppBean().getThemeDir();
-  themeDir = vreq.getContextPath() + '/' + themeDir;
+  themeDir = ContextPath.getPath(vreq) + '/' + themeDir;
 %>
 
 <!-- headContent.jsp -->


### PR DESCRIPTION
**[VIVO GitHub issue](https://github.com/vivo-project/VIVO/issues/3846)**: (please link to issue)
[VIVO PR](https://github.com/vivo-project/VIVO/pull/4011)
# What does this pull request do?
New boolean configuration property context.path.exclude to exclude tomcat application context from generated links useful in case the application is deployed with reverse proxy.

# What's new?
Created context.path.exclude configuration property to exclude context path from generated links. 
Replaced calls for context path to utility methods that allow overriding default context path.

# How should this be tested?
Default behavior when configuration property is not set should be the same.
* To test application behind proxy one would need to configure webserver and tomcat in proxy mode like described in workaround of linked issue and set  context.path.exclude = true in runtime.properties
* General navigation between application pages
* Authorization
* Edit this individual page should work the same

#Additional notes
* Duplicate tests were removed.
* This change require documentation to be updated.

# Interested parties
@VIVO-project/vivo-committers

# Reviewers' expertise
Candidates for reviewing this PR should have some of the following expertises:
1. Java

# Reviewers' report template
## General comment
A reviewer should provide here comments and suggestions for requested changes if any.
## Testing
A reviewer should briefly describe here how it was tested
## Code reviewing
A reviewer should briefly describe here which part was code reviewed