### PR TITLE
Use standard list of model names in Execute SPARQL CONSTRUCT page

### DIFF
--- a/webapp/src/main/webapp/jenaIngest/sparqlConstruct.jsp
+++ b/webapp/src/main/webapp/jenaIngest/sparqlConstruct.jsp
@@ -2,7 +2,6 @@
 
 <%@ page import="org.apache.jena.ontology.Individual"%>
 <%@ page import="org.apache.jena.ontology.OntModel"%>
-<%@ page import="org.apache.jena.rdf.model.ModelMaker"%>
 <%@ page import="edu.cornell.mannlib.vitro.webapp.modelaccess.ModelAccess"%>
 <%@ page import="edu.cornell.mannlib.vitro.webapp.modelaccess.ModelAccess.WhichService"%>
 <%@ page import="org.apache.jena.shared.Lock"%>
@@ -17,10 +16,7 @@
 <% request.setAttribute("requestedActions", SimplePermission.USE_ADVANCED_DATA_TOOLS_PAGES.ACTION); %>
 <vitro:confirmAuthorization />
 
-<%
-    ModelMaker maker = ModelAccess.on(getServletContext()).getModelMaker(WhichService.CONFIGURATION);
-%>
-
+<% List<String> modelNames = (List<String>) request.getAttribute("modelNames"); %>
 
 <%@page import="java.util.HashSet"%>
 <%@page import="java.util.Set"%>
@@ -127,8 +123,7 @@ PREFIX <%=prefixText%>: <<%=urlText%>><%}}%>
                     %> />webapp
 	assertions</li>
 	<%
-    for (Iterator it = maker.listModels(); it.hasNext(); ) {
-	String modelName = (String) it.next();
+    for (String modelName : modelNames) {
         %>
 	<li><input type="checkbox" name="sourceModelName"
 		value="<%=modelName%>"
@@ -161,8 +156,7 @@ PREFIX <%=prefixText%>: <<%=urlText%>><%}}%>
               %> />webapp
 	model</option>
 	<%
-    for (Iterator it = maker.listModels(); it.hasNext(); ) {
-    String modelName = (String) it.next();
+    for (String modelName : modelNames) {
         %>
 	<option value="<%=modelName%>"
 		<%


### PR DESCRIPTION
**[VIVO4141](https://github.com/vivo-project/VIVO/issues/4141)**:

* Other Relevant Links (Mailing list discussion, related pull requests, etc.)

# What does this pull request do?
Uses the same list of available model names in the Execute SPARQL CONSTRUCT page that is used in other ingest tool pages. Fixes current bug where only configuration models are offered as source and destination models on this page.

# How should this be tested?
1. Go to Site Admin > Ingest tools > Manage Jena Models .
2. Click the "Main Store Models" button near the top. Note the models available in this list, such as "http://vitro.mannlib.cornell.edu/filegraph/tbox/ontologies.owl".
3. Go to Site Admin > Ingest tools > Execute SPARQL CONSTRUCT.
4. Note that these same models are offered under "Select Source Models" and "Select Destination Model".
5. Return to Site Admin > Ingest tools > Manage Jena Models.
6. Click "Configuration Models".
7. Note that other models, such as "http://vitro.mannlib.cornell.edu/default/interface-i18n", are now listed.
8. Return to Site Admin > Ingest tools > Execute SPARQL CONSTRUCT.
9. Confirm that this new set of models is offered for source and destination models.

# Interested parties
@VIVO-project/vivo-committers

# Reviewers' report template
**Please update the following template which should be used by reviewers.**
## General comment
A reviewer should provide here comments and suggestions for requested changes if any.
## Testing
A reviewer should briefly describe here how it was tested
## Code reviewing
A reviewer should briefly describe here which part was code reviewed