### PR TITLE
Provide user information into model change

### DIFF
--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/auth/checks/UserOnThread.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/auth/checks/UserOnThread.java
@@ -1,0 +1,30 @@
+/* $This file is distributed under the terms of the license in LICENSE$ */
+
+package edu.cornell.mannlib.vitro.webapp.auth.checks;
+
+import javax.servlet.http.HttpServletRequest;
+
+import edu.cornell.mannlib.vitro.webapp.auth.policy.PolicyHelper;
+
+public class UserOnThread implements AutoCloseable {
+
+    private static ThreadLocal<String> threadLocal = new ThreadLocal<>();
+
+    public UserOnThread(String userId) {
+        threadLocal.set(userId);
+    }
+
+    public UserOnThread(HttpServletRequest vreq) {
+        threadLocal.set(PolicyHelper.getUserAccount(vreq).getUri());
+    }
+
+    @Override
+    public void close() {
+        threadLocal.remove();
+    }
+
+    public static String get() {
+        return threadLocal.get();
+    }
+
+}

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/accounts/admin/UserAccountsAdminController.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/accounts/admin/UserAccountsAdminController.java
@@ -74,7 +74,7 @@ public class UserAccountsAdminController extends FreemarkerHttpServlet {
 		if (page.isBogus()) {
 			return showHomePage(vreq, page.getBogusMessage());
 		} else if (page.isSubmit() && page.isValid()) {
-		    try(UserOnThread uot = new UserOnThread(vreq)){
+		    try (UserOnThread uot = new UserOnThread(vreq)) {
 		        page.updateAccount();
 		    }
 

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/accounts/admin/UserAccountsAdminController.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/accounts/admin/UserAccountsAdminController.java
@@ -6,8 +6,9 @@ import java.util.Collection;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-
+import edu.cornell.mannlib.vitro.webapp.auth.checks.UserOnThread;
 import edu.cornell.mannlib.vitro.webapp.auth.permissions.SimplePermission;
+import edu.cornell.mannlib.vitro.webapp.auth.policy.PolicyHelper;
 import edu.cornell.mannlib.vitro.webapp.auth.requestedAction.AuthorizationRequest;
 import edu.cornell.mannlib.vitro.webapp.beans.DisplayMessage;
 import edu.cornell.mannlib.vitro.webapp.controller.VitroRequest;
@@ -73,7 +74,9 @@ public class UserAccountsAdminController extends FreemarkerHttpServlet {
 		if (page.isBogus()) {
 			return showHomePage(vreq, page.getBogusMessage());
 		} else if (page.isSubmit() && page.isValid()) {
-			page.updateAccount();
+		    try(UserOnThread uot = new UserOnThread(vreq)){
+		        page.updateAccount();
+		    }
 
 			UserAccountsListPage.Message.showUpdatedAccount(vreq,
 					page.getUpdatedAccount(), page.wasPasswordEmailSent());

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/accounts/manageproxies/ManageProxiesController.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/accounts/manageproxies/ManageProxiesController.java
@@ -6,7 +6,7 @@ import java.util.Map;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-
+import edu.cornell.mannlib.vitro.webapp.auth.checks.UserOnThread;
 import edu.cornell.mannlib.vitro.webapp.auth.permissions.SimplePermission;
 import edu.cornell.mannlib.vitro.webapp.auth.requestedAction.AuthorizationRequest;
 import edu.cornell.mannlib.vitro.webapp.controller.AbstractPageHandler.Message;
@@ -69,7 +69,9 @@ public class ManageProxiesController extends FreemarkerHttpServlet {
 		ManageProxiesEditPage page = new ManageProxiesEditPage(vreq);
 
 		if (page.isValid()) {
-			page.applyEdits();
+		    try (UserOnThread uot = new UserOnThread(vreq)) {
+		        page.applyEdits();
+		    }
 			Message.setMessage(vreq, new SuccessMessage());
 		} else {
 			Message.setMessage(vreq, new FailureMessage());

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/api/SparqlUpdateApiController.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/api/SparqlUpdateApiController.java
@@ -33,6 +33,7 @@ import org.apache.jena.graph.NodeFactory;
 import org.apache.jena.sparql.modify.UsingList;
 
 import edu.cornell.mannlib.vitro.webapp.application.ApplicationUtils;
+import edu.cornell.mannlib.vitro.webapp.auth.checks.UserOnThread;
 import edu.cornell.mannlib.vitro.webapp.auth.permissions.SimplePermission;
 import edu.cornell.mannlib.vitro.webapp.auth.requestedAction.AuthorizationRequest;
 import edu.cornell.mannlib.vitro.webapp.controller.VitroRequest;
@@ -129,7 +130,7 @@ public class SparqlUpdateApiController extends VitroApiServlet {
 		SearchIndexer indexer = ApplicationUtils.instance().getSearchIndexer();
 		Dataset ds = new RDFServiceDataset(vreq.getUnfilteredRDFService());
 		GraphStore graphStore = GraphStoreFactory.create(ds);
-	    try {
+		try (UserOnThread uot = new UserOnThread(req)) {
 	        if(indexer != null) {
 	            indexer.pause();
 	        }

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/datatools/dumprestore/DumpRestoreController.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/datatools/dumprestore/DumpRestoreController.java
@@ -12,7 +12,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import org.apache.commons.lang3.StringUtils;
-
+import edu.cornell.mannlib.vitro.webapp.auth.checks.UserOnThread;
 import edu.cornell.mannlib.vitro.webapp.auth.permissions.SimplePermission;
 import edu.cornell.mannlib.vitro.webapp.auth.policy.PolicyHelper;
 import edu.cornell.mannlib.vitro.webapp.auth.requestedAction.AuthorizationRequest;
@@ -88,7 +88,7 @@ public class DumpRestoreController extends FreemarkerHttpServlet {
 			resp.sendError(HttpServletResponse.SC_FORBIDDEN);
 		}
 
-		try {
+		try (UserOnThread uot = new UserOnThread(req)) {
 			if (ACTION_RESTORE.equals(req.getPathInfo())) {
 				long tripleCount = new RestoreModelsAction(req, resp)
 						.restoreModels();

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/edit/Authenticate.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/edit/Authenticate.java
@@ -31,7 +31,6 @@ import org.apache.jena.ontology.OntModel;
 import edu.cornell.mannlib.vedit.beans.LoginStatusBean;
 import edu.cornell.mannlib.vedit.beans.LoginStatusBean.AuthenticationSource;
 import edu.cornell.mannlib.vitro.webapp.auth.checks.UserOnThread;
-import edu.cornell.mannlib.vitro.webapp.auth.policy.PolicyHelper;
 import edu.cornell.mannlib.vitro.webapp.beans.UserAccount;
 import edu.cornell.mannlib.vitro.webapp.controller.Controllers;
 import edu.cornell.mannlib.vitro.webapp.controller.VitroHttpServlet;
@@ -470,8 +469,8 @@ public class Authenticate extends VitroHttpServlet {
 	private void transitionToLoggedIn(HttpServletRequest request,
 			UserAccount user) throws LoginNotPermitted {
 		log.debug("Completed login: " + user.getEmailAddress());
-		try(UserOnThread userInfo = new UserOnThread(user.getUri())){
-		getAuthenticator(request).recordLoginAgainstUserAccount(user,
+		try(UserOnThread uot = new UserOnThread(user.getUri())){
+			getAuthenticator(request).recordLoginAgainstUserAccount(user,
 				AuthenticationSource.INTERNAL);
 		}
 	}

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/edit/Authenticate.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/edit/Authenticate.java
@@ -469,7 +469,7 @@ public class Authenticate extends VitroHttpServlet {
 	private void transitionToLoggedIn(HttpServletRequest request,
 			UserAccount user) throws LoginNotPermitted {
 		log.debug("Completed login: " + user.getEmailAddress());
-		try(UserOnThread uot = new UserOnThread(user.getUri())){
+		try (UserOnThread uot = new UserOnThread(user.getUri())) {
 			getAuthenticator(request).recordLoginAgainstUserAccount(user,
 				AuthenticationSource.INTERNAL);
 		}

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/edit/Authenticate.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/edit/Authenticate.java
@@ -30,6 +30,8 @@ import org.apache.jena.ontology.OntModel;
 
 import edu.cornell.mannlib.vedit.beans.LoginStatusBean;
 import edu.cornell.mannlib.vedit.beans.LoginStatusBean.AuthenticationSource;
+import edu.cornell.mannlib.vitro.webapp.auth.checks.UserOnThread;
+import edu.cornell.mannlib.vitro.webapp.auth.policy.PolicyHelper;
 import edu.cornell.mannlib.vitro.webapp.beans.UserAccount;
 import edu.cornell.mannlib.vitro.webapp.controller.Controllers;
 import edu.cornell.mannlib.vitro.webapp.controller.VitroHttpServlet;
@@ -468,8 +470,10 @@ public class Authenticate extends VitroHttpServlet {
 	private void transitionToLoggedIn(HttpServletRequest request,
 			UserAccount user) throws LoginNotPermitted {
 		log.debug("Completed login: " + user.getEmailAddress());
+		try(UserOnThread userInfo = new UserOnThread(user.getUri())){
 		getAuthenticator(request).recordLoginAgainstUserAccount(user,
 				AuthenticationSource.INTERNAL);
+		}
 	}
 
 	/**

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/edit/MenuManagementEdit.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/edit/MenuManagementEdit.java
@@ -24,7 +24,7 @@ import org.apache.jena.rdf.model.RDFNode;
 import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.rdf.model.ResourceFactory;
 import org.apache.jena.shared.Lock;
-
+import edu.cornell.mannlib.vitro.webapp.auth.checks.UserOnThread;
 import edu.cornell.mannlib.vitro.webapp.controller.VitroHttpServlet;
 import edu.cornell.mannlib.vitro.webapp.controller.VitroRequest;
 import edu.cornell.mannlib.vitro.webapp.dao.DisplayVocabulary;
@@ -51,15 +51,15 @@ public class MenuManagementEdit extends VitroHttpServlet {
 
     	String command = getCommand(vreq);
     	if(command != null) {
-    		processCommand(command, vreq, resp);
+    	    try (UserOnThread uot = new UserOnThread(vreq)) {
+    	        processCommand(command, vreq, resp);
+    	    }
     	} else {
     		log.error("Command is null");
     	}
         //Need to redirect correctly
     	if(!isReorder(command)){
     		resp.sendRedirect(rawRequest.getContextPath() + REDIRECT_URL);
-    	} else {
-
     	}
     }
 

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/jena/RDFUploadController.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/jena/RDFUploadController.java
@@ -34,6 +34,7 @@ import org.apache.jena.shared.JenaException;
 import org.apache.jena.shared.Lock;
 
 import edu.cornell.mannlib.vedit.beans.LoginStatusBean;
+import edu.cornell.mannlib.vitro.webapp.auth.checks.UserOnThread;
 import edu.cornell.mannlib.vitro.webapp.auth.permissions.SimplePermission;
 import edu.cornell.mannlib.vitro.webapp.controller.VitroRequest;
 import edu.cornell.mannlib.vitro.webapp.dao.WebappDaoFactory;
@@ -434,7 +435,7 @@ public class RDFUploadController extends JenaIngestController {
         ChangeSet cs = makeChangeSet(rdfService);
         cs.addAddition(in, RDFServiceUtils.getSerializationFormatFromJenaString(
                         language), modelName, userId);
-        try {
+        try (UserOnThread uot = new UserOnThread(userId)) {
             rdfService.changeSetUpdate(cs);
         } catch (RDFServiceException e) {
             throw new RuntimeException(e);
@@ -446,7 +447,7 @@ public class RDFUploadController extends JenaIngestController {
         ChangeSet cs = makeChangeSet(rdfService);
         cs.addRemoval(in, RDFServiceUtils.getSerializationFormatFromJenaString(
                         language), modelName, userId);
-        try {
+        try (UserOnThread uot = new UserOnThread(userId)) {
             rdfService.changeSetUpdate(cs);
         } catch (RDFServiceException e) {
             throw new RuntimeException(e);

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/dwr/PropertyDWR.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/dwr/PropertyDWR.java
@@ -11,7 +11,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.directwebremoting.WebContext;
 import org.directwebremoting.WebContextFactory;
-
+import edu.cornell.mannlib.vitro.webapp.auth.checks.UserOnThread;
 import edu.cornell.mannlib.vitro.webapp.beans.PropertyInstance;
 import edu.cornell.mannlib.vitro.webapp.controller.VitroRequest;
 import edu.cornell.mannlib.vitro.webapp.dao.WebappDaoFactory;
@@ -86,14 +86,19 @@ public class PropertyDWR {
         WebContext ctx = WebContextFactory.get();
         HttpServletRequest req = ctx.getHttpServletRequest();
         VitroRequest vreq = new VitroRequest(req);
-        return vreq.getUnfilteredWebappDaoFactory().getPropertyInstanceDao().insertProp(prop);
+        try (UserOnThread uot = new UserOnThread(vreq)) {
+            return vreq.getUnfilteredWebappDaoFactory().getPropertyInstanceDao().insertProp(prop);
+        }
     }
 
     public int deleteProp(String subjectUri, String predicateUri, String objectUri){
         WebContext ctx = WebContextFactory.get();
         HttpServletRequest req = ctx.getHttpServletRequest();
         VitroRequest vreq = new VitroRequest(req);
-        vreq.getUnfilteredWebappDaoFactory().getPropertyInstanceDao().deleteObjectPropertyStatement(subjectUri, predicateUri, objectUri);
+        try (UserOnThread uot = new UserOnThread(vreq)) {
+            vreq.getUnfilteredWebappDaoFactory().getPropertyInstanceDao().deleteObjectPropertyStatement(subjectUri,
+                    predicateUri, objectUri);
+        }
         return 0;
     }
 

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/VTwo/ProcessRdfForm.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/VTwo/ProcessRdfForm.java
@@ -26,7 +26,7 @@ import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.rdf.model.ResourceFactory;
 import org.apache.jena.rdf.model.Statement;
 import org.apache.jena.vocabulary.RDF;
-
+import edu.cornell.mannlib.vitro.webapp.auth.checks.UserOnThread;
 import edu.cornell.mannlib.vitro.webapp.controller.VitroRequest;
 import edu.cornell.mannlib.vitro.webapp.dao.InsertException;
 import edu.cornell.mannlib.vitro.webapp.dao.jena.DependentResourceDeleteJena;
@@ -303,7 +303,7 @@ public class ProcessRdfForm {
         cs.addRemoval(retractionsInputStream,
                 RDFServiceUtils.getSerializationFormatFromJenaString("N3"), graphUri, editorUri);
 
-        try {
+        try (UserOnThread uot = new UserOnThread(editorUri)) {
             rdfService.changeSetUpdate(cs);
         } catch (RDFServiceException e) {
             log.error(e, e);

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/rdfservice/ChangeSet.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/rdfservice/ChangeSet.java
@@ -159,6 +159,7 @@ public interface ChangeSet {
      */
     public List<Object> getPostChangeEvents();
 
+    public void setUserFromThread();
 
 
 }

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/rdfservice/ChangeSet.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/rdfservice/ChangeSet.java
@@ -46,7 +46,6 @@ public interface ChangeSet {
 	 * @param serializationFormat - format of the serialized RDF model
 	 * @param graphURI - URI of the graph to which the RDF model should be added
 	 */
-	@Deprecated
 	public void addAddition(InputStream model,
 			                RDFService.ModelSerializationFormat serializationFormat,
 			                String graphURI);
@@ -58,7 +57,6 @@ public interface ChangeSet {
 	 * @param serializationFormat - format of the serialized RDF model
 	 * @param graphURI - URI of the graph from which the RDF model should be removed
 	 */
-	@Deprecated
 	public void addRemoval(InputStream model,
 			               RDFService.ModelSerializationFormat serializationFormat,
 			               String graphURI);

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/rdfservice/impl/ChangeSetImpl.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/rdfservice/impl/ChangeSetImpl.java
@@ -6,10 +6,13 @@ import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
 
+import edu.cornell.mannlib.vitro.webapp.auth.checks.UserOnThread;
+import edu.cornell.mannlib.vitro.webapp.beans.UserAccount;
 import edu.cornell.mannlib.vitro.webapp.rdfservice.ChangeSet;
 import edu.cornell.mannlib.vitro.webapp.rdfservice.ModelChange;
 import edu.cornell.mannlib.vitro.webapp.rdfservice.ModelChange.Operation;
 import edu.cornell.mannlib.vitro.webapp.rdfservice.RDFService;
+import org.apache.commons.lang3.StringUtils;
 
 public class ChangeSetImpl implements ChangeSet {
 
@@ -120,4 +123,14 @@ public class ChangeSetImpl implements ChangeSet {
 				+ ", preChangeEvents=" + preChangeEvents
 				+ ", postChangeEvents=" + postChangeEvents + "]";
 	}
+
+    @Override
+    public void setUserFromThread() {
+        String userId = UserOnThread.get();
+        if (StringUtils.isNotBlank(userId)) {
+            for (ModelChange modelChange : modelChanges) {
+                modelChange.setUserId(userId);
+            }
+        }
+    }
 }

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/rdfservice/impl/RDFServiceImpl.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/rdfservice/impl/RDFServiceImpl.java
@@ -150,6 +150,7 @@ public abstract class RDFServiceImpl implements RDFService {
         if (registeredListeners.isEmpty() && registeredJenaListeners.isEmpty()) {
             return;
         }
+        changeSet.setUserFromThread();
         for (ModelChange modelChange : changeSet.getModelChanges()) {
             notifyListeners(modelChange);
         }

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/rdfservice/impl/jena/model/RDFServiceModel.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/rdfservice/impl/jena/model/RDFServiceModel.java
@@ -3,7 +3,6 @@
 package edu.cornell.mannlib.vitro.webapp.rdfservice.impl.jena.model;
 
 import java.io.ByteArrayInputStream;
-import java.util.Iterator;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.logging.Log;


### PR DESCRIPTION
**[VIVO GitHub issue](https://github.com/vivo-project/VIVO/issues/3832)**
Should resolve https://github.com/vivo-project/Vitro/pull/390#issuecomment-1855527028
# What does this pull request do?
Implements an option to provide user information into ModelChange in cases when modification of data is made on in-memory cached models

# How should this be tested?

1. Build and install VIVO, enable audit module
2. Try to create/delete/edit pages
3. Create/edit new individuals
4. Try using SPARQL Update API to insert data
5. Try using "Edit this individual page to modify individual data"
6. Try using "Dump and restore"
7. All of the actions above should be logged in audit interface with real uri of the user, not "http://vivoweb.org/audit/resource/unknown"

# Additional Notes:

# Interested parties
@VIVO-project/vivo-committers

# Reviewers' expertise
Candidates for reviewing this PR should have some of the following expertises:
1. Java

# Reviewers' report template

## General comment
A reviewer should provide here comments and suggestions for requested changes if any.
## Testing
A reviewer should briefly describe here how it was tested
## Code reviewing
A reviewer should briefly describe here which part was code reviewed