### PR TITLE
VIVO-4020 Order user accounts by last login time in descending order

### DIFF
--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/accounts/UserAccountsOrdering.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/accounts/UserAccountsOrdering.java
@@ -9,7 +9,7 @@ public class UserAccountsOrdering {
 	public enum Direction {
 		ASCENDING("ASC"), DESCENDING("DESC");
 
-		public static Direction DEFAULT_DIRECTION = ASCENDING;
+		public static Direction DEFAULT_DIRECTION = DESCENDING;
 
 		public static Direction fromKeyword(String keyword) {
 			if (keyword == null) {
@@ -37,7 +37,7 @@ public class UserAccountsOrdering {
 				"status"), ROLE("ps"), LOGIN_COUNT("count"), LAST_LOGIN_TIME(
 				"lastLogin");
 
-		public static Field DEFAULT_FIELD = EMAIL;
+		public static Field DEFAULT_FIELD = LAST_LOGIN_TIME;
 
 		public static Field fromName(String name) {
 			if (name == null) {

--- a/api/src/test/java/edu/cornell/mannlib/vitro/webapp/controller/accounts/UserAccountsSelectorTest.java
+++ b/api/src/test/java/edu/cornell/mannlib/vitro/webapp/controller/accounts/UserAccountsSelectorTest.java
@@ -2,7 +2,6 @@
 
 package edu.cornell.mannlib.vitro.webapp.controller.accounts;
 
-import static edu.cornell.mannlib.vitro.webapp.controller.accounts.UserAccountsOrdering.DEFAULT_ORDERING;
 import static org.junit.Assert.assertEquals;
 
 import java.io.IOException;
@@ -32,6 +31,9 @@ public class UserAccountsSelectorTest extends AbstractTestClass {
 	private static final String N3_DATA_FILENAME = "UserAccountsSelectorTest.n3";
 
 	private static final String NS_MINE = "http://vivo.mydomain.edu/individual/";
+
+    private static final UserAccountsOrdering DEFAULT_ORDERING = new UserAccountsOrdering(
+            Field.EMAIL, Direction.ASCENDING);
 
 	private static OntModel ontModel;
 

--- a/api/src/test/java/edu/cornell/mannlib/vitro/webapp/controller/accounts/UserAccountsSelectorTest.java
+++ b/api/src/test/java/edu/cornell/mannlib/vitro/webapp/controller/accounts/UserAccountsSelectorTest.java
@@ -32,7 +32,7 @@ public class UserAccountsSelectorTest extends AbstractTestClass {
 
 	private static final String NS_MINE = "http://vivo.mydomain.edu/individual/";
 
-    private static final UserAccountsOrdering DEFAULT_ORDERING = new UserAccountsOrdering(
+    private static final UserAccountsOrdering ACCOUNTS_ORDERING = new UserAccountsOrdering(
             Field.EMAIL, Direction.ASCENDING);
 
 	private static OntModel ontModel;
@@ -60,7 +60,7 @@ public class UserAccountsSelectorTest extends AbstractTestClass {
 	@Test(expected = NullPointerException.class)
 	public void modelIsNull() {
 		UserAccountsSelector.select(null,
-				criteria(10, 1, DEFAULT_ORDERING, "", ""));
+				criteria(10, 1, ACCOUNTS_ORDERING, "", ""));
 	}
 
 	@Test(expected = NullPointerException.class)
@@ -74,7 +74,7 @@ public class UserAccountsSelectorTest extends AbstractTestClass {
 
 	@Test
 	public void checkAllFields() {
-		selectOnCriteria(1, 10, DEFAULT_ORDERING, "", "");
+		selectOnCriteria(1, 10, ACCOUNTS_ORDERING, "", "");
 		assertSelectedUris(10, "user10");
 
 		UserAccount acct = selection.getUserAccounts().get(0);
@@ -99,7 +99,7 @@ public class UserAccountsSelectorTest extends AbstractTestClass {
 
 	@Test
 	public void checkFieldsForRootUser() {
-		selectOnCriteria(1, 8, DEFAULT_ORDERING, "", "");
+		selectOnCriteria(1, 8, ACCOUNTS_ORDERING, "", "");
 		assertSelectedUris(10, "user08");
 
 		UserAccount acct = selection.getUserAccounts().get(0);
@@ -125,32 +125,32 @@ public class UserAccountsSelectorTest extends AbstractTestClass {
 
 	@Test
 	public void showFirstPageOfFifteen() {
-		selectOnCriteria(15, 1, DEFAULT_ORDERING, "", "");
+		selectOnCriteria(15, 1, ACCOUNTS_ORDERING, "", "");
 		assertSelectedUris(10, "user01", "user02", "user03", "user04",
 				"user05", "user06", "user07", "user08", "user09", "user10");
 	}
 
 	@Test
 	public void showFirstPageOfOne() {
-		selectOnCriteria(1, 1, DEFAULT_ORDERING, "", "");
+		selectOnCriteria(1, 1, ACCOUNTS_ORDERING, "", "");
 		assertSelectedUris(10, "user01");
 	}
 
 	@Test
 	public void showFirstPageOfFive() {
-		selectOnCriteria(5, 1, DEFAULT_ORDERING, "", "");
+		selectOnCriteria(5, 1, ACCOUNTS_ORDERING, "", "");
 		assertSelectedUris(10, "user01", "user02", "user03", "user04", "user05");
 	}
 
 	@Test
 	public void showSecondPageOfSeven() {
-		selectOnCriteria(7, 2, DEFAULT_ORDERING, "", "");
+		selectOnCriteria(7, 2, ACCOUNTS_ORDERING, "", "");
 		assertSelectedUris(10, "user08", "user09", "user10");
 	}
 
 	@Test
 	public void showTenthPageOfThree() {
-		selectOnCriteria(3, 10, DEFAULT_ORDERING, "", "");
+		selectOnCriteria(3, 10, ACCOUNTS_ORDERING, "", "");
 		assertSelectedUris(10);
 	}
 
@@ -266,20 +266,20 @@ public class UserAccountsSelectorTest extends AbstractTestClass {
 
 	@Test
 	public void filterAgainstRole1() {
-		selectOnCriteria(20, 1, DEFAULT_ORDERING, NS_MINE + "role1", "");
+		selectOnCriteria(20, 1, ACCOUNTS_ORDERING, NS_MINE + "role1", "");
 		assertSelectedUris(6, "user01", "user02", "user03", "user05", "user06",
 				"user09");
 	}
 
 	@Test
 	public void filterAgainstRole2() {
-		selectOnCriteria(20, 1, DEFAULT_ORDERING, NS_MINE + "role2", "");
+		selectOnCriteria(20, 1, ACCOUNTS_ORDERING, NS_MINE + "role2", "");
 		assertSelectedUris(2, "user03", "user10");
 	}
 
 	@Test
 	public void filterAgainstNoSuchRole() {
-		selectOnCriteria(20, 1, DEFAULT_ORDERING, "BogusRole", "");
+		selectOnCriteria(20, 1, ACCOUNTS_ORDERING, "BogusRole", "");
 		assertSelectedUris(0);
 	}
 
@@ -289,13 +289,13 @@ public class UserAccountsSelectorTest extends AbstractTestClass {
 
 	@Test
 	public void searchTermFoundInAllThreeFields() {
-		selectOnCriteria(20, 1, DEFAULT_ORDERING, "", "bob");
+		selectOnCriteria(20, 1, ACCOUNTS_ORDERING, "", "bob");
 		assertSelectedUris(3, "user02", "user05", "user10");
 	}
 
 	@Test
 	public void searchTermNotFound() {
-		selectOnCriteria(20, 1, DEFAULT_ORDERING, "", "bogus");
+		selectOnCriteria(20, 1, ACCOUNTS_ORDERING, "", "bogus");
 		assertSelectedUris(0);
 	}
 
@@ -305,7 +305,7 @@ public class UserAccountsSelectorTest extends AbstractTestClass {
 	 */
 	@Test
 	public void searchTermContainsSpecialRegexCharacters() {
-		selectOnCriteria(20, 1, DEFAULT_ORDERING, "", "b.b");
+		selectOnCriteria(20, 1, ACCOUNTS_ORDERING, "", "b.b");
 		assertSelectedUris(0);
 	}
 
@@ -315,7 +315,7 @@ public class UserAccountsSelectorTest extends AbstractTestClass {
 
 	@Test
 	public void searchWithFilter() {
-		selectOnCriteria(20, 1, DEFAULT_ORDERING, NS_MINE + "role1", "bob");
+		selectOnCriteria(20, 1, ACCOUNTS_ORDERING, NS_MINE + "role1", "bob");
 		assertSelectedUris(2, "user02", "user05");
 	}
 


### PR DESCRIPTION
**[VIVO GitHub issue](https://github.com/vivo-project/VIVO/issues/4020)**

* Other Relevant Links (Mailing list discussion, related pull requests, etc.)

# What does this pull request do?
Changes default default sorting field to last login time.
Changes default order to descending.

# How should this be tested?
* Reproduce the problem in the issue
* Verify that by default user accounts are sorted by last login time in descending order.

# Interested parties
@hauschke @vivo-project/vivo-committers 

# Reviewers' expertise

Candidates for reviewing this PR should have some of the following expertises:
1. Java

# Reviewers' report template

## General comment
A reviewer should provide here comments and suggestions for requested changes if any.
## Testing
A reviewer should briefly describe here how it was tested
## Code reviewing
A reviewer should briefly describe here which part was code reviewed