### PR TITLE
Added DataDistributor Uri binding authorization checks

### DIFF
--- a/api/src/main/java/edu/cornell/library/scholars/webapp/controller/api/DistributeDataApiController.java
+++ b/api/src/main/java/edu/cornell/library/scholars/webapp/controller/api/DistributeDataApiController.java
@@ -8,12 +8,15 @@ import static edu.cornell.mannlib.vitro.webapp.utils.sparqlrunner.SparqlQueryRun
 
 import java.io.IOException;
 import java.io.OutputStream;
+import java.io.OutputStreamWriter;
 import java.io.PrintStream;
 import java.io.PrintWriter;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.List;
 
 import javax.servlet.ServletException;
+import javax.servlet.ServletOutputStream;
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -41,6 +44,8 @@ import org.apache.jena.rdf.model.Model;
  */
 @WebServlet(name = "DistributeDataApi", urlPatterns = { "/api/dataRequest/*" })
 public class DistributeDataApiController extends VitroApiServlet {
+    private static final String NOT_AUTHORIZED_FOR_THIS_ACTION = "Not authorized for this action.";
+
     private static final Log log = LogFactory.getLog(DistributeDataApiController.class);
 
     private static final String DISTRIBUTOR_FOR_SPECIFIED_ACTION = ""
@@ -118,14 +123,21 @@ public class DistributeDataApiController extends VitroApiServlet {
     }
 
     private void runIt(HttpServletRequest req, HttpServletResponse resp, DataDistributor instance)
-            throws DataDistributorException {
+            throws DataDistributorException, IOException {
+        ServletOutputStream outputStream = resp.getOutputStream();
         try {
             instance.init(new DataDistributorContextImpl(req));
             log.debug("Distributor is " + instance);
 
             resp.setContentType(instance.getContentType());
             resp.setCharacterEncoding("UTF-8");
-            instance.writeOutput(resp.getOutputStream());
+            instance.writeOutput(outputStream);
+        } catch (NotAuthorizedException e) {
+            log.debug("403 Forbidden");
+            resp.setStatus(403);
+            try (OutputStreamWriter writer = new OutputStreamWriter(outputStream, StandardCharsets.UTF_8)) {
+                writer.write(NOT_AUTHORIZED_FOR_THIS_ACTION);
+            }
         } catch (Exception e) {
             log.error("Failed to execute the DataDistributor", e);
             instance.close();
@@ -142,7 +154,7 @@ public class DistributeDataApiController extends VitroApiServlet {
     private void do403Forbidden(HttpServletResponse resp) throws IOException {
         log.debug("403Forbidden");
         resp.setStatus(403);
-        resp.getWriter().println("Not authorized for this action.");
+        resp.getWriter().println(NOT_AUTHORIZED_FOR_THIS_ACTION);
     }
 
     private void do500InternalServerError(String message, Exception e, HttpServletResponse resp) throws IOException {

--- a/api/src/main/java/edu/cornell/library/scholars/webapp/controller/api/DistributeDataApiController.java
+++ b/api/src/main/java/edu/cornell/library/scholars/webapp/controller/api/DistributeDataApiController.java
@@ -5,6 +5,7 @@ package edu.cornell.library.scholars.webapp.controller.api;
 import static edu.cornell.mannlib.vitro.webapp.auth.attributes.AccessOperation.EXECUTE;
 import static edu.cornell.mannlib.vitro.webapp.modelaccess.ModelNames.DISPLAY;
 import static edu.cornell.mannlib.vitro.webapp.utils.sparqlrunner.SparqlQueryRunner.createSelectQueryContext;
+import static edu.cornell.mannlib.vitro.webapp.web.ContentType.TEXT_PLAIN;
 
 import java.io.IOException;
 import java.io.OutputStream;
@@ -34,6 +35,7 @@ import edu.cornell.mannlib.vitro.webapp.controller.api.VitroApiServlet;
 import edu.cornell.mannlib.vitro.webapp.modelaccess.ModelAccess;
 import edu.cornell.mannlib.vitro.webapp.utils.configuration.ConfigurationBeanLoader;
 import edu.cornell.mannlib.vitro.webapp.utils.configuration.ConfigurationBeanLoaderException;
+import edu.cornell.mannlib.vitro.webapp.web.ContentType;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.jena.rdf.model.Model;
@@ -134,6 +136,7 @@ public class DistributeDataApiController extends VitroApiServlet {
             instance.writeOutput(outputStream);
         } catch (NotAuthorizedException e) {
             log.debug("403 Forbidden");
+            resp.setContentType(TEXT_PLAIN.getMediaType());
             resp.setStatus(403);
             try (OutputStreamWriter writer = new OutputStreamWriter(outputStream, StandardCharsets.UTF_8)) {
                 writer.write(NOT_AUTHORIZED_FOR_THIS_ACTION);

--- a/api/src/main/java/edu/cornell/library/scholars/webapp/controller/api/DistributeDataApiController.java
+++ b/api/src/main/java/edu/cornell/library/scholars/webapp/controller/api/DistributeDataApiController.java
@@ -146,19 +146,19 @@ public class DistributeDataApiController extends VitroApiServlet {
     }
 
     private void do400BadRequest(String message, HttpServletResponse resp) throws IOException {
-        log.debug("400BadRequest: " + message);
+        log.debug("400 Bad Request: " + message);
         resp.setStatus(400);
         resp.getWriter().println(message);
     }
 
     private void do403Forbidden(HttpServletResponse resp) throws IOException {
-        log.debug("403Forbidden");
+        log.debug("403 Forbidden");
         resp.setStatus(403);
         resp.getWriter().println(NOT_AUTHORIZED_FOR_THIS_ACTION);
     }
 
     private void do500InternalServerError(String message, Exception e, HttpServletResponse resp) throws IOException {
-        log.warn("500InternalServerError " + message, e);
+        log.warn("500 Internal Server Error: " + message, e);
         resp.setStatus(500);
         try {
             PrintWriter w = resp.getWriter();

--- a/api/src/main/java/edu/cornell/library/scholars/webapp/controller/api/DistributeDataApiController.java
+++ b/api/src/main/java/edu/cornell/library/scholars/webapp/controller/api/DistributeDataApiController.java
@@ -35,7 +35,6 @@ import edu.cornell.mannlib.vitro.webapp.controller.api.VitroApiServlet;
 import edu.cornell.mannlib.vitro.webapp.modelaccess.ModelAccess;
 import edu.cornell.mannlib.vitro.webapp.utils.configuration.ConfigurationBeanLoader;
 import edu.cornell.mannlib.vitro.webapp.utils.configuration.ConfigurationBeanLoaderException;
-import edu.cornell.mannlib.vitro.webapp.web.ContentType;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.jena.rdf.model.Model;

--- a/api/src/main/java/edu/cornell/library/scholars/webapp/controller/api/distribute/rdf/SelectFromContentDistributor.java
+++ b/api/src/main/java/edu/cornell/library/scholars/webapp/controller/api/distribute/rdf/SelectFromContentDistributor.java
@@ -84,6 +84,7 @@ public class SelectFromContentDistributor extends AbstractSparqlBindingDistribut
 
     @Override
     public void writeOutput(OutputStream output) throws DataDistributorException {
+        binder.checkAuthorization(ddContext, uriBindingNames);
         QueryHolder boundQuery = binder.bindValuesToQuery(uriBindingNames, literalBindingNames,
                 new QueryHolder(rawQuery));
         createSelectQueryContext(this.models.getRDFService(), boundQuery).execute().writeToOutput(output);

--- a/api/src/main/java/edu/cornell/library/scholars/webapp/controller/api/distribute/rdf/SelectFromGraphDistributor.java
+++ b/api/src/main/java/edu/cornell/library/scholars/webapp/controller/api/distribute/rdf/SelectFromGraphDistributor.java
@@ -99,6 +99,7 @@ public class SelectFromGraphDistributor extends AbstractSparqlBindingDistributor
 
     @Override
     public void writeOutput(OutputStream output) throws DataDistributorException {
+        binder.checkAuthorization(ddContext, uriBindingNames);
         QueryHolder boundQuery = binder.bindValuesToQuery(uriBindingNames, literalBindingNames,
                 new QueryHolder(rawQuery));
         Model graph = new GraphBuilders(ddContext, graphBuilders).run();

--- a/api/src/main/java/edu/cornell/library/scholars/webapp/controller/api/distribute/rdf/graphbuilder/AbstractSparqlBindingGraphBuilder.java
+++ b/api/src/main/java/edu/cornell/library/scholars/webapp/controller/api/distribute/rdf/graphbuilder/AbstractSparqlBindingGraphBuilder.java
@@ -3,23 +3,13 @@
 package edu.cornell.library.scholars.webapp.controller.api.distribute.rdf.graphbuilder;
 
 import java.util.HashSet;
-import java.util.Map;
 import java.util.Set;
 
 import edu.cornell.library.scholars.webapp.controller.api.distribute.DataDistributor.DataDistributorException;
-import edu.cornell.library.scholars.webapp.controller.api.distribute.DataDistributor.NotAuthorizedException;
 import edu.cornell.library.scholars.webapp.controller.api.distribute.DataDistributorContext;
 import edu.cornell.library.scholars.webapp.controller.api.distribute.rdf.util.VariableBinder;
-import edu.cornell.mannlib.vitro.webapp.auth.attributes.AccessOperation;
-import edu.cornell.mannlib.vitro.webapp.auth.objects.AccessObject;
-import edu.cornell.mannlib.vitro.webapp.auth.objects.IndividualAccessObject;
-import edu.cornell.mannlib.vitro.webapp.auth.requestedAction.AuthorizationRequest;
-import edu.cornell.mannlib.vitro.webapp.auth.requestedAction.SimpleAuthorizationRequest;
-import edu.cornell.mannlib.vitro.webapp.modelaccess.ModelAccess;
-import edu.cornell.mannlib.vitro.webapp.modelaccess.ModelNames;
 import edu.cornell.mannlib.vitro.webapp.utils.configuration.Property;
 import edu.cornell.mannlib.vitro.webapp.utils.sparqlrunner.QueryHolder;
-import org.apache.commons.lang3.StringUtils;
 
 /**
  * Keep track of the binding details for DataDistributors that bind request
@@ -41,27 +31,8 @@ public abstract class AbstractSparqlBindingGraphBuilder extends AbstractGraphBui
 
     protected QueryHolder bindParametersToQuery(DataDistributorContext ddContext, QueryHolder rawQuery)
             throws DataDistributorException {
-        Map<String, String[]> parameters = ddContext.getRequestParameters();
-        checkAuthorization(ddContext, parameters);
-        return new VariableBinder(parameters).bindValuesToQuery(uriBindingNames, literalBindingNames, rawQuery);
-    }
-
-    private void checkAuthorization(DataDistributorContext ddContext, Map<String, String[]> parameters)
-            throws NotAuthorizedException {
-        for (String name : uriBindingNames) {
-            if (parameters.containsKey(name)) {
-                String[] uris = parameters.get(name);
-                for (String uri : uris) {
-                    if (StringUtils.isNotBlank(uri)) {
-                        AccessObject ao = new IndividualAccessObject(uri);
-                        ao.setModel(ModelAccess.getInstance().getOntModel(ModelNames.FULL_UNION));
-                        AuthorizationRequest request = new SimpleAuthorizationRequest(ao, AccessOperation.DISPLAY);
-                        if (!ddContext.isAuthorized(request)) {
-                            throw new NotAuthorizedException();
-                        }
-                    }
-                }
-            }
-        }
+        VariableBinder binder = new VariableBinder(ddContext.getRequestParameters());
+        binder.checkAuthorization(ddContext, uriBindingNames);
+        return binder.bindValuesToQuery(uriBindingNames, literalBindingNames, rawQuery);
     }
 }

--- a/api/src/main/java/edu/cornell/library/scholars/webapp/controller/api/distribute/rdf/graphbuilder/AbstractSparqlBindingGraphBuilder.java
+++ b/api/src/main/java/edu/cornell/library/scholars/webapp/controller/api/distribute/rdf/graphbuilder/AbstractSparqlBindingGraphBuilder.java
@@ -3,13 +3,23 @@
 package edu.cornell.library.scholars.webapp.controller.api.distribute.rdf.graphbuilder;
 
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 
-import edu.cornell.library.scholars.webapp.controller.api.distribute.DataDistributor.MissingParametersException;
+import edu.cornell.library.scholars.webapp.controller.api.distribute.DataDistributor.DataDistributorException;
+import edu.cornell.library.scholars.webapp.controller.api.distribute.DataDistributor.NotAuthorizedException;
 import edu.cornell.library.scholars.webapp.controller.api.distribute.DataDistributorContext;
 import edu.cornell.library.scholars.webapp.controller.api.distribute.rdf.util.VariableBinder;
+import edu.cornell.mannlib.vitro.webapp.auth.attributes.AccessOperation;
+import edu.cornell.mannlib.vitro.webapp.auth.objects.AccessObject;
+import edu.cornell.mannlib.vitro.webapp.auth.objects.IndividualAccessObject;
+import edu.cornell.mannlib.vitro.webapp.auth.requestedAction.AuthorizationRequest;
+import edu.cornell.mannlib.vitro.webapp.auth.requestedAction.SimpleAuthorizationRequest;
+import edu.cornell.mannlib.vitro.webapp.modelaccess.ModelAccess;
+import edu.cornell.mannlib.vitro.webapp.modelaccess.ModelNames;
 import edu.cornell.mannlib.vitro.webapp.utils.configuration.Property;
 import edu.cornell.mannlib.vitro.webapp.utils.sparqlrunner.QueryHolder;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * Keep track of the binding details for DataDistributors that bind request
@@ -30,8 +40,28 @@ public abstract class AbstractSparqlBindingGraphBuilder extends AbstractGraphBui
     }
 
     protected QueryHolder bindParametersToQuery(DataDistributorContext ddContext, QueryHolder rawQuery)
-            throws MissingParametersException {
-        return new VariableBinder(ddContext.getRequestParameters()).bindValuesToQuery(uriBindingNames,
-                literalBindingNames, rawQuery);
+            throws DataDistributorException {
+        Map<String, String[]> parameters = ddContext.getRequestParameters();
+        checkAuthorization(ddContext, parameters);
+        return new VariableBinder(parameters).bindValuesToQuery(uriBindingNames, literalBindingNames, rawQuery);
+    }
+
+    private void checkAuthorization(DataDistributorContext ddContext, Map<String, String[]> parameters)
+            throws NotAuthorizedException {
+        for (String name : uriBindingNames) {
+            if (parameters.containsKey(name)) {
+                String[] uris = parameters.get(name);
+                for (String uri : uris) {
+                    if (StringUtils.isNotBlank(uri)) {
+                        AccessObject ao = new IndividualAccessObject(uri);
+                        ao.setModel(ModelAccess.getInstance().getOntModel(ModelNames.FULL_UNION));
+                        AuthorizationRequest request = new SimpleAuthorizationRequest(ao, AccessOperation.DISPLAY);
+                        if (!ddContext.isAuthorized(request)) {
+                            throw new NotAuthorizedException();
+                        }
+                    }
+                }
+            }
+        }
     }
 }

--- a/api/src/main/java/edu/cornell/library/scholars/webapp/controller/api/distribute/rdf/util/VariableBinder.java
+++ b/api/src/main/java/edu/cornell/library/scholars/webapp/controller/api/distribute/rdf/util/VariableBinder.java
@@ -10,7 +10,17 @@ import java.util.Objects;
 import java.util.Set;
 
 import edu.cornell.library.scholars.webapp.controller.api.distribute.DataDistributor.MissingParametersException;
+import edu.cornell.library.scholars.webapp.controller.api.distribute.DataDistributor.NotAuthorizedException;
+import edu.cornell.library.scholars.webapp.controller.api.distribute.DataDistributorContext;
+import edu.cornell.mannlib.vitro.webapp.auth.attributes.AccessOperation;
+import edu.cornell.mannlib.vitro.webapp.auth.objects.AccessObject;
+import edu.cornell.mannlib.vitro.webapp.auth.objects.IndividualAccessObject;
+import edu.cornell.mannlib.vitro.webapp.auth.requestedAction.AuthorizationRequest;
+import edu.cornell.mannlib.vitro.webapp.auth.requestedAction.SimpleAuthorizationRequest;
+import edu.cornell.mannlib.vitro.webapp.modelaccess.ModelAccess;
+import edu.cornell.mannlib.vitro.webapp.modelaccess.ModelNames;
 import edu.cornell.mannlib.vitro.webapp.utils.sparqlrunner.QueryHolder;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * Start with a parameter map, like from an HTTPServletRequest.
@@ -69,6 +79,25 @@ public class VariableBinder {
             throw new MissingParametersException("Unexpected multiple values for '" + name + "' parameter.");
         }
         return uris[0];
+    }
+
+    public void checkAuthorization(DataDistributorContext ddContext, Set<String> uriBindingNames)
+            throws NotAuthorizedException {
+        for (String name : uriBindingNames) {
+            if (parameters.containsKey(name)) {
+                String[] uris = parameters.get(name);
+                for (String uri : uris) {
+                    if (StringUtils.isNotBlank(uri)) {
+                        AccessObject ao = new IndividualAccessObject(uri);
+                        ao.setModel(ModelAccess.getInstance().getOntModel(ModelNames.FULL_UNION));
+                        AuthorizationRequest request = new SimpleAuthorizationRequest(ao, AccessOperation.DISPLAY);
+                        if (!ddContext.isAuthorized(request)) {
+                            throw new NotAuthorizedException();
+                        }
+                    }
+                }
+            }
+        }
     }
 
 }


### PR DESCRIPTION
Related to [VIVO GitHub issue](https://github.com/vivo-project/VIVO/issues/4118) 

# What does this pull request do?
Adds authorization checks for bound URI values in Data Distribution API

# How should this be tested?
For each type of distributors: SelectFromContentDistributor, SelectFromGraphDistributor, RDFGraphDistributor
- Create a Data distributor with URI Binding variable (In case of RDFGraphDistributor binding should be configured in dependent GraphBuilder).
- Run distributor, providing individual URI as a variable value for data distributor. 
- Make sure the distributor responds "Not authorized" if access to an individual page is denied to the user, and functions correctly if access to an individual page is allowed.


# Interested parties
@VIVO-project/vivo-committers

Candidates for reviewing this PR should have some of the following expertises:
1. Java
2. SPARQL

# Reviewers' report template
## General comment
A reviewer should provide here comments and suggestions for requested changes if any.
## Testing
A reviewer should briefly describe here how it was tested
## Code reviewing
A reviewer should briefly describe here which part was code reviewed