### PR TITLE
Avoid invalid substitutions in translation converter

### DIFF
--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/i18n/TranslationConverter.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/i18n/TranslationConverter.java
@@ -243,6 +243,7 @@ public class TranslationConverter {
 		ParameterizedSparqlString pss = new ParameterizedSparqlString();
 		pss.setCommandText(TEMPLATE_LABEL);
 		pss.setIri("uri", uri);
+		pss = new ParameterizedSparqlString(pss.toString());
 		pss.setLiteral("label", label, langTag);
 		return pss.toString();
 	}
@@ -252,12 +253,13 @@ public class TranslationConverter {
 		ParameterizedSparqlString pss = new ParameterizedSparqlString();
 		pss.setCommandText(template);
 		pss.setIri("uri", createUUID());
-		pss.setLiteral("label", label, langTag);
 		pss.setLiteral("key", key);
 		pss.setLiteral("application", application);
 		if (!StringUtils.isBlank(theme)) {
 			pss.setLiteral("theme", theme);
 		}
+		pss = new ParameterizedSparqlString(pss.toString());
+		pss.setLiteral("label", label, langTag);
 		return pss.toString();
 	}
 

--- a/api/src/test/java/edu/cornell/mannlib/vitro/webapp/i18n/TranslationConverterTest.java
+++ b/api/src/test/java/edu/cornell/mannlib/vitro/webapp/i18n/TranslationConverterTest.java
@@ -11,10 +11,12 @@ import java.io.FileReader;
 
 import org.apache.jena.graph.NodeFactory;
 import org.apache.jena.ontology.OntModel;
+import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.rdf.model.Selector;
 import org.apache.jena.rdf.model.SimpleSelector;
 import org.apache.jena.rdf.model.StmtIterator;
 import org.apache.jena.rdf.model.impl.PropertyImpl;
+import org.apache.jena.vocabulary.RDFS;
 import org.apache.log4j.Level;
 import org.apache.log4j.LogManager;
 import org.apache.log4j.Logger;
@@ -35,6 +37,7 @@ public class TranslationConverterTest {
 	private static final String INIT_N3_FILE = "src/test/resources/edu/cornell/mannlib/vitro/webapp/i18n/TranslationConverterTest/modelInitContent.n3";
 	ServletContextStub ctx = new ServletContextStub();
 	private OntModel model;
+	private boolean debug = false;
 	
     @Before
     public void init() {
@@ -76,13 +79,29 @@ public class TranslationConverterTest {
 
 		assertTrue(n3TranslationValueIsOverwrittenByProperty(model));
 
-		assertEquals(3, getCount(HAS_THEME, WILMA));
-		assertEquals(6, getCount(HAS_APP, VITRO));
+		assertEquals(4, getCount(HAS_THEME, WILMA));
+		assertEquals(7, getCount(HAS_APP, VITRO));
 		assertEquals(3, getCount(HAS_APP, VIVO));
-		// printResultModel();
+		
+		checkTranslationLabelWithUri();
+		if (debug) {
+		    printResultModel();
+		}
 	}
 
-	private void printResultModel() {
+	private void checkTranslationLabelWithUri() {
+	    Selector selector = new SimpleSelector(null, new PropertyImpl(HAS_KEY), "translation_with_uri");
+        StmtIterator it = model.listStatements(selector);
+        assertTrue(it.hasNext());
+        Resource subject = it.next().getSubject();
+        Selector labelSelector = new SimpleSelector(subject, RDFS.label, (Object) null);
+        StmtIterator it2 = model.listStatements(labelSelector);
+        assertTrue(it2.hasNext());
+        String labelText = it2.next().getObject().asLiteral().getLexicalForm();
+        assertTrue(labelText.contains("?uri"));
+    }
+
+    private void printResultModel() {
 		ByteArrayOutputStream baos = new ByteArrayOutputStream();
 		model.write(baos, "N3");
 		System.out.println(baos.toString());

--- a/api/src/test/resources/edu/cornell/mannlib/vitro/webapp/i18n/TranslationConverterTest/root/themes/wilma/all_en_CA.properties
+++ b/api/src/test/resources/edu/cornell/mannlib/vitro/webapp/i18n/TranslationConverterTest/root/themes/wilma/all_en_CA.properties
@@ -1,1 +1,3 @@
 test_key_all_en_CA = test value all_en_CA wilma
+translation_with_uri = <a href=\"/vivo/individual?uri=http://test\">link text</a>
+


### PR DESCRIPTION
# What does this pull request do?
Avoid possible substitutions in translation body if body content matches sparql variable name.
For example if translation string contains a variable with a link 
 <a href=\"/fis/individual?uri=http://d-nb.info/gnd/1080328793\">
 ?uri part match variable name and is being substituted with variable value.
 To prevent that new parameterized sparql string is being created before substitution of label value.

# How should this be tested?

- Run extended translation converter test

- Manual testing:
1. Create a translation in properties file with body that contains ?uri text
2. Start VIVO to run translation conversions
3. Check created translation in http://vitro.mannlib.cornell.edu/default/interface-i18n  graph

# Interested parties
@VIVO-project/vivo-committers

# Reviewers' expertise
Candidates for reviewing this PR should have some of the following expertises:
1. Java
# Reviewers' report template
## General comment
A reviewer should provide here comments and suggestions for requested changes if any.
## Testing
A reviewer should briefly describe here how it was tested
## Code reviewing
A reviewer should briefly describe here which part was code reviewed