### PR TITLE
VIVO-4056 Avoid forced capitalization of property group labels

### DIFF
--- a/home/src/main/resources/rdf/i18n/de_DE/interface-i18n/firsttime/vitro_UiLabel.ttl
+++ b/home/src/main/resources/rdf/i18n/de_DE/interface-i18n/firsttime/vitro_UiLabel.ttl
@@ -5889,7 +5889,7 @@ uil-data:search_for.Vitro
 uil-data:other.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;
-        rdfs:label       "anderes"@de-DE ;
+        rdfs:label       "Anderes"@de-DE ;
         uil:hasApp      "Vitro" ;
         uil:hasKey      "other" ;
         uil:hasPackage  "Vitro-languages" .

--- a/home/src/main/resources/rdf/i18n/en_CA/interface-i18n/firsttime/vitro_UiLabel.ttl
+++ b/home/src/main/resources/rdf/i18n/en_CA/interface-i18n/firsttime/vitro_UiLabel.ttl
@@ -5889,7 +5889,7 @@ uil-data:search_for.Vitro
 uil-data:other.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;
-        rdfs:label       "other"@en-CA ;
+        rdfs:label       "Other"@en-CA ;
         uil:hasApp      "Vitro" ;
         uil:hasKey      "other" ;
         uil:hasPackage  "Vitro-languages" .

--- a/home/src/main/resources/rdf/i18n/en_US/interface-i18n/firsttime/vitro_UiLabel.ttl
+++ b/home/src/main/resources/rdf/i18n/en_US/interface-i18n/firsttime/vitro_UiLabel.ttl
@@ -5889,7 +5889,7 @@ uil-data:search_for.Vitro
 uil-data:other.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;
-        rdfs:label       "other"@en-US ;
+        rdfs:label       "Other"@en-US ;
         uil:hasApp      "Vitro" ;
         uil:hasKey      "other" ;
         uil:hasPackage  "Vitro-languages" .

--- a/home/src/main/resources/rdf/i18n/es/interface-i18n/firsttime/vitro_UiLabel.ttl
+++ b/home/src/main/resources/rdf/i18n/es/interface-i18n/firsttime/vitro_UiLabel.ttl
@@ -5889,7 +5889,7 @@ uil-data:search_for.Vitro
 uil-data:other.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;
-        rdfs:label       "otro"@es ;
+        rdfs:label       "Otro"@es ;
         uil:hasApp      "Vitro" ;
         uil:hasKey      "other" ;
         uil:hasPackage  "Vitro-languages" .

--- a/home/src/main/resources/rdf/i18n/fr_CA/interface-i18n/firsttime/vitro_UiLabel.ttl
+++ b/home/src/main/resources/rdf/i18n/fr_CA/interface-i18n/firsttime/vitro_UiLabel.ttl
@@ -5889,7 +5889,7 @@ uil-data:search_for.Vitro
 uil-data:other.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;
-        rdfs:label       "autre"@fr-CA ;
+        rdfs:label       "Autre"@fr-CA ;
         uil:hasApp      "Vitro" ;
         uil:hasKey      "other" ;
         uil:hasPackage  "Vitro-languages" .

--- a/home/src/main/resources/rdf/i18n/pt_BR/interface-i18n/firsttime/vitro_UiLabel.ttl
+++ b/home/src/main/resources/rdf/i18n/pt_BR/interface-i18n/firsttime/vitro_UiLabel.ttl
@@ -5889,7 +5889,7 @@ uil-data:search_for.Vitro
 uil-data:other.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;
-        rdfs:label       "outro"@pt-BR ;
+        rdfs:label       "Outro"@pt-BR ;
         uil:hasApp      "Vitro" ;
         uil:hasKey      "other" ;
         uil:hasPackage  "Vitro-languages" .

--- a/home/src/main/resources/rdf/i18n/ru_RU/interface-i18n/firsttime/vitro_UiLabel.ttl
+++ b/home/src/main/resources/rdf/i18n/ru_RU/interface-i18n/firsttime/vitro_UiLabel.ttl
@@ -5889,7 +5889,7 @@ uil-data:search_for.Vitro
 uil-data:other.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;
-        rdfs:label       "прочее"@ru-RU ;
+        rdfs:label       "Прочее"@ru-RU ;
         uil:hasApp      "Vitro" ;
         uil:hasKey      "other" ;
         uil:hasPackage  "Vitro-languages" .

--- a/home/src/main/resources/rdf/i18n/sr_Latn_RS/interface-i18n/firsttime/vitro_UiLabel.ttl
+++ b/home/src/main/resources/rdf/i18n/sr_Latn_RS/interface-i18n/firsttime/vitro_UiLabel.ttl
@@ -5889,7 +5889,7 @@ uil-data:search_for.Vitro
 uil-data:other.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;
-        rdfs:label       "ostalo"@sr-Latn-RS ;
+        rdfs:label       "Ostalo"@sr-Latn-RS ;
         uil:hasApp      "Vitro" ;
         uil:hasKey      "other" ;
         uil:hasPackage  "Vitro-languages" .

