### PR TITLE
Option to disable language filtering in data distributors

### DIFF
--- a/api/src/main/java/edu/cornell/library/scholars/webapp/controller/api/distribute/rdf/SelectFromContentDistributor.java
+++ b/api/src/main/java/edu/cornell/library/scholars/webapp/controller/api/distribute/rdf/SelectFromContentDistributor.java
@@ -7,7 +7,10 @@ import static edu.cornell.mannlib.vitro.webapp.utils.sparqlrunner.SparqlQueryRun
 import java.io.OutputStream;
 
 import edu.cornell.library.scholars.webapp.controller.api.distribute.DataDistributorContext;
+import edu.cornell.library.scholars.webapp.controller.api.distribute.rdf.graphbuilder.GraphBuilderUtilities;
+import edu.cornell.mannlib.vitro.webapp.modelaccess.ModelAccess;
 import edu.cornell.mannlib.vitro.webapp.modelaccess.RequestModelAccess;
+import edu.cornell.mannlib.vitro.webapp.rdfservice.RDFService;
 import edu.cornell.mannlib.vitro.webapp.rdfservice.RDFService.ResultFormat;
 import edu.cornell.mannlib.vitro.webapp.utils.configuration.Property;
 import edu.cornell.mannlib.vitro.webapp.utils.sparqlrunner.QueryHolder;
@@ -93,7 +96,14 @@ public class SelectFromContentDistributor extends AbstractSparqlBindingDistribut
     public void writeOutput(OutputStream output) throws DataDistributorException {
         QueryHolder boundQuery = binder.bindValuesToQuery(uriBindingNames, literalBindingNames,
                 new QueryHolder(rawQuery));
-        createSelectQueryContext(this.models.getRDFService(), boundQuery).execute().writeToOutput(output,
+        RDFService rdfService;
+        if (GraphBuilderUtilities.isLanguageFilteringDisabledForRequest(ddContext)) {
+            rdfService = ModelAccess.getInstance().getRDFService();
+        } else {
+            rdfService = this.models.getRDFService();
+        }
+
+        createSelectQueryContext(rdfService, boundQuery).execute().writeToOutput(output,
                 ResultFormat.valueOf(resultFormat));
     }
 

--- a/api/src/main/java/edu/cornell/library/scholars/webapp/controller/api/distribute/rdf/graphbuilder/ConstructQueryGraphBuilder.java
+++ b/api/src/main/java/edu/cornell/library/scholars/webapp/controller/api/distribute/rdf/graphbuilder/ConstructQueryGraphBuilder.java
@@ -11,6 +11,7 @@ import java.util.List;
 import edu.cornell.library.scholars.webapp.controller.api.distribute.DataDistributor.DataDistributorException;
 import edu.cornell.library.scholars.webapp.controller.api.distribute.DataDistributorContext;
 import edu.cornell.library.scholars.webapp.controller.api.distribute.rdf.SelectFromContentDistributor;
+import edu.cornell.mannlib.vitro.webapp.modelaccess.ModelAccess;
 import edu.cornell.mannlib.vitro.webapp.rdfservice.RDFService;
 import edu.cornell.mannlib.vitro.webapp.utils.configuration.Property;
 import edu.cornell.mannlib.vitro.webapp.utils.sparqlrunner.QueryHolder;
@@ -97,8 +98,12 @@ public class ConstructQueryGraphBuilder extends AbstractSparqlBindingGraphBuilde
     @Override
     public Model buildGraph(DataDistributorContext ddContext) throws DataDistributorException {
         log.debug("Parameters: " + formatParameters(ddContext));
-
-        RDFService rdfService = ddContext.getRequestModels().getRDFService();
+        RDFService rdfService;
+        if (GraphBuilderUtilities.isLanguageFilteringDisabledForRequest(ddContext)) {
+            rdfService = ModelAccess.getInstance().getRDFService();
+        } else {
+            rdfService = ddContext.getRequestModels().getRDFService();
+        }
         Model m = ModelFactory.createDefaultModel();
 
         for (String rawQuery : rawQueries) {
@@ -109,4 +114,5 @@ public class ConstructQueryGraphBuilder extends AbstractSparqlBindingGraphBuilde
         }
         return m;
     }
+
 }

--- a/api/src/main/java/edu/cornell/library/scholars/webapp/controller/api/distribute/rdf/graphbuilder/GraphBuilderUtilities.java
+++ b/api/src/main/java/edu/cornell/library/scholars/webapp/controller/api/distribute/rdf/graphbuilder/GraphBuilderUtilities.java
@@ -94,4 +94,9 @@ public class GraphBuilderUtilities {
         }
 
     }
+
+    public static boolean isLanguageFilteringDisabledForRequest(DataDistributorContext ddContext) {
+        String[] lang = ddContext.getRequestParameters().get("lang");
+        return lang != null && lang.length == 1 && "*".equals(lang[0]);
+    }
 }


### PR DESCRIPTION
# What does this pull request do?
Lang parameter is already used to override preferred language. It was reused to disable language filtering in data distributors with * value provided in distributor url. 

# How should this be tested?
Create Sparql select/Sparql construct data distributors
* Run distribututors with and without lang=*
* Verify that language filtering is being disabled with the option

# Interested parties
@VIVO-project/vivo-committers

# Reviewers' expertise

Candidates for reviewing this PR should have some of the following expertises:
1. Java

# Reviewers' report template

## General comment
A reviewer should provide here comments and suggestions for requested changes if any.
## Testing
A reviewer should briefly describe here how it was tested
## Code reviewing
A reviewer should briefly describe here which part was code reviewed