### PR TITLE
Modify I18nSort document modifier to work around Jena bug

### DIFF
--- a/home/src/main/resources/rdf/display/everytime/documentModifierI18nSort.n3
+++ b/home/src/main/resources/rdf/display/everytime/documentModifierI18nSort.n3
@@ -9,8 +9,11 @@
     :hasTargetSuffix "_label_sort" ;
     :hasSelectQuery """
         PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
-        SELECT ( LCASE(MIN(?label)) AS ?singleLabel ) WHERE {
-        	?uri rdfs:label ?label .
-            BIND (LANG(?label) as ?lang )
+        # Re-add language tag after comparing plain strings in MIN() aggregation to work around Jena bug.
+        # This can be changed back to SELECT (LCASE(MIN(?label)) AS ?singleLabel) when Jena is upgraded.
+        SELECT (LCASE(IF(?lang = "", MIN(STR(?label)), STRLANG(MIN(STR(?label)), ?lang))) AS ?singleLabel)
+        WHERE {
+            ?uri rdfs:label ?label .
+            BIND (LANG(?label) as ?lang)
         } GROUP BY ?lang ORDER BY ?lang
     """ .


### PR DESCRIPTION
**[VIVO-4147](https://github.com/vivo-project/VIVO/issues/4147)**:

# What does this pull request do?
Changes documentModifierI18nSort.n3 so that the MIN() aggregration operates only on plain strings as a workaround for a Jena bug in literal comparisons that sometimes causes MIN() to return null.

# How should this be tested?
If you were able to reproduce the bug in your instance with the sample data on the VIVO-4147 issue, then, after applying the PR, re-load the same data file and the "Doe, John" should appear alphabetized correctly in the appropriate browse pages. Otherwise, just check the query for correctness and rebuild the search index confirming that counts do not change.

# Interested parties
@VIVO-project/vivo-committers

# Reviewers' expertise

Candidates for reviewing this PR should have some of the following expertises:
1. SPARQL

# Reviewers' report template
**Please update the following template which should be used by reviewers.**
## General comment
A reviewer should provide here comments and suggestions for requested changes if any.
## Testing
A reviewer should briefly describe here how it was tested
## Code reviewing
A reviewer should briefly describe here which part was code reviewed