### PR TITLE
Additional SPARQL output formats for Data Distribution API

### DIFF
--- a/api/src/main/java/edu/cornell/library/scholars/webapp/controller/api/distribute/rdf/AbstractSparqlBindingDistributor.java
+++ b/api/src/main/java/edu/cornell/library/scholars/webapp/controller/api/distribute/rdf/AbstractSparqlBindingDistributor.java
@@ -8,6 +8,7 @@ import java.util.Set;
 import edu.cornell.library.scholars.webapp.controller.api.distribute.AbstractDataDistributor;
 import edu.cornell.library.scholars.webapp.controller.api.distribute.DataDistributorContext;
 import edu.cornell.library.scholars.webapp.controller.api.distribute.rdf.util.VariableBinder;
+import edu.cornell.mannlib.vitro.webapp.controller.api.sparqlquery.ResultSetMediaType;
 import edu.cornell.mannlib.vitro.webapp.utils.configuration.Property;
 
 /**
@@ -34,5 +35,21 @@ public abstract class AbstractSparqlBindingDistributor extends AbstractDataDistr
     @Property(uri = "http://vitro.mannlib.cornell.edu/ns/vitro/ApplicationSetup#literalBinding")
     public void addLiteralBindingName(String literalBindingName) {
         this.literalBindingNames.add(literalBindingName);
+    }
+
+    protected String getContentType(String format) {
+        String contentType;
+        switch (format) {
+            case "JSON":
+                contentType = ResultSetMediaType.JSON.getContentType();
+                break;
+            case "CSV":
+                contentType = ResultSetMediaType.CSV.getContentType();
+                break;
+            default:
+                contentType = ResultSetMediaType.JSON.getContentType();
+                break;
+        }
+        return contentType;
     }
 }

--- a/api/src/main/java/edu/cornell/library/scholars/webapp/controller/api/distribute/rdf/AbstractSparqlBindingDistributor.java
+++ b/api/src/main/java/edu/cornell/library/scholars/webapp/controller/api/distribute/rdf/AbstractSparqlBindingDistributor.java
@@ -40,9 +40,6 @@ public abstract class AbstractSparqlBindingDistributor extends AbstractDataDistr
     protected String getContentType(String format) {
         String contentType;
         switch (format) {
-            case "JSON":
-                contentType = ResultSetMediaType.JSON.getContentType();
-                break;
             case "CSV":
                 contentType = ResultSetMediaType.CSV.getContentType();
                 break;

--- a/api/src/main/java/edu/cornell/library/scholars/webapp/controller/api/distribute/rdf/RdfGraphDistributor.java
+++ b/api/src/main/java/edu/cornell/library/scholars/webapp/controller/api/distribute/rdf/RdfGraphDistributor.java
@@ -10,6 +10,7 @@ import edu.cornell.library.scholars.webapp.controller.api.distribute.AbstractDat
 import edu.cornell.library.scholars.webapp.controller.api.distribute.rdf.graphbuilder.GraphBuilder;
 import edu.cornell.library.scholars.webapp.controller.api.distribute.rdf.graphbuilder.GraphBuilderUtilities.GraphBuilders;
 import edu.cornell.mannlib.vitro.webapp.utils.configuration.Property;
+import edu.cornell.mannlib.vitro.webapp.web.ContentType;
 
 /**
  * Execute one or more GraphBuilders, merge the results, and write them out as
@@ -17,20 +18,38 @@ import edu.cornell.mannlib.vitro.webapp.utils.configuration.Property;
  */
 public class RdfGraphDistributor extends AbstractDataDistributor {
     private List<GraphBuilder> graphBuilders = new ArrayList<>();
+    private String lang = "TTL";
 
     @Property(uri = "http://vitro.mannlib.cornell.edu/ns/vitro/ApplicationSetup#graphBuilder", minOccurs = 1)
     public void addGraphBuilder(GraphBuilder builder) {
         graphBuilders.add(builder);
     }
 
+    @Property(uri = "http://vitro.mannlib.cornell.edu/ns/vitro/ApplicationSetup#rdfLang", maxOccurs = 1)
+    public void setLang(String lang) {
+        this.lang = lang;
+    }
+
     @Override
     public String getContentType() throws DataDistributorException {
-        return "text/turtle";
+        String contentType;
+        switch (lang) {
+            case "RDF/XML":
+                contentType = ContentType.RDFXML.getMediaType();
+                break;
+            case "N3":
+                contentType = ContentType.N3.getMediaType();
+                break;
+            default:
+                contentType = ContentType.TURTLE.getMediaType();
+                break;
+        }
+        return contentType;
     }
 
     @Override
     public void writeOutput(OutputStream output) throws DataDistributorException {
-        new GraphBuilders(ddContext, graphBuilders).run().write(output, "TTL");
+        new GraphBuilders(ddContext, graphBuilders).run().write(output, lang);
     }
 
     @Override

--- a/api/src/main/java/edu/cornell/library/scholars/webapp/controller/api/distribute/rdf/SelectFromContentDistributor.java
+++ b/api/src/main/java/edu/cornell/library/scholars/webapp/controller/api/distribute/rdf/SelectFromContentDistributor.java
@@ -8,6 +8,7 @@ import java.io.OutputStream;
 
 import edu.cornell.library.scholars.webapp.controller.api.distribute.DataDistributorContext;
 import edu.cornell.mannlib.vitro.webapp.modelaccess.RequestModelAccess;
+import edu.cornell.mannlib.vitro.webapp.rdfservice.RDFService.ResultFormat;
 import edu.cornell.mannlib.vitro.webapp.utils.configuration.Property;
 import edu.cornell.mannlib.vitro.webapp.utils.sparqlrunner.QueryHolder;
 
@@ -65,6 +66,7 @@ import edu.cornell.mannlib.vitro.webapp.utils.sparqlrunner.QueryHolder;
 public class SelectFromContentDistributor extends AbstractSparqlBindingDistributor {
     private RequestModelAccess models;
     private String rawQuery;
+    private String resultFormat = "JSON";
 
     @Property(uri = "http://vitro.mannlib.cornell.edu/ns/vitro/ApplicationSetup#query", minOccurs = 1, maxOccurs = 1)
     public void setRawQuery(String query) {
@@ -77,16 +79,22 @@ public class SelectFromContentDistributor extends AbstractSparqlBindingDistribut
         this.models = ddc.getRequestModels();
     }
 
+    @Property(uri = "http://vitro.mannlib.cornell.edu/ns/vitro/ApplicationSetup#resultFormat", maxOccurs = 1)
+    public void setResultFormat(String resultFormat) {
+        this.resultFormat = resultFormat;
+    }
+
     @Override
     public String getContentType() throws DataDistributorException {
-        return "application/sparql-results+json";
+        return getContentType(resultFormat);
     }
 
     @Override
     public void writeOutput(OutputStream output) throws DataDistributorException {
         QueryHolder boundQuery = binder.bindValuesToQuery(uriBindingNames, literalBindingNames,
                 new QueryHolder(rawQuery));
-        createSelectQueryContext(this.models.getRDFService(), boundQuery).execute().writeToOutput(output);
+        createSelectQueryContext(this.models.getRDFService(), boundQuery).execute().writeToOutput(output,
+                ResultFormat.valueOf(resultFormat));
     }
 
     @Override

--- a/api/src/main/java/edu/cornell/library/scholars/webapp/controller/api/distribute/rdf/SelectFromGraphDistributor.java
+++ b/api/src/main/java/edu/cornell/library/scholars/webapp/controller/api/distribute/rdf/SelectFromGraphDistributor.java
@@ -11,6 +11,7 @@ import java.util.List;
 import edu.cornell.library.scholars.webapp.controller.api.distribute.DataDistributorContext;
 import edu.cornell.library.scholars.webapp.controller.api.distribute.rdf.graphbuilder.GraphBuilder;
 import edu.cornell.library.scholars.webapp.controller.api.distribute.rdf.graphbuilder.GraphBuilderUtilities.GraphBuilders;
+import edu.cornell.mannlib.vitro.webapp.rdfservice.RDFService.ResultFormat;
 import edu.cornell.mannlib.vitro.webapp.utils.configuration.Property;
 import edu.cornell.mannlib.vitro.webapp.utils.sparqlrunner.QueryHolder;
 import org.apache.jena.rdf.model.Model;
@@ -76,6 +77,7 @@ import org.apache.jena.rdf.model.Model;
 public class SelectFromGraphDistributor extends AbstractSparqlBindingDistributor {
     private String rawQuery;
     private List<GraphBuilder> graphBuilders = new ArrayList<>();
+    private String resultFormat = "JSON";
 
     @Property(uri = "http://vitro.mannlib.cornell.edu/ns/vitro/ApplicationSetup#query", minOccurs = 1, maxOccurs = 1)
     public void setRawQuery(String query) {
@@ -87,6 +89,11 @@ public class SelectFromGraphDistributor extends AbstractSparqlBindingDistributor
         graphBuilders.add(builder);
     }
 
+    @Property(uri = "http://vitro.mannlib.cornell.edu/ns/vitro/ApplicationSetup#resultFormat", maxOccurs = 1)
+    public void setResultFormat(String resultFormat) {
+        this.resultFormat  = resultFormat;
+    }
+
     @Override
     public void init(DataDistributorContext ddc) throws DataDistributorException {
         super.init(ddc);
@@ -94,7 +101,7 @@ public class SelectFromGraphDistributor extends AbstractSparqlBindingDistributor
 
     @Override
     public String getContentType() throws DataDistributorException {
-        return "application/sparql-results+json";
+        return getContentType(resultFormat);
     }
 
     @Override
@@ -102,7 +109,8 @@ public class SelectFromGraphDistributor extends AbstractSparqlBindingDistributor
         QueryHolder boundQuery = binder.bindValuesToQuery(uriBindingNames, literalBindingNames,
                 new QueryHolder(rawQuery));
         Model graph = new GraphBuilders(ddContext, graphBuilders).run();
-        createSelectQueryContext(graph, boundQuery).execute().writeToOutput(output);
+        createSelectQueryContext(graph, boundQuery).execute().writeToOutput(output,
+                ResultFormat.valueOf(resultFormat));
     }
 
     @Override

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/utils/sparqlrunner/ModelSelectQueryContext.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/utils/sparqlrunner/ModelSelectQueryContext.java
@@ -2,6 +2,10 @@
 
 package edu.cornell.mannlib.vitro.webapp.utils.sparqlrunner;
 
+import static org.apache.jena.riot.resultset.ResultSetLang.SPARQLResultSetJSON;
+import static org.apache.jena.riot.resultset.ResultSetLang.SPARQLResultSetCSV;
+import static org.apache.jena.riot.resultset.ResultSetLang.SPARQLResultSetXML;
+
 import java.io.OutputStream;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -17,7 +21,8 @@ import org.apache.jena.query.ResultSet;
 import org.apache.jena.query.ResultSetFormatter;
 import org.apache.jena.query.Syntax;
 import org.apache.jena.rdf.model.Model;
-
+import org.apache.jena.riot.Lang;
+import edu.cornell.mannlib.vitro.webapp.rdfservice.RDFService.ResultFormat;
 import edu.cornell.mannlib.vitro.webapp.utils.sparqlrunner.SparqlQueryRunner.ExecutingSelectQueryContext;
 import edu.cornell.mannlib.vitro.webapp.utils.sparqlrunner.SparqlQueryRunner.SelectQueryContext;
 
@@ -111,19 +116,43 @@ class ModelSelectQueryContext implements SelectQueryContext {
 
 		@Override
 		public void writeToOutput(OutputStream output) {
-			String qString = query.getQueryString();
-			try {
-				Query q = QueryFactory.create(qString, SYNTAX);
-				QueryExecution qexec = QueryExecutionFactory.create(q, model);
-				try {
-					ResultSetFormatter.outputAsJSON(output, qexec.execSelect());
-				} finally {
-					qexec.close();
-				}
-			} catch (Exception e) {
-				log.error("problem while running query '" + qString + "'", e);
-			}
+		    writeToOutput(output, ResultFormat.JSON);
 		}
+
+        @Override
+        public void writeToOutput(OutputStream output, ResultFormat format) {
+            String qString = query.getQueryString();
+            try {
+                Query q = QueryFactory.create(qString, SYNTAX);
+                QueryExecution qexec = QueryExecutionFactory.create(q, model);
+                try {
+                    ResultSetFormatter.output(output, qexec.execSelect(), getLang(format)) ;
+                } finally {
+                    qexec.close();
+                }
+            } catch (Exception e) {
+                log.error("problem while running query '" + qString + "'", e);
+            }
+            
+        }
+        
+        public static Lang getLang(ResultFormat format) {
+            Lang result;
+            switch (format) {
+                case CSV:
+                    result = SPARQLResultSetCSV;
+                    break;
+                case JSON:
+                    result = SPARQLResultSetJSON;
+                    break;
+                case XML:
+                    result = SPARQLResultSetXML;
+                    break;
+                default:
+                    throw new RuntimeException("Unrecognized result format");
+            }
+            return result;
+        }
 
 	}
 }

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/utils/sparqlrunner/RdfServiceSelectQueryContext.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/utils/sparqlrunner/RdfServiceSelectQueryContext.java
@@ -14,8 +14,9 @@ import org.apache.commons.io.IOUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.jena.query.ResultSet;
-
+import org.apache.jena.riot.Lang;
 import edu.cornell.mannlib.vitro.webapp.rdfservice.RDFService;
+import edu.cornell.mannlib.vitro.webapp.rdfservice.RDFService.ResultFormat;
 import edu.cornell.mannlib.vitro.webapp.rdfservice.impl.RDFServiceUtils;
 import edu.cornell.mannlib.vitro.webapp.utils.sparqlrunner.SparqlQueryRunner.ExecutingSelectQueryContext;
 import edu.cornell.mannlib.vitro.webapp.utils.sparqlrunner.SparqlQueryRunner.SelectQueryContext;
@@ -102,15 +103,20 @@ class RdfServiceSelectQueryContext implements SelectQueryContext {
 
 		@Override
 		public void writeToOutput(OutputStream output) {
-			try {
-				InputStream resultStream = rdfService.sparqlSelectQuery(
-						query.getQueryString(), JSON);
-				IOUtils.copy(resultStream, output);
-			} catch (Exception e) {
-				log.error(
-						"problem while running query '"
-								+ query.getQueryString() + "'", e);
-			}
+		    writeToOutput(output, JSON);
 		}
+
+        @Override
+        public void writeToOutput(OutputStream output, ResultFormat format) {
+            try {
+                InputStream resultStream = rdfService.sparqlSelectQuery(
+                        query.getQueryString(), format);
+                IOUtils.copy(resultStream, output);
+            } catch (Exception e) {
+                log.error(
+                        "problem while running query '"
+                                + query.getQueryString() + "'", e);
+            }
+        }		
 	}
 }

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/utils/sparqlrunner/SparqlQueryRunner.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/utils/sparqlrunner/SparqlQueryRunner.java
@@ -7,8 +7,8 @@ import java.io.OutputStream;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.jena.rdf.model.Model;
-
 import edu.cornell.mannlib.vitro.webapp.rdfservice.RDFService;
+import edu.cornell.mannlib.vitro.webapp.rdfservice.RDFService.ResultFormat;
 
 /**
  * A conversational tool for handling SPARQL queries.
@@ -87,6 +87,8 @@ public final class SparqlQueryRunner {
 		public <T> T parse(ResultSetParser<T> parser);
 
 		public void writeToOutput(OutputStream output);
+		
+		public void writeToOutput(OutputStream output, ResultFormat format);
 	}
 
 	// ------------- CONSTRUCT ----------- //

--- a/home/src/main/resources/rdf/i18n/en_US/interface-i18n/firsttime/vitro_UiLabel.ttl
+++ b/home/src/main/resources/rdf/i18n/en_US/interface-i18n/firsttime/vitro_UiLabel.ttl
@@ -6563,6 +6563,13 @@ uil-data:dd_config_actionName.Vitro
         uil:hasApp       "Vitro" ;
         uil:hasKey       "dd_config_http://vitro.mannlib.cornell.edu/ns/vitro/ApplicationSetup#actionName" .
 
+uil-data:dd_config_rdfLang.Vitro
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         uil:UILabel ;
+        rdfs:label       "RDF serialization language"@en-US ;
+        uil:hasApp       "Vitro" ;
+        uil:hasKey       "dd_config_http://vitro.mannlib.cornell.edu/ns/vitro/ApplicationSetup#rdfLang" .
+
 uil-data:dd_config_uriBinding.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;

--- a/home/src/main/resources/rdf/i18n/en_US/interface-i18n/firsttime/vitro_UiLabel.ttl
+++ b/home/src/main/resources/rdf/i18n/en_US/interface-i18n/firsttime/vitro_UiLabel.ttl
@@ -1273,6 +1273,7 @@ uil-data:rebuild_search_index.Vitro
 uil-data:password_saved.Vitro
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;
+        
         rdfs:label       "Your password has been saved."@en-US ;
         uil:hasApp      "Vitro" ;
         uil:hasKey      "password_saved" ;
@@ -6569,6 +6570,13 @@ uil-data:dd_config_rdfLang.Vitro
         rdfs:label       "RDF serialization language"@en-US ;
         uil:hasApp       "Vitro" ;
         uil:hasKey       "dd_config_http://vitro.mannlib.cornell.edu/ns/vitro/ApplicationSetup#rdfLang" .
+
+uil-data:dd_config_resultFormat.Vitro
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         uil:UILabel ;
+        rdfs:label       "Result format"@en-US ;
+        uil:hasApp       "Vitro" ;
+        uil:hasKey       "dd_config_http://vitro.mannlib.cornell.edu/ns/vitro/ApplicationSetup#resultFormat" .
 
 uil-data:dd_config_uriBinding.Vitro
         rdf:type         owl:NamedIndividual ;

--- a/webapp/src/main/webapp/templates/freemarker/body/admin/admin-dataDistributor-edit-DataDistributor.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/body/admin/admin-dataDistributor-edit-DataDistributor.ftl
@@ -79,13 +79,21 @@
         </label>
         <#switch property.parameterType.name>
             <#case 'java.lang.String'>
-                <#if fields[property.propertyUri]??>
-                    <#assign values = fields[property.propertyUri] />
-                    <#list values as value>
-                        <@inputField property.propertyUri value required />
-                    </#list>
+                <#if property.propertyUri == "http://vitro.mannlib.cornell.edu/ns/vitro/ApplicationSetup#rdfLang">
+	                <select name="${property.propertyUri}">
+                        <option value="N3" <#if fields[property.propertyUri]?? && fields[property.propertyUri]?seq_contains('N3')>selected</#if> >N3</option>
+                        <option value="TTL" <#if fields[property.propertyUri]?? && fields[property.propertyUri]?seq_contains('TTL')>selected</#if> >TTL</option>
+                        <option value="RDF/XML" <#if fields[property.propertyUri]?? && fields[property.propertyUri]?seq_contains('RDF/XML')>selected</#if> >RDF/XML</option>
+	                </select>
                 <#else>
-                    <@inputField property.propertyUri "" required />
+                	<#if fields[property.propertyUri]??>
+	                    <#assign values = fields[property.propertyUri] />
+	                    <#list values as value>
+	                        <@inputField property.propertyUri value required />
+	                    </#list>
+	                <#else>
+	                    <@inputField property.propertyUri "" required />
+	                </#if>
                 </#if>
                 <#break>
             <#case 'edu.cornell.library.scholars.webapp.controller.api.distribute.DataDistributor'>

--- a/webapp/src/main/webapp/templates/freemarker/body/admin/admin-dataDistributor-edit-DataDistributor.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/body/admin/admin-dataDistributor-edit-DataDistributor.ftl
@@ -85,6 +85,11 @@
                         <option value="TTL" <#if fields[property.propertyUri]?? && fields[property.propertyUri]?seq_contains('TTL')>selected</#if> >TTL</option>
                         <option value="RDF/XML" <#if fields[property.propertyUri]?? && fields[property.propertyUri]?seq_contains('RDF/XML')>selected</#if> >RDF/XML</option>
 	                </select>
+                <#elseif property.propertyUri == "http://vitro.mannlib.cornell.edu/ns/vitro/ApplicationSetup#resultFormat">
+	                <select name="${property.propertyUri}">
+                        <option value="JSON" <#if fields[property.propertyUri]?? && fields[property.propertyUri]?seq_contains('JSON')>selected</#if> >JSON</option>
+                        <option value="CSV" <#if fields[property.propertyUri]?? && fields[property.propertyUri]?seq_contains('CSV')>selected</#if> >CSV</option>
+	                </select>
                 <#else>
                 	<#if fields[property.propertyUri]??>
 	                    <#assign values = fields[property.propertyUri] />


### PR DESCRIPTION
Related to [VIVO 4118](https://github.com/vivo-project/VIVO/issues/4118)
Related to [VIVO 4119](https://github.com/vivo-project/VIVO/issues/4119)

* Other Relevant Links (Mailing list discussion, related pull requests, etc.)

# What does this pull request do?

Options to define output formats for SPARQL based Data distributors

# What's new?
- Added CSV output option for SPARQL Select Distributors
- Added RDF/XML output option for SPARQL Construct Distributors
- Added N3 output option for SPARQL Construct Distributors

# How should this be tested?
* Create Select from content Distributor, set result format to CSV, run distributor, check the output is CSV. Repeat the test with standard JSON result format.
* Create Construct Query Graph builder and RDF Graph distributor, set RDF serialization option to RDF/XML, run distributor, check the output is RDF/XML. Repeat the test for N3 and TTL options.

# Interested parties
@VIVO-project/vivo-committers

# Reviewers' expertise

Candidates for reviewing this PR should have some of the following expertises:
1. Java
2. FreeMarker
3. SPARQL

# Reviewers' report template
## General comment
A reviewer should provide here comments and suggestions for requested changes if any.
## Testing
A reviewer should briefly describe here how it was tested
## Code reviewing
A reviewer should briefly describe here which part was code reviewed