### PR TITLE
SearchEngineSmokeTest fix

### DIFF
--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/modules/searchEngine/SearchEngine.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/modules/searchEngine/SearchEngine.java
@@ -4,6 +4,9 @@ package edu.cornell.mannlib.vitro.webapp.modules.searchEngine;
 
 import java.util.Collection;
 
+import javax.servlet.ServletContextEvent;
+import javax.servlet.ServletContextListener;
+
 import edu.cornell.mannlib.vitro.webapp.modules.Application;
 
 /**
@@ -96,4 +99,9 @@ public interface SearchEngine extends Application.Module {
 	 * Find the number of documents in the search index.
 	 */
 	int documentCount() throws SearchEngineException;
+
+	/**
+	 * Execute engine tests
+	 */
+	void test(ServletContextListener scl, ServletContextEvent sce);
 }

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/searchengine/InstrumentedSearchEngineWrapper.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/searchengine/InstrumentedSearchEngineWrapper.java
@@ -12,6 +12,9 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
+import javax.servlet.ServletContextEvent;
+import javax.servlet.ServletContextListener;
+
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
@@ -261,6 +264,11 @@ public class InstrumentedSearchEngineWrapper implements SearchEngine {
 				throw new ArrayIndexOutOfBoundsException(i);
 			}
 		}
+	}
+
+	@Override
+	public void test(ServletContextListener scl, ServletContextEvent sce) {
+		innerEngine.test(scl, sce);
 	}
 
 }

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/searchengine/elasticsearch/ElasticSearchEngine.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/searchengine/elasticsearch/ElasticSearchEngine.java
@@ -6,6 +6,9 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
 
+import javax.servlet.ServletContextEvent;
+import javax.servlet.ServletContextListener;
+
 import edu.cornell.mannlib.vitro.webapp.config.ConfigurationProperties;
 import edu.cornell.mannlib.vitro.webapp.modules.Application;
 import edu.cornell.mannlib.vitro.webapp.modules.ComponentStartupStatus;
@@ -16,6 +19,8 @@ import edu.cornell.mannlib.vitro.webapp.modules.searchEngine.SearchQuery;
 import edu.cornell.mannlib.vitro.webapp.modules.searchEngine.SearchResponse;
 import edu.cornell.mannlib.vitro.webapp.searchengine.base.BaseSearchInputDocument;
 import edu.cornell.mannlib.vitro.webapp.searchengine.base.BaseSearchQuery;
+import edu.cornell.mannlib.vitro.webapp.servlet.setup.ElasticSmokeTest;
+
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.http.client.methods.CloseableHttpResponse;
@@ -137,4 +142,9 @@ public class ElasticSearchEngine implements SearchEngine {
     public int documentCount() throws SearchEngineException {
         return new ESCounter(baseUrl).count();
     }
+
+	@Override
+	public void test(ServletContextListener scl, ServletContextEvent sce) {
+		new ElasticSmokeTest(scl).doTest(sce);
+	}
 }

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/searchengine/solr/SolrSearchEngine.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/searchengine/solr/SolrSearchEngine.java
@@ -9,9 +9,12 @@ import java.util.Arrays;
 import java.util.Collection;
 
 import javax.servlet.ServletContext;
+import javax.servlet.ServletContextEvent;
+import javax.servlet.ServletContextListener;
 
 import edu.cornell.mannlib.vitro.webapp.searchengine.base.SearchEngineUtil;
-import edu.cornell.mannlib.vitro.webapp.servlet.setup.SearchEngineSmokeTest;
+import edu.cornell.mannlib.vitro.webapp.servlet.setup.SolrSmokeTest;
+
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.impl.client.StandardHttpRequestRetryHandler;
 import org.apache.solr.client.solrj.SolrClient;
@@ -21,7 +24,6 @@ import org.apache.solr.client.solrj.impl.ConcurrentUpdateSolrClient;
 import org.apache.solr.client.solrj.impl.HttpSolrClient;
 import org.apache.solr.client.solrj.response.QueryResponse;
 
-import edu.cornell.mannlib.vitro.webapp.config.ConfigurationProperties;
 import edu.cornell.mannlib.vitro.webapp.config.ContextPath;
 import edu.cornell.mannlib.vitro.webapp.modules.Application;
 import edu.cornell.mannlib.vitro.webapp.modules.ComponentStartupStatus;
