### PR TITLE
Decouple installation and deployment

### DIFF
--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/application/ApplicationSetup.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/application/ApplicationSetup.java
@@ -45,6 +45,8 @@ public class ApplicationSetup implements ServletContextListener {
 			this.vitroHomeDir = VitroHomeDirectory.find(ctx);
 			ss.info(this, vitroHomeDir.getDiscoveryMessage());
 
+			this.vitroHomeDir.populate();
+
 			locateApplicationConfigFile();
 			loadApplicationConfigFile();
 			createConfigurationBeanLoader();

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/application/VitroHomeDirectory.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/application/VitroHomeDirectory.java
@@ -176,8 +176,7 @@ public class VitroHomeDirectory {
 		private void confirmValidDirectory() {
 			Path vhd = getPath();
 			if (!Files.exists(vhd)) {
-				throw new IllegalStateException("Vitro home directory '" + vhd
-						+ "' does not exist.");
+			    createHomeDirectory(vhd);
 			}
 			if (!Files.isDirectory(vhd)) {
 				throw new IllegalStateException("Vitro home directory '" + vhd
@@ -239,6 +238,18 @@ public class VitroHomeDirectory {
         }
         log.info("Copied home files to " + vhdDir.toPath());
         
+    }
+
+    /**
+     * Create home directory
+     */
+    private static void createHomeDirectory(Path vhdDir) {
+        try {
+            vhdDir.toFile().mkdirs();
+        } catch (Exception e) {
+            log.error(e, e);
+            throw new RuntimeException("Failed to create home directory " + vhdDir);
+        }
     }
 
     /**

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/application/VitroHomeDirectory.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/application/VitroHomeDirectory.java
@@ -75,7 +75,7 @@ public class VitroHomeDirectory {
         String location = "/WEB-INF/resources/home-files";
         homeSourcePath = context.getRealPath(location);
         if (homeSourcePath == null) {
-            throw new RuntimeException(String.format("Application home files not found in: %s", location));
+            throw new IllegalStateException(String.format("Application home files not found in: %s", location));
         }
     }
 
@@ -243,15 +243,15 @@ public class VitroHomeDirectory {
         File homeDestination = getPath().toFile();
 
         if (!homeDestination.isDirectory() || homeDestination.list() == null) {
-            throw new RuntimeException("Application home dir is not a directory! " + homeDestination);
+            throw new IllegalStateException("Application home dir is not a directory! " + homeDestination);
         }
         if (!homeDestination.canWrite()) {
-            throw new RuntimeException("Application home dir is not writable! " + homeDestination);
+            throw new IllegalStateException("Application home dir is not writable! " + homeDestination);
         }
         try {
             copy(homeDestination);
         } catch(Exception e) {
-            throw new RuntimeException("Failed to copy home files! " + homeDestination, e);
+            throw new IllegalStateException("Failed to copy home files! " + homeDestination, e);
         }
         log.info("Copied home files to " + homeDestination.toPath());
     }
@@ -263,7 +263,7 @@ public class VitroHomeDirectory {
         try {
             homeDestination.toFile().mkdirs();
         } catch (Exception e) {
-            throw new RuntimeException("Failed to create home directory " + homeDestination, e);
+            throw new IllegalStateException("Failed to create home directory " + homeDestination, e);
         }
     }
 
@@ -274,12 +274,13 @@ public class VitroHomeDirectory {
         File homeSrcPath = new File(getSourcePath());
         File[] contents = homeSrcPath.listFiles();
         for (File child : contents) {
-            if (!excludedHomeFiles.contains(child.getName())) {
-                if (child.isDirectory()) {
-                    FileUtils.copyDirectoryToDirectory(child, homeDestination);
-                } else {
-                    FileUtils.copyFileToDirectory(child, homeDestination);
-                }
+            if (excludedHomeFiles.contains(child.getName())) {
+                continue;
+            }
+            if (child.isDirectory()) {
+                FileUtils.copyDirectoryToDirectory(child, homeDestination);
+            } else {
+                FileUtils.copyFileToDirectory(child, homeDestination);
             }
         }
     }

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/application/VitroHomeDirectory.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/application/VitroHomeDirectory.java
@@ -27,40 +27,37 @@ import org.apache.commons.logging.LogFactory;
  * Encapsulates some of the info relating to the Vitro home directory.
  */
 public class VitroHomeDirectory {
-	private static final Log log = LogFactory.getLog(VitroHomeDirectory.class);
+    private static final Log log = LogFactory.getLog(VitroHomeDirectory.class);
 
-	public static VitroHomeDirectory find(ServletContext ctx) {
-		HomeDirectoryFinder finder = new HomeDirectoryFinder(ctx);
-		return new VitroHomeDirectory(ctx, finder.getPath(),
-				finder.getMessage());
-	}
+    public static VitroHomeDirectory find(ServletContext ctx) {
+        HomeDirectoryFinder finder = new HomeDirectoryFinder(ctx);
+        return new VitroHomeDirectory(ctx, finder.getPath(), finder.getMessage());
+    }
 
-	private final ServletContext ctx;
-	private final Path path;
-	private final String discoveryMessage;
+    private final ServletContext ctx;
+    private final Path path;
+    private final String discoveryMessage;
     private Set<String> excludedHomeFiles = new HashSet<>(Arrays.asList("rdf"));
     private String homeSourcePath;
 
+    public VitroHomeDirectory(ServletContext ctx, Path path, String discoveryMessage) {
+        this.ctx = ctx;
+        this.path = path;
+        this.discoveryMessage = discoveryMessage;
+        setHomeSourcePath(ctx);
+    }
 
-	public VitroHomeDirectory(ServletContext ctx, Path path,
-			String discoveryMessage) {
-		this.ctx = ctx;
-		this.path = path;
-		this.discoveryMessage = discoveryMessage;
-		setHomeSourcePath(ctx);
-	}
+    public ServletContext getCtx() {
+        return ctx;
+    }
 
-	public ServletContext getCtx() {
-		return ctx;
-	}
+    public Path getPath() {
+        return path;
+    }
 
-	public Path getPath() {
-		return path;
-	}
-
-	public String getDiscoveryMessage() {
-		return discoveryMessage;
-	}
+    public String getDiscoveryMessage() {
+        return discoveryMessage;
+    }
 
     /**
      * Get source home file directory path
@@ -79,162 +76,142 @@ public class VitroHomeDirectory {
         }
     }
 
-	/**
-	 * Find something that specifies the location of the Vitro home directory.
-	 * Look in the JDNI environment, the system properties, and the
-	 * build.properties file.
-	 *
-	 * If we don't find it, fail. If we find it more than once, use the first
-	 * one (with a warning). If it is not an existing, readable directory, fail.
-	 */
-	private static class HomeDirectoryFinder {
-		/** JNDI path that defines the Vitro home directory */
-		private static final String VHD_JNDI_PATH = "java:comp/env/vitro/home";
+    /**
+     * Find something that specifies the location of the Vitro home directory. Look in the JDNI environment, the system
+     * properties, and the build.properties file.
+     *
+     * If we don't find it, fail. If we find it more than once, use the first one (with a warning). If it is not an
+     * existing, readable directory, fail.
+     */
+    private static class HomeDirectoryFinder {
+        /** JNDI path that defines the Vitro home directory */
+        private static final String VHD_JNDI_PATH = "java:comp/env/vitro/home";
 
-		/** System property that defines the Vitro home directory */
-		private static final String VHD_SYSTEM_PROPERTY = "vitro.home";
+        /** System property that defines the Vitro home directory */
+        private static final String VHD_SYSTEM_PROPERTY = "vitro.home";
 
-		/** build.properties property that defines the Vitro home directory */
-		private static final String VHD_BUILD_PROPERTY = "vitro.home";
+        /** build.properties property that defines the Vitro home directory */
+        private static final String VHD_BUILD_PROPERTY = "vitro.home";
 
-		private final ServletContext ctx;
-		private final List<Found> foundLocations = new ArrayList<>();
+        private final ServletContext ctx;
+        private final List<Found> foundLocations = new ArrayList<>();
 
-		public HomeDirectoryFinder(ServletContext ctx) {
-			this.ctx = ctx;
+        public HomeDirectoryFinder(ServletContext ctx) {
+            this.ctx = ctx;
 
-			getVhdFromJndi();
-			getVhdFromSystemProperties();
-			getVhdFromBuildProperties();
-			confirmExactlyOneResult();
-			confirmValidDirectory();
-		}
+            getVhdFromJndi();
+            getVhdFromSystemProperties();
+            getVhdFromBuildProperties();
+            confirmExactlyOneResult();
+            confirmValidDirectory();
+        }
 
-		public String getMessage() {
-			return foundLocations.get(0).getMessage();
-		}
+        public String getMessage() {
+            return foundLocations.get(0).getMessage();
+        }
 
-		public Path getPath() {
-			return foundLocations.get(0).getPath();
-		}
+        public Path getPath() {
+            return foundLocations.get(0).getPath();
+        }
 
-		public void getVhdFromJndi() {
-			try {
-				String vhdPath = (String) new InitialContext()
-						.lookup(VHD_JNDI_PATH);
-				if (vhdPath == null) {
-					log.debug("Didn't find a JNDI value at '" + VHD_JNDI_PATH
-							+ "'.");
-				} else {
-					log.debug("'" + VHD_JNDI_PATH + "' as specified by JNDI: "
-							+ vhdPath);
-					String message = String.format(
-							"JNDI environment '%s' was set to '%s'",
-							VHD_JNDI_PATH, vhdPath);
-					foundLocations.add(new Found(Paths.get(vhdPath), message));
-				}
-			} catch (Exception e) {
-				log.debug("JNDI lookup failed. " + e);
-			}
-		}
+        public void getVhdFromJndi() {
+            try {
+                String vhdPath = (String) new InitialContext().lookup(VHD_JNDI_PATH);
+                if (vhdPath == null) {
+                    log.debug("Didn't find a JNDI value at '" + VHD_JNDI_PATH + "'.");
+                } else {
+                    log.debug("'" + VHD_JNDI_PATH + "' as specified by JNDI: " + vhdPath);
+                    String message = String.format("JNDI environment '%s' was set to '%s'", VHD_JNDI_PATH, vhdPath);
+                    foundLocations.add(new Found(Paths.get(vhdPath), message));
+                }
+            } catch (Exception e) {
+                log.debug("JNDI lookup failed. " + e);
+            }
+        }
 
-		private void getVhdFromSystemProperties() {
-			String vhdPath = System.getProperty(VHD_SYSTEM_PROPERTY);
-			if (vhdPath == null) {
-				log.debug("Didn't find a system property value at '"
-						+ VHD_SYSTEM_PROPERTY + "'.");
-			} else {
-				log.debug("'" + VHD_SYSTEM_PROPERTY
-						+ "' as specified by system property: " + vhdPath);
-				String message = String.format(
-						"System property '%s' was set to '%s'",
-						VHD_SYSTEM_PROPERTY, vhdPath);
-				foundLocations.add(new Found(Paths.get(vhdPath), message));
-			}
-		}
+        private void getVhdFromSystemProperties() {
+            String vhdPath = System.getProperty(VHD_SYSTEM_PROPERTY);
+            if (vhdPath == null) {
+                log.debug("Didn't find a system property value at '" + VHD_SYSTEM_PROPERTY + "'.");
+            } else {
+                log.debug("'" + VHD_SYSTEM_PROPERTY + "' as specified by system property: " + vhdPath);
+                String message = String.format("System property '%s' was set to '%s'", VHD_SYSTEM_PROPERTY, vhdPath);
+                foundLocations.add(new Found(Paths.get(vhdPath), message));
+            }
+        }
 
-		private void getVhdFromBuildProperties() {
-			try {
-				Map<String, String> buildProps = new BuildProperties(ctx)
-						.getMap();
-				String vhdPath = buildProps.get(VHD_BUILD_PROPERTY);
-				if (vhdPath == null) {
-					log.debug("build properties doesn't contain a value for '"
-							+ VHD_BUILD_PROPERTY + "'.");
-				} else {
-					log.debug("'" + VHD_BUILD_PROPERTY
-							+ "' as specified by build.properties: " + vhdPath);
-					String message = String.format(
-							"In resource '%s', '%s' was set to '%s'.",
-							WEBAPP_PATH_BUILD_PROPERTIES, VHD_BUILD_PROPERTY,
-							vhdPath);
-					foundLocations.add(new Found(Paths.get(vhdPath), message));
-				}
-			} catch (Exception e) {
-				log.warn("Reading build properties failed. " + e);
-			}
-		}
+        private void getVhdFromBuildProperties() {
+            try {
+                Map<String, String> buildProps = new BuildProperties(ctx).getMap();
+                String vhdPath = buildProps.get(VHD_BUILD_PROPERTY);
+                if (vhdPath == null) {
+                    log.debug("build properties doesn't contain a value for '" + VHD_BUILD_PROPERTY + "'.");
+                } else {
+                    log.debug("'" + VHD_BUILD_PROPERTY + "' as specified by build.properties: " + vhdPath);
+                    String message = String.format("In resource '%s', '%s' was set to '%s'.",
+                            WEBAPP_PATH_BUILD_PROPERTIES, VHD_BUILD_PROPERTY, vhdPath);
+                    foundLocations.add(new Found(Paths.get(vhdPath), message));
+                }
+            } catch (Exception e) {
+                log.warn("Reading build properties failed. " + e);
+            }
+        }
 
-		private void confirmExactlyOneResult() {
-			if (foundLocations.isEmpty()) {
-				String message = String.format("Can't find a value "
-						+ "for the Vitro home directory. "
-						+ "Looked in JNDI environment at '%s'. "
-						+ "Looked for a system property named '%s'. "
-						+ "Looked in 'WEB-INF/resources/build.properties' "
-						+ "for '%s'.", VHD_JNDI_PATH, VHD_SYSTEM_PROPERTY,
-						VHD_BUILD_PROPERTY);
-				throw new IllegalStateException(message);
-			} else if (foundLocations.size() > 1) {
-				String message = "Found multiple values for the "
-						+ "Vitro home directory: " + foundLocations;
-				log.warn(message);
-			}
-		}
+        private void confirmExactlyOneResult() {
+            if (foundLocations.isEmpty()) {
+                String message = String.format("Can't find a value " +
+                        "for the Vitro home directory. " +
+                        "Looked in JNDI environment at '%s'. " +
+                        "Looked for a system property named '%s'. " +
+                        "Looked in 'WEB-INF/resources/build.properties' " +
+                        "for '%s'.", VHD_JNDI_PATH, VHD_SYSTEM_PROPERTY, VHD_BUILD_PROPERTY);
+                throw new IllegalStateException(message);
+            } else if (foundLocations.size() > 1) {
+                String message = "Found multiple values for the " + "Vitro home directory: " + foundLocations;
+                log.warn(message);
+            }
+        }
 
-		private void confirmValidDirectory() {
-			Path vhd = getPath();
-			if (!Files.exists(vhd)) {
-			    createHomeDirectory(vhd);
-			}
-			if (!Files.isDirectory(vhd)) {
-				throw new IllegalStateException("Vitro home directory '" + vhd
-						+ "' is not a directory.");
-			}
-			if (!Files.isReadable(vhd)) {
-				throw new IllegalStateException(
-						"Cannot read Vitro home directory '" + vhd + "'.");
-			}
-			if (!Files.isWritable(vhd)) {
-				throw new IllegalStateException(
-						"Can't write to Vitro home directory: '" + vhd + "'.");
-			}
-		}
+        private void confirmValidDirectory() {
+            Path vhd = getPath();
+            if (!Files.exists(vhd)) {
+                createHomeDirectory(vhd);
+            }
+            if (!Files.isDirectory(vhd)) {
+                throw new IllegalStateException("Vitro home directory '" + vhd + "' is not a directory.");
+            }
+            if (!Files.isReadable(vhd)) {
+                throw new IllegalStateException("Cannot read Vitro home directory '" + vhd + "'.");
+            }
+            if (!Files.isWritable(vhd)) {
+                throw new IllegalStateException("Can't write to Vitro home directory: '" + vhd + "'.");
+            }
+        }
 
-		/** We found it: where and how. */
-		private static class Found {
-			private final Path path;
-			private final String message;
+        /** We found it: where and how. */
+        private static class Found {
+            private final Path path;
+            private final String message;
 
-			public Found(Path path, String message) {
-				this.path = path;
-				this.message = message;
-			}
+            public Found(Path path, String message) {
+                this.path = path;
+                this.message = message;
+            }
 
-			public Path getPath() {
-				return path;
-			}
+            public Path getPath() {
+                return path;
+            }
 
-			public String getMessage() {
-				return message;
-			}
+            public String getMessage() {
+                return message;
+            }
 
-			@Override
-			public String toString() {
-				return "Found[path=" + path + ", message=" + message + "]";
-			}
-		}
-	}
+            @Override
+            public String toString() {
+                return "Found[path=" + path + ", message=" + message + "]";
+            }
+        }
+    }
 
     /**
      * Populates home directory with home files, excluding the rdf directory
@@ -250,7 +227,7 @@ public class VitroHomeDirectory {
         }
         try {
             copy(homeDestination);
-        } catch(Exception e) {
+        } catch (Exception e) {
             throw new IllegalStateException("Failed to copy home files! " + homeDestination, e);
         }
         log.info("Copied home files to " + homeDestination.toPath());

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/migration/rel18/FauxPropertiesUpdater.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/migration/rel18/FauxPropertiesUpdater.java
@@ -78,8 +78,7 @@ public class FauxPropertiesUpdater {
 	}
 
 	private boolean locateFile() {
-		String homePath = ApplicationUtils.instance().getHomeDirectory()
-				.getPath().toString();
+		String homePath = ApplicationUtils.instance().getHomeDirectory().getSourcePath();
 		propertyConfigPath = Paths.get(homePath, PATH_TO_PROPERTY_CONFIG);
 		if (Files.exists(propertyConfigPath)) {
 			return true;

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/servlet/setup/FileGraphSetup.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/servlet/setup/FileGraphSetup.java
@@ -33,7 +33,7 @@ import org.apache.jena.query.Dataset;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
 
-import edu.cornell.mannlib.vitro.webapp.application.ApplicationUtils;
+import edu.cornell.mannlib.vitro.webapp.application.VitroHomeDirectory;
 import edu.cornell.mannlib.vitro.webapp.dao.jena.RDFServiceDataset;
 import edu.cornell.mannlib.vitro.webapp.modelaccess.ModelAccess;
 import edu.cornell.mannlib.vitro.webapp.modelaccess.ModelNames;
@@ -121,8 +121,8 @@ public class FileGraphSetup implements ServletContextListener {
 	private Set<Path> getFilegraphPaths(ServletContext ctx, String... strings) {
 		StartupStatus ss = StartupStatus.getBean(ctx);
 
-		String homeDirProperty = ApplicationUtils.instance().getHomeDirectory().getPath().toString();
-		Path filegraphDir = Paths.get(homeDirProperty, strings);
+		String homeDirPath = VitroHomeDirectory.getHomeSrcPath(ctx);
+		Path filegraphDir = Paths.get(homeDirPath, strings);
 
 		Set<Path> paths = new TreeSet<>();
 		if (Files.isDirectory(filegraphDir)) {

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/servlet/setup/FileGraphSetup.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/servlet/setup/FileGraphSetup.java
@@ -32,8 +32,7 @@ import org.apache.jena.ontology.OntModelSpec;
 import org.apache.jena.query.Dataset;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
-
-import edu.cornell.mannlib.vitro.webapp.application.VitroHomeDirectory;
+import edu.cornell.mannlib.vitro.webapp.application.ApplicationUtils;
 import edu.cornell.mannlib.vitro.webapp.dao.jena.RDFServiceDataset;
 import edu.cornell.mannlib.vitro.webapp.modelaccess.ModelAccess;
 import edu.cornell.mannlib.vitro.webapp.modelaccess.ModelNames;
@@ -121,7 +120,7 @@ public class FileGraphSetup implements ServletContextListener {
 	private Set<Path> getFilegraphPaths(ServletContext ctx, String... strings) {
 		StartupStatus ss = StartupStatus.getBean(ctx);
 
-		String homeDirPath = VitroHomeDirectory.getHomeSrcPath(ctx);
+		String homeDirPath = ApplicationUtils.instance().getHomeDirectory().getSourcePath();
 		Path filegraphDir = Paths.get(homeDirPath, strings);
 
 		Set<Path> paths = new TreeSet<>();

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/servlet/setup/RDFFilesLoader.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/servlet/setup/RDFFilesLoader.java
@@ -32,7 +32,7 @@ import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.rdf.model.Statement;
 import org.apache.jena.rdf.model.StmtIterator;
 
-import edu.cornell.mannlib.vitro.webapp.application.ApplicationUtils;
+import edu.cornell.mannlib.vitro.webapp.application.VitroHomeDirectory;
 
 import javax.servlet.ServletContext;
 
@@ -81,7 +81,7 @@ public class RDFFilesLoader {
 	public static void loadFirstTimeFiles(ServletContext ctx, String modelPath, Model model,
 			boolean firstTime) {
 		if (firstTime) {
-			String home = locateHomeDirectory();
+			String home = locateHomeDirectory(ctx);
 
 			// Load common files
 			Set<Path> paths = getPaths(home, RDF, modelPath, FIRST_TIME);
@@ -113,7 +113,7 @@ public class RDFFilesLoader {
 	public static void loadEveryTimeFiles(ServletContext ctx, String modelPath, OntModel model) {
 		OntModel everytimeModel = ModelFactory
 				.createOntologyModel(OntModelSpec.OWL_MEM);
-		String home = locateHomeDirectory();
+		String home = locateHomeDirectory(ctx);
 
 		// Load common files
 		Set<Path> paths = getPaths(home, RDF, modelPath, EVERY_TIME);
@@ -220,9 +220,8 @@ public class RDFFilesLoader {
 			return DEFAULT_RDF_FORMAT;
 	}
 
-	private static String locateHomeDirectory() {
-		return ApplicationUtils.instance().getHomeDirectory().getPath()
-				.toString();
+	private static String locateHomeDirectory(ServletContext ctx) {
+		return VitroHomeDirectory.getHomeSrcPath(ctx);
 	}
 
 	/**

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/servlet/setup/RDFFilesLoader.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/servlet/setup/RDFFilesLoader.java
@@ -31,8 +31,7 @@ import org.apache.jena.rdf.model.RDFNode;
 import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.rdf.model.Statement;
 import org.apache.jena.rdf.model.StmtIterator;
-
-import edu.cornell.mannlib.vitro.webapp.application.VitroHomeDirectory;
+import edu.cornell.mannlib.vitro.webapp.application.ApplicationUtils;
 
 import javax.servlet.ServletContext;
 
@@ -221,7 +220,7 @@ public class RDFFilesLoader {
 	}
 
 	private static String locateHomeDirectory(ServletContext ctx) {
-		return VitroHomeDirectory.getHomeSrcPath(ctx);
+		return ApplicationUtils.instance().getHomeDirectory().getSourcePath();
 	}
 
 	/**

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/servlet/setup/UpdateKnowledgeBase.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/servlet/setup/UpdateKnowledgeBase.java
@@ -13,6 +13,7 @@ import java.io.IOException;
 import java.io.StringWriter;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -106,7 +107,7 @@ public class UpdateKnowledgeBase {
 			settings.setInferenceOntModelSelector(ModelAccess.on(ctx).getOntModelSelector(INFERENCES_ONLY));
 			settings.setUnionOntModelSelector(ModelAccess.on(ctx).getOntModelSelector());
 
-		    Path homeDir = ApplicationUtils.instance().getHomeDirectory().getPath();
+		    Path homeDir = Paths.get(ApplicationUtils.instance().getHomeDirectory().getSourcePath());
 			settings.setDisplayModel(ModelAccess.on(ctx).getOntModel(DISPLAY));
 			OntModel oldTBoxModel = loadModelFromDirectory(ctx.getRealPath(oldTBoxModelDir()));
 			settings.setOldTBoxModel(oldTBoxModel);

--- a/api/src/test/java/edu/cornell/mannlib/vitro/webapp/application/VitroHomeDirectoryTest.java
+++ b/api/src/test/java/edu/cornell/mannlib/vitro/webapp/application/VitroHomeDirectoryTest.java
@@ -1,0 +1,50 @@
+package edu.cornell.mannlib.vitro.webapp.application;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import stubs.javax.servlet.ServletContextStub;
+
+public class VitroHomeDirectoryTest {
+
+    private static final String FILE = "file";
+    private static final String CONFIG = "config";
+    private static final String RDF = "rdf";
+    @Rule
+    public TemporaryFolder src = new TemporaryFolder();
+    @Rule
+    public TemporaryFolder dst = new TemporaryFolder();
+
+    @Test
+    public void testGetHomeSrcPath() {
+        ServletContextStub sc = new ServletContextStub();
+        String expectedPath = "/opt/tomcat/webapp/app/WEB-INF/resources/home-files";
+        sc.setRealPath("/WEB-INF/resources/home-files", expectedPath);
+        VitroHomeDirectory vhd = new VitroHomeDirectory(sc, dst.getRoot().toPath(), "");
+        String realPath = vhd.getSourcePath();
+        assertEquals(expectedPath, realPath);
+    }
+
+    @Test
+    public void testPopulate() throws Exception {
+        ServletContextStub sc = new ServletContextStub();
+        src.newFolder(RDF);
+        src.newFile(FILE);
+        src.newFolder(CONFIG);
+        sc.setRealPath("/WEB-INF/resources/home-files", src.getRoot().getAbsolutePath());
+        VitroHomeDirectory vhd = new VitroHomeDirectory(sc, dst.getRoot().toPath(), "");
+        vhd.populate();
+        Set<String> files = new HashSet<String>(Arrays.asList(dst.getRoot().list()));
+        assertTrue(files.contains(CONFIG));
+        assertTrue(files.contains(FILE));
+        assertFalse(files.contains(RDF));
+    }
+}

--- a/checkstyle-suppressions.xml
+++ b/checkstyle-suppressions.xml
@@ -48,7 +48,6 @@
     <suppress files="src[\\/]main[\\/]java[\\/]edu[\\/]cornell[\\/]mannlib[\\/]vitro[\\/]webapp[\\/]application[\\/]ApplicationSetup\.java" checks="."/>
     <suppress files="src[\\/]main[\\/]java[\\/]edu[\\/]cornell[\\/]mannlib[\\/]vitro[\\/]webapp[\\/]application[\\/]ApplicationUtils\.java" checks="."/>
     <suppress files="src[\\/]main[\\/]java[\\/]edu[\\/]cornell[\\/]mannlib[\\/]vitro[\\/]webapp[\\/]application[\\/]BuildProperties\.java" checks="."/>
-    <suppress files="src[\\/]main[\\/]java[\\/]edu[\\/]cornell[\\/]mannlib[\\/]vitro[\\/]webapp[\\/]application[\\/]VitroHomeDirectory\.java" checks="."/>
     <suppress files="src[\\/]main[\\/]java[\\/]edu[\\/]cornell[\\/]mannlib[\\/]vitro[\\/]webapp[\\/]auth[\\/]identifier[\\/]ActiveIdentifierBundleFactories\.java" checks="."/>
     <suppress files="src[\\/]main[\\/]java[\\/]edu[\\/]cornell[\\/]mannlib[\\/]vitro[\\/]webapp[\\/]auth[\\/]identifier[\\/]ArrayIdentifierBundle\.java" checks="."/>
     <suppress files="src[\\/]main[\\/]java[\\/]edu[\\/]cornell[\\/]mannlib[\\/]vitro[\\/]webapp[\\/]auth[\\/]identifier[\\/]Identifier\.java" checks="."/>

--- a/installer/home/pom.xml
+++ b/installer/home/pom.xml
@@ -2,101 +2,40 @@
     xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-
     <modelVersion>4.0.0</modelVersion>
-
     <groupId>org.vivoweb</groupId>
     <artifactId>vitro-installer-home</artifactId>
     <version>1.15.1-SNAPSHOT</version>
     <packaging>pom</packaging>
-
     <parent>
         <groupId>org.vivoweb</groupId>
         <artifactId>vitro-installer</artifactId>
         <version>1.15.1-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
-
     <name>Vitro Install Home</name>
-
     <properties>
         <default-theme>vitro</default-theme>
     </properties>
 
-    <profiles>
-        <profile>
-            <id>install</id>
-            <activation>
-                <property><name>vitro-dir</name></property>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <artifactId>maven-assembly-plugin</artifactId>
-                        <configuration>
-                            <descriptors>
-                                <descriptor>src/main/assembly/home.xml</descriptor>
-                            </descriptors>
-                            <appendAssemblyId>false</appendAssemblyId>
-                        </configuration>
-                        <executions>
-                            <execution>
-                                <phase>package</phase>
-                                <goals>
-                                    <goal>single</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-                    <plugin>
-                        <artifactId>maven-antrun-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>remove-webapp</id>
-                                <phase>verify</phase>
-                                <goals>
-                                    <goal>run</goal>
-                                </goals>
-                                <configuration>
-                                    <target>
-                                        <delete dir="${vitro-dir}/rdf" />
-                                    </target>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-                    <plugin>
-                        <artifactId>maven-resources-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>install</id>
-                                <phase>install</phase>
-                                <goals>
-                                    <goal>copy-resources</goal>
-                                </goals>
-                                <configuration>
-                                    <outputDirectory>${vitro-dir}</outputDirectory>
-                                    <resources>
-                                        <resource>
-                                            <directory>${project.build.directory}/${project.build.finalName}</directory>
-                                        </resource>
-                                    </resources>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
-
     <build>
         <plugins>
             <plugin>
-                <artifactId>maven-install-plugin</artifactId>
+                <artifactId>maven-assembly-plugin</artifactId>
                 <configuration>
-                    <skip>true</skip>
+                    <descriptors>
+                        <descriptor>src/main/assembly/home.xml</descriptor>
+                    </descriptors>
+                    <appendAssemblyId>false</appendAssemblyId>
                 </configuration>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/installer/home/src/main/assembly/home.xml
+++ b/installer/home/src/main/assembly/home.xml
@@ -3,7 +3,7 @@
           xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 http://maven.apache.org/xsd/assembly-1.1.3.xsd">
     <id>home</id>
     <formats>
-        <format>dir</format>
+        <format>tar</format>
     </formats>
     <includeBaseDirectory>false</includeBaseDirectory>
     <dependencySets>

--- a/installer/webapp/pom.xml
+++ b/installer/webapp/pom.xml
@@ -30,6 +30,34 @@
                 <plugins>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-dependency-plugin</artifactId>
+                        <configuration>
+                            <skip>false</skip>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>include-home</id>
+                                <phase>process-resources</phase>
+                                <goals>
+                                    <goal>unpack</goal>
+                                </goals>
+                                <configuration>
+                                    <artifactItems>
+                                        <artifactItem>
+                                            <groupId>org.vivoweb</groupId>
+                                            <artifactId>vitro-installer-home</artifactId>
+                                            <version>${project.version}</version>
+                                            <type>tar</type>
+                                            <outputDirectory>
+                                                target/${app-name}/WEB-INF/resources/home-files</outputDirectory>
+                                        </artifactItem>
+                                    </artifactItems>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-war-plugin</artifactId>
                         <configuration>
                             <archive>
@@ -57,53 +85,19 @@
             </build>
         </profile>
         <profile>
-            <id>install</id>
+            <id>deploy</id>
             <activation>
                 <property><name>tomcat-dir</name></property>
             </activation>
             <build>
                 <plugins>
                     <plugin>
-                        <artifactId>maven-antrun-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>remove-webapp</id>
-                                <phase>verify</phase>
-                                <goals>
-                                    <goal>run</goal>
-                                </goals>
-                                <configuration>
-                                    <target>
-                                        <delete dir="${tomcat-dir}/webapps/${project.build.finalName}" />
-                                    </target>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-                    <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-dependency-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>install</id>
-                                <phase>install</phase>
-                                <goals>
-                                    <goal>unpack</goal>
-                                </goals>
-                                <configuration>
-                                    <artifactItems>
-                                        <artifactItem>
-                                            <groupId>${project.groupId}</groupId>
-                                            <artifactId>${project.artifactId}</artifactId>
-                                            <version>${project.version}</version>
-                                            <type>war</type>
-                                            <overWrite>true</overWrite>
-                                            <outputDirectory>${tomcat-dir}/webapps/${project.build.finalName}</outputDirectory>
-                                        </artifactItem>
-                                    </artifactItems>
-                                </configuration>
-                            </execution>
-                        </executions>
+                        <artifactId>maven-war-plugin</artifactId>
+                        <version>3.2.1</version>
+                        <configuration>
+                            <outputDirectory>${tomcat-dir}/webapps/</outputDirectory>
+                        </configuration>
                     </plugin>
                 </plugins>
             </build>


### PR DESCRIPTION
**[VIVO GitHub issue](https://github.com/vivo-project/VIVO/issues/3034)**
[VIVO PR](https://github.com/vivo-project/VIVO/pull/4017)
# What does this pull request do?
Decoupled deployment and installation processes
Changed delivery of home directory: package it's contents as part of war artifact, update default files on home directory except rdf subdirectory on startup. 
In case tomcat directory is not provided artifact will not be copied into tomcat webapps directory

# What's new?
Changed deployment: war artifact is copied into webapp directory, not unpacked
Home directory contents are copied into war artifact
On startup path to home directory is being created if not already exists.
RDFFilesLoader and FileGraphSetup were adjusted to read home/rdf files from tomcat webapp application directory

# How should this be tested?
Test update of already installed instance and installation of new instance. 
- Verify that mvn install -s example-settings.xml work as before
- Remove tomcat directory from xml file, copy created war file manually to tomcat webapp directory, that should result in deployment of application.


# Additional Notes:
This change require documentation to be updated

# Interested parties
@VIVO-project/vivo-committers

# Reviewers' expertise

Candidates for reviewing this PR should have some of the following expertises:
1. Java
2. Maven
# Reviewers' report template
**Please update the following template which should be used by reviewers.**
## General comment
A reviewer should provide here comments and suggestions for requested changes if any.
## Testing
A reviewer should briefly describe here how it was tested
## Code reviewing
A reviewer should briefly describe here which part was code reviewed