--- a/webapp/src/main/webapp/templates/freemarker/body/partials/individual/individual-property-group-menus.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/body/partials/individual/individual-property-group-menus.ftl
@@ -19,7 +19,7 @@
                         	<#assign groupnameHtmlId = p.createPropertyGroupHtmlId(groupname) >
                             <#-- capitalize will capitalize each word in the name; cap_first only the first. We may need a custom
                             function to capitalize all except function words. -->
-                            <li role="listitem"><a href="#${groupnameHtmlId}" title="${i18n().group_name}">${groupname?capitalize}</a></li>
+                            <li role="listitem"><a href="#${groupnameHtmlId}" title="${i18n().group_name}">${groupname}</a></li>
                         </#if>
                       </#if>
                     </#list>
@@ -44,7 +44,7 @@
         <#if groupName?has_content>
     		<#--the function replaces spaces in the name with underscores, also called for the property group menu-->
         	<#assign groupNameHtmlId = p.createPropertyGroupHtmlId(groupName) >
-            <h2 id="${groupNameHtmlId}">${groupName?capitalize}</h2>
+            <h2 id="${groupNameHtmlId}">${groupName}</h2>
         <#else>
             <h2 id="properties">${i18n().properties_capitalized}</h2>
         </#if>

--- a/webapp/src/main/webapp/templates/freemarker/body/partials/individual/individual-property-group-tabs.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/body/partials/individual/individual-property-group-tabs.ftl
@@ -20,11 +20,11 @@
     	    <#assign groupNameHtmlId = "${i18n().properties}" >
         </#if>
         <#if tabCount = 1 >
-            <li class="selectedGroupTab clickable" groupName="${groupNameHtmlId?replace("/","-")}">${p.capitalizeGroupName(groupName)}</li>
+            <li class="selectedGroupTab clickable" groupName="${groupNameHtmlId?replace("/","-")}">${groupName}</li>
             <li class="groupTabSpacer">&nbsp;</li>
             <#assign tabCount = 2>
         <#else>
-            <li class="nonSelectedGroupTab clickable" groupName="${groupNameHtmlId?replace("/","-")}">${p.capitalizeGroupName(groupName)}</li>
+            <li class="nonSelectedGroupTab clickable" groupName="${groupNameHtmlId?replace("/","-")}">${groupName}</li>
             <li class="groupTabSpacer">&nbsp;</li>
         </#if>
     </#if>
@@ -50,7 +50,7 @@
         <#if groupName?has_content>
 		    <#--the function replaces spaces in the name with underscores, also called for the property group menu-->
     	    <#assign groupNameHtmlId = p.createPropertyGroupHtmlId(groupName) >
-            <h2 id="${groupNameHtmlId?replace("/","-")}" pgroup="tabs" class="hidden">${p.capitalizeGroupName(groupName)}</h2>
+            <h2 id="${groupNameHtmlId?replace("/","-")}" pgroup="tabs" class="hidden">${groupName}</h2>
         <#else>
             <h2 id="properties" pgroup="tabs" class="hidden">${i18n().properties_capitalized}</h2>
         </#if>

--- a/webapp/src/main/webapp/templates/freemarker/body/partials/individual/individual-propertyGroupMenu.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/body/partials/individual/individual-propertyGroupMenu.ftl
@@ -18,7 +18,7 @@
                         	<#assign groupnameHtmlId = p.createPropertyGroupHtmlId(groupname) >
                             <#-- capitalize will capitalize each word in the name; cap_first only the first. We may need a custom
                             function to capitalize all except function words. -->
-                            <li role="listitem"><a href="#${groupnameHtmlId}" title="${i18n().group_name}">${groupname?capitalize}</a></li>
+                            <li role="listitem"><a href="#${groupnameHtmlId}" title="${i18n().group_name}">${groupname}</a></li>
                         </#if>
                     </#list>
                 </ul>

--- a/webapp/src/main/webapp/templates/freemarker/lib/lib-properties.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/lib/lib-properties.ftl
@@ -348,7 +348,3 @@ name will be used as the label. -->
     <#local groupName = groupName?replace("&", "-and-")>
     <#return groupName>
 </#function>
-
-<#function capitalizeGroupName propertyGroupName>
-    <#return propertyGroupName?cap_first>
-</#function>


### PR DESCRIPTION
**[VIVO GitHub issue](https://github.com/vivo-project/VIVO/issues/4056)**
[VIVO PR](https://github.com/vivo-project/VIVO/pull/4064)

# What does this pull request do?
Removed capitalization of property groups in Freemarker code
Applied capitalization to 'Other' property group option


# How should this be tested?
* Rename a property group
* Verify that new property group label is displayed without modification in profile


# Interested parties
@VIVO-project/vivo-committers

# Reviewers' expertise

Candidates for reviewing this PR should have some of the following expertises:
1. FreeMarker
1. Natural language knowledge
    1. English
    2. German
    3. Spanish
    4. French
    5. Portuguese
    6. Russian
    7. Serbian

# Reviewers' report template
## General comment
A reviewer should provide here comments and suggestions for requested changes if any.
## Testing
A reviewer should briefly describe here how it was tested
## Code reviewing
A reviewer should briefly describe here which part was code reviewed