### PR TITLE
Display error in case home source directory is not accessible

### DIFF
--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/application/ApplicationSetup.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/application/ApplicationSetup.java
@@ -13,7 +13,7 @@ import javax.servlet.ServletContextListener;
 
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
-
+import edu.cornell.mannlib.vitro.webapp.application.VitroHomeDirectory.HomeSourceException;
 import edu.cornell.mannlib.vitro.webapp.startup.StartupStatus;
 import edu.cornell.mannlib.vitro.webapp.utils.configuration.ConfigurationBeanLoader;
 import edu.cornell.mannlib.vitro.webapp.utils.configuration.ConfigurationBeanLoaderException;
@@ -57,6 +57,8 @@ public class ApplicationSetup implements ServletContextListener {
 
 			ApplicationUtils.setInstance(app);
 			ss.info(this, "Application is configured.");
+		} catch(HomeSourceException e) {
+			ss.fatal(this, e.getMessage());
 		} catch (Exception e) {
 			ss.fatal(this, "Failed to initialize the Application.", e);
 		}

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/application/VitroHomeDirectory.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/application/VitroHomeDirectory.java
@@ -91,7 +91,7 @@ public class VitroHomeDirectory {
             super(String.format("Home source directory %s " +
                     cause +
                     "<br>" +
-                    "Try to remove deployed tomcat application directory %s and restart tomcat.", homeSourcePath,
+                    "Try to remove deployed Tomcat application directory %s and restart Tomcat.", homeSourcePath,
                     context.getRealPath("/")));
         }
     }

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/application/VitroHomeDirectory.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/application/VitroHomeDirectory.java
@@ -74,6 +74,26 @@ public class VitroHomeDirectory {
         if (homeSourcePath == null) {
             throw new IllegalStateException(String.format("Application home files not found in: %s", location));
         }
+        File homeSource = new File(homeSourcePath);
+        if (!homeSource.exists()) {
+            throw new HomeSourceException(context, "doesn't exist.");
+        }
+        if (!homeSource.canRead()) {
+            throw new HomeSourceException(context, "can't be read.");
+        }
+        if (!homeSource.isDirectory()) {
+            throw new HomeSourceException(context, "is not a directory.");
+        }
+    }
+
+    public class HomeSourceException extends RuntimeException {
+        public HomeSourceException(ServletContext context, String cause) {
+            super(String.format("Home source directory %s " +
+                    cause +
+                    "<br>" +
+                    "Try to remove deployed tomcat application directory %s and restart tomcat.", homeSourcePath,
+                    context.getRealPath("/")));
+        }
     }
 
     /**

--- a/api/src/test/java/edu/cornell/mannlib/vitro/webapp/application/VitroHomeDirectoryTest.java
+++ b/api/src/test/java/edu/cornell/mannlib/vitro/webapp/application/VitroHomeDirectoryTest.java
@@ -26,11 +26,10 @@ public class VitroHomeDirectoryTest {
     @Test
     public void testGetHomeSrcPath() {
         ServletContextStub sc = new ServletContextStub();
-        String expectedPath = "/opt/tomcat/webapp/app/WEB-INF/resources/home-files";
-        sc.setRealPath("/WEB-INF/resources/home-files", expectedPath);
+        sc.setRealPath("/WEB-INF/resources/home-files", src.getRoot().getAbsolutePath());
         VitroHomeDirectory vhd = new VitroHomeDirectory(sc, dst.getRoot().toPath(), "");
         String realPath = vhd.getSourcePath();
-        assertEquals(expectedPath, realPath);
+        assertEquals(src.getRoot().getAbsolutePath(), realPath);
     }
 
     @Test


### PR DESCRIPTION
# What does this pull request do?
Added custom exception in case home source directory doesn't exist (could happen in case tomcat application redeployment fails).

# How should this be tested?
* Build and install VIVO
* Manually delete directory tomcat/webapps/${app-name}/WEB-INF/resources/home-files
* Restart tomcat
* Open VIVO
* You should see error report containing error description and instruction how to solve the issue.
* Follow instructions and check if that fixed the issue.

# Interested parties
@brianjlowe @chenejac 

# Reviewers' expertise
Candidates for reviewing this PR should have some of the following expertises:
1. Java

# Reviewers' report template
## General comment
A reviewer should provide here comments and suggestions for requested changes if any.
## Testing
A reviewer should briefly describe here how it was tested
## Code reviewing
A reviewer should briefly describe here which part was code reviewed