@@ -203,6 +205,10 @@ public class SolrSearchEngine implements SearchEngine {
 		return (int) response.getResults().getNumFound();
 	}
 
+	@Override
+	public void test(ServletContextListener scl, ServletContextEvent sce) {
+		new SolrSmokeTest(scl).doTest(sce);
+	}
 	/**
 	 * If there is a SocketTimeoutException in the causal chain for this
 	 * exception, then wrap it in a SearchEngineNotRespondingException instead

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/servlet/setup/ElasticSmokeTest.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/servlet/setup/ElasticSmokeTest.java
@@ -36,6 +36,9 @@ public class ElasticSmokeTest {
         final StartupStatus ss = StartupStatus.getBean(sce.getServletContext());
 
         String elasticUrlString = ConfigurationProperties.getInstance().getProperty("vitro.local.searchengine.url", "");
+
+        log.debug("Initializing ElasticSearch: " + elasticUrlString);
+
         if (elasticUrlString.isEmpty()) {
             ss.fatal(listener, "Can't connect to ElasticSearch engine. "
                 + "runtime.properties must contain a value for "

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/servlet/setup/SearchEngineSmokeTest.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/servlet/setup/SearchEngineSmokeTest.java
@@ -2,24 +2,17 @@
 
 package edu.cornell.mannlib.vitro.webapp.servlet.setup;
 
-import java.io.IOException;
-import java.net.MalformedURLException;
 import java.util.Objects;
 
 import javax.servlet.ServletContextEvent;
 import javax.servlet.ServletContextListener;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import edu.cornell.mannlib.vitro.webapp.searchengine.base.SearchEngineUtil;
-import edu.cornell.mannlib.vitro.webapp.searchengine.elasticsearch.ESHttpClient;
-import edu.cornell.mannlib.vitro.webapp.startup.StartupStatus;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.apache.http.HttpEntity;
-import org.apache.http.client.methods.CloseableHttpResponse;
-import org.apache.http.client.methods.HttpGet;
-import org.apache.http.util.EntityUtils;
+
+import edu.cornell.mannlib.vitro.webapp.application.ApplicationUtils;
+import edu.cornell.mannlib.vitro.webapp.searchengine.base.SearchEngineUtil;
+import edu.cornell.mannlib.vitro.webapp.startup.StartupStatus;
 
 /**
  * Start up the appropriate search engine smoke test based on the configured URL property.
@@ -28,53 +21,6 @@ public class SearchEngineSmokeTest implements ServletContextListener {
 
     private static final Log log = LogFactory.getLog(SearchEngineSmokeTest.class);
 
-    private static ServiceType identifyService(String url) throws MalformedURLException {
-        String baseServiceUrl = getBaseServiceUrl(url);
-
-        ServiceType serviceType = ServiceType.UNKNOWN;
-        HttpGet request = new HttpGet(baseServiceUrl);
-
-        try(CloseableHttpResponse response = ESHttpClient.execute(request)) {
-            HttpEntity entity = response.getEntity();
-            if (entity != null) {
-                String result = EntityUtils.toString(entity);
-
-                if (result.contains("Solr")) {
-                    return ServiceType.SOLR;
-                }
-
-                ObjectMapper mapper = new ObjectMapper();
-                JsonNode rootNode = mapper.readTree(result);
-
-                if (rootNode.has("version")) {
-                    JsonNode versionNode = rootNode.get("version");
-                    if (versionNode.has("distribution") &&
-                        "opensearch".equals(versionNode.get("distribution").asText())) {
-                        serviceType = ServiceType.OPENSEARCH;
-                    } else if (versionNode.has("number")) {
-                        serviceType = ServiceType.ELASTIC;
-                    }
-                }
-            }
-        } catch (IOException e) {
-            System.err.println("Request failed: " + e.getMessage());
-        }
-
-        return serviceType;
-    }
-
-    private static String getBaseServiceUrl(String url) {
-        if (url.endsWith("/")) {
-            url = url.substring(0, url.length() - 1);
-        }
-
-        int lastSlashIndex = url.lastIndexOf('/');
-        if (lastSlashIndex != -1) {
-            return url.substring(0, lastSlashIndex);
-        }
-        return url;
-    }
-
     @Override
     public void contextInitialized(ServletContextEvent sce) {
         final StartupStatus ss = StartupStatus.getBean(sce.getServletContext());
@@ -82,33 +28,16 @@ public class SearchEngineSmokeTest implements ServletContextListener {
         String searchEngineUrlString = SearchEngineUtil.getSearchEngineURLProperty();
 
         if (Objects.isNull(searchEngineUrlString) || searchEngineUrlString.isEmpty()) {
-            ss.fatal(this, "No search engine is configured");
+            ss.fatal(this, "Search engine URL is not set.");
         }
 
-        ServiceType service = ServiceType.UNKNOWN;
         try {
-            service = identifyService(searchEngineUrlString);
-        } catch (MalformedURLException e) {
-            ss.fatal(this, "Search engine service URL is malformed.");
+        	ApplicationUtils.instance().getSearchEngine().test(this, sce);
+        } catch (Exception e) {
+        	log.error(e, e);
+        	ss.fatal(this, e.getMessage());
         }
 
-
-        switch (service) {
-            case ELASTIC:
-                log.debug("Initializing ElasticSearch: " + searchEngineUrlString);
-                new ElasticSmokeTest(this).doTest(sce);
-                break;
-            case OPENSEARCH:
-                log.debug("Initializing OpenSearch: " + searchEngineUrlString);
-                new ElasticSmokeTest(this).doTest(sce);
-                break;
-            case SOLR:
-                log.debug("Initializing Solr: " + searchEngineUrlString);
-                new SolrSmokeTest(this).doTest(sce);
-                break;
-            default:
-                ss.fatal(this, "Unknown search engine service is configured");
-        }
     }
 
     @Override
@@ -116,11 +45,6 @@ public class SearchEngineSmokeTest implements ServletContextListener {
         // nothing to tear down.
     }
 
-    private enum ServiceType {
-        ELASTIC,
-        OPENSEARCH,
-        SOLR,
-        UNKNOWN
-    }
+    
 
 }

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/servlet/setup/SolrSmokeTest.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/servlet/setup/SolrSmokeTest.java
@@ -54,6 +54,9 @@ public class SolrSmokeTest {
 		final StartupStatus ss = StartupStatus.getBean(sce.getServletContext());
 
 		String solrUrlString = SearchEngineUtil.getSearchEngineURLProperty();
+
+		log.debug("Initializing Solr: " + solrUrlString);
+
 		if (Objects.isNull(solrUrlString) || solrUrlString.isEmpty()) {
 			ss.fatal(listener, "Can't connect to Solr search engine. "
 					+ "runtime.properties must contain a value for "

--- a/api/src/test/java/stubs/edu/cornell/mannlib/vitro/webapp/modules/searchEngine/SearchEngineStub.java
+++ b/api/src/test/java/stubs/edu/cornell/mannlib/vitro/webapp/modules/searchEngine/SearchEngineStub.java
@@ -6,6 +6,9 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 
+import javax.servlet.ServletContextEvent;
+import javax.servlet.ServletContextListener;
+
 import edu.cornell.mannlib.vitro.webapp.modules.Application;
 import edu.cornell.mannlib.vitro.webapp.modules.ComponentStartupStatus;
 import edu.cornell.mannlib.vitro.webapp.modules.searchEngine.SearchEngine;
@@ -122,5 +125,11 @@ public class SearchEngineStub implements SearchEngine {
 	public int documentCount() throws SearchEngineException {
 		throw new RuntimeException(
 				"SearchEngineStub.documentCount() not implemented.");
+	}
+
+	@Override
+	public void test(ServletContextListener scl, ServletContextEvent sce) {
+		throw new RuntimeException(
+				"SearchEngineStub.test() not implemented.");
 	}
 }


### PR DESCRIPTION
# What does this pull request do?
Fixes failing SearchEngineSmokeTest  while using Solr as test is currently dependent on ESHttpClient (not initialized for Solr).
Refactored  SearchEngineSmokeTest: moved execution of implementation specific tests to respective engine implementations avoiding the need to identify the search engine.

# How should this be tested?
* Reproduce the problem
* Apply PR
* run VIVO with Solr
* run VIVO with Elastic Search

# Interested parties
@brianjlowe  @chenejac  @VIVO-project/vivo-committers

# Reviewers' expertise

Candidates for reviewing this PR should have some of the following expertises:
1. Java

# Reviewers' report template
## General comment
A reviewer should provide here comments and suggestions for requested changes if any.
## Testing
A reviewer should briefly describe here how it was tested
## Code reviewing
A reviewer should briefly describe here which part was code reviewed