### PR TITLE
WCAG - Aria Attributes

### DIFF
--- a/home/src/main/resources/rdf/i18n/en_US/interface-i18n/firsttime/vitro_UiLabel.ttl
+++ b/home/src/main/resources/rdf/i18n/en_US/interface-i18n/firsttime/vitro_UiLabel.ttl
@@ -5566,6 +5566,14 @@ uil-data:page.Vitro
         uil:hasKey      "page" ;
         uil:hasPackage  "Vitro-languages" .
 
+uil-data:pagination.Vitro
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         uil:UILabel ;
+        rdfs:label       "Pagination"@en-US ;
+        uil:hasApp      "Vitro" ;
+        uil:hasKey      "pagination" ;
+        uil:hasPackage  "Vitro-languages" .
+
 uil-data:type_more_characters.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;

--- a/webapp/src/main/webapp/css/vitro.css
+++ b/webapp/src/main/webapp/css/vitro.css
@@ -82,6 +82,18 @@
   clear: both;
 }
 
+/* SCREEN READER ONLY */
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+}
+
 /* <------ INDEX PAGE*/
 .siteMap h2 {
     padding-bottom: 0;

--- a/webapp/src/main/webapp/js/individual/propertyGroupControls.js
+++ b/webapp/src/main/webapp/js/individual/propertyGroupControls.js
@@ -29,9 +29,11 @@ $(document).ready(function(){
                 $.each($('li.selectedGroupTab'), function() {
                     $(this).removeClass("selectedGroupTab clickable");
                     $(this).addClass("nonSelectedGroupTab clickable");
+                    $(this).attr("aria-selected", "false");
                 });
                 $propertyGroupLi.removeClass("nonSelectedGroupTab clickable");
                 $propertyGroupLi.addClass("selectedGroupTab clickable");
+                $propertyGroupLi.attr("aria-selected", "true");
             }
             if ( $propertyGroupLi.attr("groupname") == "viewAll" ) {
                 processViewAllTab();
@@ -79,9 +81,11 @@ $(document).ready(function(){
                     // select the correct tab
                     $('li[groupName="' + tabName + '"]').removeClass("nonSelectedGroupTab clickable");
                     $('li[groupName="' + tabName + '"]').addClass("selectedGroupTab clickable");
+                    $('li[groupName="' + tabName + '"]').attr("aria-selected", "true");
                     // deselect the first tab
                     $firstTab.removeClass("selectedGroupTab clickable");
                     $firstTab.addClass("nonSelectedGroupTab clickable");
+                    $firstTab.attr("aria-selected", "false");
                     $('section.property-group:visible').hide();
                     // show the selected tab section
                     $('section#' + tabName).show();
@@ -168,9 +172,11 @@ $(document).ready(function(){
                     var $firstTab = $('li.clickable').first();
                     $firstTab.removeClass("selectedGroupTab clickable");
                     $firstTab.addClass("nonSelectedGroupTab clickable");
+                    $firstTab.attr("aria-selected", "false");
                     // select the stored tab
                     $("li[groupName='" + groupName + "']").removeClass("nonSelectedGroupTab clickable");
                     $("li[groupName='" + groupName + "']").addClass("selectedGroupTab clickable");
+                    $("li[groupName='" + groupName + "']").attr("aria-selected", "true");
                     // hide the first tab section
                     $('section.property-group:visible').hide();
 

--- a/webapp/src/main/webapp/js/languageMenuUtils.js
+++ b/webapp/src/main/webapp/js/languageMenuUtils.js
@@ -8,13 +8,19 @@ $(function() {
     $("ul.language-dropdown li#language-menu").on("mouseenter", function(){
 		$("a#lang-link").html(theText);
         $(this).addClass("hover");
-        $('ul:first',this).css('visibility', 'visible');
+        $('ul:first',this)
+			.css('visibility', 'visible')
+			.attr('aria-hidden', 'false');
+		$(this).attr('aria-expanded', 'true');
         $("ul.language-dropdown ul.sub_menu li").css('width', ($("ul.language-dropdown").width() - 4) + 'px');
 
     }).on("mouseleave", function(){
     	$("a#lang-link").html(imgHTML);
         $(this).removeClass("hover");
-        $('ul:first',this).css('visibility', 'hidden');
+        $('ul:first',this)
+			.css('visibility', 'hidden')
+			.attr('aria-hidden', 'true');
+		$(this).attr('aria-expanded', 'false');
     });
 
     $("ul.language-dropdown li ul li:has(ul)").find("a:first").append(" &raquo; ");

--- a/webapp/src/main/webapp/js/menupage/browseByVClass.js
+++ b/webapp/src/main/webapp/js/menupage/browseByVClass.js
@@ -176,7 +176,7 @@ var browseByVClass = {
             pagination += '<li class="round';
             // Test for active page
             if ( pages[i].text == page) {
-                pagination += ' selected';
+                pagination += ' selected aria-current="page"';
                 anchorOpen = "";
                 anchorClose = "";
             }
@@ -197,10 +197,14 @@ var browseByVClass = {
     // Toggle the active class so it's clear which is selected
     selectedVClass: function(vclassUri) {
         // Remove active class on all vClasses
-        $('#browse-classes li a.selected').removeClass('selected');
+        $('#browse-classes li a.selected')
+            .removeClass('selected')
+            .$('aria-current', 'false');
 
         // Add active class for requested vClass
-        $('#browse-classes li a[data-uri="'+ vclassUri +'"]').addClass('selected');
+        $('#browse-classes li a[data-uri="'+ vclassUri +'"]')
+            .addClass('selected')
+            .$('aria-current', 'true');
     },
 
     // Toggle the active letter so it's clear which is selected
@@ -210,10 +214,15 @@ var browseByVClass = {
             alpha = "all";
         }
         // Remove active class on all letters
-        $('#alpha-browse-individuals li a.selected').removeClass('selected');
+        // Remove active class and aria-selected on all letters
+        $('#alpha-browse-individuals li a.selected')
+            .removeClass('selected')
+            .attr('aria-current', 'false');
 
-        // Add active class for requested alpha
-        $('#alpha-browse-individuals li a[data-alpha="'+ alpha +'"]').addClass('selected');
+        // Add active class and aria-selected for requested alpha
+        $('#alpha-browse-individuals li a[data-alpha="'+ alpha +'"]')
+            .addClass('selected')
+            .attr('aria-current', 'true');
 
         return alpha;
     },

--- a/webapp/src/main/webapp/js/menupage/browseByVClass.js
+++ b/webapp/src/main/webapp/js/menupage/browseByVClass.js
@@ -244,9 +244,9 @@ var browseByVClass = {
         var alpha = this.selectedAlpha(alpha);
 
         if ( alpha != "all" ) {
-            nothingToSeeHere = '<p class="no-individuals">' + browseByVClass.thereAreNoEntriesStartingWith + ' <em>'+ alpha.toUpperCase() +'</em>.</p> <p class="no-individuals">' + browseByVClass.tryAnotherLetter + '</p>';
+            nothingToSeeHere = '<div aria-live="polite"><p class="no-individuals">' + browseByVClass.thereAreNoEntriesStartingWith + ' <em>'+ alpha.toUpperCase() +'</em>.</p> <p class="no-individuals">' + browseByVClass.tryAnotherLetter + '</p></div>';
         } else {
-            nothingToSeeHere = '<p class="no-individuals">' + browseByVClass.thereAreNoEntriesStartingWith + '</p> <p class="no-individuals">' + browseByVClass.selectAnotherClass + '</p>';
+            nothingToSeeHere = '<div aria-live="polite"><p class="no-individuals">' + browseByVClass.thereAreNoEntriesStartingWith + '</p> <p class="no-individuals">' + browseByVClass.selectAnotherClass + '</p></div>';
         }
 
         browseByVClass.individualsContainer.prepend(nothingToSeeHere);

--- a/webapp/src/main/webapp/js/menupage/browseByVClass.js
+++ b/webapp/src/main/webapp/js/menupage/browseByVClass.js
@@ -25,6 +25,7 @@ var browseByVClass = {
         this.alphaIndexLinks = $('#alpha-browse-individuals li a');
         this.individualsInVClass = $('#individuals-in-class ul');
         this.individualsContainer = $('#individuals-in-class');
+        this.individualsListInfo = $('#individuals-list-info');
     },
 
     // Event listeners. Called on page load
@@ -231,8 +232,8 @@ var browseByVClass = {
 
     // Wipe the currently displayed individuals, no-content message, and existing pagination
     wipeSlate: function() {
-        browseByVClass.individualsInVClass.empty();
-        $('div.no-individuals-container').remove();
+        browseByVClass.individualsInVClass.children(':not(#individuals-list-info)').remove();
+        $('#individuals-list-info > .no-individuals').remove();
         $('.pagination').remove();
     },
 
@@ -244,12 +245,11 @@ var browseByVClass = {
         var alpha = this.selectedAlpha(alpha);
 
         if ( alpha != "all" ) {
-            nothingToSeeHere = '<div aria-live="polite" class="no-individuals-container"><p class="no-individuals">' + browseByVClass.thereAreNoEntriesStartingWith + ' <em>'+ alpha.toUpperCase() +'</em>.</p> <p class="no-individuals">' + browseByVClass.tryAnotherLetter + '</p></div>';
+            nothingToSeeHere = '<p class="no-individuals aria-atomic="true">' + browseByVClass.thereAreNoEntriesStartingWith + ' '+ alpha.toUpperCase() +'.</p> <p class="no-individuals">' + browseByVClass.tryAnotherLetter + '</p>';
         } else {
-            nothingToSeeHere = '<div aria-live="polite" class="no-individuals-container"><p class="no-individuals">' + browseByVClass.thereAreNoEntriesStartingWith + '</p> <p class="no-individuals">' + browseByVClass.selectAnotherClass + '</p></div>';
+            nothingToSeeHere = '<p class="no-individuals" aria-atomic="true">' + browseByVClass.thereAreNoEntriesStartingWith + '</p> <p class="no-individuals">' + browseByVClass.selectAnotherClass + '</p>';
         }
-
-        browseByVClass.individualsContainer.prepend(nothingToSeeHere);
+        browseByVClass.individualsListInfo.append(nothingToSeeHere);
     }
 
 };

--- a/webapp/src/main/webapp/js/menupage/browseByVClass.js
+++ b/webapp/src/main/webapp/js/menupage/browseByVClass.js
@@ -232,7 +232,7 @@ var browseByVClass = {
     // Wipe the currently displayed individuals, no-content message, and existing pagination
     wipeSlate: function() {
         browseByVClass.individualsInVClass.empty();
-        $('p.no-individuals').remove();
+        $('div.no-individuals-container').remove();
         $('.pagination').remove();
     },
 
@@ -244,9 +244,9 @@ var browseByVClass = {
         var alpha = this.selectedAlpha(alpha);
 
         if ( alpha != "all" ) {
-            nothingToSeeHere = '<div aria-live="polite"><p class="no-individuals">' + browseByVClass.thereAreNoEntriesStartingWith + ' <em>'+ alpha.toUpperCase() +'</em>.</p> <p class="no-individuals">' + browseByVClass.tryAnotherLetter + '</p></div>';
+            nothingToSeeHere = '<div aria-live="polite" class="no-individuals-container"><p class="no-individuals">' + browseByVClass.thereAreNoEntriesStartingWith + ' <em>'+ alpha.toUpperCase() +'</em>.</p> <p class="no-individuals">' + browseByVClass.tryAnotherLetter + '</p></div>';
         } else {
-            nothingToSeeHere = '<div aria-live="polite"><p class="no-individuals">' + browseByVClass.thereAreNoEntriesStartingWith + '</p> <p class="no-individuals">' + browseByVClass.selectAnotherClass + '</p></div>';
+            nothingToSeeHere = '<div aria-live="polite" class="no-individuals-container"><p class="no-individuals">' + browseByVClass.thereAreNoEntriesStartingWith + '</p> <p class="no-individuals">' + browseByVClass.selectAnotherClass + '</p></div>';
         }
 
         browseByVClass.individualsContainer.prepend(nothingToSeeHere);

--- a/webapp/src/main/webapp/js/menupage/browseByVClass.js
+++ b/webapp/src/main/webapp/js/menupage/browseByVClass.js
@@ -176,11 +176,13 @@ var browseByVClass = {
             pagination += '<li class="round';
             // Test for active page
             if ( pages[i].text == page) {
-                pagination += ' selected aria-current="page"';
+                pagination += ' selected" aria-current="page"';
                 anchorOpen = "";
                 anchorClose = "";
+            } else {
+                pagination += '"';
             }
-            pagination += '" role="listitem">';
+            pagination += ' role="listitem">';
             pagination += anchorOpen;
             pagination += pages[i].text;
             pagination += anchorClose;
@@ -199,12 +201,12 @@ var browseByVClass = {
         // Remove active class on all vClasses
         $('#browse-classes li a.selected')
             .removeClass('selected')
-            .$('aria-current', 'false');
+            .removeAttr('aria-current');
 
         // Add active class for requested vClass
         $('#browse-classes li a[data-uri="'+ vclassUri +'"]')
             .addClass('selected')
-            .$('aria-current', 'true');
+            .attr('aria-current', 'true');
     },
 
     // Toggle the active letter so it's clear which is selected
@@ -217,7 +219,7 @@ var browseByVClass = {
         // Remove active class and aria-selected on all letters
         $('#alpha-browse-individuals li a.selected')
             .removeClass('selected')
-            .attr('aria-current', 'false');
+            .removeAttr('aria-current');
 
         // Add active class and aria-selected for requested alpha
         $('#alpha-browse-individuals li a[data-alpha="'+ alpha +'"]')

--- a/webapp/src/main/webapp/js/searchDownload.js
+++ b/webapp/src/main/webapp/js/searchDownload.js
@@ -3,27 +3,45 @@
 $(document).ready(function(){
 
     function configSlider() {
-        $( "#slider-vertical" ).slider({
-        orientation: "vertical",
-        range: "min",
-        min: 10,
-        max: 1000,
-        value: 500,
-        slide: function( event, ui ) {
-            $( "#amount" ).val( ui.value );
-            $('#csvDownload').attr("href", urlsBase + '/search?' + queryText +'&csv=1&documentsNumber=' + ui.value);
-            $('#xmlDownload').attr("href", urlsBase + '/search?' + queryText +'&xml=1&documentsNumber=' + ui.value);
+
+        $("#slider-vertical").slider({
+            orientation: "vertical",
+            range: "min",
+            min: 10,
+            max: 1000,
+            value: 500,
+            slide: function(event, ui) {
+                $("#amount").val(ui.value);
+                $('#csvDownload').attr("href", urlsBase + '/search?' + queryText + '&csv=1&documentsNumber=' + ui.value);
+                $('#xmlDownload').attr("href", urlsBase + '/search?' + queryText + '&xml=1&documentsNumber=' + ui.value);
+                // Update aria-valuenow on slide
+                $("#slider-vertical .ui-slider-handle").attr("aria-valuenow", ui.value);
+                $("#slider-vertical .ui-slider-range").attr("role", "presentation");
+                $("#slider-vertical .ui-slider-range").attr("aria-hidden", "true");
+
+            },
+            create: function(event, ui) {
+                // Set ARIA attributes on the slider handle after creation
+                var $handle = $("#slider-vertical .ui-slider-handle");
+                $handle.attr({
+                    "role": "slider",
+                    "aria-valuemin": 10,
+                    "aria-valuemax": 1000,
+                    "aria-valuenow": 500,
+                    "aria-orientation": "vertical",
+                    "aria-label": i18nStrings.downloadResultsMaxResultsSliderString
+                });
             }
         });
-        $( "#amount" ).val( $( "#slider-vertical" ).slider( "value" ) );
+        $("#amount").val($("#slider-vertical").slider("value"));
     }
 
     setTooltip("#downloadIcon", {
         title: '<div class="clearfix"><div style="float:right; width:150px;border-left: 1px solid #A6B1B0; padding: 3px 0 0 20px">'
                     	+'<p><label for="amount" style="font-size:14px;">Maximum Records:</label>'
                     	+'<input disabled type="text" id="amount" style="margin-left:35px; border: 0; color: #f6931f; font-weight: bold; width:45px" /></p>'
-                    	+'<div id="slider-vertical" style="margin-left:52px; margin-top: -20px; height: 100px; background-color:white"></div>'
-                    	+'<br /><a class="close" href="#">close</a></div>'
+                    	+'<div id="slider-vertical" aria-label="Adjust maximum number of records" style="margin-left:52px; margin-top: -20px; height: 100px; background-color:white"></div>'
+                    	+'<br aria-hidden="true"/><a class="close" href="#">close</a></div>'
                     	+'<div style="float:left; font-size:14px; width:280px; padding: 3px 0 0 20px"><p><label>Download the results from this search</label></p> '
                     	+'<p class ="download-url"><a id=xmlDownload href="' + urlsBase + '/search?' + queryText +'&amp;xml=1&amp;documentsNumber=500">download results in XML format</a></p>'
                     	+'<p class ="download-url"><a id=csvDownload href="' + urlsBase + '/search?' + queryText +'&amp;csv=1&amp;documentsNumber=500">download results in CSV format</a></p>'

--- a/webapp/src/main/webapp/js/userMenu/userMenuUtils.js
+++ b/webapp/src/main/webapp/js/userMenu/userMenuUtils.js
@@ -4,7 +4,10 @@ $(function(){
 
     $("ul.dropdown li").on("mouseenter", function(){
         $(this).addClass("hover");
-        $('ul:first',this).css('visibility', 'visible');
+        $('ul:first',this)
+			.css('visibility', 'visible')
+			.attr('aria-hidden', 'false');
+		$(this).attr('aria-expanded', 'true');
         if ( $('ul.dropdown').width() > 88 ) {
             $('ul:first li',this).css('width', ($("ul.dropdown").width() - 22) + 'px');
         }
@@ -13,7 +16,10 @@ $(function(){
     }).on("mouseleave", function(){
 
         $(this).removeClass("hover");
-        $('ul:first',this).css('visibility', 'hidden');
+        $('ul:first',this)
+			.css('visibility', 'hidden')
+			.attr('aria-hidden', 'true');
+		$(this).attr('aria-expanded', 'false');
 
     });
 

--- a/webapp/src/main/webapp/js/vitroUtils.js
+++ b/webapp/src/main/webapp/js/vitroUtils.js
@@ -29,6 +29,7 @@ $(document).ready(function(){
              //$(this).css('background','url(../../themes/vivo-cornell/images/filteredSearchActive.gif) no-repeat right top');
              $(this).removeClass('filter-default');
              $(this).addClass('filter-active');
+             $(this).attr('aria-expanded', 'true');
 
              //Reveal filter select list
              $searchFilterList.css('display','block');
@@ -40,6 +41,7 @@ $(document).ready(function(){
              //$('a.filter-search').css('background','url(../../themes/vivo-cornell/images/filteredSearch.gif) no-repeat right top');
              $(this).removeClass('filter-active');
              $(this).addClass('filter-default');
+             $(this).attr('aria-expanded', 'false');
 
              //Hide filter select list
              $searchFilterList.css('display','none');

--- a/webapp/src/main/webapp/templates/freemarker/body/accounts/userAccounts-add.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/body/accounts/userAccounts-add.ftl
@@ -38,13 +38,13 @@
 <section id="add-account" role="region">
     <form method="POST" action="${formUrls.add}" class="customForm" role="add new account">
         <label for="email-address">${strings.email_address}<span class="requiredHint"> *</span></label>
-        <input type="text" name="emailAddress" value="${emailAddress}" id="email-address" role="input" />
+        <input type="text" name="emailAddress" value="${emailAddress}" id="email-address" />
 
         <label for="first-name">${strings.first_name}<span class="requiredHint"> *</span></label>
-        <input type="text" name="firstName" value="${firstName}" id="first-name" role="input" />
+        <input type="text" name="firstName" value="${firstName}" id="first-name" />
 
         <label for="last-name">${strings.last_name}<span class="requiredHint"> *</span></label>
-        <input type="text" name="lastName" value="${lastName}" id="last-name" role="input" />
+        <input type="text" name="lastName" value="${lastName}" id="last-name" />
 
         <#include "userAccounts-associateProfilePanel.ftl">
 
@@ -61,11 +61,11 @@
         <#else>
             <section id="passwordContainer" role="region">
                 <label for="initial-password">${strings.initial_password}<span class="requiredHint"> *</span></label>
-                <input type="password" name="initialPassword" value="${initialPassword}" id="initial-password" role="input" />
+                <input type="password" name="initialPassword" value="${initialPassword}" id="initial-password" />
                 <p class="note">${strings.minimum_password_length(minimumLength, maximumLength)}</p>
 
                 <label for="confirm-password">${strings.confirm_initial_password}<span class="requiredHint"> *</span></label>
-                <input type="password" name="confirmPassword" value="${confirmPassword}" id="confirm-password" role="input" />
+                <input type="password" name="confirmPassword" value="${confirmPassword}" id="confirm-password" />
             </section>
         </#if>
 

--- a/webapp/src/main/webapp/templates/freemarker/body/accounts/userAccounts-createPassword.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/body/accounts/userAccounts-createPassword.ftl
@@ -25,16 +25,16 @@
     <p>${strings.enter_new_password(userAccount.emailAddress)}</p>
 
     <form method="POST" action="${formUrls.createPassword}" class="customForm" role="create password">
-        <input type="hidden" name="user" value="${userAccount.emailAddress}" role="input" />
-        <input type="hidden" name="key"  value="${userAccount.emailKey}" role="input" />
+        <input type="hidden" name="user" value="${userAccount.emailAddress}" />
+        <input type="hidden" name="key"  value="${userAccount.emailKey}" />
 
         <label for="new-password">${strings.new_password}<span class="requiredHint"> *</span></label>
-        <input type="password" name="newPassword" value="${newPassword}" id="new-password" role="input" />
+        <input type="password" name="newPassword" value="${newPassword}" id="new-password" />
 
         <p class="note">${strings.minimum_password_length(minimumLength, maximumLength)}</p>
 
         <label for="confirm-password">${strings.confirm_password}<span class="requiredHint"> *</span></label>
-        <input type="password" name="confirmPassword" value="${confirmPassword}" id="confirm-password" role="input" />
+        <input type="password" name="confirmPassword" value="${confirmPassword}" id="confirm-password" />
 
         <p><input type="submit" name="submit" value="${strings.save_changes}" class="submit"/></p>
 

--- a/webapp/src/main/webapp/templates/freemarker/body/accounts/userAccounts-edit.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/body/accounts/userAccounts-edit.ftl
@@ -38,13 +38,13 @@
 <section id="edit-account" role="region">
     <form method="POST" action="${formUrls.edit}" id="userAccountForm" class="customForm" role="edit account">
         <label for="email-address">${strings.email_address}<span class="requiredHint"> *</span></label>
-        <input type="text" name="emailAddress" value="${emailAddress}" id="email-address" role="input" />
+        <input type="text" name="emailAddress" value="${emailAddress}" id="email-address" />
 
         <label for="first-name">${strings.first_name}<span class="requiredHint"> *</span></label>
-        <input type="text" name="firstName" value="${firstName}" id="first-name" role="input" />
+        <input type="text" name="firstName" value="${firstName}" id="first-name" />
 
         <label for="last-name">${strings.last_name}<span class="requiredHint"> *</span></label>
-        <input type="text" name="lastName" value="${lastName}" id="last-name" role="input" />
+        <input type="text" name="lastName" value="${lastName}" id="last-name" />
 
 		<#if externalAuthPermitted??>
             <#include "userAccounts-associateProfilePanel.ftl">
@@ -71,12 +71,12 @@
         <#else>
             <section id="passwordContainer" <#if externalAuthOnly?? >class="hidden"</#if> role="region">
                 <label for="new-password">${strings.new_password}</label>
-                <input type="password" name="newPassword" value="${newPassword}" id="new-password" role="input" />
+                <input type="password" name="newPassword" value="${newPassword}" id="new-password" />
                 <p class="note">${strings.minimum_password_length(minimumLength, maximumLength)}<br />
                 ${strings.leave_password_unchanged}</p>
 
                 <label for="confirm-password">${strings.confirm_password}</label>
-                <input type="password" name="confirmPassword" value="${confirmPassword}" id="confirm-password" role="input" />
+                <input type="password" name="confirmPassword" value="${confirmPassword}" id="confirm-password" />
             </section>
         </#if>
 

--- a/webapp/src/main/webapp/templates/freemarker/body/accounts/userAccounts-firstTimeExternal.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/body/accounts/userAccounts-firstTimeExternal.ftl
@@ -29,17 +29,17 @@
     <p>${strings.please_provide_contact_information}</p>
 
     <form method="POST" action="${formUrls.firstTimeExternal}" class="customForm" role="my account">
-        <input type="hidden" name="externalAuthId" value="${externalAuthId}" role="input" />
-        <input type="hidden" name="afterLoginUrl" value="${afterLoginUrl}" role="input" />
+        <input type="hidden" name="externalAuthId" value="${externalAuthId}" />
+        <input type="hidden" name="afterLoginUrl" value="${afterLoginUrl}" />
 
         <label for="first-name">${strings.first_name}<span class="requiredHint"> *</span></label>
-        <input type="text" name="firstName" value="${firstName}" id="first-name" role="input" />
+        <input type="text" name="firstName" value="${firstName}" id="first-name" />
 
         <label for="last-name">${strings.last_name}<span class="requiredHint"> *</span></label>
-        <input type="text" name="lastName" value="${lastName}" id="last-name" role="input" />
+        <input type="text" name="lastName" value="${lastName}" id="last-name" />
 
         <label for="email-address">${strings.email_address}<span class="requiredHint"> *</span></label>
-        <input type="text" name="emailAddress" value="${emailAddress}" id="email-address" role="input" />
+        <input type="text" name="emailAddress" value="${emailAddress}" id="email-address" />
 
         <#if emailIsEnabled??>
             <p class="note">${strings.first_time_login_note}</p>

--- a/webapp/src/main/webapp/templates/freemarker/body/accounts/userAccounts-myAccount.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/body/accounts/userAccounts-myAccount.ftl
@@ -54,24 +54,24 @@
         </#if>
 
         <label for="email-address">${strings.email_address}<span class="requiredHint"> *</span></label>
-        <input type="text" name="emailAddress" value="${emailAddress}" id="email-address" role="input" />
+        <input type="text" name="emailAddress" value="${emailAddress}" id="email-address" />
 
         <p class="note">${strings.email_change_will_be_confirmed}</p>
 
         <label for="first-name">${strings.first_name}<span class="requiredHint"> *</span></label>
-        <input type="text" name="firstName" value="${firstName}" id="first-name" role="input" />
+        <input type="text" name="firstName" value="${firstName}" id="first-name" />
 
         <label for="last-name">${strings.last_name}<span class="requiredHint"> *</span></label>
-        <input type="text" name="lastName" value="${lastName}" id="last-name" role="input" />
+        <input type="text" name="lastName" value="${lastName}" id="last-name" />
 
         <#if !externalAuth??>
             <label for="new-password">${strings.new_password}</label>
-            <input type="password" name="newPassword" value="${newPassword}" id="new-password" role="input" />
+            <input type="password" name="newPassword" value="${newPassword}" id="new-password" />
 
             <p class="note">${strings.minimum_password_length(minimumLength, maximumLength)}<br />${strings.leave_password_unchanged}</p>
 
             <label for="confirm-password">${strings.confirm_password}</label>
-            <input type="password" name="confirmPassword" value="${confirmPassword}" id="confirm-password" role="input" />
+            <input type="password" name="confirmPassword" value="${confirmPassword}" id="confirm-password" />
         </#if>
 
         <p>

--- a/webapp/src/main/webapp/templates/freemarker/body/accounts/userAccounts-myProxiesPanel.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/body/accounts/userAccounts-myProxiesPanel.ftl
@@ -9,7 +9,7 @@
 
     <label for="addProfileEditor">${strings.add_profile_editor}</label>
     <input id="addProfileEditor" type="text" name="proxySelectorAC" class="acSelector" size="35"
-            value="${strings.select_existing_last_name}" role="input" />
+            value="${strings.select_existing_last_name}" />
     <span><img class="loading-profileMyAccoount hidden" src="${urls.images}/indicatorWhite.gif" /></span>
 
     <p class="search-status">
@@ -43,7 +43,7 @@
                     <br />
                     <a class='remove-proxy' href="." templatePart="remove" title="${strings.remove_selection_title}">${strings.remove_selection}</a>
 
-                    <input type="hidden" name="proxyUri" value="%uri%" role="input" />
+                    <input type="hidden" name="proxyUri" value="%uri%" />
                 </p>
             </li>
         </div>

--- a/webapp/src/main/webapp/templates/freemarker/body/accounts/userAccounts-resetPassword.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/body/accounts/userAccounts-resetPassword.ftl
@@ -29,12 +29,12 @@
         <input type="hidden" name="key"  value="${userAccount.emailKey}" />
 
         <label for="new-password">${strings.new_password}<span class="requiredHint"> *</span></label>
-        <input type="password" name="newPassword" value="${newPassword}" id="new-password" role="input" />
+        <input type="password" name="newPassword" value="${newPassword}" id="new-password" />
 
         <p class="note">${strings.minimum_password_length(minimumLength, maximumLength)}</p>
 
         <label for="confirm-password">${strings.confirm_password}<span class="requiredHint"> *</span></label>
-        <input type="password" name="confirmPassword" value="${confirmPassword}" id="confirm-password" role="input" />
+        <input type="password" name="confirmPassword" value="${confirmPassword}" id="confirm-password" />
 
         <p><input type="submit" name="submit" value="${strings.save_changes}" class="submit"/></p>
 

--- a/webapp/src/main/webapp/templates/freemarker/body/individual/individual-menu.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/body/individual/individual-menu.ftl
@@ -26,7 +26,7 @@
 	    <form id="pageListForm" action="${urls.base}/editRequestDispatch" method="get">
 	        <input type="hidden" name="typeOfNew" value="http://vitro.mannlib.cornell.edu/ontologies/display/1.1#Page">
 	        <input type="hidden" name="switchToDisplayModel" value="1">
-	        <input type="hidden" name="editForm" value="edu.cornell.mannlib.vitro.webapp.edit.n3editing.configuration.generators.ManagePageGenerator" role="input">
+	        <input type="hidden" name="editForm" value="edu.cornell.mannlib.vitro.webapp.edit.n3editing.configuration.generators.ManagePageGenerator">
 	   		<input type="hidden" name="addMenuItem" value="true" />
 	   		<input id="submit" value="Add new menu page" role="button" type="submit" >
 	   		<input type="hidden" name="returnURL" value="${returnURL?url}" />

--- a/webapp/src/main/webapp/templates/freemarker/body/individual/manageLabelsForIndividualAddForm.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/body/individual/manageLabelsForIndividualAddForm.ftl
@@ -9,7 +9,7 @@
 
 <input type="hidden" name="editKey" id="editKey" value="${editKey}"/>
 
-<input type="submit" class="submit" id="submit" value="${i18n().save_button}" role="button" role="input" />
+<input type="submit" class="submit" id="submit" value="${i18n().save_button}" role="button" />
 ${i18n().or}
 <a href="${urls.referringPage}" class="cancel" title="${i18n().cancel_title}" >${i18n().cancel_link}</a>
 

--- a/webapp/src/main/webapp/templates/freemarker/body/manageproxies/manageProxies-list.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/body/manageproxies/manageProxies-list.ftl
@@ -30,7 +30,7 @@
 
             <section name="proxyProxiesPanel">
                 <label for="selectProfileEditors">${i18n().select_editors}</label>
-                <input id="selectProfileEditors" type="text" name="proxySelectorAC" class="acSelector" size="35" value="${i18n().select_last_name}" role="input" /><span><img class="loading-relateEditor hidden" src="${urls.images}/indicatorWhite.gif" alt="${i18n().processing_indicator}"/></span>
+                <input id="selectProfileEditors" type="text" name="proxySelectorAC" class="acSelector" size="35" value="${i18n().select_last_name}" /><span><img class="loading-relateEditor hidden" src="${urls.images}/indicatorWhite.gif" alt="${i18n().processing_indicator}"/></span>
                 <p class="search-status"><span name='proxySelectorSearchStatus' moreCharsText='${i18n().type_more_chars}' noMatchText='${i18n().no_match}'>&nbsp;</span></p>
 
                 <#-- Magic div that holds all of the proxy data and the template that shows how to display it. -->
@@ -62,7 +62,7 @@
 
           <section name="proxyProfilesPanel" role="region">
               <label for="selectProfiles">${i18n().select_profiles}</label>
-              <input id="selectProfiles" type="text" name="proxySelectorAC" class="acSelector" size="35" value="${i18n().select_last_name}" role="input" /><span><img class="loading-relateProfile hidden" src="${urls.images}/indicatorWhite.gif"  alt="${i18n().processing_indicator}"/></span>
+              <input id="selectProfiles" type="text" name="proxySelectorAC" class="acSelector" size="35" value="${i18n().select_last_name}" /><span><img class="loading-relateProfile hidden" src="${urls.images}/indicatorWhite.gif"  alt="${i18n().processing_indicator}"/></span>
 
               <p class="search-status"><span name='proxySelectorSearchStatus' moreCharsText='${i18n().type_more_chars}' noMatchText='${i18n().no_match}'>&nbsp;</span></p>
 
@@ -82,7 +82,7 @@
                                 <br /><a class='remove-proxy' href="." templatePart="remove" title="${i18n().remove_selection}">${i18n().remove_selection}</a>
                             </p>
 
-                            <input type="hidden" name="profileUri" templatePart="uriField" value="%uri%" role="input" />
+                            <input type="hidden" name="profileUri" templatePart="uriField" value="%uri%" />
                         </li>
                     </div>
                 </ul>
@@ -98,7 +98,7 @@
 
 <section id="search-proxy" role="region">
     <form action="${formUrls.list}" method="POST">
-        <input type="text" name="searchTerm" role="input" />
+        <input type="text" name="searchTerm" />
         <input class="submit" type="submit" name="searchByProxy" value="${i18n().search_button}" role="button" />
             <#if page.previous??>
                | <a href="${formUrls.list}?pageIndex=${page.previous}&searchTerm=${searchTerm}" title="${i18n().previous}">${i18n().previous}</a>
@@ -140,7 +140,7 @@
 
             <section name="proxyProfilesPanel" role="region">
                 <label for="addProfile">${i18n().add_profile}</label>
-                <input id="addProfile" type="text" name="proxySelectorAC" class="acSelector" size="35" value="${i18n().select_last_name}" role="input" /><span><img class="loading-addProfile hidden"  alt="${i18n().processing_indicator}" src="${urls.images}/indicatorWhite.gif" /></span>
+                <input id="addProfile" type="text" name="proxySelectorAC" class="acSelector" size="35" value="${i18n().select_last_name}" /><span><img class="loading-addProfile hidden"  alt="${i18n().processing_indicator}" src="${urls.images}/indicatorWhite.gif" /></span>
 
                 <p class="search-status"><span name='proxySelectorSearchStatus' moreCharsText='${i18n().type_more_chars}' noMatchText='${i18n().no_match}'>&nbsp;</span></p>
                 <p name="excludeUri" style="display: none">${r.proxyInfos[0].profileUri}<p>
@@ -172,7 +172,7 @@
                             </p>
                         </li>
 
-                        <input type="hidden" name="profileUri" templatePart="uriField" value="%uri%" role="input" />
+                        <input type="hidden" name="profileUri" templatePart="uriField" value="%uri%" />
                     </div>
                 </ul>
             </section>

--- a/webapp/src/main/webapp/templates/freemarker/body/manageproxies/manageProxies-list.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/body/manageproxies/manageProxies-list.ftl
@@ -28,7 +28,7 @@
         <fieldset class="proxy">
             <legend>${i18n().select_editors}</legend>
 
-            <section name="proxyProxiesPanel" role="section">
+            <section name="proxyProxiesPanel">
                 <label for="selectProfileEditors">${i18n().select_editors}</label>
                 <input id="selectProfileEditors" type="text" name="proxySelectorAC" class="acSelector" size="35" value="${i18n().select_last_name}" role="input" /><span><img class="loading-relateEditor hidden" src="${urls.images}/indicatorWhite.gif" alt="${i18n().processing_indicator}"/></span>
                 <p class="search-status"><span name='proxySelectorSearchStatus' moreCharsText='${i18n().type_more_chars}' noMatchText='${i18n().no_match}'>&nbsp;</span></p>

--- a/webapp/src/main/webapp/templates/freemarker/body/menupage/page-pageList.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/body/menupage/page-pageList.ftl
@@ -27,7 +27,7 @@
   <form id="addIndividualClass" action="${urls.base}/editRequestDispatch" method="get">
       <input type="hidden" name="typeOfNew" value="http://vitro.mannlib.cornell.edu/ontologies/display/1.1#Page">
       <input type="hidden" name="switchToDisplayModel" value="1">
-      <input type="hidden" name="editForm" value="${generators.NewIndividualFormGenerator}" role="input">
+      <input type="hidden" name="editForm" value="${generators.NewIndividualFormGenerator}">
       <input type="submit" id="submit" value="${i18n().add_page}" role="button">
   </form>
 

--- a/webapp/src/main/webapp/templates/freemarker/body/pagemanagement/page-pageList.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/body/pagemanagement/page-pageList.ftl
@@ -27,7 +27,7 @@
   <form id="addIndividualClass" action="${urls.base}/editRequestDispatch" method="get">
       <input type="hidden" name="typeOfNew" value="http://vitro.mannlib.cornell.edu/ontologies/display/1.1#Page">
       <input type="hidden" name="switchToDisplayModel" value="1">
-      <input type="hidden" name="editForm" value="${generators.NewIndividualFormGenerator}" role="input">
+      <input type="hidden" name="editForm" value="${generators.NewIndividualFormGenerator}">
       <input type="submit" id="submit" value="${i18n().Add_page}" role="button">
   </form>
 

--- a/webapp/src/main/webapp/templates/freemarker/body/pagemanagement/pageList.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/body/pagemanagement/pageList.ftl
@@ -66,7 +66,7 @@
   <form id="pageListForm" action="${urls.base}/editRequestDispatch" method="get">
       <input type="hidden" name="typeOfNew" value="http://vitro.mannlib.cornell.edu/ontologies/display/1.1#Page">
       <input type="hidden" name="switchToDisplayModel" value="1">
-      <input type="hidden" name="editForm" value="edu.cornell.mannlib.vitro.webapp.edit.n3editing.configuration.generators.ManagePageGenerator" role="input">
+      <input type="hidden" name="editForm" value="edu.cornell.mannlib.vitro.webapp.edit.n3editing.configuration.generators.ManagePageGenerator">
  	<input id="submit" value="${i18n().add_page}" role="button" type="submit" >
   </form>
   <br />

--- a/webapp/src/main/webapp/templates/freemarker/body/partials/individual/individual-property-group-tabs.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/body/partials/individual/individual-property-group-tabs.ftl
@@ -7,8 +7,8 @@
 <#assign tabCount = 1 >
 <#assign sectionCount = 1 >
 <!-- ${propertyGroups.all?size} -->
-<ul class="propertyTabsList">
-    <li  class="groupTabSpacer">&nbsp;</li>
+<ul class="propertyTabsList" role="tablist" >
+    <li  class="groupTabSpacer" aria-hidden="true" >&nbsp;</li>
 <#list propertyGroups.all as groupTabs>
     <#if ( groupTabs.properties?size > 0 ) >
         <#assign groupName = groupTabs.getName(nameForOtherGroup)>
@@ -20,18 +20,18 @@
     	    <#assign groupNameHtmlId = "${i18n().properties}" >
         </#if>
         <#if tabCount = 1 >
-            <li class="selectedGroupTab clickable" groupName="${groupNameHtmlId?replace("/","-")}">${groupName}</li>
-            <li class="groupTabSpacer">&nbsp;</li>
+            <li class="selectedGroupTab clickable" id="tab-${groupNameHtmlId?replace("/","-")}" aria-controls="${groupNameHtmlId?replace("/","-")}" groupName="${groupNameHtmlId?replace("/","-")}" aria-selected="true" role="tab" tabindex="0" >${p.capitalizeGroupName(groupName)}</li>
+            <li class="groupTabSpacer" aria-hidden="true">&nbsp;</li>
             <#assign tabCount = 2>
         <#else>
-            <li class="nonSelectedGroupTab clickable" groupName="${groupNameHtmlId?replace("/","-")}">${groupName}</li>
-            <li class="groupTabSpacer">&nbsp;</li>
+            <li class="nonSelectedGroupTab clickable" id="tab-${groupNameHtmlId?replace("/","-")}" aria-controls="${groupNameHtmlId?replace("/","-")}" groupName="${groupNameHtmlId?replace("/","-")}" aria-selected="false" role="tab" tabindex="0" >${p.capitalizeGroupName(groupName)}</li>
+            <li class="groupTabSpacer" aria-hidden="true">&nbsp;</li>
         </#if>
     </#if>
 </#list>
 <#if (propertyGroups.all?size > 1) >
-    <li  class="nonSelectedGroupTab clickable" groupName="viewAll">${i18n().view_all_capitalized}</li>
-    <li  class="groupTabSpacer">&nbsp;</li>
+    <li class="nonSelectedGroupTab clickable" id="tab-viewAll" groupName="viewAll" aria-selected="false" role="tab" tabindex="0" >${i18n().view_all_capitalized}</li>
+    <li class="groupTabSpacer" aria-hidden="true">&nbsp;</li>
 </#if>
 </ul>
 <#list propertyGroups.all as group>
@@ -39,7 +39,7 @@
         <#assign groupName = group.getName(nameForOtherGroup)>
         <#assign groupNameHtmlId = p.createPropertyGroupHtmlId(groupName) >
         <#assign verbose = (verbosePropertySwitch.currentValue)!false>
-        <section id="${groupNameHtmlId?replace("/","-")}" class="property-group" role="region" style="<#if (sectionCount > 1) >display:none<#else>display:block</#if>">
+        <section id="${groupNameHtmlId?replace("/","-")}" aria-labelledby="tab-${groupNameHtmlId?replace("/","-")}" class="property-group" role="tabpanel" style="<#if (sectionCount > 1) >display:none<#else>display:block</#if>">
         <nav id="scroller" class="scroll-up hidden" role="navigation">
             <a href="#branding" title="${i18n().scroll_to_menus}" >
                 <img src="${urls.images}/individual/scroll-up.gif" alt="${i18n().scroll_to_menus}" />

--- a/webapp/src/main/webapp/templates/freemarker/body/partials/menupage/menupage-browse.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/body/partials/menupage/menupage-browse.ftl
@@ -28,9 +28,9 @@
             <h3 class="selected-class"></h3>
             <#assign alphabet = ["A", "B", "C", "D", "E", "F", "G" "H", "I", "J", "K", "L", "M", "N", "O", "P", "Q", "R", "S", "T", "U", "V", "W", "X", "Y", "Z"] />
             <ul id="alpha-browse-individuals">
-                <li><a href="#" class="selected" data-alpha="all" title="${i18n().select_all}">${i18n().all}</a></li>
+                <li><a href="#" class="selected" aria-current="false" data-alpha="all" title="${i18n().select_all}">${i18n().all}</a></li>
                 <#list alphabet as letter>
-                    <li><a href="#" data-alpha="${letter?lower_case}" title="${i18n().browse_all_starts_with(letter)}">${letter}</a></li>
+                    <li><a href="#" data-alpha="${letter?lower_case}" aria-current="false" title="${i18n().browse_all_starts_with(letter)}">${letter}</a></li>
                 </#list>
             </ul>
         </nav>

--- a/webapp/src/main/webapp/templates/freemarker/body/partials/menupage/menupage-browse.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/body/partials/menupage/menupage-browse.ftl
@@ -38,7 +38,8 @@
 
     <section id="individuals-in-class" role="region">
         <ul role="list">
-
+            <div aria-live="polite" id="individuals-list-info"></div>
+            
             <#-- Will be populated dynamically via AJAX request -->
         </ul>
     </section>

--- a/webapp/src/main/webapp/templates/freemarker/body/partials/menupage/menupage-browse.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/body/partials/menupage/menupage-browse.ftl
@@ -28,9 +28,9 @@
             <h3 class="selected-class"></h3>
             <#assign alphabet = ["A", "B", "C", "D", "E", "F", "G" "H", "I", "J", "K", "L", "M", "N", "O", "P", "Q", "R", "S", "T", "U", "V", "W", "X", "Y", "Z"] />
             <ul id="alpha-browse-individuals">
-                <li><a href="#" class="selected" aria-current="false" data-alpha="all" title="${i18n().select_all}">${i18n().all}</a></li>
+                <li><a href="#" class="selected" data-alpha="all" title="${i18n().select_all}">${i18n().all}</a></li>
                 <#list alphabet as letter>
-                    <li><a href="#" data-alpha="${letter?lower_case}" aria-current="false" title="${i18n().browse_all_starts_with(letter)}">${letter}</a></li>
+                    <li><a href="#" data-alpha="${letter?lower_case}" title="${i18n().browse_all_starts_with(letter)}">${letter}</a></li>
                 </#list>
             </ul>
         </nav>

--- a/webapp/src/main/webapp/templates/freemarker/body/recomputeInferences.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/body/recomputeInferences.ftl
@@ -2,7 +2,7 @@
 
 <#if formAction?has_content>
     <form method="post" action="${formAction}">
-        <input class="submit" type="submit" value="${i18n().recompute_inferences}" name="submit" role="input" />
+        <input class="submit" type="submit" value="${i18n().recompute_inferences}" name="submit" />
     </form>
 </#if>
 

--- a/webapp/src/main/webapp/templates/freemarker/body/search/search-pagedResults.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/body/search/search-pagedResults.ftl
@@ -45,14 +45,14 @@ ${headScripts.add('<script type="text/javascript" src="${urls.base}/js/wNumb.min
 
 <#-- Paging controls -->
     <#if (pagingLinks?size > 0)>
-        <div class="searchpages">
+        <div class="searchpages" aria-label="${i18n().pagination}">
             ${i18n().pages}:
             <#if prevPage??><a class="prev" href="${prevPage?html}" title="${i18n().previous}">${i18n().previous}</a></#if>
             <#list pagingLinks as link>
                 <#if link.url??>
                     <a href="${link.url?html}" title="${i18n().page_link}">${link.text?html}</a>
                 <#else>
-                    <span>${link.text?html}</span> <#-- no link if current page -->
+                    <span aria-current="page">${link.text?html}</span> <#-- no link if current page -->
                 </#if>
             </#list>
             <#if nextPage??><a class="next" href="${nextPage?html}" title="${i18n().next_capitalized}">${i18n().next_capitalized}</a></#if>

--- a/webapp/src/main/webapp/templates/freemarker/body/search/search-pagedResults.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/body/search/search-pagedResults.ftl
@@ -310,7 +310,7 @@ ${headScripts.add('<script type="text/javascript" src="${urls.base}/js/wNumb.min
 </#macro>
 
 <#macro createUserInput filter>
-    <input form="search-form" id="filter_input_${filter.id?html}"  placeholder="${i18n().search_field_placeholder}" class="search-vivo" type="text" name="filter_input_${filter.id?html}" value="${filter.inputText?html}" autocapitalize="none" />
+	<input form="search-form" id="filter_input_${filter.id?html}"  placeholder="${i18n().search_field_placeholder}" aria-label="${i18n().search_field_placeholder}" class="search-vivo" type="text" name="filter_input_${filter.id?html}" value="${filter.inputText?html}" autocapitalize="none" />
 </#macro>
 
 <#macro getInput filter filterValue valueID valueNumber form="search-form">

--- a/webapp/src/main/webapp/templates/freemarker/body/siteAdmin/siteAdmin-dataInput.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/body/siteAdmin/siteAdmin-dataInput.ftl
@@ -13,7 +13,7 @@
             <select id="VClassURI" name="typeOfNew" class="form-item long-options" role="select">
                 <@form.optionGroups groups=dataInput.groupedClassOptions />
             </select>
-            <input type="hidden" name="editForm" value="${generators.NewIndividualFormGenerator}" role="input" />
+            <input type="hidden" name="editForm" value="${generators.NewIndividualFormGenerator}" />
             <input type="submit" id="submit" value="${i18n().add_individual_of_class}" role="button" />
         </form>
 

--- a/webapp/src/main/webapp/templates/freemarker/edit/forms/autoCompleteObjectPropForm.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/edit/forms/autoCompleteObjectPropForm.ftl
@@ -51,7 +51,7 @@
 <#if editConfiguration.propertySelectFromExisting = true>
     <#if rangeOptionsExist  = true >
         <form class="customForm" action = "${submitUrl}">
-            <input type="hidden" name="editKey" id="editKey" value="${editKey}" role="input" />
+            <input type="hidden" name="editKey" id="editKey" value="${editKey}" />
             <#if editConfiguration.propertyPublicDescription?has_content>
                 <p>${editConfiguration.propertyPublicDescription}</p>
              </#if>

--- a/webapp/src/main/webapp/templates/freemarker/edit/forms/confirmDeleteIndividualForm.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/edit/forms/confirmDeleteIndividualForm.ftl
@@ -14,8 +14,8 @@
 <form action="${editConfiguration.deleteIndividualProcessingUrl}" method="get">
     <h2>${i18n().confirm_individual_deletion} </h2>
 
-    <input type="hidden" name="individualUri"    value="${editConfiguration.objectUri}" role="input" />
-    <input type="hidden" name="redirectUrl"    value="${redirectUrl}" role="input" />
+    <input type="hidden" name="individualUri" value="${editConfiguration.objectUri}" />
+    <input type="hidden" name="redirectUrl" value="${redirectUrl}" />
     <p>
       <#if individualType??>
        ${individualType}

--- a/webapp/src/main/webapp/templates/freemarker/edit/forms/confirmDeletePropertyForm.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/edit/forms/confirmDeletePropertyForm.ftl
@@ -28,16 +28,16 @@
         </#if>
     </p>
 
-    <input type="hidden" name="subjectUri"   value="${editConfiguration.subjectUri}" role="input" />
-    <input type="hidden" name="predicateUri" value="${editConfiguration.predicateUri}" role="input" />
-    <input type="hidden" name="domainUri" value="${editConfiguration.domainUri!}" role="input" />
-    <input type="hidden" name="rangeUri" value="${editConfiguration.rangeUri!}" role="input" />
+    <input type="hidden" name="subjectUri" value="${editConfiguration.subjectUri}" />
+    <input type="hidden" name="predicateUri" value="${editConfiguration.predicateUri}" />
+    <input type="hidden" name="domainUri" value="${editConfiguration.domainUri!}" />
+    <input type="hidden" name="rangeUri" value="${editConfiguration.rangeUri!}" />
     <input type="hidden" name="deleteObjectUri" value="${editConfiguration.customDeleteObjectUri!}" />
     <#if editConfiguration.dataProperty = true>
-        <input type="hidden" name="datapropKey" value="${editConfiguration.datapropKey}" role="input" />
-        <input type="hidden" name="vitroNsProp" value="${editConfiguration.vitroNsProperty}" role="input" />
+        <input type="hidden" name="datapropKey" value="${editConfiguration.datapropKey}" />
+        <input type="hidden" name="vitroNsProp" value="${editConfiguration.vitroNsProperty}" />
     <#else>
-        <input type="hidden" name="objectUri"    value="${editConfiguration.objectUri}" role="input" />
+        <input type="hidden" name="objectUri" value="${editConfiguration.objectUri}" />
     </#if>
 
    <br />

--- a/webapp/src/main/webapp/templates/freemarker/edit/forms/dateTimeEntryForm.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/edit/forms/dateTimeEntryForm.ftl
@@ -1,7 +1,7 @@
 <#-- $This file is distributed under the terms of the license in LICENSE$ -->
 
 <fieldset class="dateTime">
-  <input type="hidden" id="literal" name="literal" value="${literalValues}" role="input"/>
+  <input type="hidden" id="literal" name="literal" value="${literalValues}"/>
   <#if datatype?contains("#date") || datatype?contains("Year") >
     <label for="dateTimeField-year">${i18n()[('label.dateTimeWithPrecision.year_capitalized')]}</label>
     <input class="text-field" name="dateTimeField-year" id="dateTimeField-year" type="text" value="" size="4" maxlength="4" />

--- a/webapp/src/main/webapp/templates/freemarker/edit/forms/defaultAddMissingIndividualForm.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/edit/forms/defaultAddMissingIndividualForm.ftl
@@ -14,8 +14,8 @@ ${i18n().new_entry_for(editConfiguration.propertyPublicDomainTitle, editConfigur
 <h2>${formTitle}</h2>
 
 <form class="editForm" action="${submitUrl}">
-    <input type="hidden" name="editKey" id="editKey" value="${editKey}" role="input" />
-    <input type="text" name="name" id="name" label="name (required)" size="30" role="input" />
+    <input type="hidden" name="editKey" id="editKey" value="${editKey}" />
+    <input type="text" name="name" id="name" label="name (required)" size="30" />
 
     <p class="submit">
         <input type="submit" id="submit" value="${submitLabel}" role="submit" />

--- a/webapp/src/main/webapp/templates/freemarker/edit/forms/defaultDataPropertyForm.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/edit/forms/defaultDataPropertyForm.ftl
@@ -26,7 +26,7 @@
 <#assign datatype = editConfiguration.dataPredicateProperty.rangeDatatypeURI!"none" />
 
 <form class="editForm" action = "${submitUrl}" method="post">
-    <input type="hidden" name="editKey" id="editKey" value="${editKey}" role="input" />
+    <input type="hidden" name="editKey" id="editKey" value="${editKey}" />
     <#if editConfiguration.dataPredicatePublicDescription?has_content>
        <label for="${editConfiguration.dataLiteral}"><p class="propEntryHelpText">${editConfiguration.dataPredicatePublicDescription}</p></label>
     </#if>

--- a/webapp/src/main/webapp/templates/freemarker/edit/forms/defaultOfferCreateNewOptionForm.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/edit/forms/defaultOfferCreateNewOptionForm.ftl
@@ -13,13 +13,13 @@
  </#if>
 
 <#assign typesList = editConfiguration.offerTypesCreateNew />
-<form class="editForm" action="${editConfiguration.mainEditUrl}" role="input" />
-    <input type="hidden" value="${editConfiguration.subjectUri}" name="subjectUri" role="input" />
-    <input type="hidden" value="${editConfiguration.predicateUri}" name="predicateUri" role="input" />
-    <input type="hidden" value="${objectUri}" name="objectUri" role="input" />
+<form class="editForm" action="${editConfiguration.mainEditUrl}" />
+    <input type="hidden" value="${editConfiguration.subjectUri}" name="subjectUri" />
+    <input type="hidden" value="${editConfiguration.predicateUri}" name="predicateUri" />
+    <input type="hidden" value="${objectUri}" name="objectUri" />
    <input type="hidden" name="domainUri" value="${editConfiguration.domainUri!}"/>
     <input type="hidden" name="rangeUri" value="${editConfiguration.rangeUri!}"/>
-    <input type="hidden" value="create" name="cmd" role="input" />
+    <input type="hidden" value="create" name="cmd" />
 
     <select id="typeOfNew" name="typeOfNew" role="selection">
     <#assign typeKeys = typesList?keys />

--- a/webapp/src/main/webapp/templates/freemarker/edit/forms/defaultPropertyForm.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/edit/forms/defaultPropertyForm.ftl
@@ -17,7 +17,7 @@
     <#if rangeOptionsExist  = true >
         <#assign rangeOptionKeys = rangeOptions?keys />
         <form class="editForm" action = "${submitUrl}">
-            <input type="hidden" name="editKey" id="editKey" value="${editKey}" role="input" />
+            <input type="hidden" name="editKey" id="editKey" value="${editKey}" />
             <#if editConfiguration.propertyPublicDescription?has_content>
                 <p>${editConfiguration.propertyPublicDescription}</p>
              </#if>

--- a/webapp/src/main/webapp/templates/freemarker/edit/forms/menuManagement-remove.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/edit/forms/menuManagement-remove.ftl
@@ -6,13 +6,13 @@
 
 <section id="remove-menu-item" role="region">
     <form method="POST" action="${formUrls}" class="customForm" role="remove menu item">
-        <input type="hidden" name="menuItem" id="menuItem" value="${menuItem}" role="input" />
-        <input type="hidden" name="cmd" id="cmd" value="Remove" role="input" />
-        <input type="hidden" name="switchToDisplayModel" id="switchToDisplayModel" value="true" role="input" />
+        <input type="hidden" name="menuItem" id="menuItem" value="${menuItem}" />
+        <input type="hidden" name="cmd" id="cmd" value="Remove" />
+        <input type="hidden" name="switchToDisplayModel" id="switchToDisplayModel" value="true" />
 
         <p>${i18n().confirm_menu_item_delete} <em>${menuName}</em> ${i18n().menu_item}?</p>
 
-        <input type="submit" name="removeMenuItem" value="${i18n().remove_menu_item}" class="submit" role="input" /> ${i18n().or} <a class="cancel" href="${cancelUrl}" title="${i18n().cancel_title}">${i18n().cancel_link}</a>
+        <input type="submit" name="removeMenuItem" value="${i18n().remove_menu_item}" class="submit" /> ${i18n().or} <a class="cancel" href="${cancelUrl}" title="${i18n().cancel_title}">${i18n().cancel_link}</a>
     </form>
 </section>
 

--- a/webapp/src/main/webapp/templates/freemarker/edit/forms/menuManagement.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/edit/forms/menuManagement.ftl
@@ -19,15 +19,15 @@
 
 <section id="${menuAction?lower_case}-menu-item" role="region">
     <form method="POST" action="${formUrls}" class="customForm" role="${menuAction} menu item">
-        <input type="hidden" name="cmd" id="cmd" value="${menuAction}" role="input" />
-        <input type="hidden" name="menuItem" id="menuItem" value="${menuItem}" role="input" />
-        <input type="hidden" name="switchToDisplayModel" id="switchToDisplayModel" value="true" role="input" />
+        <input type="hidden" name="cmd" id="cmd" value="${menuAction}" />
+        <input type="hidden" name="menuItem" id="menuItem" value="${menuItem}" />
+        <input type="hidden" name="switchToDisplayModel" id="switchToDisplayModel" value="true" />
 
         <label for="menu-name">${i18n().name}<span class="requiredHint"> *</span></label>
-        <input type="text" name="menuName" value="${menuName}" role="input" />
+        <input type="text" name="menuName" value="${menuName}" />
 
         <label for="pretty-url">${i18n().pretty_url}<span class="requiredHint"> *</span></label>
-        <input type="text" name="prettyUrl" value="${prettyUrl}" role="input" />
+        <input type="text" name="prettyUrl" value="${prettyUrl}" />
         <p class="note">${i18n().start_with_leading_slash}</p>
 
         <p>${i18n().template_capitalized}<span class="requiredHint"> *</span></p>
@@ -35,11 +35,11 @@
         <input type="radio" class="default-template" name="selectedTemplate" value="default" <#if selectedTemplateType = "default">checked</#if> role="radio" />
         <label class="inline" for="default"> ${i18n().default}</label>
         <br />
-        <input type="radio" name="selectedTemplate" class="custom-template" value="custom" <#if selectedTemplateType = "custom">checked</#if> role="input" />
+        <input type="radio" name="selectedTemplate" class="custom-template" value="custom" <#if selectedTemplateType = "custom">checked</#if> />
         <label class="inline" for="custom"> ${i18n().custom_template_mixed_caps}</label>
 
         <section id="custom-template" <#if selectedTemplateType != 'custom'>class="hidden" </#if>role="region">
-            <input type="text" name="customTemplate" value="${customTemplate!}" size="40" role="input" /><span class="requiredHint"> *</span>
+            <input type="text" name="customTemplate" value="${customTemplate!}" size="40" /><span class="requiredHint"> *</span>
         </section>
 
         <section id="existingContentType" name="existingContentType" ${existingClassGroupStyle} role="region">
@@ -92,7 +92,7 @@
             </ul>
         </section>
 
-        <input type="submit" name="submit-${menuAction}" value="${i18n().save_changes}" class="submit" role="input" /> ${i18n().or} <a class="cancel" href="${cancelUrl}" title="${i18n().cancel_title}">${i18n().cancel_link}</a>
+        <input type="submit" name="submit-${menuAction}" value="${i18n().save_changes}" class="submit" /> ${i18n().or} <a class="cancel" href="${cancelUrl}" title="${i18n().cancel_title}">${i18n().cancel_link}</a>
 
         <p class="requiredHint">* ${i18n().required_fields}</p>
     </form>

--- a/webapp/src/main/webapp/templates/freemarker/edit/forms/pageManagement--fixedHtml.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/edit/forms/pageManagement--fixedHtml.ftl
@@ -3,7 +3,7 @@
 
 <section id="fixedHtml" class="contentSectionContainer">
     <label id="fixedHTMLVariableLabel" for="fixedHTMLVariable">${i18n().variable_name_all_caps}<span class="requiredHint"> *</span></label>
-    <input type="text" name="saveToVar" size="20" value="" id="fixedHTMLSaveToVar" role="input" />
+    <input type="text" name="saveToVar" size="20" value="" id="fixedHTMLSaveToVar" />
     <label id="fixedHTMLValueLabel" for="fixedHTMLValue">${i18n().enter_fixed_html_here}<span id="fixedHTMLValueSpan"></span><span class="requiredHint"> *</span></label>
     <textarea id="fixedHTMLValue" name="htmlValue" cols="70" rows="15" style="margin-bottom:7px"></textarea><br />
     <input  type="button" id="doneWithContent" name="doneWithContent" value="${i18n().save_this_content}" class="doneWithContent" />

--- a/webapp/src/main/webapp/templates/freemarker/edit/forms/pageManagement--searchIndividuals.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/edit/forms/pageManagement--searchIndividuals.ftl
@@ -5,7 +5,7 @@
 <#assign classes = pageData.classes />
 <section id="searchIndividuals" class="contentSectionContainer">
     <label id="variableLabel" for="variable">${i18n().variable_name_all_caps}<span class="requiredHint"> *</span></label>
-    <input type="text" name="saveToVar" size="20" value="" id="saveToVar" role="input" />
+    <input type="text" name="saveToVar" size="20" value="" id="saveToVar" />
     <label id="vclassUriLabel" for="vclassUri">${i18n().select_vclass_uri}<span class="requiredHint"> *</span></label>
     <br/>
     <select name="vclassUri" id="vclassUri">

--- a/webapp/src/main/webapp/templates/freemarker/edit/forms/pageManagement--sparqlQuery.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/edit/forms/pageManagement--sparqlQuery.ftl
@@ -2,10 +2,10 @@
 <#--This contains the template for the Sparql Query content type that is to be cloned and used in page management-->
 <section id="sparqlQuery" class="contentSectionContainer">
     <label id="variableLabel" for="variable">${i18n().variable_name_all_caps}<span class="requiredHint"> *</span></label>
-    <input type="text" name="saveToVar" size="20" value="" id="saveToVar" role="input" />
+    <input type="text" name="saveToVar" size="20" value="" id="saveToVar" />
     <#--Hiding query model for now-->
     <#-- <label id="queryModelLabel" for="queryModel">${i18n().query_model}</label>  -->
-    <input type="text" name="queryModel" size="20" value="" id="queryModel" role="input" style="display:none"/>
+    <input type="text" name="queryModel" size="20" value="" id="queryModel" style="display:none"/>
     <label id="queryLabel" for="queryLabel"><span id="querySpan">${i18n().enter_sparql_query_here}</span><span class="requiredHint"> *</span></label>
     <textarea id="query" name="query" cols="70" rows="15" style="margin-bottom:7px"></textarea><br />
     <input  type="button" id="doneWithContent" class="doneWithContent" name="doneWithContent" value="${i18n().save_this_content}" />

--- a/webapp/src/main/webapp/templates/freemarker/edit/forms/pageManagement.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/edit/forms/pageManagement.ftl
@@ -68,7 +68,7 @@
 <section id="pageDetailsContainer">
     <#--form method="POST" action="${formUrls}" role="${menuAction} menu item"-->
 	<form id="managePage" method="POST" action="${submitUrl}" role="add page">
-	        <input type="hidden" name="switchToDisplayModel" id="switchToDisplayModel" value="1" role="input" />
+	        <input type="hidden" name="switchToDisplayModel" id="switchToDisplayModel" value="1" />
 	        <input type="hidden" id="editKey" name="editKey" value="${editKey}" />
     <h2>${pageHeading}</h2>
     <!--Drop down for the types of content possible-->
@@ -99,21 +99,21 @@
     <div id="leftSide">
         <section id="pageDetails" role="region" >
             <label for="page-name">${i18n().title_capitalized}<span class="requiredHint"> *</span></label>
-            <input id="pageName" type="text" name="pageName" value="${pageName!''}" role="input" />
+            <input id="pageName" type="text" name="pageName" value="${pageName!''}" />
             <label for="pretty-url">${i18n().pretty_url}<span class="requiredHint"> *</span></label>
-            <input type="text" name="prettyUrl" value="${prettyUrl!''}" role="input" />
+            <input type="text" name="prettyUrl" value="${prettyUrl!''}" />
             <p class="note">${i18n().begin_with_slash_no_example} <br />${i18n().slash_example}</p>
             <p id="templatePTag">${i18n().template_capitalized}<span class="requiredHint"> *</span></p>
             <input type="radio" class="default-template" name="selectedTemplate" value="default" <#if selectedTemplateType = "default">checked="checked"</#if> role="radio" />
             <label class="inline" for="default"> ${i18n().default}</label>
             <br />
-            <input type="radio" name="selectedTemplate" class="custom-template" value="custom" <#if selectedTemplateType = "custom">checked="checked"</#if> role="input" />
+            <input type="radio" name="selectedTemplate" class="custom-template" value="custom" <#if selectedTemplateType = "custom">checked="checked"</#if> />
             <label class="inline" for="custom"> ${i18n().custom_template_requiring_content}</label>
             <br /><div id="selfContainedDiv">
-            <input type="radio" name="selectedTemplate" class="selfContained-template" value="selfContained" <#if selectedTemplateType = "selfContained">checked="checked"</#if> role="input" />
+            <input type="radio" name="selectedTemplate" class="selfContained-template" value="selfContained" <#if selectedTemplateType = "selfContained">checked="checked"</#if> />
             <label class="inline" for="selfContained"> ${i18n().custom_template_containing_content}</label></div>
             <section id="custom-template" <#if selectedTemplateType ="default">class="hidden" </#if>role="region">
-                <input type="text" name="customTemplate" value="${customTemplate!''}" size="33" role="input" /><span class="requiredHint"> *</span>
+                <input type="text" name="customTemplate" value="${customTemplate!''}" size="33" /><span class="requiredHint"> *</span>
                 <input type="hidden" name="selfContainedTemplate" value="${selfContainedTemplate!''}"/>
             </section>
             <p id="menuCheckboxPTag"><input id="menuCheckbox" type="checkbox" name="menuCheckbox"
@@ -130,7 +130,7 @@
                 <label for="default">${i18n().menu_item_name}</label>
 
                 <input type="hidden" id="menuItem" name="menuItem" value="${menuItem!''}" />
-                <input type="text" id="menuLinkText" name="menuLinkText" value="${menuLinkText!''}" size="28" role="input" />
+                <input type="text" id="menuLinkText" name="menuLinkText" value="${menuLinkText!''}" size="28" />
                 <input type="hidden" id="menuPosition" name="menuPosition" value="${menuPosition!''}" />
 
 
@@ -153,7 +153,7 @@
         </section>
     </div>
     <section >
-        <span id="saveButton" ><input  id="pageSave" type="submit" name="submit-Add" value="${saveBtnText}" class="submit" role="input" /> or </span>
+        <span id="saveButton" ><input  id="pageSave" type="submit" name="submit-Add" value="${saveBtnText}" class="submit" /> or </span>
         <a class="cancel" href="${cancelUrl!}"  id="cancelPage" title="${i18n().cancel_title}">${i18n().cancel_link}</a>
         <br />
         <p class="requiredHint">* ${i18n().required_fields}</p>

--- a/webapp/src/main/webapp/templates/freemarker/edit/forms/rdfTypeForm.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/edit/forms/rdfTypeForm.ftl
@@ -13,7 +13,7 @@
     <#if rangeOptionsExist  = true >
         <#assign rangeOptionKeys = rangeOptions?keys />
         <form class="editForm" action = "${submitUrl}">
-            <input type="hidden" name="editKey" id="editKey" value="${editKey}" role="input" />
+            <input type="hidden" name="editKey" id="editKey" value="${editKey}" />
             <select id="object" name="object" role="select">
                 <#list rangeOptionKeys as key>
                  <option value="${key}" <#if editConfiguration.objectUri?has_content && editConfiguration.objectUri = key>selected</#if> role="option">${rangeOptions[key]}</option>

--- a/webapp/src/main/webapp/templates/freemarker/edit/forms/rdfsLabelForm.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/edit/forms/rdfsLabelForm.ftl
@@ -11,12 +11,12 @@
 <#assign literalValues = "${editConfiguration.dataLiteralValuesAsString}" />
 
 <form class="editForm" action = "${submitUrl}" method="post">
-    <input type="text" name="${editConfiguration.varNameForObject}" id="label" size="70" value="${literalValues?html}" role="input"/>
-    <input type="hidden" name="editKey" id="editKey" value="${editKey}" role="input"/>
-    <input type="hidden" name="vitroNsProp" value="true" role="input"/>
+    <input type="text" name="${editConfiguration.varNameForObject}" id="label" size="70" value="${literalValues?html}"/>
+    <input type="hidden" name="editKey" id="editKey" value="${editKey}"/>
+    <input type="hidden" name="vitroNsProp" value="true"/>
 
     <p class="submit">
-        <input type="submit" id="submit" value="${submitLabel}" role="input"/>
+        <input type="submit" id="submit" value="${submitLabel}"/>
         or <a href="${cancelUrl}" class="cancel" title="${i18n().cancel_title}">${i18n().cancel_link}</a>
     </p>
 

--- a/webapp/src/main/webapp/templates/freemarker/lib/lib-properties.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/lib/lib-properties.ftl
@@ -278,7 +278,7 @@ name will be used as the label. -->
         <#local imageLabel><@addLinkWithLabel mainImage editable "${i18n().photo}" /></#local>
         ${imageLabel}
         <#if showPlaceholder == "always" || (showPlaceholder="with_add_link" && imageLabel?has_content)>
-            <img class="individual-photo" src="${placeholderImageUrl(individual.uri)}" title = "${i18n().no_image}" alt="${i18n().placeholder_image}" width="${imageWidth!}" />
+            <img class="individual-photo" src="${placeholderImageUrl(individual.uri)}" title = "${i18n().no_image}" alt="" width="${imageWidth!}" />
         </#if>
     </#if>
 </#macro>

--- a/webapp/src/main/webapp/templates/freemarker/lib/lib-properties.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/lib/lib-properties.ftl
@@ -348,3 +348,7 @@ name will be used as the label. -->
     <#local groupName = groupName?replace("&", "-and-")>
     <#return groupName>
 </#function>
+
+<#function capitalizeGroupName propertyGroupName>
+    <#return propertyGroupName?cap_first>
+</#function>

--- a/webapp/src/main/webapp/templates/freemarker/widgets/widget-login.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/widgets/widget-login.ftl
@@ -56,10 +56,10 @@
             <div ${infoClassHide} ${infoClassShow}>
 
                 <label for="loginName">${i18n().email_capitalized}</label>
-                <input id="loginName" name="loginName" class="text-field focus" type="text" value="${loginName!}" autocapitalize="off" required autofocus />
+                <input id="loginName" name="loginName" class="text-field focus" type="text" value="${loginName!}" autocapitalize="off" autocomplete="username" required autofocus />
 
                 <label for="loginPassword">${i18n().password_capitalized}</label>
-                <input id="loginPassword" name="loginPassword" class="text-field" type="password" required />
+                <input id="loginPassword" name="loginPassword" class="text-field" type="password" autocomplete="current-password" required />
 
                 <p class="submit">
                     <input name="loginForm" class="green button" type="submit" value="${i18n().login_button}"/>

--- a/webapp/src/main/webapp/themes/vitro/templates/page-home.ftl
+++ b/webapp/src/main/webapp/themes/vitro/templates/page-home.ftl
@@ -30,18 +30,18 @@
                 </ul>
 
                 <section id="search-home" role="region">
-                    <h3>${i18n().search_vitro} <span class="search-filter-selected">filteredSearch</span></h3>
+                    <h3 id="search-input-label">${i18n().search_vitro} <span class="search-filter-selected">filteredSearch</span></h3>
 
                     <fieldset>
                         <legend>${i18n().search_form}</legend>
                         <form id="search-homepage" action="${urls.search}" name="search-home" role="search" method="GET" >
                             <div id="search-home-field">
-                                <input type="text" name="querytext" class="search-homepage" value="${querytext!}" autocapitalize="off" />
+                                <input type="text" name="querytext" aria-label="${i18n().search_vitro}" aria-labelledby="search-input-label" class="search-homepage" value="${querytext!}" autocapitalize="off" />
+                                <a class="filter-search filter-default" href="#" aria-expanded="false" title="${i18n().filter_search}"><span class="displace">${i18n().filter_search}</span></a>
                                 <input type="submit" value="${i18n().search_button}" class="search" />
                                 <input type="hidden" name="filters_category" class="search-homepage" value="" autocapitalize="off" />
                             </div>
 
-                            <a class="filter-search filter-default" href="#" title="${i18n().filter_search}"><span class="displace">${i18n().filter_search}</span></a>
 
                             <ul id="filter-search-nav">
                                 <li><a class="active" href="">${i18n().all_capitalized}</a></li>


### PR DESCRIPTION
**[VIVO GitHub issue](https://github.com/vivo-project/VIVO/issues/4099)**
**[VIVO PR](https://github.com/vivo-project/VIVO/pull/4138)**

# What's new?
1. Added aria-expanded
- Used on toggleable UI elements (e.g. filter/search dropdown).
- Why: Improves accessibility by exposing the current expanded/collapsed state to screen readers.

2. Improved aria-label usage
- Added descriptive labels for icon-only buttons (e.g. URI and QR code buttons).
- Why: Provides meaningful context for assistive technologies where visual labels are missing.

3. Added/verified aria-labelledby
- Linked input fields to their corresponding visible labels.
- Why: Ensures screen readers correctly associate inputs with their labels, improving form usability.

4. Introduced aria-live="polite" regions
- Used for dynamic content updates (e.g. search results or list updates).
- Why: Allows screen readers to announce updates without interrupting the user’s current task.

5. Ensured proper use of aria-hidden="true"
- Applied to purely decorative icons (e.g. images inside buttons where text alternatives already exist).
- Why: Prevents redundant or confusing announcements from screen readers.

6. Fixed and improved role attributes
- Defined semantic roles like region and list where appropriate. Removed redundant `role="input"` in input fields
- Why: Improves the structure of the page for assistive technologies.

7. Improved image alt attributes
- Ensured all meaningful images have descriptive alt text.
- Why: Provides equivalent information for users who cannot see images.

8. Added aria-current="page" in pagination
- Used to indicate the currently active page or navigation item.
- Why: Helps screen readers and assistive technologies understand the user’s current location in the app/navigation.

9. Added aria-atomic
- Applied to dynamic regions where updates should be read as a whole.
- Why: Ensures screen readers announce the entire updated content, not just the changed part (useful for status messages or result summaries).

10. aria-selected
- Used for selectable items (tabs, list items, options).
- Why: Communicates which item is currently selected in a group.

# How should this be tested?
Use a screen reader to verify accessibility behavior.
On macOS, enable VoiceOver with `Command + F5`


# Reviewers' expertise

Candidates for reviewing this PR should have some of the following expertises:
1. HTML, CSS, JavaScript
1. Natural language knowledge
    1. English
    2. German
    3. Spanish
    4. French
    5. Portuguese
    6. Russian
    7. Serbian
