### PR TITLE
Added a confirmation dialog for deleting/cleaning a model.

### DIFF
--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/jena/JenaIngestController.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/jena/JenaIngestController.java
@@ -71,6 +71,7 @@ import edu.cornell.mannlib.vitro.webapp.dao.jena.BlankNodeFilteringModelMaker;
 import edu.cornell.mannlib.vitro.webapp.dao.jena.RDFServiceGraph;
 import edu.cornell.mannlib.vitro.webapp.dao.jena.event.EditEvent;
 import edu.cornell.mannlib.vitro.webapp.edit.n3editing.VTwo.N3EditUtils;
+import edu.cornell.mannlib.vitro.webapp.i18n.I18n;
 import edu.cornell.mannlib.vitro.webapp.modelaccess.ModelAccess;
 import edu.cornell.mannlib.vitro.webapp.modelaccess.ModelAccess.WhichService;
 import edu.cornell.mannlib.vitro.webapp.rdfservice.ChangeSet;
@@ -203,6 +204,7 @@ public class JenaIngestController extends BaseEditController {
         }
 
         request.setAttribute("modelNames", modelNames);
+        request.setAttribute("i18n", I18n.bundle(request));
 
         try {
             JSPPageHandler.renderBasicPage(request, response, bodyJsp);

--- a/home/src/main/resources/rdf/i18n/en_US/interface-i18n/firsttime/vitro_UiLabel.ttl
+++ b/home/src/main/resources/rdf/i18n/en_US/interface-i18n/firsttime/vitro_UiLabel.ttl
@@ -6928,3 +6928,20 @@ uil-data:confirm_remove_custom_css.Vitro
         uil:hasApp       "Vitro" ;
         uil:hasKey       "confirm_remove_custom_css" ;
         uil:hasPackage   "Vitro-languages" .
+
+uil-data:confirm_clear_model.Vitro
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         uil:UILabel ;
+        rdfs:label       "Are you sure you want to clear the model?"@en-US ;
+        uil:hasApp       "Vitro" ;
+        uil:hasKey       "confirm_clear_model" ;
+        uil:hasPackage   "Vitro-languages" .
+
+uil-data:confirm_remove_model.Vitro
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         uil:UILabel ;
+        rdfs:label       "Are you sure you want to remove the model?"@en-US ;
+        uil:hasApp       "Vitro" ;
+        uil:hasKey       "confirm_remove_model" ;
+        uil:hasPackage   "Vitro-languages" .
+

--- a/webapp/src/main/webapp/jenaIngest/listModels.jsp
+++ b/webapp/src/main/webapp/jenaIngest/listModels.jsp
@@ -67,7 +67,7 @@ function init(){
             <a href="${outputModelURL}">output model</a>
             </td>
             <td>
-            <form action="ingest" method="post">
+            <form action="ingest" method="post" onsubmit="return confirm('${i18n.text('confirm_clear_model')}');">
                 <input type="hidden" name="action" value="clearModel"/>
                 <input type="hidden" name="modelName" value="${modelName}"/>
                 <input type="hidden" name="modelType" value="${modelType}"/>
@@ -75,7 +75,7 @@ function init(){
             </form>
             </td>
             <td>
-            <form action="ingest" method="post">
+            <form action="ingest" method="post" onsubmit="return confirm('${i18n.text('confirm_remove_model')}');">
                 <input type="hidden" name="action" value="removeModel"/>
                 <input type="hidden" name="modelName" value="${modelName}"/>
                 <input type="hidden" name="modelType" value="${modelType}"/>


### PR DESCRIPTION
**[VIVO GitHub issue](https://github.com/vivo-project/VIVO/issues/2729)**

# What does this pull request do?
Added a confirmation dialog for deleting/cleaning a model.

# How should this be tested?
* Open ingest tools as root Site Admin - > Ingest tools -> Manage Jena Models
* Click on "clear statements" button below http://vitro.mannlib.cornell.edu/default/vitro-kb-inf  model
* See the dialog. Try both options.
* Click on "remove" button below http://vitro.mannlib.cornell.edu/default/vitro-kb-inf  model
* See the dialog. Try both options.

# Interested parties
@VIVO-project/vivo-committers

# Reviewers' expertise
Candidates for reviewing this PR should have some of the following expertises:
1. Java
2. HTML
3. JavaScript
4. JSP

# Reviewers' report template
## General comment
A reviewer should provide here comments and suggestions for requested changes if any.
## Testing
A reviewer should briefly describe here how it was tested
## Code reviewing
A reviewer should briefly describe here which part was code reviewed