### PR TITLE
Use transactional dataset in RDFServiceImplTest

### DIFF
--- a/api/src/test/java/edu/cornell/mannlib/vitro/webapp/rdfservice/impl/RDFServiceImplTest.java
+++ b/api/src/test/java/edu/cornell/mannlib/vitro/webapp/rdfservice/impl/RDFServiceImplTest.java
@@ -15,7 +15,7 @@ public class RDFServiceImplTest {
 
     @Test
     public void getConcurrentGraphUrisTest() throws RDFServiceException, InterruptedException {
-        Dataset testDataSet = DatasetFactory.createGeneral();
+        Dataset testDataSet = DatasetFactory.create();
         Model m1 = VitroModelFactory.createModel();
         testDataSet.addNamedModel("test:init1", m1);
         Model m2 = VitroModelFactory.createModel();


### PR DESCRIPTION
# What does this pull request do?
Lately RDFServiceImplTest failed for some PRs. This PR fixes the test by using transactional dataset implementation.

# Interested parties
@VIVO-project/vivo-committers

# Reviewers' expertise
Candidates for reviewing this PR should have some of the following expertises:
1. Java